### PR TITLE
chore(cli): use caret range for @outputai/output in project template

### DIFF
--- a/.changeset/cli-caret-framework-version.md
+++ b/.changeset/cli-caret-framework-version.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Use caret range (^) for @outputai/output dependency in scaffolded project template, allowing minor and patch updates without requiring a CLI upgrade.


### PR DESCRIPTION
## Summary

- The `package.json.template` already uses `^{{frameworkVersion}}` for the `@outputai/output` dependency, ensuring scaffolded projects allow minor and patch updates without requiring a CLI upgrade
- Adds a patch changeset for `@outputai/cli` to document this

## Test plan

- [ ] Run `output init` and verify the generated `package.json` has `^<version>` for `@outputai/output`