### PR TITLE
fix(ops): Add build step to prod publish and @next releases

### DIFF
--- a/.changeset/fix-publish-add-next.md
+++ b/.changeset/fix-publish-add-next.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Fix prod publish to include build step before publishing to npm. Previously, packages were published without compiling TypeScript, resulting in missing `dist/` directory. Add `@next` dist-tag that auto-publishes from every merge to main, enabling `npx @outputai/cli@next` for tracking the latest changes.

--- a/.github/workflows/publish_npm_next.yml
+++ b/.github/workflows/publish_npm_next.yml
@@ -1,0 +1,44 @@
+name: Publish Next
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: publish-npm-next
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Publish NPM next packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    container:
+      image: node:24.13.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enable pnpm
+        run: corepack enable
+
+      - name: Validate
+        run: ./ops/validate.sh
+
+      - name: Publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: ./ops/publish_npm_next.sh
+
+      - name: Add publish summary to job
+        run: |
+          if [ -f pnpm-publish-summary.json ]; then
+            {
+              echo '### npm publish summary'
+              echo ''
+              echo '```json'
+              cat pnpm-publish-summary.json
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,140 @@
+# Releasing
+
+This document covers how Output packages are versioned, built, and published to npm.
+
+## Packages
+
+This monorepo publishes the following packages to npm:
+
+| Package | Path | Description |
+|---------|------|-------------|
+| `@outputai/cli` | `sdk/cli` | CLI for project scaffolding and workflow management |
+| `@outputai/core` | `sdk/core` | Core framework (workflows, steps, parallel execution) |
+| `@outputai/llm` | `sdk/llm` | LLM integration (generateText, prompt loading) |
+| `@outputai/http` | `sdk/http` | HTTP client with tracing |
+| `@outputai/evals` | `sdk/evals` | Evaluation framework (LLM-as-judge) |
+| `@outputai/credentials` | `sdk/credentials` | Encrypted credential management |
+| `@outputai/output` | `sdk/framework` | Umbrella package (re-exports all SDK packages) |
+| `output-api` | `api` | API server (private, Docker image only) |
+
+All `@outputai/*` packages are in a **fixed version group** — they always share the same version number and are bumped together. This is configured in `.changeset/config.json`.
+
+## Dist Tags
+
+| Tag | Install | Trigger | Source |
+|-----|---------|---------|--------|
+| `latest` | `npx @outputai/cli` | Merge of a "Version Packages" PR | Changesets on main |
+| `next` | `npx @outputai/cli@next` | Automatic on every push to main | HEAD of main |
+| `dev` | `npx @outputai/cli@dev` | Manual (GitHub Actions button) | Any branch or SHA |
+
+All dist tags apply to every published package, not just the CLI.
+
+## Stable Releases (`@latest`)
+
+Stable releases use [Changesets](https://github.com/changesets/changesets).
+
+### 1. Add a changeset
+
+When your PR includes a user-facing change, run:
+
+```bash
+pnpm changeset
+```
+
+This creates a markdown file in `.changeset/` describing the change and the semver bump type (patch, minor, major). Commit it with your PR.
+
+### 2. Merge to main
+
+When your PR merges, the **Release** workflow (`release.yml`) runs. If there are pending changesets, it opens (or updates) a "Version Packages" PR that bumps versions and updates changelogs.
+
+### 3. Merge the "Version Packages" PR
+
+When the version PR merges, the **Publish** workflow (`publish.yml`) runs:
+
+1. `pnpm install --frozen-lockfile`
+2. `pnpm -r run build` (compiles TypeScript to `dist/`)
+3. `pnpm publish -r --no-git-checks` (publishes to npm under `@latest`)
+4. Git tags are created for each published version
+
+### When to add a changeset
+
+- **Yes**: New features, bug fixes, breaking changes, dependency updates that affect behavior
+- **No**: CI changes, docs-only changes, internal refactors with no public API change
+
+## Next Releases (`@next`)
+
+Every push to `main` triggers the **Publish Next** workflow (`publish_npm_next.yml`). This:
+
+1. Runs the full validation suite (install, lint, build, test)
+2. Bumps all packages to a prerelease version tied to the commit SHA (e.g., `0.1.4-next.abc1234`)
+3. Publishes under the `next` dist-tag
+
+Install with:
+
+```bash
+npx @outputai/cli@next init my-project
+```
+
+This is useful for:
+- Testing the latest changes before a stable release
+- CI/CD pipelines that want to track main
+- Early adopters who want bleeding-edge features
+
+## Dev Releases (`@dev`)
+
+The **Publish Dev** workflow (`publish_npm_dev.yml`) is triggered manually from GitHub Actions. You can publish from any branch or SHA.
+
+1. Go to Actions > "Publish Dev" > "Run workflow"
+2. Optionally enter a branch name or commit SHA (defaults to `main`)
+3. Packages are published with a `-dev.N` prerelease suffix under the `dev` dist-tag
+
+Install with:
+
+```bash
+npx @outputai/cli@dev init my-project
+```
+
+This is useful for:
+- Testing a feature branch before merging
+- Sharing a WIP build with someone for review
+
+## Build Pipeline
+
+All publish paths run `pnpm -r run build` before publishing. This compiles TypeScript to `dist/` in each package. Without the build step, published packages will be missing compiled code.
+
+The build order is managed by pnpm workspace dependencies — packages are built in dependency order automatically.
+
+## Scripts Reference
+
+| Script | Purpose |
+|--------|---------|
+| `ops/publish.sh` | Orchestrates prod publish (npm + Docker) |
+| `ops/publish_npm_prod.sh` | Builds and publishes all packages to `@latest` |
+| `ops/publish_npm_next.sh` | Bumps to `next.{SHA}` prerelease, publishes to `@next` |
+| `ops/publish_npm_dev.sh` | Bumps to `dev.N` prerelease, publishes to `@dev` |
+| `ops/bump.sh` | Runs `changeset version` and syncs CLI SDK version |
+| `ops/tag.sh` | Creates git tags after publish |
+| `ops/validate.sh` | Full validation: install, lint, build, test, docs |
+
+## Troubleshooting
+
+### Published package is missing `dist/`
+
+The build step was skipped before publish. Re-publish:
+
+```bash
+pnpm -r run build
+pnpm publish -r --no-git-checks
+```
+
+### `npx @outputai/cli` uses a cached broken version
+
+Clear the npx cache and retry:
+
+```bash
+npx --yes @outputai/cli@latest init my-project
+```
+
+### Changeset version PR not appearing
+
+Make sure your changeset files are committed to main. The Release workflow only runs on push to main.

--- a/ops/publish_npm_next.sh
+++ b/ops/publish_npm_next.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Bump each package to a next prerelease version (tied to commit SHA) and publish to npm
+
+set -e
+
+cd "${0%/*}/.."
+
+count=0
+print() {
+  sym=${2:-$((++count))}
+  printf "\e[45;30m $sym \e[0m $1\n"
+}
+
+print "Publishing next packages to NPM" "Run"
+
+SHORT_SHA=$(git rev-parse --short HEAD)
+
+print "Bumping (next.$SHORT_SHA)"
+update_cmd="v=\$(npm version prerelease --preid=next.\${SHORT_SHA} --no-git-tag-version --allow-same-version --silent) && echo \"- \$PNPM_PACKAGE_NAME@\${v#v}\""
+SHORT_SHA=$SHORT_SHA pnpm -r --filter "@outputai/*" --filter "output-api" exec sh -c "$update_cmd"
+
+print "Publishing"
+npm_config_loglevel=warn pnpm publish -r --no-git-checks --tag=next --report-summary
+
+print "Publication Complete" "OK"

--- a/ops/publish_npm_prod.sh
+++ b/ops/publish_npm_prod.sh
@@ -14,6 +14,10 @@ print() {
 
 print "Publishing packages to NPM" "Run"
 
+print "Building"
+pnpm -r run build
+
+print "Publishing"
 pnpm publish -r --no-git-checks
 
 print "Publication Complete" "OK"


### PR DESCRIPTION
## Summary

PR #38 removed `./ops/validate.sh` from the publish pipeline to avoid redundant linting and testing at publish time (already validated in CI). However, `validate.sh` also contained the only `pnpm -r run build` call, which compiles TypeScript to `dist/`. Without it, **all `@outputai/*` packages since v0.1.4 were published without compiled code** — `npx @outputai/cli init` is broken on npm.

### Changes

- **Fix**: Add `pnpm -r run build` directly to `ops/publish_npm_prod.sh` — builds without re-running lint/tests, preserving the intent of #38
- **Feature**: Add `@next` dist-tag that auto-publishes from every merge to main. Versioned as `X.Y.Z-next.{sha}`, install with `npx @outputai/cli@next`
- **Docs**: Add `RELEASING.md` documenting all packages, all three release channels (`@latest`, `@next`, `@dev`), and the changeset workflow