### PR TITLE
fix(claude-plugin): Fix invalid marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "outputai",
-      "source": "outputai",
+      "source": "./outputai",
       "description": "Output.ai Workflow Assistants",
       "version": "0.0.1",
       "author": {
@@ -19,7 +19,7 @@
     },
     {
       "name": "outputai-flow-migrator",
-      "source": "outputai-flow-migrator",
+      "source": "./outputai-flow-migrator",
       "description": "Output.ai Flow SDK to Output SDK Migrator",
       "version": "0.0.1",
       "author": {

--- a/coding_assistants/claude/plugins/outputai-flow-migrator/commands/plan_flow_workflow_migration.md
+++ b/coding_assistants/claude/plugins/outputai-flow-migrator/commands/plan_flow_workflow_migration.md
@@ -1,5 +1,5 @@
 ---
-argument-hint: [workflow-path] [additional-instructions]
+argument-hint: "[workflow-path] [additional-instructions]"
 description: Create a migration plan for converting a Flow SDK workflow to Output SDK
 version: 0.1.0
 model: opus

--- a/coding_assistants/claude/plugins/outputai/commands/build_workflow.md
+++ b/coding_assistants/claude/plugins/outputai/commands/build_workflow.md
@@ -1,5 +1,5 @@
 ---
-argument-hint: [workflow-plan-file-path] [workflow-name] [workflow-directory]
+argument-hint: "[workflow-plan-file-path] [workflow-name] [workflow-directory]"
 description: Workflow Implementation Command for Output SDK
 version: 0.1.3
 model: opus


### PR DESCRIPTION
## Overview

- Relative plugin `source` paths in `marketplace.json` must start with `./` — bare names like `"outputai"` are rejected by the validator
- Multi-bracket `argument-hint` values (e.g. `[a] [b]`) must be quoted strings to prevent YAML from parsing them as flow sequences
- All three affected files now pass `claude plugin validate`