### PR TITLE
docs: expand RELEASING.md with beginner-friendly changeset guide

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -17,84 +17,156 @@ This monorepo publishes the following packages to npm:
 | `@outputai/output` | `sdk/framework` | Umbrella package (re-exports all SDK packages) |
 | `output-api` | `api` | API server (private, Docker image only) |
 
-All `@outputai/*` packages are in a **fixed version group** — they always share the same version number and are bumped together. This is configured in `.changeset/config.json`.
+All `@outputai/*` packages and `output-api` are in a **fixed version group** — they always share the same version number and are bumped together. This is configured in `.changeset/config.json`.
 
-## Dist Tags
+## How It Works (The Big Picture)
 
-| Tag | Install | Trigger | Source |
-|-----|---------|---------|--------|
-| `latest` | `npx @outputai/cli` | Merge of a "Version Packages" PR | Changesets on main |
-| `next` | `npx @outputai/cli@next` | Automatic on every push to main | HEAD of main |
-| `dev` | `npx @outputai/cli@dev` | Manual (GitHub Actions button) | Any branch or SHA |
+There are three ways packages get published, each tied to a **dist tag** on npm:
+
+```
+                          ┌──────────────────────────────┐
+  You merge a PR          │  push to main triggers two   │
+  ─────────────────────►  │  workflows in parallel:       │
+                          │                              │
+                          │  1. release.yml              │
+                          │     → opens "Version         │
+                          │       Packages" PR           │
+                          │       (if changesets exist)   │
+                          │                              │
+                          │  2. publish_npm_next.yml     │
+                          │     → publishes @next        │
+                          │       immediately             │
+                          └──────────────────────────────┘
+
+  You merge the                publish.yml
+  "Version Packages" PR  ───►  → publishes @latest
+                               → creates git tags
+
+  You click "Run workflow"     publish_npm_dev.yml
+  in GitHub Actions       ───► → publishes @dev
+  (any branch/SHA)
+```
+
+| Tag | Version example | Install | When it publishes |
+|-----|-----------------|---------|-------------------|
+| `latest` | `0.1.4` | `npx @outputai/cli` | When you merge the "Version Packages" PR |
+| `next` | `0.1.4-next.abc1234` | `npx @outputai/cli@next` | Automatically on every push to main |
+| `dev` | `0.1.4-dev.0` | `npx @outputai/cli@dev` | Manually from GitHub Actions (any branch) |
 
 All dist tags apply to every published package, not just the CLI.
 
-## Stable Releases (`@latest`)
+## What Are Changesets?
 
-Stable releases use [Changesets](https://github.com/changesets/changesets).
+[Changesets](https://github.com/changesets/changesets) is a tool that manages version bumps and changelogs for monorepos. Instead of manually editing `package.json` versions, you describe what changed and let the tooling handle the rest.
 
-### 1. Add a changeset
+A changeset is a small markdown file that lives in `.changeset/` and describes:
+1. **Which packages** are affected
+2. **What kind of bump** (patch, minor, major)
+3. **A description** of the change
 
-When your PR includes a user-facing change, run:
+Here's a real example from this repo (`.changeset/fix-publish-add-next.md`):
+
+```markdown
+---
+"@outputai/cli": patch
+---
+
+Fix prod publish to include build step before publishing to npm.
+```
+
+The frontmatter (`---` block) says "bump `@outputai/cli` by a patch version." Since all our packages are in a fixed group, this actually bumps **all** of them together.
+
+### Do I need to add a changeset?
+
+| Change type | Changeset needed? |
+|-------------|:-:|
+| New feature, bug fix, breaking change | Yes |
+| Dependency update that affects behavior | Yes |
+| CI/CD changes, docs-only, internal refactors | No |
+| Claude plugin updates | No |
+
+If unsure, ask: "Would a user installing our packages notice this change?" If yes, add a changeset.
+
+## Stable Releases (`@latest`) — Step by Step
+
+This is the full lifecycle of a stable release:
+
+### Step 1: Add a changeset to your PR
+
+While working on your feature branch, run:
 
 ```bash
 pnpm changeset
 ```
 
-This creates a markdown file in `.changeset/` describing the change and the semver bump type (patch, minor, major). Commit it with your PR.
+The CLI will ask you:
+1. Which packages changed? (select with space, confirm with enter)
+2. Is it a major, minor, or patch bump?
+3. Write a summary of the change
 
-### 2. Merge to main
+This creates a file like `.changeset/cool-dogs-jump.md` (random name). Commit it with your PR.
 
-When your PR merges, the **Release** workflow (`release.yml`) runs. If there are pending changesets, it opens (or updates) a "Version Packages" PR that bumps versions and updates changelogs.
+> You can also create the file by hand — it's just markdown with YAML frontmatter.
 
-### 3. Merge the "Version Packages" PR
+### Step 2: Merge your PR to main
 
-When the version PR merges, the **Publish** workflow (`publish.yml`) runs:
+Nothing special here. Just merge as usual. Two things happen automatically:
 
-1. `pnpm install --frozen-lockfile`
-2. `pnpm -r run build` (compiles TypeScript to `dist/`)
-3. `pnpm publish -r --no-git-checks` (publishes to npm under `@latest`)
-4. Git tags are created for each published version
+1. **`@next` publishes immediately** — your change is available via `@outputai/cli@next` within minutes.
 
-### When to add a changeset
+2. **The Release workflow** (`release.yml`) picks up any `.changeset/*.md` files and opens (or updates) a PR titled **"Version Packages"**. This PR:
+   - Deletes the changeset files
+   - Bumps `version` in every `package.json`
+   - Updates `CHANGELOG.md` in each package
+   - Syncs the CLI's embedded SDK version
 
-- **Yes**: New features, bug fixes, breaking changes, dependency updates that affect behavior
-- **No**: CI changes, docs-only changes, internal refactors with no public API change
+   You don't need to merge this immediately. Multiple PRs with changesets can accumulate — the "Version Packages" PR will keep updating itself.
+
+### Step 3: Merge the "Version Packages" PR
+
+When you're ready to cut a stable release, merge the "Version Packages" PR. The **Publish workflow** (`publish.yml`) runs and:
+
+1. Installs dependencies (`pnpm install --frozen-lockfile`)
+2. Builds all packages (`pnpm -r run build`)
+3. Publishes to npm under `@latest` (`pnpm publish -r --no-git-checks`)
+4. Publishes the API Docker image
+5. Creates git tags (e.g., `v0.1.4`)
+
+That's it. Users running `npx @outputai/cli` will now get the new version.
 
 ## Next Releases (`@next`)
 
-Every push to `main` triggers the **Publish Next** workflow (`publish_npm_next.yml`). This:
+Every push to `main` triggers `publish_npm_next.yml`. This happens automatically — no changeset needed.
 
+What it does:
 1. Runs the full validation suite (install, lint, build, test)
 2. Bumps all packages to a prerelease version tied to the commit SHA (e.g., `0.1.4-next.abc1234`)
 3. Publishes under the `next` dist-tag
 
-Install with:
+This means every merged PR is immediately available:
 
 ```bash
 npx @outputai/cli@next init my-project
 ```
 
-This is useful for:
-- Testing the latest changes before a stable release
+Useful for:
+- Testing changes before a stable release
 - CI/CD pipelines that want to track main
-- Early adopters who want bleeding-edge features
+- Early adopters who want the latest
 
 ## Dev Releases (`@dev`)
 
-The **Publish Dev** workflow (`publish_npm_dev.yml`) is triggered manually from GitHub Actions. You can publish from any branch or SHA.
+`publish_npm_dev.yml` is triggered manually from GitHub Actions. You can publish from **any branch or SHA**.
 
-1. Go to Actions > "Publish Dev" > "Run workflow"
+1. Go to **Actions > "Publish Dev" > "Run workflow"**
 2. Optionally enter a branch name or commit SHA (defaults to `main`)
 3. Packages are published with a `-dev.N` prerelease suffix under the `dev` dist-tag
-
-Install with:
 
 ```bash
 npx @outputai/cli@dev init my-project
 ```
 
-This is useful for:
+Useful for:
 - Testing a feature branch before merging
 - Sharing a WIP build with someone for review
 
@@ -138,3 +210,7 @@ npx --yes @outputai/cli@latest init my-project
 ### Changeset version PR not appearing
 
 Make sure your changeset files are committed to main. The Release workflow only runs on push to main.
+
+### I merged my PR but `@latest` didn't update
+
+That's expected. Merging your PR only publishes to `@next`. The `@latest` tag only updates when you merge the "Version Packages" PR. If no "Version Packages" PR exists, your PR probably didn't include a changeset.


### PR DESCRIPTION
Add visual flow diagram, explain what changesets are with real examples, walk through the pnpm changeset CLI, and clarify how @next/@latest/@dev dist tags relate to each other.