### PR TITLE
feat: Add config cost template to scaffold

### DIFF
--- a/docs/guides/operations/deployment/railway.mdx
+++ b/docs/guides/operations/deployment/railway.mdx
@@ -19,6 +19,8 @@ After running `output init`, your repository looks like this:
 
 ```
 your-workflows/
+├── config/
+│   └── costs.yml
 ├── src/
 │   └── workflows/
 │       └── your_workflow/

--- a/docs/guides/operations/deployment/render.mdx
+++ b/docs/guides/operations/deployment/render.mdx
@@ -18,6 +18,8 @@ After running `output init`, your repository looks like this:
 
 ```
 your-workflows/
+├── config/
+│   └── costs.yml
 ├── src/
 │   └── workflows/
 │       └── your_workflow/

--- a/docs/guides/plan.md
+++ b/docs/guides/plan.md
@@ -135,7 +135,7 @@ Output is the first framework designed with AI Coding in mind. We are fully inte
 
 The CLI is how you interact with Output - whether directly or through Claude Code. This isn't a reference page, it's a teaching page that explains the development workflow. Start with the mental model: Output projects have workflows that you develop locally and run against Temporal. The CLI bridges your code and the runtime. Cover each command in depth:
 
-**`output init <project-name>`** - Creates a new project folder and scaffolds the complete structure. You don't need to create the folder first - the CLI creates it. Generates: `.env.example`, `.gitignore`, `package.json` with Output dependencies, `tsconfig.json`, `README.md`, `.outputai/` folder for Claude Code integration, and `src/simple/` with an example workflow. Show the output, explain each file's purpose. Works seamlessly with VS Code Claude Code extension.
+**`output init <project-name>`** - Creates a new project folder and scaffolds the complete structure. You don't need to create the folder first - the CLI creates it. Generates: `.env.example`, `.gitignore`, `package.json` with Output dependencies, `tsconfig.json`, `README.md`, `.outputai/` folder for Claude Code integration, `config/costs.yml` for LLM pricing overrides, and `src/simple/` with an example workflow. Show the output, explain each file's purpose. Works seamlessly with VS Code Claude Code extension.
 
 **`output dev`** - Starts the development environment. This is the command you run and leave running. It starts the Temporal worker, watches for file changes, and hot-reloads workflows. Explain what "worker" means: it's the process that executes your workflow code. Show how to read the worker logs.
 

--- a/docs/guides/plan.md
+++ b/docs/guides/plan.md
@@ -135,7 +135,7 @@ Output is the first framework designed with AI Coding in mind. We are fully inte
 
 The CLI is how you interact with Output - whether directly or through Claude Code. This isn't a reference page, it's a teaching page that explains the development workflow. Start with the mental model: Output projects have workflows that you develop locally and run against Temporal. The CLI bridges your code and the runtime. Cover each command in depth:
 
-**`output init <project-name>`** - Creates a new project folder and scaffolds the complete structure. You don't need to create the folder first - the CLI creates it. Generates: `.env.example`, `.gitignore`, `package.json` with Output dependencies, `tsconfig.json`, `README.md`, `.outputai/` folder for Claude Code integration, `config/costs.yml` for LLM pricing overrides, and `src/simple/` with an example workflow. Show the output, explain each file's purpose. Works seamlessly with VS Code Claude Code extension.
+**`output init <project-name>`** - Creates a new project folder and scaffolds the complete structure. You don't need to create the folder first - the CLI creates it. Generates: `.env.example`, `.gitignore`, `package.json` with Output dependencies, `tsconfig.json`, `README.md`, `.outputai/` folder for Claude Code integration, `config/costs.yml` for pricing overrides, and `src/simple/` with an example workflow. Show the output, explain each file's purpose. Works seamlessly with VS Code Claude Code extension.
 
 **`output dev`** - Starts the development environment. This is the command you run and leave running. It starts the Temporal worker, watches for file changes, and hot-reloads workflows. Explain what "worker" means: it's the process that executes your workflow code. Show how to read the worker logs.
 

--- a/docs/guides/start-here/getting-started.mdx
+++ b/docs/guides/start-here/getting-started.mdx
@@ -73,7 +73,7 @@ The CLI creates the project, configures your `.env`, and installs dependencies. 
 ```
 content-workflows/
 ├── config/
-│   └── costs.yml                    # LLM pricing overrides
+│   └── costs.yml                    # Pricing overrides (LLM and API services)
 ├── src/
 │   ├── shared/                      # Shared code across workflows
 │   │   ├── clients/                 # API clients

--- a/docs/guides/start-here/getting-started.mdx
+++ b/docs/guides/start-here/getting-started.mdx
@@ -72,6 +72,8 @@ The CLI creates the project, configures your `.env`, and installs dependencies. 
 
 ```
 content-workflows/
+├── config/
+│   └── costs.yml                    # LLM pricing overrides
 ├── src/
 │   ├── shared/                      # Shared code across workflows
 │   │   ├── clients/                 # API clients

--- a/sdk/cli/src/services/copy_assets.spec.ts
+++ b/sdk/cli/src/services/copy_assets.spec.ts
@@ -19,4 +19,9 @@ describe( 'copy-assets build output', () => {
       expect( fs.existsSync( filePath ), `Missing dotfile template in dist: ${dotfile}` ).toBe( true );
     }
   } );
+
+  it( 'should include config templates in dist/templates/project/', () => {
+    const configFile = path.join( distTemplatesDir, 'config', 'costs.yml.template' );
+    expect( fs.existsSync( configFile ), 'Missing config/costs.yml.template in dist' ).toBe( true );
+  } );
 } );

--- a/sdk/cli/src/templates/project/config/costs.yml.template
+++ b/sdk/cli/src/templates/project/config/costs.yml.template
@@ -2,8 +2,6 @@
 # Prices are per million tokens, in USD
 # Entries here are merged with built-in defaults (project values take precedence)
 # Model names support prefix matching: 'claude-sonnet-4' matches 'claude-sonnet-4-20250514'
-# You can also add a services: block to override API service pricing
-
 # models:
 #   # =============================================================================
 #   # Anthropic
@@ -19,3 +17,13 @@
 #     input: 3.00
 #     output: 15.00
 #     cached_input: 0.30
+
+# services:
+#   # =============================================================================
+#   # Jina Reader API - Token-based
+#   # =============================================================================
+#   jina:
+#     type: token
+#     url_pattern: "r.jina.ai"
+#     usage_path: "body.data.usage.tokens"
+#     per_million: 0.045

--- a/sdk/cli/src/templates/project/config/costs.yml.template
+++ b/sdk/cli/src/templates/project/config/costs.yml.template
@@ -1,18 +1,20 @@
-# LLM Token Pricing Configuration
-# Prices are per million tokens
-# Use this file to optionally override LLM costs
+# Token & API Pricing Configuration
+# Prices are per million tokens, in USD
+# Entries here are merged with built-in defaults (project values take precedence)
+# Model names support prefix matching: 'claude-sonnet-4' matches 'claude-sonnet-4-20250514'
+# You can also add a services: block to override API service pricing
 
 # models:
 #   # =============================================================================
 #   # Anthropic
 #   # =============================================================================
-#   claude-haiku-4-5-20251001:
+#   claude-haiku-4-5:
 #     provider: anthropic
 #     input: 1.00
 #     output: 5.00
 #     cached_input: 0.10
 
-#   claude-sonnet-4-20250514:
+#   claude-sonnet-4:
 #     provider: anthropic
 #     input: 3.00
 #     output: 15.00

--- a/sdk/cli/src/templates/project/config/costs.yml.template
+++ b/sdk/cli/src/templates/project/config/costs.yml.template
@@ -1,0 +1,19 @@
+# LLM Token Pricing Configuration
+# Prices are per million tokens
+# Use this file to optionally override LLM costs
+
+# models:
+#   # =============================================================================
+#   # Anthropic
+#   # =============================================================================
+#   claude-haiku-4-5-20251001:
+#     provider: anthropic
+#     input: 1.00
+#     output: 5.00
+#     cached_input: 0.10
+
+#   claude-sonnet-4-20250514:
+#     provider: anthropic
+#     input: 3.00
+#     output: 15.00
+#     cached_input: 0.30


### PR DESCRIPTION
Adds a `config` folder in the root of projects generated with `output init`, and provides a default `cost.yml` file with examples to override the CLI cost calculation. 