### PR TITLE
fix: Resolve credential references in CLI commands

### DIFF
--- a/.changeset/tall-seals-give.md
+++ b/.changeset/tall-seals-give.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+ensure credential references are resolved when running CLI commands

--- a/sdk/cli/bin/run.js
+++ b/sdk/cli/bin/run.js
@@ -2,8 +2,10 @@
 
 import { execute } from '@oclif/core';
 import { loadEnvironment } from '../dist/utils/env_loader.js';
+import { resolveCredentialRefs } from '@outputai/credentials';
 
 // Load environment variables from .env files before executing CLI
 loadEnvironment();
+resolveCredentialRefs();
 
 await execute( { dir: import.meta.url } );

--- a/sdk/credentials/src/credentials.spec.ts
+++ b/sdk/credentials/src/credentials.spec.ts
@@ -449,6 +449,89 @@ describe( 'credentials module', () => {
     } );
   } );
 
+  describe( 'resolveCredentialRefs', () => {
+    const refKey = generateKey();
+    const refCiphertext = encrypt( YAML_CONTENT, refKey );
+
+    const loadResolveCredentialRefs = async () => {
+      vi.resetModules();
+      const mod = await import( './index.js' );
+      return mod.resolveCredentialRefs;
+    };
+
+    afterEach( () => {
+      delete process.env.ANTHROPIC_API_KEY;
+      delete process.env.OPENAI_API_KEY;
+    } );
+
+    it( 'should resolve credential: env vars to decrypted values', async () => {
+      process.env.OUTPUT_CREDENTIALS_KEY = refKey;
+      process.env.ANTHROPIC_API_KEY = 'credential:anthropic.api_key';
+
+      vi.doMock( 'node:fs', () => ( {
+        readFileSync: () => refCiphertext,
+        existsSync: ( path: string ) => path.endsWith( 'credentials.yml.enc' )
+      } ) );
+
+      const resolve = await loadResolveCredentialRefs();
+      const resolved = resolve();
+
+      expect( resolved ).toEqual( [ 'ANTHROPIC_API_KEY' ] );
+      expect( process.env.ANTHROPIC_API_KEY ).toBe( 'sk-ant-test' );
+    } );
+
+    it( 'should leave non-credential env vars unchanged', async () => {
+      process.env.OUTPUT_CREDENTIALS_KEY = refKey;
+      process.env.ANTHROPIC_API_KEY = 'sk-ant-already-set';
+
+      vi.doMock( 'node:fs', () => ( {
+        readFileSync: () => refCiphertext,
+        existsSync: ( path: string ) => path.endsWith( 'credentials.yml.enc' )
+      } ) );
+
+      const resolve = await loadResolveCredentialRefs();
+      const resolved = resolve();
+
+      expect( resolved ).toEqual( [] );
+      expect( process.env.ANTHROPIC_API_KEY ).toBe( 'sk-ant-already-set' );
+    } );
+
+    it( 'should skip credential refs that do not resolve to a value', async () => {
+      process.env.OUTPUT_CREDENTIALS_KEY = refKey;
+      process.env.OPENAI_API_KEY = 'credential:nonexistent.path';
+
+      vi.doMock( 'node:fs', () => ( {
+        readFileSync: () => refCiphertext,
+        existsSync: ( path: string ) => path.endsWith( 'credentials.yml.enc' )
+      } ) );
+
+      const resolve = await loadResolveCredentialRefs();
+      const resolved = resolve();
+
+      expect( resolved ).toEqual( [] );
+      expect( process.env.OPENAI_API_KEY ).toBe( 'credential:nonexistent.path' );
+    } );
+
+    it( 'should resolve multiple credential refs in one call', async () => {
+      process.env.OUTPUT_CREDENTIALS_KEY = refKey;
+      process.env.ANTHROPIC_API_KEY = 'credential:anthropic.api_key';
+      process.env.OPENAI_API_KEY = 'credential:aws.secret';
+
+      vi.doMock( 'node:fs', () => ( {
+        readFileSync: () => refCiphertext,
+        existsSync: ( path: string ) => path.endsWith( 'credentials.yml.enc' )
+      } ) );
+
+      const resolve = await loadResolveCredentialRefs();
+      const resolved = resolve();
+
+      expect( resolved ).toContain( 'ANTHROPIC_API_KEY' );
+      expect( resolved ).toContain( 'OPENAI_API_KEY' );
+      expect( process.env.ANTHROPIC_API_KEY ).toBe( 'sk-ant-test' );
+      expect( process.env.OPENAI_API_KEY ).toBe( 'aws-secret' );
+    } );
+  } );
+
   describe( 'custom provider', () => {
     it( 'should use a custom provider when set via registry', async () => {
       const customProvider = {


### PR DESCRIPTION
Fix an issue I noticed where `output workflow plan` would fail with a bad API key message: 

```
❯ output init
✔ What is your project name? newproject
✔ What folder name should be used? newproject
Created project folder: newproject
Created 16 project files
Credentials initialized
✔ Would you like to configure API credentials now? Yes
✔ anthropic.api_key (secret): ************************************************************************************************************

[... normal things ...]

📁 PROJECT DETAILS

  ▸ Name: newproject
  ▸ Type: Output Project
  ▸ Structure: .outputai/ (agents), workflows/ (implementations)

[ ... all the normal stuff, no errors ...]

🔑 Secrets: Use npx output credentials show|get|edit
         to manage your project secrets.

Happy building with Output! 🚀

❯ output workflow plan --description "a workflow that finds the next PGA tour event and then researches top 3 likely winners"
Checking .outputai directory structure...

Generating plan name...
    AI_APICallError: invalid x-api-key
```

We were loading the `.env` file, but we weren't resolving things like `ANTHROPIC_API_KEY=credential:anthropic.api_key` to the actual key, instead we were left with literally `credential:anthropic.api_key` as the value
