### PR TITLE
fix(cli): fix plan and generate command save instructions and logic

### DIFF
--- a/.changeset/fix-plan-generate-cli.md
+++ b/.changeset/fix-plan-generate-cli.md
@@ -1,0 +1,10 @@
+---
+"@outputai/cli": patch
+---
+
+Fix plan and generate CLI commands
+
+- Suppress Claude file writes and next-step suggestions during plan generation (the CLI owns those responsibilities)
+- Validate plan file existence before creating workflow skeleton in generate command
+- Roll back created skeleton files if workflow build step fails
+- Fix empty workflow name in "already exists" error message

--- a/sdk/cli/src/commands/init.ts
+++ b/sdk/cli/src/commands/init.ts
@@ -1,6 +1,7 @@
 import { Args, Command, Flags } from '@oclif/core';
 import { UserCancelledError } from '#types/errors.js';
 import { runInit } from '#services/project_scaffold.js';
+import { getErrorMessage } from '#utils/error_utils.js';
 
 export default class Init extends Command {
   static description = 'Initialize a new Output project by scaffolding the complete project structure';
@@ -36,8 +37,7 @@ export default class Init extends Command {
       }
 
       // runInit handles cleanup internally and throws Error with message
-      const errorMessage = error instanceof Error ? error.message : String( error );
-      this.error( errorMessage );
+      this.error( getErrorMessage( error ) );
     }
   }
 }

--- a/sdk/cli/src/commands/workflow/generate.ts
+++ b/sdk/cli/src/commands/workflow/generate.ts
@@ -6,7 +6,7 @@ import { getWorkflowGenerateSuccessMessage } from '#services/messages.js';
 import { DEFAULT_OUTPUT_DIRS } from '#utils/paths.js';
 import type { WorkflowGenerationResult } from '#types/generator.js';
 import path from 'node:path';
-import fs from 'node:fs/promises';
+import * as fsSync from 'node:fs';
 
 export default class Generate extends Command {
   static override description = 'Generate a new Output workflow from a skeleton or plan file';
@@ -62,14 +62,10 @@ export default class Generate extends Command {
     }
 
     const projectRoot = process.cwd();
+    const absolutePlanPath = planFile ? path.resolve( projectRoot, planFile ) : '';
 
-    if ( planFile ) {
-      const absolutePlanPath = path.resolve( projectRoot, planFile );
-      try {
-        await fs.access( absolutePlanPath );
-      } catch {
-        this.error( `Plan file not found: ${absolutePlanPath}` );
-      }
+    if ( planFile && !fsSync.existsSync( absolutePlanPath ) ) {
+      this.error( `Plan file not found: ${absolutePlanPath}` );
     }
 
     const result = await generateWorkflow( {
@@ -87,16 +83,14 @@ export default class Generate extends Command {
 
       await ensureOutputAISystem( projectRoot );
 
-      const absolutePlanPath = path.resolve( projectRoot, planFile );
+      const buildOutput = await buildWorkflow( absolutePlanPath, result.targetDir, args.name )
+        .catch( ( error: unknown ): never => {
+          fsSync.rmSync( result.targetDir, { recursive: true, force: true } );
+          const message = error instanceof Error ? error.message : String( error );
+          this.error( `Workflow implementation failed, created files have been rolled back: ${message}` );
+        } );
 
-      try {
-        const buildOutput = await buildWorkflow( absolutePlanPath, result.targetDir, args.name );
-        await buildWorkflowInteractiveLoop( buildOutput );
-      } catch ( error ) {
-        await fs.rm( result.targetDir, { recursive: true, force: true } );
-        const message = error instanceof Error ? error.message : String( error );
-        this.error( `Workflow implementation failed, created files have been rolled back: ${message}` );
-      }
+      await buildWorkflowInteractiveLoop( buildOutput );
 
       this.log( ux.colorize( 'green', '\nWorkflow implementation complete!\n' ) );
     }

--- a/sdk/cli/src/commands/workflow/generate.ts
+++ b/sdk/cli/src/commands/workflow/generate.ts
@@ -4,7 +4,9 @@ import { buildWorkflow, buildWorkflowInteractiveLoop } from '#services/workflow_
 import { ensureOutputAISystem } from '#services/coding_agents.js';
 import { getWorkflowGenerateSuccessMessage } from '#services/messages.js';
 import { DEFAULT_OUTPUT_DIRS } from '#utils/paths.js';
+import type { WorkflowGenerationResult } from '#types/generator.js';
 import path from 'node:path';
+import fs from 'node:fs/promises';
 
 export default class Generate extends Command {
   static override description = 'Generate a new Output workflow from a skeleton or plan file';
@@ -59,44 +61,50 @@ export default class Generate extends Command {
       this.error( 'Full workflow generation not implemented yet. Please use --skeleton flag or --plan-file' );
     }
 
-    try {
-      const result = await generateWorkflow( {
-        name: args.name,
-        description: flags.description,
-        outputDir: flags['output-dir'],
-        skeleton: flags.skeleton,
-        force: flags.force
-      } );
+    const projectRoot = process.cwd();
 
-      if ( planFile ) {
-        this.log( '\nStarting AI-assisted workflow implementation...\n' );
-
-        const projectRoot = process.cwd();
-        await ensureOutputAISystem( projectRoot );
-
-        const absolutePlanPath = path.resolve( projectRoot, planFile );
-
-        const buildOutput = await buildWorkflow(
-          absolutePlanPath,
-          result.targetDir,
-          args.name
-        );
-
-        await buildWorkflowInteractiveLoop( buildOutput );
-
-        this.log( ux.colorize( 'green', '\nWorkflow implementation complete!\n' ) );
+    if ( planFile ) {
+      const absolutePlanPath = path.resolve( projectRoot, planFile );
+      try {
+        await fs.access( absolutePlanPath );
+      } catch {
+        this.error( `Plan file not found: ${absolutePlanPath}` );
       }
-
-      this.displaySuccess( result );
-    } catch ( error ) {
-      if ( error instanceof Error ) {
-        this.error( error.message );
-      }
-      throw error;
     }
+
+    const result = await generateWorkflow( {
+      name: args.name,
+      description: flags.description,
+      outputDir: flags['output-dir'],
+      skeleton: flags.skeleton,
+      force: flags.force
+    } ).catch( ( error: unknown ): never => {
+      this.error( error instanceof Error ? error.message : String( error ) );
+    } );
+
+    if ( planFile ) {
+      this.log( '\nStarting AI-assisted workflow implementation...\n' );
+
+      await ensureOutputAISystem( projectRoot );
+
+      const absolutePlanPath = path.resolve( projectRoot, planFile );
+
+      try {
+        const buildOutput = await buildWorkflow( absolutePlanPath, result.targetDir, args.name );
+        await buildWorkflowInteractiveLoop( buildOutput );
+      } catch ( error ) {
+        await fs.rm( result.targetDir, { recursive: true, force: true } );
+        const message = error instanceof Error ? error.message : String( error );
+        this.error( `Workflow implementation failed, created files have been rolled back: ${message}` );
+      }
+
+      this.log( ux.colorize( 'green', '\nWorkflow implementation complete!\n' ) );
+    }
+
+    this.displaySuccess( result );
   }
 
-  private displaySuccess( result: { workflowName: string; targetDir: string; filesCreated: string[] } ): void {
+  private displaySuccess( result: WorkflowGenerationResult ): void {
     const message = getWorkflowGenerateSuccessMessage(
       result.workflowName,
       result.targetDir,

--- a/sdk/cli/src/commands/workflow/generate.ts
+++ b/sdk/cli/src/commands/workflow/generate.ts
@@ -7,6 +7,7 @@ import { DEFAULT_OUTPUT_DIRS } from '#utils/paths.js';
 import type { WorkflowGenerationResult } from '#types/generator.js';
 import path from 'node:path';
 import * as fsSync from 'node:fs';
+import { getErrorMessage } from '#utils/error_utils.js';
 
 export default class Generate extends Command {
   static override description = 'Generate a new Output workflow from a skeleton or plan file';
@@ -75,7 +76,7 @@ export default class Generate extends Command {
       skeleton: flags.skeleton,
       force: flags.force
     } ).catch( ( error: unknown ): never => {
-      this.error( error instanceof Error ? error.message : String( error ) );
+      this.error( getErrorMessage( error ) );
     } );
 
     if ( planFile ) {
@@ -86,7 +87,7 @@ export default class Generate extends Command {
       const buildOutput = await buildWorkflow( absolutePlanPath, result.targetDir, args.name )
         .catch( ( error: unknown ): never => {
           fsSync.rmSync( result.targetDir, { recursive: true, force: true } );
-          const message = error instanceof Error ? error.message : String( error );
+          const message = getErrorMessage( error );
           this.error( `Workflow implementation failed, created files have been rolled back: ${message}` );
         } );
 

--- a/sdk/cli/src/commands/workflow/plan.ts
+++ b/sdk/cli/src/commands/workflow/plan.ts
@@ -90,6 +90,6 @@ export default class WorkflowPlan extends Command {
     const modifiedSavedPath = await writePlanFile( planName, modifiedPlanContent, projectRoot );
     this.log( `✅ Plan saved to: ${modifiedSavedPath}\n` );
     const generateCmd = ux.colorize( 'cyan', `npx output workflow generate <WORKFLOW_NAME> --plan-file=${modifiedSavedPath}` );
-    this.log( `⏭️  To execute this plan run: ${generateCmd}` );
+    this.log( `⏭️  To execute this plan run: ${generateCmd}\n` );
   }
 }

--- a/sdk/cli/src/commands/workflow/plan.ts
+++ b/sdk/cli/src/commands/workflow/plan.ts
@@ -89,5 +89,7 @@ export default class WorkflowPlan extends Command {
     const modifiedPlanContent = await this.planModificationLoop( planContent );
     const modifiedSavedPath = await writePlanFile( planName, modifiedPlanContent, projectRoot );
     this.log( `✅ Plan saved to: ${modifiedSavedPath}\n` );
+    const generateCmd = ux.colorize( 'cyan', `npx output workflow generate <WORKFLOW_NAME> --plan-file=${modifiedSavedPath}` );
+    this.log( `⏭️  To execute this plan run: ${generateCmd}` );
   }
 }

--- a/sdk/cli/src/commands/workflow/plan.ts
+++ b/sdk/cli/src/commands/workflow/plan.ts
@@ -73,7 +73,7 @@ export default class WorkflowPlan extends Command {
       return originalPlanContent;
     }
 
-    const modifiedPlanContent = await replyToClaude( modifications, PLAN_COMMAND_OPTIONS );
+    const modifiedPlanContent = await replyToClaude( modifications, { anthropicOpts: PLAN_COMMAND_OPTIONS } );
     return this.planModificationLoop( modifiedPlanContent );
   }
 

--- a/sdk/cli/src/services/claude_client.ts
+++ b/sdk/cli/src/services/claude_client.ts
@@ -251,9 +251,10 @@ async function singleQuery( prompt: string, options: Options = {} ) {
 
 export async function replyToClaude(
   message: string,
-  options: Options = {}
+  options: Options = {},
+  instructionsType: InstructionsType = 'plan'
 ) {
-  return singleQuery( applyInstructions( message ), { continue: true, ...options } );
+  return singleQuery( applyInstructions( message, instructionsType ), { continue: true, ...options } );
 }
 
 /**

--- a/sdk/cli/src/services/claude_client.ts
+++ b/sdk/cli/src/services/claude_client.ts
@@ -53,6 +53,10 @@ export const PLAN_COMMAND_OPTIONS: Options = {
   allowedTools: [ 'Read', 'Grep', 'WebSearch', 'WebFetch', 'TodoWrite' ]
 };
 
+interface ClaudeQueryOptions extends Options {
+  instructionsType?: InstructionsType;
+}
+
 export const BUILD_COMMAND_OPTIONS: Options = {
   permissionMode: 'bypassPermissions'
 };
@@ -251,10 +255,9 @@ async function singleQuery( prompt: string, options: Options = {} ) {
 
 export async function replyToClaude(
   message: string,
-  options: Options = {},
-  instructionsType: InstructionsType = 'plan'
+  { instructionsType = 'plan', ...claudeOptions }: ClaudeQueryOptions = {}
 ) {
-  return singleQuery( applyInstructions( message, instructionsType ), { continue: true, ...options } );
+  return singleQuery( applyInstructions( message, instructionsType ), { continue: true, ...claudeOptions } );
 }
 
 /**

--- a/sdk/cli/src/services/claude_client.ts
+++ b/sdk/cli/src/services/claude_client.ts
@@ -4,11 +4,12 @@
 import { Options, query, SDKMessage, SDKSystemMessage } from '@anthropic-ai/claude-agent-sdk';
 import { ux } from '@oclif/core';
 import * as cliProgress from 'cli-progress';
-import type { Todo, InstructionsType, SystemValidation } from '#types/domain.js';
+import type { Todo, SystemValidation } from '#types/domain.js';
 import { getErrorMessage, toError } from '#utils/error_utils.js';
 import { config } from '#config.js';
 
-const ADDITIONAL_INSTRUCTIONS = `
+export const ADDITIONAL_INSTRUCTIONS = {
+  PLAN: `
 ! IMPORTANT !
 1. Use TodoWrite to track your progress through plan creation.
 
@@ -29,9 +30,8 @@ date: <plan-date>
 5. DO NOT write the plan to disk — the CLI will handle saving the file to the plans directory.
 
 6. DO NOT suggest any next steps, follow-up commands, or instructions for the user — the CLI will inform the user of next steps after saving.
-`;
-
-const ADDITIONAL_INSTRUCTIONS_BUILD = `
+`,
+  BUILD: `
 ! IMPORTANT !
 1. Use TodoWrite to track your progress through workflow implementation.
 
@@ -40,7 +40,8 @@ const ADDITIONAL_INSTRUCTIONS_BUILD = `
 3. Implement all workflow files following Output.ai patterns and best practices.
 
 4. After you mark all todos as complete, provide a summary of what was implemented.
-`;
+`
+} as const;
 
 const PLAN_COMMAND = 'outputai:plan_workflow';
 const BUILD_COMMAND = 'outputai:build_workflow';
@@ -53,8 +54,9 @@ export const PLAN_COMMAND_OPTIONS: Options = {
   allowedTools: [ 'Read', 'Grep', 'WebSearch', 'WebFetch', 'TodoWrite' ]
 };
 
-interface ClaudeQueryOptions extends Options {
-  instructionsType?: InstructionsType;
+interface ReplyToClaudeOptions {
+  anthropicOpts?: Options;
+  applyAdditionalInstructions?: string;
 }
 
 export const BUILD_COMMAND_OPTIONS: Options = {
@@ -143,11 +145,8 @@ function getTodoWriteMessage( message: SDKMessage ): TodoWriteMessage | null {
   return todoWriteMessage ?? null;
 }
 
-function applyInstructions( initialMessage: string, instructionsType: InstructionsType = 'plan' ): string {
-  const instructions = instructionsType === 'build' ?
-    ADDITIONAL_INSTRUCTIONS_BUILD :
-    ADDITIONAL_INSTRUCTIONS;
-  return `${initialMessage}\n\n${instructions}`;
+function applyInstructions( message: string, instructions: string ): string {
+  return `${message}\n\n${instructions}`;
 }
 
 interface ProgressUpdate {
@@ -255,9 +254,9 @@ async function singleQuery( prompt: string, options: Options = {} ) {
 
 export async function replyToClaude(
   message: string,
-  { instructionsType = 'plan', ...claudeOptions }: ClaudeQueryOptions = {}
+  { anthropicOpts, applyAdditionalInstructions = ADDITIONAL_INSTRUCTIONS.PLAN }: ReplyToClaudeOptions = {}
 ) {
-  return singleQuery( applyInstructions( message, instructionsType ), { continue: true, ...claudeOptions } );
+  return singleQuery( applyInstructions( message, applyAdditionalInstructions ), { continue: true, ...anthropicOpts } );
 }
 
 /**
@@ -270,7 +269,7 @@ export async function replyToClaude(
 export async function invokePlanWorkflow(
   description: string
 ): Promise<string> {
-  return singleQuery( applyInstructions( `/${PLAN_COMMAND} ${description}` ), PLAN_COMMAND_OPTIONS );
+  return singleQuery( applyInstructions( `/${PLAN_COMMAND} ${description}`, ADDITIONAL_INSTRUCTIONS.PLAN ), PLAN_COMMAND_OPTIONS );
 }
 
 /**
@@ -294,5 +293,5 @@ export async function invokeBuildWorkflow(
     `/${BUILD_COMMAND} ${commandArgs} ${additionalInstructions}` :
     `/${BUILD_COMMAND} ${commandArgs}`;
 
-  return singleQuery( applyInstructions( fullCommand, 'build' ), BUILD_COMMAND_OPTIONS );
+  return singleQuery( applyInstructions( fullCommand, ADDITIONAL_INSTRUCTIONS.BUILD ), BUILD_COMMAND_OPTIONS );
 }

--- a/sdk/cli/src/services/claude_client.ts
+++ b/sdk/cli/src/services/claude_client.ts
@@ -12,9 +12,9 @@ const ADDITIONAL_INSTRUCTIONS = `
 ! IMPORTANT !
 1. Use TodoWrite to track your progress through plan creation.
 
-2. Please response with only the final version of the plan.
+2. Please respond with only the final version of the plan content.
 
-3. Response in a markdown format with these metadata headers:
+3. Respond in a markdown format with these metadata headers:
 
 ---
 title: <plan-title>
@@ -25,6 +25,10 @@ date: <plan-date>
 <plan-content>
 
 4. After you mark all todos as complete, you must respond with the final version of the plan.
+
+5. DO NOT write the plan to disk — the CLI will handle saving the file to the plans directory.
+
+6. DO NOT suggest any next steps, follow-up commands, or instructions for the user — the CLI will inform the user of next steps after saving.
 `;
 
 const ADDITIONAL_INSTRUCTIONS_BUILD = `

--- a/sdk/cli/src/services/project_scaffold.ts
+++ b/sdk/cli/src/services/project_scaffold.ts
@@ -188,8 +188,7 @@ function formatInitError( error: unknown, projectPath: string | null ): string {
     case 'EPERM': return `Operation not permitted${pathSuffix}`;
     case 'ENOENT': return `Required file or directory not found${pathSuffix}`;
     default: {
-      const originalMessage = error instanceof Error ? error.message : String( error );
-      return `Failed to create project${pathSuffix}: ${originalMessage}`;
+      return `Failed to create project${pathSuffix}: ${getErrorMessage( error )}`;
     }
   }
 }

--- a/sdk/cli/src/services/workflow_builder.spec.ts
+++ b/sdk/cli/src/services/workflow_builder.spec.ts
@@ -171,7 +171,7 @@ describe( 'workflow-builder service', () => {
 
       const result = await buildWorkflowInteractiveLoop( 'Initial implementation' );
 
-      expect( replyToClaude ).toHaveBeenCalledWith( 'Add error handling', BUILD_COMMAND_OPTIONS, 'build' );
+      expect( replyToClaude ).toHaveBeenCalledWith( 'Add error handling', { ...BUILD_COMMAND_OPTIONS, instructionsType: 'build' } );
       expect( result ).toBe( 'Updated implementation with error handling' );
       expect( input ).toHaveBeenCalledTimes( 2 );
     } );
@@ -189,8 +189,8 @@ describe( 'workflow-builder service', () => {
       const result = await buildWorkflowInteractiveLoop( 'Initial implementation' );
 
       expect( replyToClaude ).toHaveBeenCalledTimes( 2 );
-      expect( replyToClaude ).toHaveBeenNthCalledWith( 1, 'Add logging', BUILD_COMMAND_OPTIONS, 'build' );
-      expect( replyToClaude ).toHaveBeenNthCalledWith( 2, 'Add validation', BUILD_COMMAND_OPTIONS, 'build' );
+      expect( replyToClaude ).toHaveBeenNthCalledWith( 1, 'Add logging', { ...BUILD_COMMAND_OPTIONS, instructionsType: 'build' } );
+      expect( replyToClaude ).toHaveBeenNthCalledWith( 2, 'Add validation', { ...BUILD_COMMAND_OPTIONS, instructionsType: 'build' } );
       expect( result ).toBe( 'Implementation with logging and validation' );
     } );
 

--- a/sdk/cli/src/services/workflow_builder.spec.ts
+++ b/sdk/cli/src/services/workflow_builder.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { buildWorkflow, buildWorkflowInteractiveLoop } from './workflow_builder.js';
-import { BUILD_COMMAND_OPTIONS, invokeBuildWorkflow, replyToClaude } from './claude_client.js';
+import { ADDITIONAL_INSTRUCTIONS, BUILD_COMMAND_OPTIONS, invokeBuildWorkflow, replyToClaude } from './claude_client.js';
 import { input } from '@inquirer/prompts';
 import { ux } from '@oclif/core';
 import fs from 'node:fs/promises';
@@ -171,7 +171,10 @@ describe( 'workflow-builder service', () => {
 
       const result = await buildWorkflowInteractiveLoop( 'Initial implementation' );
 
-      expect( replyToClaude ).toHaveBeenCalledWith( 'Add error handling', { ...BUILD_COMMAND_OPTIONS, instructionsType: 'build' } );
+      expect( replyToClaude ).toHaveBeenCalledWith( 'Add error handling', {
+        anthropicOpts: BUILD_COMMAND_OPTIONS,
+        applyAdditionalInstructions: ADDITIONAL_INSTRUCTIONS.BUILD
+      } );
       expect( result ).toBe( 'Updated implementation with error handling' );
       expect( input ).toHaveBeenCalledTimes( 2 );
     } );
@@ -189,8 +192,14 @@ describe( 'workflow-builder service', () => {
       const result = await buildWorkflowInteractiveLoop( 'Initial implementation' );
 
       expect( replyToClaude ).toHaveBeenCalledTimes( 2 );
-      expect( replyToClaude ).toHaveBeenNthCalledWith( 1, 'Add logging', { ...BUILD_COMMAND_OPTIONS, instructionsType: 'build' } );
-      expect( replyToClaude ).toHaveBeenNthCalledWith( 2, 'Add validation', { ...BUILD_COMMAND_OPTIONS, instructionsType: 'build' } );
+      expect( replyToClaude ).toHaveBeenNthCalledWith( 1, 'Add logging', {
+        anthropicOpts: BUILD_COMMAND_OPTIONS,
+        applyAdditionalInstructions: ADDITIONAL_INSTRUCTIONS.BUILD
+      } );
+      expect( replyToClaude ).toHaveBeenNthCalledWith( 2, 'Add validation', {
+        anthropicOpts: BUILD_COMMAND_OPTIONS,
+        applyAdditionalInstructions: ADDITIONAL_INSTRUCTIONS.BUILD
+      } );
       expect( result ).toBe( 'Implementation with logging and validation' );
     } );
 

--- a/sdk/cli/src/services/workflow_builder.spec.ts
+++ b/sdk/cli/src/services/workflow_builder.spec.ts
@@ -171,7 +171,7 @@ describe( 'workflow-builder service', () => {
 
       const result = await buildWorkflowInteractiveLoop( 'Initial implementation' );
 
-      expect( replyToClaude ).toHaveBeenCalledWith( 'Add error handling', BUILD_COMMAND_OPTIONS );
+      expect( replyToClaude ).toHaveBeenCalledWith( 'Add error handling', BUILD_COMMAND_OPTIONS, 'build' );
       expect( result ).toBe( 'Updated implementation with error handling' );
       expect( input ).toHaveBeenCalledTimes( 2 );
     } );
@@ -189,8 +189,8 @@ describe( 'workflow-builder service', () => {
       const result = await buildWorkflowInteractiveLoop( 'Initial implementation' );
 
       expect( replyToClaude ).toHaveBeenCalledTimes( 2 );
-      expect( replyToClaude ).toHaveBeenNthCalledWith( 1, 'Add logging', BUILD_COMMAND_OPTIONS );
-      expect( replyToClaude ).toHaveBeenNthCalledWith( 2, 'Add validation', BUILD_COMMAND_OPTIONS );
+      expect( replyToClaude ).toHaveBeenNthCalledWith( 1, 'Add logging', BUILD_COMMAND_OPTIONS, 'build' );
+      expect( replyToClaude ).toHaveBeenNthCalledWith( 2, 'Add validation', BUILD_COMMAND_OPTIONS, 'build' );
       expect( result ).toBe( 'Implementation with logging and validation' );
     } );
 

--- a/sdk/cli/src/services/workflow_builder.spec.ts
+++ b/sdk/cli/src/services/workflow_builder.spec.ts
@@ -251,7 +251,7 @@ describe( 'workflow-builder service', () => {
 
       // Should return original implementation after error
       expect( result ).toBe( 'Original implementation' );
-      expect( ux.error ).toHaveBeenCalledWith(
+      expect( ux.stdout ).toHaveBeenCalledWith(
         expect.stringContaining( 'Failed to apply modifications' )
       );
       expect( ux.stdout ).toHaveBeenCalledWith(

--- a/sdk/cli/src/services/workflow_builder.ts
+++ b/sdk/cli/src/services/workflow_builder.ts
@@ -76,7 +76,7 @@ async function processModification( modification: string, currentOutput: string 
   }
 
   try {
-    const updatedOutput = await replyToClaude( modification, BUILD_COMMAND_OPTIONS, 'build' );
+    const updatedOutput = await replyToClaude( modification, { ...BUILD_COMMAND_OPTIONS, instructionsType: 'build' } );
     displayImplementationOutput( updatedOutput, '✓ Implementation updated!' );
     return updatedOutput;
   } catch ( error ) {

--- a/sdk/cli/src/services/workflow_builder.ts
+++ b/sdk/cli/src/services/workflow_builder.ts
@@ -76,7 +76,7 @@ async function processModification( modification: string, currentOutput: string 
   }
 
   try {
-    const updatedOutput = await replyToClaude( modification, BUILD_COMMAND_OPTIONS );
+    const updatedOutput = await replyToClaude( modification, BUILD_COMMAND_OPTIONS, 'build' );
     displayImplementationOutput( updatedOutput, '✓ Implementation updated!' );
     return updatedOutput;
   } catch ( error ) {

--- a/sdk/cli/src/services/workflow_builder.ts
+++ b/sdk/cli/src/services/workflow_builder.ts
@@ -88,7 +88,7 @@ async function processModification( modification: string, currentOutput: string 
     displayImplementationOutput( updatedOutput, '✓ Implementation updated!' );
     return updatedOutput;
   } catch ( error ) {
-    ux.error( `Failed to apply modifications: ${getErrorMessage( error )}` );
+    ux.stdout( ux.colorize( 'red', `Failed to apply modifications: ${getErrorMessage( error )}` ) );
     ux.stdout( 'Continuing with previous version...\n' );
     return currentOutput;
   }

--- a/sdk/cli/src/services/workflow_builder.ts
+++ b/sdk/cli/src/services/workflow_builder.ts
@@ -1,7 +1,12 @@
 /**
  * Workflow builder service for implementing workflows from plan files
  */
-import { BUILD_COMMAND_OPTIONS, invokeBuildWorkflow as invokeBuildWorkflowFromClient, replyToClaude } from './claude_client.js';
+import {
+  ADDITIONAL_INSTRUCTIONS,
+  BUILD_COMMAND_OPTIONS,
+  invokeBuildWorkflow as invokeBuildWorkflowFromClient,
+  replyToClaude
+} from './claude_client.js';
 import { input } from '@inquirer/prompts';
 import { ux } from '@oclif/core';
 import fs from 'node:fs/promises';
@@ -76,7 +81,10 @@ async function processModification( modification: string, currentOutput: string 
   }
 
   try {
-    const updatedOutput = await replyToClaude( modification, { ...BUILD_COMMAND_OPTIONS, instructionsType: 'build' } );
+    const updatedOutput = await replyToClaude( modification, {
+      anthropicOpts: BUILD_COMMAND_OPTIONS,
+      applyAdditionalInstructions: ADDITIONAL_INSTRUCTIONS.BUILD
+    } );
     displayImplementationOutput( updatedOutput, '✓ Implementation updated!' );
     return updatedOutput;
   } catch ( error ) {

--- a/sdk/cli/src/services/workflow_generator.ts
+++ b/sdk/cli/src/services/workflow_generator.ts
@@ -19,9 +19,9 @@ function validateConfig( config: WorkflowGenerationConfig ): void {
  */
 import * as fsSync from 'node:fs';
 
-async function checkTargetDirectory( targetDir: string, force: boolean ): Promise<void> {
+async function checkTargetDirectory( name: string, targetDir: string, force: boolean ): Promise<void> {
   if ( fsSync.existsSync( targetDir ) && !force ) {
-    throw new WorkflowExistsError( config.name, targetDir );
+    throw new WorkflowExistsError( name, targetDir );
   }
 }
 
@@ -34,7 +34,7 @@ export async function generateWorkflow( config: WorkflowGenerationConfig ): Prom
   const targetDir = createTargetDir( config.outputDir, config.name );
   const templatesDir = getTemplateDir( 'workflow' );
 
-  await checkTargetDirectory( targetDir, config.force );
+  await checkTargetDirectory( config.name, targetDir, config.force );
   await fs.mkdir( targetDir, { recursive: true } );
 
   const variables = prepareTemplateVariables( config.name, config.description || '' );

--- a/sdk/cli/src/services/workflow_generator.ts
+++ b/sdk/cli/src/services/workflow_generator.ts
@@ -21,7 +21,7 @@ import * as fsSync from 'node:fs';
 
 async function checkTargetDirectory( targetDir: string, force: boolean ): Promise<void> {
   if ( fsSync.existsSync( targetDir ) && !force ) {
-    throw new WorkflowExistsError( '', targetDir );
+    throw new WorkflowExistsError( config.name, targetDir );
   }
 }
 

--- a/sdk/cli/src/types/domain.ts
+++ b/sdk/cli/src/types/domain.ts
@@ -6,8 +6,6 @@ export type TodoStatus = 'pending' | 'in_progress' | 'completed';
 
 export type FileMappingType = 'template' | 'symlink' | 'copy';
 
-export type InstructionsType = 'plan' | 'build';
-
 export interface Todo {
   content: string;
   activeForm: string;


### PR DESCRIPTION
## Problem

- **OUT-331** — When `workflow plan` is invoked via the CLI, Claude attempts to write the plan file itself and fails because write tools are not in its allowed set, resulting in the message "I wasn't able to write the plan file due to permissions" and no file on disk
- **OUT-332** — Claude's post-flight instructions tell the user to run `/outputai:build_workflow` (the Claude slash command) instead of `npx output workflow generate`, and references the plan file before it has been written
- **OUT-336** — `workflow generate --plan-file` creates the boilerplate skeleton before validating the plan file exists; if the plan is missing (or build fails), the orphaned skeleton is left on disk with no rollback; additionally, re-running after a failed attempt shows `Workflow "" already exists` with an empty name

## Solution

- Extend `ADDITIONAL_INSTRUCTIONS` in `claude_client.ts` to explicitly tell Claude not to write the plan file and not to suggest follow-up commands — the CLI owns both responsibilities
- In `generate.ts`, validate that `--plan-file` points to an existing file **before** calling `generateWorkflow()` so no skeleton is created on a bad path
- Wrap the `buildWorkflow` call in a try/catch that removes the created `targetDir` on failure, ensuring a clean state for retry
- Fix `WorkflowExistsError` in `workflow_generator.ts` to pass `config.name` instead of `''`, producing a meaningful error message on re-run

Closes OUT-331, OUT-332, OUT-336