### PR TITLE
chore(cli): add changeset for ink refactor

### DIFF
--- a/.changeset/ink-dev-panel.md
+++ b/.changeset/ink-dev-panel.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Replaced log-update/ANSI output in `output dev` with an Ink-based terminal UI, fixing a layout bug where text overlapped after a Docker service recovered from unhealthy. The dev panel now re-renders correctly on all state transitions.


### PR DESCRIPTION
Adds a missing changeset for the Ink migration landed in #97.