### PR TITLE
chore: Renaming api/api.js to api/index.js

### DIFF
--- a/.claude/agents/api-expert.md
+++ b/.claude/agents/api-expert.md
@@ -42,7 +42,7 @@ You are an expert in API server development for the Output project, with deep kn
 - Consider workflow lifecycle management through REST endpoints
 - Emphasize proper error handling and client feedback
 - Reference api/README.md for current endpoint documentation
-- Provide examples from api/src/api.js patterns
+- Provide examples from api/src/index.js patterns
 - Consider scalability and production deployment needs
 
 ## Common API Scenarios

--- a/api/README.md
+++ b/api/README.md
@@ -115,15 +115,13 @@ The AWS credentials are used by the `/workflow/:id/trace-log` endpoint to fetch 
 
 ## Editing the API
 
-**Source of truth**: `src/api.js` with `@swagger` JSDoc comments
+**Source of truth**: `src/index.js` with `@swagger` JSDoc comments
 
 **Workflow**:
 
-1. Edit Express routes and `@swagger` comments in `src/api.js`
-2. Regenerate OpenAPI spec:
-   - From project root: `npm run build:packages`
-   - From `api/` directory: `npm run build` or `npm run generate:openapi`
-3. `openapi.json` is regenerated automatically
+1. Edit Express routes in `src/index.js`;
+2. Edit _@swagger_ comments in the same file to match the new API state;
+3. When building, those comments will generate the `openapi.json` file.
 
 **Do not manually edit** `openapi.json` - changes will be overwritten.
 

--- a/api/scripts/generate_openapi.js
+++ b/api/scripts/generate_openapi.js
@@ -5,10 +5,13 @@ import { writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
-const __filename = fileURLToPath( import.meta.url );
-const __dirname = dirname( __filename );
+const __dirname = dirname( fileURLToPath( import.meta.url ) );
+const specsFile = join( __dirname, '..', 'src', 'index.js' );
+const outputFile = join( __dirname, '..', 'openapi.json' );
 
-const options = {
+console.log( '\x1b[0;34m%s\x1b[0m', '[API]: Generating OpenAPI spec JSON' );
+
+const spec = swaggerJsdoc( {
   definition: {
     openapi: '3.0.0',
     info: {
@@ -32,21 +35,9 @@ const options = {
     },
     security: process.env.NODE_ENV === 'production' ? [ { BasicAuth: [] } ] : []
   },
-  apis: [ join( __dirname, '..', 'src', 'api.js' ) ]
-};
-
-const openapiSpecification = swaggerJsdoc( options );
-
-const json = JSON.stringify( openapiSpecification, null, 2 ) + '\n';
-
-const outputPaths = [
-  join( __dirname, '..', 'openapi.json' ),
-  join( __dirname, '..', '..', 'docs', 'guides', 'openapi.json' )
-];
-
-outputPaths.forEach( p => {
-  writeFileSync( p, json );
-  console.log( `✅ OpenAPI specification generated at: ${p}` );
+  apis: [ specsFile ]
 } );
 
-export default openapiSpecification;
+writeFileSync( outputFile, JSON.stringify( spec, null, 2 ) + '\n', 'utf-8' );
+
+console.log( '\x1b[0;32m%s\x1b[0m', 'OpenAPI json created' );

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -15,16 +15,12 @@ const client = await temporalClient.init().catch( e => {
   process.exit( 1 );
 } );
 
-// set payload limit for POST in application/json format.
-// the default is 100kb but input for some workflows may be much larger.
+// Sets payload limit for POST in application/json format. Some workflow have very large payloads
 app.use( express.json( { limit: '2mb' } ) );
-// set payload limit for POST in application/x-www-form-urlencode format,
-// just for consistency
+// Also sets payload limit for POST in application/x-www-form-urlencode format,
 app.use( express.urlencoded( { extended: true, limit: '2mb' } ) );
-
 // Request ID tracking
 app.use( requestIdMiddleware );
-
 // HTTP request logging via Morgan → Winston
 app.use( createHttpLoggingMiddleware() );
 
@@ -426,8 +422,8 @@ app.post( '/workflow/start', async ( req, res ) => {
     workflowId: z.string().optional(),
     taskQueue: z.string().optional()
   } ).parse( req.body );
-  const result = await client.startWorkflow( workflowName, input, { workflowId, taskQueue } );
-  res.json( result );
+
+  res.json( await client.startWorkflow( workflowName, input, { workflowId, taskQueue } ) );
 } );
 
 /**
@@ -493,8 +489,7 @@ app.get( '/workflow/:id/status', async ( req, res ) => {
  *         $ref: '#/components/responses/InternalServerError'
  */
 app.patch( '/workflow/:id/stop', async ( req, res ) => {
-  const result = await client.stopWorkflow( req.params.id );
-  res.json( result );
+  res.json( await client.stopWorkflow( req.params.id ) );
 } );
 
 /**

--- a/api/src/index.spec.js
+++ b/api/src/index.spec.js
@@ -76,7 +76,7 @@ const PORT = 3000;
 
 describe( 'API endpoints', () => {
   beforeAll( async () => {
-    await import( './api.js' );
+    await import( './index.js' );
   } );
 
   beforeEach( () => {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,7 +16,7 @@ services:
       - OUTPUT_API_PORT=3001
       - OUTPUT_CATALOG_ID=main
       - TEMPORAL_ADDRESS=temporal:7233
-    command: node /app/api/src/api.js
+    command: node /app/api/src/index.js
     ports:
       - '3001:3001'
     volumes:
@@ -29,7 +29,7 @@ services:
         condition: service_healthy
     image: node:24.13.0-slim
     healthcheck:
-      test: [ 'CMD', 'npx', '--yes', 'output-healthcheck' ]
+      test: [ 'CMD-SHELL', 'npx', 'output-healthcheck' ]
       interval: 3s
       timeout: 10s
       retries: 20

--- a/ops/api.Dockerfile
+++ b/ops/api.Dockerfile
@@ -24,4 +24,4 @@ WORKDIR /app/api
 ENV NODE_ENV=production
 
 # Use node directly so SIGINT and SIGTERM are forwarded
-CMD ["node", "./src/api.js"]
+CMD ["node", "./src/index.js"]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:integration": "vitest run --config vitest.integration.config.js",
     "test:e2e": "./ops/test_e2e.sh",
     "test:all": "npm test && npm run test:integration npm run test:e2e",
-    "build:packages": "pnpm -r run build",
+    "build:packages": "pnpm -r run build && cp ./api/openapi.json ./docs/guides/openapi.json",
     "dev": "npm run build:packages && npm run dev:build:api && npm run dev:up",
     "output": "./sdk/cli/bin/run.js",
     "dev:build:api": "docker build -f ops/api.Dockerfile -t outputai/api:dev .",


### PR DESCRIPTION
## Changes
- Renaming `api/api.js` to `api/index.js`: keep in tandem with other projects;
- Refactored `api/scripts/generate_openapi.js` to not write `openapi.json` to `docs/guides` and simplified code: api should not know about sibling folders;
- Added `cp` command when building the lib to copy `api/openapi.json` to `docs/guides/openapi.json`;
- Fixed an issue with the docker compose worker container not reporting health correctly by changing command prefix from`CMD` to `CMD-SHELL`.