### PR TITLE
chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.1

### DIFF
--- a/.changeset/nice-spoons-see.md
+++ b/.changeset/nice-spoons-see.md
@@ -1,0 +1,5 @@
+---
+"@outputai/llm": patch
+---
+
+Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0

--- a/.changeset/nice-spoons-see.md
+++ b/.changeset/nice-spoons-see.md
@@ -2,4 +2,4 @@
 "@outputai/llm": patch
 ---
 
-Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0
+Updating @exalabs/ai-sdk from 1.0.5 to 2.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,13 @@ settings:
 catalogs:
   default:
     '@aws-sdk/client-s3':
+<<<<<<< HEAD
       specifier: 3.1015.0
       version: 3.1015.0
+=======
+      specifier: 3.1012.0
+      version: 3.1012.0
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
     '@temporalio/activity':
       specifier: 1.15.0
       version: 1.15.0
@@ -366,8 +371,13 @@ importers:
         specifier: 3.0.26
         version: 3.0.26(zod@4.3.6)
       '@exalabs/ai-sdk':
+<<<<<<< HEAD
         specifier: 1.0.5
         version: 1.0.5(ai@6.0.137(zod@4.3.6))
+=======
+        specifier: 2.0.0
+        version: 2.0.0(ai@6.0.116(zod@4.3.6))
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
       '@outputai/core':
         specifier: 'workspace:'
         version: link:../core
@@ -988,10 +998,10 @@ packages:
     resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@exalabs/ai-sdk@1.0.5':
-    resolution: {integrity: sha512-+2Sv8+JmrjFrmpiOlE9bzbZeko8ceym7lR3mkopLtnhjZp+EjDOm3rxaouf7nxwG6E6f0y3F2VZfmt0wupq7eA==}
+  '@exalabs/ai-sdk@2.0.0':
+    resolution: {integrity: sha512-883EwfpesP37OBp23AQgFMsFYqDAWMeo0i2Kh+Oaz4q9gTj++XCh+K6pJgGC3yMgf6oz116+6MXkerziIut1kg==}
     peerDependencies:
-      ai: ^5.0.83
+      ai: ^6.0.0
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -2483,10 +2493,6 @@ packages:
 
   '@smithy/smithy-client@4.12.7':
     resolution: {integrity: sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/types@4.13.0':
-    resolution: {integrity: sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.13.1':
@@ -4249,6 +4255,7 @@ packages:
       debug:
         optional: true
 
+<<<<<<< HEAD
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -4257,6 +4264,8 @@ packages:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
 
+=======
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -4322,6 +4331,7 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+<<<<<<< HEAD
   function.prototype.name@1.1.8:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
     engines: {node: '>= 0.4'}
@@ -4329,6 +4339,8 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+=======
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
     engines: {node: '>=18'}
@@ -5091,6 +5103,7 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
+<<<<<<< HEAD
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -5106,6 +5119,8 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
+=======
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
 
@@ -5383,6 +5398,7 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+<<<<<<< HEAD
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -5399,6 +5415,8 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
+=======
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   moo@0.5.3:
     resolution: {integrity: sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==}
 
@@ -5671,6 +5689,7 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+<<<<<<< HEAD
   pac-proxy-agent@7.2.0:
     resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
     engines: {node: '>= 14'}
@@ -5679,6 +5698,8 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
+=======
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
@@ -5735,9 +5756,12 @@ packages:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
 
+<<<<<<< HEAD
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
+=======
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
@@ -6170,8 +6194,13 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+<<<<<<< HEAD
   rollup@4.60.0:
     resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
+=======
+  rollup@4.59.0:
+    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -7242,7 +7271,11 @@ snapshots:
     dependencies:
       '@ai-sdk/anthropic': 3.0.64(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
+<<<<<<< HEAD
       '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
+=======
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
       '@smithy/eventstream-codec': 4.2.12
       '@smithy/util-utf8': 4.2.2
       aws4fetch: 1.0.20
@@ -7273,7 +7306,11 @@ snapshots:
       '@ai-sdk/anthropic': 3.0.64(zod@4.3.6)
       '@ai-sdk/google': 3.0.53(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
+<<<<<<< HEAD
       '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
+=======
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
       google-auth-library: 10.6.2
       zod: 4.3.6
     transitivePeerDependencies:
@@ -7785,7 +7822,7 @@ snapshots:
 
   '@aws-sdk/types@3.973.4':
     dependencies:
-      '@smithy/types': 4.13.0
+      '@smithy/types': 4.13.1
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.6':
@@ -8159,7 +8196,11 @@ snapshots:
       '@eslint/core': 1.1.1
       levn: 0.4.1
 
+<<<<<<< HEAD
   '@exalabs/ai-sdk@1.0.5(ai@6.0.137(zod@4.3.6))':
+=======
+  '@exalabs/ai-sdk@2.0.0(ai@6.0.116(zod@4.3.6))':
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
     dependencies:
       ai: 6.0.137(zod@4.3.6)
       zod: 3.25.76
@@ -8595,10 +8636,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
 
+<<<<<<< HEAD
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
 
+=======
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -10055,10 +10099,6 @@ snapshots:
       '@smithy/protocol-http': 5.3.12
       '@smithy/types': 4.13.1
       '@smithy/util-stream': 4.5.20
-      tslib: 2.8.1
-
-  '@smithy/types@4.13.0':
-    dependencies:
       tslib: 2.8.1
 
   '@smithy/types@4.13.1':
@@ -12086,12 +12126,15 @@ snapshots:
 
   follow-redirects@1.15.11: {}
 
+<<<<<<< HEAD
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
 
   form-data-encoder@2.1.4: {}
 
+=======
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -12165,6 +12208,7 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+<<<<<<< HEAD
   function.prototype.name@1.1.8:
     dependencies:
       call-bind: 1.0.8
@@ -12176,6 +12220,8 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+=======
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   gaxios@7.1.4:
     dependencies:
       extend: 3.0.2
@@ -12879,8 +12925,11 @@ snapshots:
 
   isarray@2.0.5: {}
 
+<<<<<<< HEAD
   isexe@2.0.0: {}
 
+=======
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   jake@10.9.4:
     dependencies:
       async: 3.2.6
@@ -13089,6 +13138,7 @@ snapshots:
 
   long@5.3.2: {}
 
+<<<<<<< HEAD
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -13099,6 +13149,8 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
+=======
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   lunr@2.3.9: {}
 
   magic-string@0.30.21:
@@ -13704,6 +13756,7 @@ snapshots:
 
   minimist@1.2.8: {}
 
+<<<<<<< HEAD
   minipass@7.1.3: {}
 
   minizlib@3.1.0:
@@ -13734,6 +13787,8 @@ snapshots:
 
   mitt@3.0.1: {}
 
+=======
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   moo@0.5.3: {}
 
   morgan@1.10.1:
@@ -14013,6 +14068,7 @@ snapshots:
 
   p-try@2.2.0: {}
 
+<<<<<<< HEAD
   pac-proxy-agent@7.2.0:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
@@ -14031,6 +14087,8 @@ snapshots:
       degenerator: 5.0.1
       netmask: 2.0.2
 
+=======
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.11
@@ -14087,8 +14145,11 @@ snapshots:
 
   path-key@4.0.0: {}
 
+<<<<<<< HEAD
   path-parse@1.0.7: {}
 
+=======
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   path-to-regexp@8.3.0: {}
 
   path-type@4.0.0: {}
@@ -14639,7 +14700,11 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+<<<<<<< HEAD
   rollup@4.60.0:
+=======
+  rollup@4.59.0:
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
@@ -15813,12 +15878,15 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+<<<<<<< HEAD
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+=======
+>>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,13 +7,8 @@ settings:
 catalogs:
   default:
     '@aws-sdk/client-s3':
-<<<<<<< HEAD
       specifier: 3.1015.0
       version: 3.1015.0
-=======
-      specifier: 3.1012.0
-      version: 3.1012.0
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
     '@temporalio/activity':
       specifier: 1.15.0
       version: 1.15.0
@@ -371,25 +366,20 @@ importers:
         specifier: 3.0.26
         version: 3.0.26(zod@4.3.6)
       '@exalabs/ai-sdk':
-<<<<<<< HEAD
-        specifier: 1.0.5
-        version: 1.0.5(ai@6.0.137(zod@4.3.6))
-=======
-        specifier: 2.0.0
-        version: 2.0.0(ai@6.0.116(zod@4.3.6))
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
+        specifier: 2.0.1
+        version: 2.0.1(ai@6.0.138(zod@4.3.6))
       '@outputai/core':
         specifier: 'workspace:'
         version: link:../core
       '@perplexity-ai/ai-sdk':
         specifier: 0.1.2
-        version: 0.1.2(ai@6.0.137(zod@4.3.6))(zod@4.3.6)
+        version: 0.1.2(ai@6.0.138(zod@4.3.6))(zod@4.3.6)
       '@tavily/ai-sdk':
         specifier: 0.4.1
-        version: 0.4.1(ai@6.0.137(zod@4.3.6))(zod@4.3.6)
+        version: 0.4.1(ai@6.0.138(zod@4.3.6))(zod@4.3.6)
       ai:
-        specifier: 6.0.137
-        version: 6.0.137(zod@4.3.6)
+        specifier: 6.0.138
+        version: 6.0.138(zod@4.3.6)
       decimal.js:
         specifier: 10.6.0
         version: 10.6.0
@@ -441,8 +431,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.79':
-    resolution: {integrity: sha512-Wk2QJpqd0em5YcR49uoMCy9msyANAYgjXdlRcqqRt2fz4rNLnMMrKOlLwAXoFzR1ElR3bj4e/k6hscRfjpzSGA==}
+  '@ai-sdk/gateway@3.0.80':
+    resolution: {integrity: sha512-uM7kpZB5l977lW7+2X1+klBUxIZQ78+1a9jHlaHFEzcOcmmslTl3sdP0QqfuuBcO0YBM2gwOiqVdp8i4TRQYcw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -643,10 +633,6 @@ packages:
 
   '@aws-sdk/token-providers@3.1015.0':
     resolution: {integrity: sha512-3OSD4y110nisRhHzFOjoEeHU4GQL4KpzkX9PxzWaiZe0Yg2+thZKM0Pn9DjYwezH5JYfh/K++xK/SE0IHGrmCQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/types@3.973.4':
-    resolution: {integrity: sha512-RW60aH26Bsc016Y9B98hC0Plx6fK5P2v/iQYwMzrSjiDh1qRMUCP6KrXHYEHe3uFvKiOC93Z9zk4BJsUi6Tj1Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.6':
@@ -998,8 +984,8 @@ packages:
     resolution: {integrity: sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@exalabs/ai-sdk@2.0.0':
-    resolution: {integrity: sha512-883EwfpesP37OBp23AQgFMsFYqDAWMeo0i2Kh+Oaz4q9gTj++XCh+K6pJgGC3yMgf6oz116+6MXkerziIut1kg==}
+  '@exalabs/ai-sdk@2.0.1':
+    resolution: {integrity: sha512-qrZGJbrrk3MwEFYhhzzJgQarWnica3dBkt86Ex8S8vak2rYNC2EI1hSwVEBmQQeNtLd8tx1J8xSKwQ/5mya6cA==}
     peerDependencies:
       ai: ^6.0.0
 
@@ -3100,8 +3086,8 @@ packages:
     resolution: {integrity: sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==}
     engines: {node: '>=12'}
 
-  ai@6.0.137:
-    resolution: {integrity: sha512-9e/mNMTmXmMkmldEJPIumy9FFBuUWHUyj2yF8EglC3VVOhVVBwlnpeHYSFKdNc13Jj6Hso3EJcZioMaofgCs4A==}
+  ai@6.0.138:
+    resolution: {integrity: sha512-49OfPe0f5uxJ6jUdA5BBXjIinP6+ZdYfAtpF2aEH64GA5wPcxH2rf/TBUQQ0bbamBz/D+TLMV18xilZqOC+zaA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -4255,7 +4241,6 @@ packages:
       debug:
         optional: true
 
-<<<<<<< HEAD
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -4264,8 +4249,6 @@ packages:
     resolution: {integrity: sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==}
     engines: {node: '>= 14.17'}
 
-=======
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -4331,7 +4314,6 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
-<<<<<<< HEAD
   function.prototype.name@1.1.8:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
     engines: {node: '>= 0.4'}
@@ -4339,8 +4321,6 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-=======
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   gaxios@7.1.4:
     resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
     engines: {node: '>=18'}
@@ -5103,7 +5083,6 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
-<<<<<<< HEAD
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -5119,8 +5098,6 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
-=======
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
 
@@ -5398,7 +5375,6 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-<<<<<<< HEAD
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -5415,8 +5391,6 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
-=======
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   moo@0.5.3:
     resolution: {integrity: sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==}
 
@@ -5689,7 +5663,6 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-<<<<<<< HEAD
   pac-proxy-agent@7.2.0:
     resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
     engines: {node: '>= 14'}
@@ -5698,8 +5671,6 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
-=======
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
@@ -5736,10 +5707,6 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
-  path-expression-matcher@1.1.3:
-    resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
-    engines: {node: '>=14.0.0'}
-
   path-expression-matcher@1.2.0:
     resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
     engines: {node: '>=14.0.0'}
@@ -5756,12 +5723,9 @@ packages:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
 
-<<<<<<< HEAD
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-=======
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
@@ -6194,13 +6158,8 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
-<<<<<<< HEAD
   rollup@4.60.0:
     resolution: {integrity: sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==}
-=======
-  rollup@4.59.0:
-    resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -7256,9 +7215,6 @@ packages:
   zod@3.24.0:
     resolution: {integrity: sha512-Hz+wiY8yD0VLA2k/+nsg2Abez674dDGTai33SwNvMPuf9uIrBC9eFgIMQxBBbHFxVXi8W+5nX9DcAh9YNSQm/w==}
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -7271,11 +7227,7 @@ snapshots:
     dependencies:
       '@ai-sdk/anthropic': 3.0.64(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
-<<<<<<< HEAD
       '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
-=======
-      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
       '@smithy/eventstream-codec': 4.2.12
       '@smithy/util-utf8': 4.2.2
       aws4fetch: 1.0.20
@@ -7294,7 +7246,7 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/gateway@3.0.79(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.80(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
@@ -7306,11 +7258,7 @@ snapshots:
       '@ai-sdk/anthropic': 3.0.64(zod@4.3.6)
       '@ai-sdk/google': 3.0.53(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
-<<<<<<< HEAD
       '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
-=======
-      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
       google-auth-library: 10.6.2
       zod: 4.3.6
     transitivePeerDependencies:
@@ -7464,7 +7412,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.4
+      '@aws-sdk/types': 3.973.6
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -7819,11 +7767,6 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
-
-  '@aws-sdk/types@3.973.4':
-    dependencies:
-      '@smithy/types': 4.13.1
-      tslib: 2.8.1
 
   '@aws-sdk/types@3.973.6':
     dependencies:
@@ -8196,14 +8139,10 @@ snapshots:
       '@eslint/core': 1.1.1
       levn: 0.4.1
 
-<<<<<<< HEAD
-  '@exalabs/ai-sdk@1.0.5(ai@6.0.137(zod@4.3.6))':
-=======
-  '@exalabs/ai-sdk@2.0.0(ai@6.0.116(zod@4.3.6))':
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
+  '@exalabs/ai-sdk@2.0.1(ai@6.0.138(zod@4.3.6))':
     dependencies:
-      ai: 6.0.137(zod@4.3.6)
-      zod: 3.25.76
+      ai: 6.0.138(zod@4.3.6)
+      zod: 4.3.6
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -8636,13 +8575,10 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
 
-<<<<<<< HEAD
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
 
-=======
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -9451,9 +9387,9 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
 
-  '@perplexity-ai/ai-sdk@0.1.2(ai@6.0.137(zod@4.3.6))(zod@4.3.6)':
+  '@perplexity-ai/ai-sdk@0.1.2(ai@6.0.138(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      ai: 6.0.137(zod@4.3.6)
+      ai: 6.0.138(zod@4.3.6)
       zod: 4.3.6
 
   '@protobufjs/aspromise@1.1.2': {}
@@ -10438,10 +10374,10 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tavily/ai-sdk@0.4.1(ai@6.0.137(zod@4.3.6))(zod@4.3.6)':
+  '@tavily/ai-sdk@0.4.1(ai@6.0.138(zod@4.3.6))(zod@4.3.6)':
     dependencies:
       '@tavily/core': 0.6.4
-      ai: 6.0.137(zod@4.3.6)
+      ai: 6.0.138(zod@4.3.6)
       zod: 4.3.6
     transitivePeerDependencies:
       - debug
@@ -10902,9 +10838,9 @@ snapshots:
       clean-stack: 4.2.0
       indent-string: 5.0.0
 
-  ai@6.0.137(zod@4.3.6):
+  ai@6.0.138(zod@4.3.6):
     dependencies:
-      '@ai-sdk/gateway': 3.0.79(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.80(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.21(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
@@ -12036,7 +11972,7 @@ snapshots:
 
   fast-xml-builder@1.1.4:
     dependencies:
-      path-expression-matcher: 1.1.3
+      path-expression-matcher: 1.2.0
 
   fast-xml-parser@5.5.8:
     dependencies:
@@ -12126,15 +12062,12 @@ snapshots:
 
   follow-redirects@1.15.11: {}
 
-<<<<<<< HEAD
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
 
   form-data-encoder@2.1.4: {}
 
-=======
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -12208,7 +12141,6 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-<<<<<<< HEAD
   function.prototype.name@1.1.8:
     dependencies:
       call-bind: 1.0.8
@@ -12220,8 +12152,6 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-=======
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   gaxios@7.1.4:
     dependencies:
       extend: 3.0.2
@@ -12925,11 +12855,8 @@ snapshots:
 
   isarray@2.0.5: {}
 
-<<<<<<< HEAD
   isexe@2.0.0: {}
 
-=======
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   jake@10.9.4:
     dependencies:
       async: 3.2.6
@@ -13138,7 +13065,6 @@ snapshots:
 
   long@5.3.2: {}
 
-<<<<<<< HEAD
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -13149,8 +13075,6 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
-=======
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   lunr@2.3.9: {}
 
   magic-string@0.30.21:
@@ -13756,7 +13680,6 @@ snapshots:
 
   minimist@1.2.8: {}
 
-<<<<<<< HEAD
   minipass@7.1.3: {}
 
   minizlib@3.1.0:
@@ -13787,8 +13710,6 @@ snapshots:
 
   mitt@3.0.1: {}
 
-=======
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   moo@0.5.3: {}
 
   morgan@1.10.1:
@@ -14068,7 +13989,6 @@ snapshots:
 
   p-try@2.2.0: {}
 
-<<<<<<< HEAD
   pac-proxy-agent@7.2.0:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
@@ -14087,8 +14007,6 @@ snapshots:
       degenerator: 5.0.1
       netmask: 2.0.2
 
-=======
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.11
@@ -14135,8 +14053,6 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-expression-matcher@1.1.3: {}
-
   path-expression-matcher@1.2.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -14145,11 +14061,8 @@ snapshots:
 
   path-key@4.0.0: {}
 
-<<<<<<< HEAD
   path-parse@1.0.7: {}
 
-=======
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   path-to-regexp@8.3.0: {}
 
   path-type@4.0.0: {}
@@ -14259,7 +14172,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.0
-      '@types/node': 24.10.15
+      '@types/node': 25.5.0
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -14700,11 +14613,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-<<<<<<< HEAD
   rollup@4.60.0:
-=======
-  rollup@4.59.0:
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
@@ -15878,15 +15787,12 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-<<<<<<< HEAD
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-=======
->>>>>>> 7c1ffa7 (chore: Updating @exalabs/ai-sdk from 1.0.5 to 2.0.0)
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -15977,8 +15883,6 @@ snapshots:
   zod@3.23.8: {}
 
   zod@3.24.0: {}
-
-  zod@3.25.76: {}
 
   zod@4.3.6: {}
 

--- a/sdk/llm/package.json
+++ b/sdk/llm/package.json
@@ -15,11 +15,11 @@
     "@ai-sdk/google-vertex": "4.0.95",
     "@ai-sdk/openai": "3.0.48",
     "@ai-sdk/perplexity": "3.0.26",
-    "@exalabs/ai-sdk": "1.0.5",
+    "@exalabs/ai-sdk": "2.0.1",
     "@outputai/core": "workspace:",
     "@perplexity-ai/ai-sdk": "0.1.2",
     "@tavily/ai-sdk": "0.4.1",
-    "ai": "6.0.137",
+    "ai": "6.0.138",
     "decimal.js": "10.6.0",
     "gray-matter": "4.0.3",
     "liquidjs": "10.25.1"


### PR DESCRIPTION
## Updating @exalabs/ai-sdk from 1.0.5 to 2.0.1

### Change analysis:
#### Exa’s documented major / platform changes
From [SDK changes: highlights removed and contents returned by default](https://docs.exa.ai/changelog/sdk-major-version-changes) (Oct 28, 2025):
- Search includes page contents by default in SDKs — you can opt out if you want faster, lighter searches.
Highlights removed from SDKs (_they note highlights later came back in exa-js 2.0.11, not necessarily in @exalabs/ai-sdk_).
- `use_autoprompt` removed from API responses platform-wide.

#### What @exalabs/ai-sdk 2.0.1 changes on npm (vs 1.0.5)
Comparing the published tarballs, 2.0.1is almost the same as 1.0.5:
- `webSearch` export and `types.d.ts` are unchanged between the two versions.
- Runtime change: extra request headers (`x-exa-integration`, `User-Agent` with package version).
- Peer dependency: ai moves from ^5.0.83 → ^6.0.0.

### v2.0.0 bug
v2 had a bug, preventing it from [start](https://github.com/exa-labs/ai-sdk/pull/7). It was fixed in version [v2.0.1](https://github.com/exa-labs/ai-sdk/pull/9.):