### PR TITLE
chore: update example project to separate types and have proper credentials instructions

### DIFF
--- a/.changeset/giant-monkeys-cough.md
+++ b/.changeset/giant-monkeys-cough.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Fix best practices in the output init example: move blogContentSchema from steps.ts to types.ts, and update README template to use npx output credentials flow instead of .env

--- a/sdk/cli/src/templates/project/README.md.template
+++ b/sdk/cli/src/templates/project/README.md.template
@@ -19,6 +19,7 @@ src/
         ├── workflow.ts        # Main workflow
         ├── steps.ts           # Workflow steps
         ├── evaluators.ts      # Quality evaluators
+        ├── types.ts           # Shared types and schemas
         ├── utils.ts           # Local utilities
         ├── prompts/           # LLM prompts
         └── scenarios/         # Test scenarios
@@ -55,17 +56,18 @@ The `src/shared/` directory contains code shared across multiple workflows:
 npm install
 ```
 
-### 2. Configure Environment
+### 2. Configure Credentials
 
-Copy `.env.example` to `.env` and add your API keys:
+Initialize and add your API keys using the Output credentials manager:
 
 ```bash
-cp .env.example .env
+npx output credentials init
+npx output credentials edit
 ```
 
-Edit `.env` to add:
-- `ANTHROPIC_API_KEY` - for Claude LLM integration
-- `OPENAI_API_KEY` - for OpenAI LLM integration (optional)
+Add your keys in the editor:
+- `anthropic.api_key` - for Claude LLM integration
+- `openai.api_key` - for OpenAI LLM integration (optional)
 
 ### 3. Start Output Services
 

--- a/sdk/cli/src/templates/project/src/workflows/blog_evaluator/steps.ts.template
+++ b/sdk/cli/src/templates/project/src/workflows/blog_evaluator/steps.ts.template
@@ -1,12 +1,6 @@
 import { step, z } from '@outputai/core';
 import { fetchBlogContent } from '../../clients/jina.js';
-
-const blogContentSchema = z.object( {
-  title: z.string(),
-  url: z.string(),
-  content: z.string(),
-  tokenCount: z.number()
-} );
+import { blogContentSchema } from './types.js';
 
 export const fetchContent = step( {
   name: 'fetch_blog_content',


### PR DESCRIPTION
## Overview

- Move `blogContentSchema` out of `steps.ts` and import it from `types.ts` to follow the single-responsibility convention
- Update the README template to replace the outdated `.env` copy flow with `npx output credentials init` + `npx output credentials edit`
- Add `types.ts` to the project structure listing in the README

Closes OUT-329