### PR TITLE
feat(cc-plugin): add workflow cost skill and fix null pricing config crash

### DIFF
--- a/.changeset/clean-ads-matter.md
+++ b/.changeset/clean-ads-matter.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Fix null crash in `workflow cost` when pricing config is empty or missing

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "outputai",
       "source": "./coding_assistants/claude/plugins/outputai",
       "description": "Output.ai Workflow Assistants",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "author": {
         "name": "Output.ai"
       }

--- a/coding_assistants/claude/plugins/outputai/.claude-plugin/plugin.json
+++ b/coding_assistants/claude/plugins/outputai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "outputai",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Workflow development tools",
     "author": {
       "name": "Output.ai",

--- a/coding_assistants/claude/plugins/outputai/hooks/SESSION_START_CONTEXT.md
+++ b/coding_assistants/claude/plugins/outputai/hooks/SESSION_START_CONTEXT.md
@@ -6,7 +6,7 @@ This project uses the Output.ai framework for building durable, LLM-powered work
 
 **Invoke these skills to load full context:**
 
-1. **`output-meta-project-context`** - Load complete Output SDK documentation, patterns, conventions, and available tools inventory (5 agents, 3 commands, 32 skills)
+1. **`output-meta-project-context`** - Load complete Output SDK documentation, patterns, conventions, and available tools inventory (5 agents, 3 commands, 33 skills)
 
 Please make sure to conciously use appropriate skills and agents for the task at hand.
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-workflow-cost/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-workflow-cost/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: output-dev-workflow-cost
+description: Calculate and display the cost of an Output SDK workflow execution run. Use when checking LLM token costs, API service costs, or total spend for a specific workflow run.
+allowed-tools: [Bash]
+---
+
+# Workflow Run Cost
+
+## Overview
+
+This skill helps you calculate the cost of a completed workflow execution using the Output CLI. It breaks down costs by LLM model (token usage) and external API service calls.
+
+## When to Use This Skill
+
+- Checking how much a workflow run cost in LLM tokens
+- Analyzing API service spend per workflow execution
+- Comparing costs between workflow runs
+- Presenting cost data during a demo or review
+
+---
+
+## Step 1: Get a Workflow Run ID
+
+The `workflow cost` command requires a **workflow run ID** — not the workflow name.
+
+A run ID looks like: `process_transcripts_2026-03-23-19-35-17-000Z_c2biRk_F9rYktF-wagBf5`
+
+### If you already have a run ID, skip to Step 2.
+
+### If you don't have a run ID:
+
+**Option A — List recent runs** (use skill: `output-workflow-runs-list`):
+```bash
+npx output workflow runs list <workflowName> --limit 5
+```
+Copy the run ID from the most recent completed run.
+
+**Option B — Run the workflow now and capture the ID:**
+
+If you know the input, run it synchronously and the run ID will be in the output:
+```bash
+npx output workflow run <workflowName> --input '{"key": "value"}'
+```
+
+Or asynchronously (use skill: `output-workflow-start`):
+```bash
+npx output workflow start <workflowName> --input '{"key": "value"}'
+# Returns: Workflow ID: <runId>
+```
+
+If you don't know the input, check for a scenario file (use skill: `output-dev-scenario-file`) or the workflow's `inputSchema` in its `types.ts`.
+
+> **Note:** The workflow **name** (e.g. `process_transcripts`) identifies the workflow type. The workflow **run ID** (e.g. `process_transcripts_2026-03-23T19:35:17.000Z_abc123`) identifies a specific execution. `workflow cost` requires the run ID.
+
+---
+
+## Step 2: Calculate the Cost
+
+### Basic usage (text output):
+```bash
+npx output workflow cost <runId>
+```
+
+### With a local trace file:
+```bash
+npx output workflow cost <runId> path/to/trace.json
+```
+
+### JSON output (for programmatic use or display):
+```bash
+npx output workflow cost <runId> --format json
+```
+
+### Verbose — show per-call breakdown:
+```bash
+npx output workflow cost <runId> --verbose
+```
+
+### All flags:
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--format <type>` | Output format: `text` or `json` | `text` |
+| `--verbose` | Show detailed per-LLM-call breakdown | `false` |
+
+---
+
+## Understanding the Output
+
+### Text format example:
+```
+Workflow: process_transcripts
+Duration: 12.3s
+
+LLM Costs:
+  claude-sonnet-4 — 1,234 in / 567 out tokens — $0.0123
+
+Services:
+  jina — 2 requests — $0.004
+
+Total Cost: $0.0163
+```
+
+### JSON format fields:
+```json
+{
+  "workflowName": "process_transcripts",
+  "durationMs": 12300,
+  "llmTotalCost": 0.0123,
+  "totalInputTokens": 1234,
+  "totalOutputTokens": 567,
+  "services": [{ "serviceName": "jina", "totalCost": 0.004 }],
+  "totalCost": 0.0163
+}
+```
+
+---
+
+## Examples
+
+**Get cost of the last run:**
+```bash
+# First get the run ID
+npx output workflow runs list process_transcripts --limit 1 --format json
+
+# Then get the cost
+npx output workflow cost process_transcripts_2026-03-23T19:35:17.000Z_abc123
+```
+
+**Get cost as JSON and extract total:**
+```bash
+npx output workflow cost <runId> --format json | jq '.totalCost'
+```
+
+**Show full per-call breakdown:**
+```bash
+npx output workflow cost <runId> --verbose
+```
+
+---
+
+## Related Skills
+
+- `output-workflow-runs-list` — Find run IDs from execution history
+- `output-workflow-start` — Start a workflow and capture its run ID
+- `output-workflow-run` — Run a workflow synchronously
+- `output-dev-scenario-file` — Create or find scenario files for workflow input

--- a/coding_assistants/claude/plugins/outputai/skills/output-meta-project-context/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-meta-project-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: output-meta-project-context
-description: Comprehensive guide to Output.ai Framework for building durable, LLM-powered workflows orchestrated by Temporal. Covers project structure, workflow patterns, steps, LLM integration, HTTP clients, CLI commands, and complete inventory of available tools.
+description: Comprehensive guide to Output.ai Framework for building durable, LLM-powered workflows orchestrated by Temporal. Covers project structure, workflow patterns, steps, LLM integration, HTTP clients, CLI commands, and complete inventory of available tools (5 agents, 3 commands, 33 skills).
 allowed-tools: [Read]
 ---
 
@@ -127,12 +127,13 @@ src/
 | `output-workflow-status` | Check async workflow status |
 | `output-workflow-result` | Get async workflow result |
 
-#### Monitoring & Debugging (4)
+#### Monitoring & Debugging (5)
 | Skill | Purpose |
 |-------|---------|
 | `output-workflow-stop` | Stop running workflow |
 | `output-workflow-trace` | Trace workflow execution |
 | `output-workflow-runs-list` | List workflow run history |
+| `output-dev-workflow-cost` | Calculate cost of a workflow run |
 | `output-services-check` | Verify Output services status |
 
 #### Error Diagnosis (6)

--- a/sdk/cli/src/commands/workflow/cost.ts
+++ b/sdk/cli/src/commands/workflow/cost.ts
@@ -14,10 +14,10 @@ export default class WorkflowCost extends Command {
   static override description = 'Calculate the cost of a workflow execution';
 
   static override examples = [
-    '<%= config.bin %> <%= command.id %> my_workflow',
-    '<%= config.bin %> <%= command.id %> my_workflow --verbose',
-    '<%= config.bin %> <%= command.id %> my_workflow path/to/trace.json',
-    '<%= config.bin %> <%= command.id %> my_workflow --format json'
+    '<%= config.bin %> <%= command.id %> my_workflow_id',
+    '<%= config.bin %> <%= command.id %> my_workflow_id --verbose',
+    '<%= config.bin %> <%= command.id %> my_workflow_id path/to/trace.json',
+    '<%= config.bin %> <%= command.id %> my_workflow_id --format json'
   ];
 
   static override args = {

--- a/sdk/cli/src/services/cost_calculator.ts
+++ b/sdk/cli/src/services/cost_calculator.ts
@@ -48,12 +48,17 @@ export function loadPricingConfig( configPath?: string ): PricingConfig {
   const bundledPath = new URL( '../assets/config/costs.yml', import.meta.url ).pathname;
   const bundled = loadYaml( configPath ?? bundledPath );
 
+  if ( !bundled ) {
+    console.warn( 'Warning: bundled pricing config is empty or missing. Add a config/costs.yml to your project to define model pricing.' );
+    return { models: {}, services: {} };
+  }
+
   const projectPath = join( process.cwd(), 'config', 'costs.yml' );
   if ( !configPath && existsSync( projectPath ) ) {
     const project = loadYaml( projectPath );
     return {
-      models: { ...bundled.models, ...project.models },
-      services: { ...bundled.services, ...project.services }
+      models: { ...bundled.models, ...( project?.models ?? {} ) },
+      services: { ...bundled.services, ...( project?.services ?? {} ) }
     };
   }
 


### PR DESCRIPTION
Closes OUT-327

## Problem

- `npx output workflow cost` crashes with `Cannot read properties of null (reading 'models')` when a project-level `config/costs.yml` exists but is empty, because `yaml.load()` returns `null` and the spread `...project.models` throws
- The bundled pricing config had no null guard, so any empty/missing YAML would also crash rather than degrade gracefully
- No CC plugin skill existed to teach the agent how to use `npx output workflow cost`, making it hard to discover during demos

## Solution

- Fixed `loadPricingConfig` in `cost_calculator.ts` to guard against `null` from `yaml.load()`: falls back to `{ models: {}, services: {} }` with a warning if bundled config is null, and uses optional chaining on project-level config
- Added new skill `output-dev-workflow-cost` documenting the command, its flags, the workflowId vs workflowName distinction, and fallback steps for getting a run ID
- Bumped plugin version to `0.1.2` and updated the skills inventory in `output-meta-project-context` (32 → 33 skills)