### PR TITLE
chore: Fixing local dev env worker healthcheck [OUT-340]

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,7 +29,7 @@ services:
         condition: service_healthy
     image: node:24.13.0-slim
     healthcheck:
-      test: [ 'CMD-SHELL', 'npx', 'output-healthcheck' ]
+      test: [ 'CMD-SHELL', 'cd ./test_workflows && npx output-healthcheck' ]
       interval: 3s
       timeout: 10s
       retries: 20

--- a/sdk/cli/src/assets/docker/docker-compose-dev.yml
+++ b/sdk/cli/src/assets/docker/docker-compose-dev.yml
@@ -105,7 +105,7 @@ services:
         condition: service_healthy
     image: node:24.13.0-slim
     healthcheck:
-      test: [ 'CMD', 'npx', '--yes', 'output-healthcheck' ]
+      test: [ 'CMD-SHELL', 'npx output-healthcheck' ]
       interval: 3s
       timeout: 10s
       retries: 20


### PR DESCRIPTION
Docker compose worker container health-check was not working locally due to misuse of `CMD` vs `CMD-SHELL` and being called in the wrong directory.

This PR also simplifies the command used in the CLI, without any side effects:
```bash
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2026-03-30T22:46:24.529995429Z",
      "End": "2026-03-30T22:46:26.704867763Z",
      "ExitCode": 0,
      "Output": "Query response: pong\n"
    },
    {
      "Start": "2026-03-30T22:46:29.7058375Z",
      "End": "2026-03-30T22:46:29.997007875Z",
      "ExitCode": 0,
      "Output": "Query response: pong\n"
    },
    {
      "Start": "2026-03-30T22:46:33.001625293Z",
      "End": "2026-03-30T22:46:33.289138169Z",
      "ExitCode": 0,
      "Output": "Query response: pong\n"
    },
    {
      "Start": "2026-03-30T22:46:36.292164712Z",
      "End": "2026-03-30T22:46:36.578431962Z",
      "ExitCode": 0,
      "Output": "Query response: pong\n"
    },
    {
      "Start": "2026-03-30T22:46:39.579621213Z",
      "End": "2026-03-30T22:46:39.870963588Z",
      "ExitCode": 0,
      "Output": "Query response: pong\n"
    }
  ]
}
```