### PR TITLE
fix(ops): Render docs build command

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,7 @@ services:
   - type: web
     name: output-ai-reference-code-docs
     runtime: static
-    buildCommand: npm ci && npm run docs:generate
+    buildCommand: pnpm install && pnpm run docs:generate
     staticPublishPath: ./docs/reference
     repo: https://github.com/growthxai/output
     branch: main


### PR DESCRIPTION
Render config file `render.yml` was still using `npm ci` command, swithing to `pnpm install`.