### PR TITLE
docs: remove individual package install sections

### DIFF
--- a/docs/guides/packages/cli.mdx
+++ b/docs/guides/packages/cli.mdx
@@ -5,12 +5,6 @@ description: "Command-line interface for creating, running, and debugging Output
 
 The `output` CLI is how you create projects, start development services, run workflows, and debug executions. It's the main way you interact with Output during development.
 
-## Installation
-
-```bash
-npm install -g @outputai/cli
-```
-
 ## Quick Start
 
 ```bash

--- a/docs/guides/packages/core.mdx
+++ b/docs/guides/packages/core.mdx
@@ -5,12 +5,6 @@ description: "Workflow orchestration, worker runtime, and the building blocks fo
 
 The `@outputai/core` package is the foundation of every Output app. It gives you `workflow`, `step`, and `evaluator` — the three building blocks for defining what your app does. It also provides the worker runtime that connects to Temporal and runs your workflows in production.
 
-## Installation
-
-```bash
-npm install @outputai/core
-```
-
 ## What's in the Package
 
 ```typescript

--- a/docs/guides/packages/credentials.mdx
+++ b/docs/guides/packages/credentials.mdx
@@ -7,14 +7,6 @@ AI apps need a lot of API keys. Sharing `.env` files is risky, and coding agents
 
 You manage credentials through the [CLI](/packages/cli) and read them in your steps with a simple dot-notation API.
 
-## Installation
-
-```bash
-npm install @outputai/credentials
-```
-
-Peer dependencies: `@outputai/core`
-
 ## What's in the Package
 
 ```typescript

--- a/docs/guides/packages/evals.mdx
+++ b/docs/guides/packages/evals.mdx
@@ -7,14 +7,6 @@ The `@outputai/evals` package lets you test workflow quality across datasets —
 
 This is the complement to [evaluator steps](/evaluators/evaluator-step) that run inside workflows. Those evaluators power generate-evaluate-retry loops in production. Evaluation workflows answer a different question: "across a set of known inputs, does my workflow still produce acceptable output?" For the full guide, see [Evaluation Workflow](/evaluators/workflow-evaluators).
 
-## Installation
-
-```bash
-npm install @outputai/evals
-```
-
-Peer dependencies: `@outputai/core`, `@outputai/llm`
-
 ## What's in the Package
 
 ```typescript

--- a/docs/guides/packages/http.mdx
+++ b/docs/guides/packages/http.mdx
@@ -7,12 +7,6 @@ The `@outputai/http` package gives you an HTTP client that automatically shows u
 
 Under the hood, it wraps [ky](https://github.com/sindresorhus/ky), a lightweight HTTP client built on `fetch`.
 
-## Installation
-
-```bash
-npm install @outputai/http
-```
-
 ## Creating a Client
 
 The typical pattern is to create a client per external service in your [clients directory](/clients), then import it in your steps:

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -5,12 +5,6 @@ description: "Generate and stream text, objects, and arrays from LLMs with promp
 
 The `@outputai/llm` package is how you call LLMs from your steps and evaluators. It wraps the [AI SDK](https://sdk.vercel.ai/docs) and adds [prompt files](/prompts) — version-controlled `.prompt` files that live alongside your code and define the provider, model, temperature, and message template in one place.
 
-## Installation
-
-```bash
-npm install @outputai/llm
-```
-
 ## Generate Functions
 
 `generateText` is the primary function for LLM calls. Use the `output` parameter with `Output.*` helpers to control the response shape. Use `streamText` for streaming responses:


### PR DESCRIPTION
## Summary

- Removed Installation sections from all 6 package docs (core, cli, llm, http, evals, credentials)
- All packages are bundled in the `@outputai/output` umbrella package — users install via `npx @outputai/cli init`, no separate `npm install` needed