### PR TITLE
chore(claude-plugin): Add claude code plugin docs and bump version to match 0.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "outputai",
       "source": "./coding_assistants/claude/plugins/outputai",
       "description": "Output.ai Workflow Assistants",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "author": {
         "name": "Output.ai"
       }

--- a/coding_assistants/claude/plugins/README.md
+++ b/coding_assistants/claude/plugins/README.md
@@ -1,0 +1,22 @@
+# Output.ai Claude Plugins
+The folder contains Claude Plugins for Output.ai.
+
+Learn more about Output.ai at [output.ai](https://docs.output.ai).
+
+## Installation
+```bash
+claude
+> /plugin marketplace add growthxai/output
+> /plugin install outputai@outputai
+```
+
+Afterwards you should see slash commands in the Claude Code autocomplete.
+
+```bash
+/outputai:plan_workflow
+/outputai:build_workflow
+/outputai:debug_workflow
+# ... and more
+```
+
+as well as skills and agents.

--- a/coding_assistants/claude/plugins/outputai/.claude-plugin/plugin.json
+++ b/coding_assistants/claude/plugins/outputai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "outputai",
-    "version": "0.0.1",
+    "version": "0.1.0",
     "description": "Workflow development tools",
     "author": {
       "name": "Output.ai",

--- a/docs/guides/coding-assistants/claude-code.mdx
+++ b/docs/guides/coding-assistants/claude-code.mdx
@@ -1,0 +1,35 @@
+---
+title: "Claude Code"
+description: "Output.ai ships a Claude Code plugin with commands for planning, building, and debugging workflows"
+---
+
+The Output plugin adds Claude Code commands tuned for Output workflows: `plan-workflow`, `build-workflow`, and `debug-workflow`. These give Claude the context it needs to generate correct, idiomatic Output code.
+
+## Automatic install
+
+When you create a new project, the plugin is installed automatically:
+
+```bash
+npx @outputai/cli init
+```
+
+That's it — the plugin is registered and ready to use.
+
+## Keeping it up to date
+
+To update the plugin alongside your CLI:
+
+```bash
+npx output update --agents
+```
+
+## Manual install via Claude CLI
+
+If you need to install or reinstall the plugin directly:
+
+```bash
+claude plugin marketplace add growthxai/output
+claude plugin install outputai@outputai
+```
+
+The first command registers the Output marketplace. The second installs the plugin from it.

--- a/docs/guides/coding-assistants/claude-code.mdx
+++ b/docs/guides/coding-assistants/claude-code.mdx
@@ -36,4 +36,4 @@ The first command registers the Output marketplace. The second installs the plug
 
 ## Plugin reference
 
-For a complete list of all commands, agents, and hooks included in the plugin, see the [plugin source on GitHub](https://github.com/growthxai/output/tree/main/coding_assistants/claude/plugins/outputai).
+For a complete list of all commands, agents, and hooks included in the plugin, see the [plugin source on GitHub](https://github.com/growthxai/output/tree/main/coding_assistants/claude/plugins/).

--- a/docs/guides/coding-assistants/claude-code.mdx
+++ b/docs/guides/coding-assistants/claude-code.mdx
@@ -33,3 +33,7 @@ claude plugin install outputai@outputai
 ```
 
 The first command registers the Output marketplace. The second installs the plugin from it.
+
+## Plugin reference
+
+For a complete list of all commands, agents, and hooks included in the plugin, see the [plugin source on GitHub](https://github.com/growthxai/output/tree/main/coding_assistants/claude/plugins/outputai).

--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -80,12 +80,6 @@
             ]
           },
           {
-            "group": "Coding Assistants",
-            "pages": [
-              "coding-assistants/claude-code"
-            ]
-          },
-          {
             "group": "Production Readiness",
             "pages": [
               "operations/credentials",
@@ -95,6 +89,12 @@
               "operations/testing",
               "operations/tracing",
               "operations/cost-estimation"
+            ]
+          },
+          {
+            "group": "Coding Assistants",
+            "pages": [
+              "coding-assistants/claude-code"
             ]
           },
           {

--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -80,6 +80,12 @@
             ]
           },
           {
+            "group": "Coding Assistants",
+            "pages": [
+              "coding-assistants/claude-code"
+            ]
+          },
+          {
             "group": "Production Readiness",
             "pages": [
               "operations/credentials",

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -115,6 +115,6 @@ export const summarizeContent = step({
   </Card>
 </CardGroup>
 
-<Card title="Get Started" icon="rocket" href="/getting-started">
+<Card title="Get Started" icon="rocket" href="/start-here/getting-started">
   Set up your first Output project in 5 minutes
 </Card>

--- a/docs/guides/start-here/getting-started.mdx
+++ b/docs/guides/start-here/getting-started.mdx
@@ -609,16 +609,13 @@ Run it again and check the execution interface. You'll see `summarizeContent` an
 You've built your first real Output workflow. Here's where to go next:
 
 <CardGroup cols={2}>
-  <Card title="CLI Reference" icon="terminal" href="/cli">
+  <Card title="CLI Reference" icon="terminal" href="/packages/cli">
     All commands in depth—run, start, status, terminate, and more.
   </Card>
   <Card title="Workflows" icon="diagram-project" href="/workflows">
     Control flow, child workflows, scenarios, and advanced patterns.
   </Card>
-  <Card title="Claude Code Integration" icon="wand-magic-sparkles" href="/claude-code">
+  <Card title="Claude Code Integration" icon="wand-magic-sparkles" href="/coding-assistants/claude-code">
     Deep dive on AI-assisted workflow development.
-  </Card>
-  <Card title="Course" icon="graduation-cap" href="/guides/course">
-    8-lesson progressive tutorial building production workflows.
   </Card>
 </CardGroup>

--- a/docs/guides/workflows/index.mdx
+++ b/docs/guides/workflows/index.mdx
@@ -266,6 +266,6 @@ Once you have a workflow, you'll want to explore these related concepts:
 
 - [Steps](/steps) — Where I/O happens: API calls, LLM requests, database queries
 - [Child Workflows](/workflows/child-workflows) — Compose workflows by calling other workflows
-- [Parallel Execution](/workflows/tools) — Run multiple steps concurrently with `executeInParallel`
+- [Parallel Execution](/workflows/parallel-execution) — Run multiple steps concurrently with `executeInParallel`
 - [External Integration](/workflows/external-integration) — Send data out, receive input, and query status
 - [Connecting to External APIs](/clients) — Build typed, traced API clients

--- a/sdk/cli/src/services/generate_plan_name@v1.prompt
+++ b/sdk/cli/src/services/generate_plan_name@v1.prompt
@@ -1,6 +1,6 @@
 ---
 provider: anthropic
-model: claude-sonnet-4-20250514
+model: claude-haiku-4-5
 temperature: 0.3
 ---
 


### PR DESCRIPTION
## Overview
This PR is essentially a release PR after confirming the plugin migration to the monorepo is successful.

1. Adds a docs section for installing and running the claude code plugin yourself
1. Bumps version to v0.1.0 match other packages

Additionally it
1. Fixes some broken links discovered by our new ci
2. Updates our name planner to use haiku