### PR TITLE
chore(cli): Fix creds editor env

### DIFF
--- a/sdk/cli/src/commands/credentials/edit.ts
+++ b/sdk/cli/src/commands/credentials/edit.ts
@@ -46,14 +46,19 @@ export default class CredentialsEdit extends Command {
       );
     }
 
-    const editor = process.env.EDITOR || process.env.VISUAL || 'vi';
+    const editorEnv = process.env.EDITOR || process.env.VISUAL || 'vi';
+    const [ editorCmd, ...editorArgs ] = editorEnv.split( /\s+/ );
     const plaintext = decryptCredentials( environment, workflow );
     const tmpFile = path.join( os.tmpdir(), `output-credentials-${Date.now()}.yml` );
 
     try {
       fs.writeFileSync( tmpFile, plaintext, { mode: 0o600 } );
 
-      const result = spawnSync( editor, [ tmpFile ], { stdio: 'inherit' } );
+      const result = spawnSync( editorCmd, [ ...editorArgs, tmpFile ], { stdio: 'inherit' } );
+
+      if ( result.error ) {
+        this.error( `Failed to launch editor: ${result.error.message}` );
+      }
 
       if ( result.status !== 0 ) {
         this.error( `Editor exited with non-zero status: ${result.status}` );


### PR DESCRIPTION
## Problem

- `EDITOR="cursor --wait"` caused `spawnSync` to look for an executable literally named `"cursor --wait"`, failing with `status: null`
- The command returned "Saved successfully" immediately without waiting for the editor to close

## Solution

- Split the `EDITOR` env var on whitespace so flags like `--wait` are passed as separate args to `spawnSync`
- Added an explicit `result.error` check to surface spawn failures with a clear message