### PR TITLE
fix(ops): Use GITHUB_SHA in next publish to avoid git safe.directory error

### DIFF
--- a/ops/publish_npm_next.sh
+++ b/ops/publish_npm_next.sh
@@ -14,7 +14,9 @@ print() {
 
 print "Publishing next packages to NPM" "Run"
 
-SHORT_SHA=$(git rev-parse --short HEAD)
+# Use GITHUB_SHA in CI, fall back to git locally
+SHORT_SHA=${GITHUB_SHA:+${GITHUB_SHA:0:7}}
+SHORT_SHA=${SHORT_SHA:-$(git rev-parse --short HEAD)}
 
 print "Bumping (next.$SHORT_SHA)"
 update_cmd="v=\$(npm version prerelease --preid=next.\${SHORT_SHA} --no-git-tag-version --allow-same-version --silent) && echo \"- \$PNPM_PACKAGE_NAME@\${v#v}\""


### PR DESCRIPTION
## Summary

The `publish_npm_next.sh` script uses `git rev-parse --short HEAD` to get the commit SHA for the prerelease version. In CI, the container-based runner (`node:24.13.0`) flags the checkout directory as dubious ownership, causing git to fail.

Fix: use the `GITHUB_SHA` env var (already available in GitHub Actions) with a local git fallback for running the script outside CI.