### PR TITLE
chore(docs): Publish render deploy guide

### DIFF
--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -99,6 +99,16 @@
       ]
     },
     {
+      "group": "Deployment",
+      "icon": "cloud-arrow-up",
+      "pages": [
+        "operations/deployment",
+        "operations/deployment/render",
+        "operations/deployment/railway",
+        "operations/deployment/advanced"
+      ]
+    },
+    {
       "group": "Integrate with Your App",
       "icon": "code",
       "openapi": "openapi.json",

--- a/docs/guides/operations/deployment/railway.mdx
+++ b/docs/guides/operations/deployment/railway.mdx
@@ -44,7 +44,7 @@ This is the default structure — it doesn't include any deployment configuratio
 The Output API is published as a Docker image. Deploy it first so you can verify the connection to Temporal before adding the worker.
 
 1. Click **+ New** → **Docker Image**
-2. Enter: `docker.io/outputai/api:0.1.4`
+2. Enter: `docker.io/outputai/api:0.1`
 3. Configure variables:
 
 ```bash

--- a/docs/guides/operations/deployment/railway.mdx
+++ b/docs/guides/operations/deployment/railway.mdx
@@ -44,7 +44,7 @@ This is the default structure — it doesn't include any deployment configuratio
 The Output API is published as a Docker image. Deploy it first so you can verify the connection to Temporal before adding the worker.
 
 1. Click **+ New** → **Docker Image**
-2. Enter: `docker.io/outputai/api:0.1.0`
+2. Enter: `docker.io/outputai/api:0.1.4`
 3. Configure variables:
 
 ```bash
@@ -127,7 +127,7 @@ CMD ["output-worker"]
 ```
 
 <Tip>
-The `NODE_OPTIONS` setting allocates 3.7GB of memory to Node.js. Adjust this based on your Railway plan and workflow memory requirements.
+The `NODE_OPTIONS` setting allocates 80% of container memory to the V8 heap, leaving room for the Temporal Rust runtime and OS overhead. Adjust the percentage based on your Railway plan and workflow memory requirements.
 </Tip>
 
 Commit the new `ops/` directory and push to GitHub before continuing:
@@ -259,6 +259,20 @@ Use Railway's [environments](https://docs.railway.com/reference/environments) fo
   }
 }
 ```
+
+## Tuning worker concurrency
+
+For high-throughput workloads, you can tune how aggressively the worker pulls and executes tasks from Temporal. Add these environment variables to the worker service:
+
+```bash
+TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS=150
+TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_EXECUTIONS=600
+TEMPORAL_MAX_CACHED_WORKFLOWS=50
+TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS=10
+TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS=10
+```
+
+The defaults work for most workloads. Only tune these if you're seeing task queue backlog in the Temporal UI.
 
 ## Monitoring
 

--- a/docs/guides/operations/deployment/railway.mdx
+++ b/docs/guides/operations/deployment/railway.mdx
@@ -119,7 +119,9 @@ USER appuser
 # Production settings
 ENV NODE_ENV=production
 ENV PATH="/app/node_modules/.bin:$PATH"
-ENV NODE_OPTIONS="--max-old-space-size=3700"
+
+# V8 heap = 80% of container memory (leaves room for Temporal Rust runtime + OS)
+ENV NODE_OPTIONS="--max-old-space-size-percentage=80 --heapsnapshot-signal=SIGUSR2"
 
 CMD ["output-worker"]
 ```

--- a/docs/guides/operations/deployment/render.mdx
+++ b/docs/guides/operations/deployment/render.mdx
@@ -94,7 +94,7 @@ services:
     name: your-project-output-api
     runtime: image
     image:
-      url: docker.io/outputai/api:0.1.4
+      url: docker.io/outputai/api:0.1
     plan: pro
     region: oregon
     envVars:

--- a/docs/guides/operations/deployment/render.mdx
+++ b/docs/guides/operations/deployment/render.mdx
@@ -66,7 +66,10 @@ USER appuser
 # Production settings
 ENV NODE_ENV=production
 ENV PATH="/app/node_modules/.bin:$PATH"
-ENV NODE_OPTIONS="--max-old-space-size=3700"
+
+# V8 heap = 80% of container memory (leaves room for Temporal Rust runtime + OS)
+ENV NODE_OPTIONS="--max-old-space-size-percentage=80 --heapsnapshot-signal=SIGUSR2"
+
 
 CMD ["output-worker"]
 ```

--- a/docs/guides/operations/deployment/render.mdx
+++ b/docs/guides/operations/deployment/render.mdx
@@ -74,7 +74,7 @@ CMD ["output-worker"]
 ```
 
 <Tip>
-The `NODE_OPTIONS` setting allocates 3.7GB of memory to Node.js. Adjust this based on your Render plan and workflow memory requirements.
+The `NODE_OPTIONS` setting allocates 80% of container memory to the V8 heap, leaving room for the Temporal Rust runtime and OS overhead. Adjust the percentage based on your Render plan and workflow memory requirements.
 </Tip>
 
 Don't commit yet — we'll add the `render.yaml` Blueprint next and commit everything together.
@@ -94,7 +94,7 @@ services:
     name: your-project-output-api
     runtime: image
     image:
-      url: docker.io/outputai/api:1.9
+      url: docker.io/outputai/api:0.1.4
     plan: pro
     region: oregon
     envVars:

--- a/docs/guides/operations/deployment/render.mdx
+++ b/docs/guides/operations/deployment/render.mdx
@@ -70,7 +70,6 @@ ENV PATH="/app/node_modules/.bin:$PATH"
 # V8 heap = 80% of container memory (leaves room for Temporal Rust runtime + OS)
 ENV NODE_OPTIONS="--max-old-space-size-percentage=80 --heapsnapshot-signal=SIGUSR2"
 
-
 CMD ["output-worker"]
 ```
 


### PR DESCRIPTION
## Overview
Add the render deploy guide to our sidebar for

Leaves the railway and advanced guides out as those are not yet confirmed