### PR TITLE
chore: Refactoring e2e tests to fix output colors, reduce amount of n…

### DIFF
--- a/ops/test_e2e.sh
+++ b/ops/test_e2e.sh
@@ -7,21 +7,29 @@ cd "${0%/*}/.."
 count=0
 print() {
   sym=${2:-$((++count))}
-  echo -e "\e[44;30m $sym \e[0m $1"
+  printf "\e[45;30m $sym \e[0m $1\n"
 }
 
-# Compose file path written by `npm run build:packages` (copy-assets step)
-COMPOSE_FILE="./sdk/cli/dist/assets/docker/docker-compose-dev.yml"
+print "End-to-end tests" "Run"
 
 export OUTPUT_API_URL="http://localhost:3001"
 export OUTPUT_API_VERSION="dev"
 export OUTPUT_WORKFLOWS_DIR="test_workflows"
 
+ERROR=""
 cleanup() {
-  print "Cleaning up..." "↓"
-  docker compose -f "$COMPOSE_FILE" --project-directory "$(pwd)" \
-    down -v --remove-orphans 2>/dev/null || true
+  local code=$?
+  print "Tearing down..."
+  docker compose -p output-sdk down -v --remove-orphans
+
+  if [[ code -eq 1 ]]; then
+    print "\e[31m$ERROR" "Error"
+  else
+    print "Test passed" "OK"
+  fi
+  exit $code
 }
+
 trap cleanup EXIT
 
 # Ensure .env exists (worker reads it via env_file in the compose)
@@ -30,68 +38,41 @@ if [ ! -f test_workflows/.env ]; then
   printf 'ANTHROPIC_API_KEY=dummy\nOPENAI_API_KEY=dummy\n' > test_workflows/.env
 fi
 
-# Step 1: install dependencies and build all SDK packages.
-# Runs inside the same node image used by the worker so native modules match.
-# build:packages also triggers copy-assets which writes docker-compose-dev.yml
-# to sdk/cli/dist/assets/docker/ — required for the cleanup compose call above.
-print "Installing dependencies and building packages..."
+# Install dependencies and build all SDK packages.
+print "Installing and building..."
 docker run --rm \
   -v "$(pwd):/app" \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
-  -e CI=1 \
   -w /app \
-  node:24.13.0-slim sh -c "corepack enable && pnpm install --frozen-lockfile && npm run build:packages"
+  node:24.13.0-slim sh -c "corepack enable && pnpm install --frozen-lockfile && npm run build:packages" | tail -n 25
 
-# Step 2: build the API docker image.
+# Build the API docker image.
 print "Building API docker image..."
 npm run dev:build:api
 
-# Step 3: start services via the CLI in detached mode.
-# --detached runs `docker compose up -d` and exits immediately, so the
-# CLI's 120s health-wait timeout is never reached and containers keep
-# running for our own readiness polling below.
+# Start services via the CLI in detached mode.
 print "Starting dev environment..."
 npm run dev:up -- --detached
 
-# Wait for the worker to connect and register the catalog.
-# workflow list fails until both the API is accepting connections and the
-# catalog is registered — covering all readiness in a single poll loop.
-# In CI this typically takes 3-5 minutes total.
-print "Waiting for worker to connect (polling via CLI workflow list)..."
-MAX_ATTEMPTS=200
-ATTEMPT=0
-until npm run --silent output -- workflow list > /dev/null 2>&1; do
-  ATTEMPT=$((ATTEMPT + 1))
-  if [ "$ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
-    print "TIMEOUT: Worker did not connect after $((MAX_ATTEMPTS * 3))s" "✗"
-    echo "--- worker logs ---"
-    docker compose -f "$COMPOSE_FILE" --project-directory "$(pwd)" \
-      logs worker --tail 200 2>/dev/null || true
-    exit 1
-  fi
-  sleep 3
-done
-print "Worker connected and catalog available (after $((ATTEMPT * 3))s)"
-
-# Step 4: run the simple workflow using the CLI — pure math, no LLM required.
-# Worker is already connected so this completes in a few seconds.
-# --format json outputs the API response body prefixed with a log line;
-# awk strips everything before the opening '{' before piping to jq.
-print "Running 'simple' workflow with input [1, 2, 3, 4, 5]..."
-CLI_OUTPUT=$(npm run --silent output -- workflow run simple \
-  --input '{"values":[1,2,3,4,5]}' \
-  --format json) || {
-  print "Workflow run failed — dumping logs" "✗"
-  docker compose -f "$COMPOSE_FILE" --project-directory "$(pwd)" \
-    logs --tail 200 2>/dev/null || true
+# Run the simple workflow using the CLI since everything is up
+print "Executing test workflow..."
+CLI_OUTPUT=$(npm run --silent output -- workflow run simple --input '{"values":[1,2,3,4,5]}' --format json) || {
+  printf "\e[36m\n[CLI output]\n\e[90m$CLI_OUTPUT\n"
+  printf "\e[36m\n[Worker container tail]\n\e[90m...\n"
+  docker compose -p output-sdk logs --no-color --no-log-prefix --tail 50 worker
+  printf "\e[36m\n[API container tail]\n\e[90m...\n"
+  docker compose -p output-sdk logs --no-color --no-log-prefix --tail 25 api | sed -r 's/\x1B\[[0-9;]*[mK]//g'
+  printf "\e[0m"
+  ERROR="Workflow execution failure"
   exit 1
 }
-echo "Output: $CLI_OUTPUT"
 
+# Matches the result against the expectation
+EXPECT=15
 RESULT=$(echo "$CLI_OUTPUT" | awk '/^\{/,0' | jq -r '.output.result')
-if [ "$RESULT" = "15" ]; then
-  print "PASSED: simple workflow returned result=15" "✓"
-else
-  print "FAILED: expected result=15, got result=$RESULT" "✗"
+if [ "$RESULT" != "$EXPECT" ]; then
+  ERROR="Invalid workflow result, got $RESULT but was expecting $EXPECT"
   exit 1
 fi
+
+exit 0


### PR DESCRIPTION
- Fix output colors (it was printing control chars);
- Removing noise by filtering and tailing docker output in case of error;
- Removing unnecessary step to wait for the worker as `npm run dev:up -- --detached` already waits for the healthcheck;
- Simplifying syntax;
- Fix issue were failed workflows were exiting with code 0.