### PR TITLE
feat(core): add workflow aliases for backward-compatible renaming

### DIFF
--- a/.changeset/plain-suns-decide.md
+++ b/.changeset/plain-suns-decide.md
@@ -1,0 +1,6 @@
+---
+"@outputai/core": minor
+"output-api": minor
+---
+
+Add support for Workflow alias names

--- a/api/src/clients/temporal_client.js
+++ b/api/src/clients/temporal_client.js
@@ -176,14 +176,15 @@ export default {
 
         // the catalog worker has the same name of the task queue
         const catalog = await getCatalog( { client, taskQueue } );
-        const workflowExists = catalog.workflows.some( w => w.name === workflowName );
-        if ( !workflowExists ) {
+        const resolved = catalog.workflows.find( w => w.name === workflowName || w.aliases?.includes( workflowName ) );
+        if ( !resolved ) {
           throw new WorkflowNotFoundError( `Workflow "${workflowName}" is not available at worker "${taskQueue}"` );
         }
 
+        const resolvedName = resolved.name;
         const workflowId = userWorkflowId ?? buildWorkflowId();
         const executionTimeout = timeout ?? workflowExecutionMaxWaiting;
-        const handle = await client.workflow.start( workflowName, { args: [ input ], taskQueue, workflowId, workflowExecutionTimeout } );
+        const handle = await client.workflow.start( resolvedName, { args: [ input ], taskQueue, workflowId, workflowExecutionTimeout } );
 
         try {
           const result = await Promise.race( [

--- a/api/src/clients/temporal_client.js
+++ b/api/src/clients/temporal_client.js
@@ -151,6 +151,26 @@ export default {
 
     logger.info( 'Temporal client connected', { address, namespace } );
 
+    /**
+     * Resolve a workflow name (or alias) to the canonical workflow name via the catalog.
+     *
+     * @param {object} catalog - The catalog object
+     * @param {string} workflowName - The workflow name or alias
+     * @param {string} taskQueue - The task queue (for error messages)
+     * @returns {string} The canonical workflow name
+     * @throws {WorkflowNotFoundError}
+     */
+    const resolveWorkflowName = ( catalog, workflowName, taskQueue ) => {
+      const resolved = catalog.workflows.find( w => w.name === workflowName || w.aliases?.includes( workflowName ) );
+      if ( !resolved ) {
+        throw new WorkflowNotFoundError( `Workflow "${workflowName}" is not available at worker "${taskQueue}"` );
+      }
+      if ( resolved.name !== workflowName ) {
+        logger.info( 'Workflow alias resolved', { alias: workflowName, resolvedName: resolved.name, taskQueue } );
+      }
+      return resolved.name;
+    };
+
     return {
       /**
        * Workflow execution result
@@ -176,12 +196,8 @@ export default {
 
         // the catalog worker has the same name of the task queue
         const catalog = await getCatalog( { client, taskQueue } );
-        const resolved = catalog.workflows.find( w => w.name === workflowName || w.aliases?.includes( workflowName ) );
-        if ( !resolved ) {
-          throw new WorkflowNotFoundError( `Workflow "${workflowName}" is not available at worker "${taskQueue}"` );
-        }
+        const resolvedName = resolveWorkflowName( catalog, workflowName, taskQueue );
 
-        const resolvedName = resolved.name;
         const workflowId = userWorkflowId ?? buildWorkflowId();
         const executionTimeout = timeout ?? workflowExecutionMaxWaiting;
         const handle = await client.workflow.start( resolvedName, { args: [ input ], taskQueue, workflowId, workflowExecutionTimeout } );
@@ -232,8 +248,10 @@ export default {
        */
       async startWorkflow( workflowName, input, options = {} ) {
         const { workflowId: userWorkflowId, taskQueue = defaultTaskQueue } = options;
+        const catalog = await getCatalog( { client, taskQueue } );
+        const resolvedName = resolveWorkflowName( catalog, workflowName, taskQueue );
         const workflowId = userWorkflowId ?? buildWorkflowId();
-        await client.workflow.start( workflowName, { args: [ input ], taskQueue, workflowId, workflowExecutionTimeout } );
+        await client.workflow.start( resolvedName, { args: [ input ], taskQueue, workflowId, workflowExecutionTimeout } );
         return { workflowId };
       },
 

--- a/api/src/clients/temporal_client.spec.js
+++ b/api/src/clients/temporal_client.spec.js
@@ -179,6 +179,31 @@ describe( 'temporal_client', () => {
       } );
     } );
 
+    it( 'should resolve alias to primary workflow name', async () => {
+      const successResult = { output: { data: 'aliased' }, trace: null };
+
+      mockQuery.mockResolvedValue( {
+        workflows: [ { name: 'new_name', aliases: [ 'old_name' ] } ]
+      } );
+      mockStart.mockResolvedValue( {
+        result: () => Promise.resolve( successResult )
+      } );
+      mockGetHandle
+        .mockReturnValueOnce( { query: mockQuery } )
+        .mockReturnValue( { result: () => Promise.resolve( successResult ) } );
+
+      const temporalClient = ( await import( './temporal_client.js' ) ).default;
+      const client = await temporalClient.init();
+      const result = await client.runWorkflow( 'old_name', { input: 'data' } );
+
+      expect( result.status ).toBe( 'completed' );
+      expect( result.output ).toEqual( { data: 'aliased' } );
+      // Verify the resolved primary name was used for Temporal start
+      expect( mockStart ).toHaveBeenCalledWith( 'new_name', expect.objectContaining( {
+        args: [ { input: 'data' } ]
+      } ) );
+    } );
+
     it( 'should throw non-WorkflowFailedError errors', async () => {
       const timeoutError = new WorkflowExecutionTimedOutError();
 

--- a/api/src/clients/temporal_client.spec.js
+++ b/api/src/clients/temporal_client.spec.js
@@ -204,6 +204,30 @@ describe( 'temporal_client', () => {
       } ) );
     } );
 
+    it( 'should log when alias is resolved', async () => {
+      const successResult = { output: {}, trace: null };
+
+      mockQuery.mockResolvedValue( {
+        workflows: [ { name: 'new_name', aliases: [ 'old_name' ] } ]
+      } );
+      mockStart.mockResolvedValue( {
+        result: () => Promise.resolve( successResult )
+      } );
+      mockGetHandle
+        .mockReturnValueOnce( { query: mockQuery } )
+        .mockReturnValue( { result: () => Promise.resolve( successResult ) } );
+
+      const temporalClient = ( await import( './temporal_client.js' ) ).default;
+      const client = await temporalClient.init();
+      await client.runWorkflow( 'old_name', {} );
+
+      expect( mockLoggerInfo ).toHaveBeenCalledWith( 'Workflow alias resolved', {
+        alias: 'old_name',
+        resolvedName: 'new_name',
+        taskQueue: 'test-queue'
+      } );
+    } );
+
     it( 'should throw non-WorkflowFailedError errors', async () => {
       const timeoutError = new WorkflowExecutionTimedOutError();
 
@@ -221,6 +245,30 @@ describe( 'temporal_client', () => {
       await expect( client.runWorkflow( 'test-workflow', { input: 'data' } ) )
         .rejects
         .toThrow( WorkflowExecutionTimedOutError );
+    } );
+  } );
+
+  describe( 'startWorkflow', () => {
+    it( 'should resolve alias to primary workflow name', async () => {
+      mockQuery.mockResolvedValue( {
+        workflows: [ { name: 'new_name', aliases: [ 'old_name' ] } ]
+      } );
+      mockStart.mockResolvedValue( {} );
+      mockGetHandle.mockReturnValue( { query: mockQuery } );
+
+      const temporalClient = ( await import( './temporal_client.js' ) ).default;
+      const client = await temporalClient.init();
+      const result = await client.startWorkflow( 'old_name', { input: 'data' } );
+
+      expect( result.workflowId ).toBe( 'test-uuid' );
+      expect( mockStart ).toHaveBeenCalledWith( 'new_name', expect.objectContaining( {
+        args: [ { input: 'data' } ]
+      } ) );
+      expect( mockLoggerInfo ).toHaveBeenCalledWith( 'Workflow alias resolved', {
+        alias: 'old_name',
+        resolvedName: 'new_name',
+        taskQueue: 'test-queue'
+      } );
     } );
   } );
 

--- a/docs/guides/workflows/index.mdx
+++ b/docs/guides/workflows/index.mdx
@@ -51,6 +51,7 @@ The `fn` function is your workflow logic. It calls steps in sequence, and each s
 | `outputSchema` | `ZodSchema` | Zod schema for output validation |
 | `fn` | `function` | The workflow implementation |
 | `options` | `object` | Optional workflow options (see [Options](#options)) |
+| `aliases` | `string[]` | Optional alternative names for backward-compatible renaming (see [Aliases](#aliases)) |
 
 ## Workflow Rules
 
@@ -213,6 +214,28 @@ export default workflow({
 ```
 
 This only has effect when tracing is enabled globally; if tracing is off, the flag does nothing.
+
+## Aliases
+
+When you rename a workflow, existing callers still reference the old name. Aliases let you declare alternative names that resolve to the canonical workflow, so you can rename without a coordinated multi-deploy process:
+
+```typescript workflow.ts
+export default workflow({
+  name: 'lead_enrichment_v2',
+  description: 'Enriches sales leads with company data',
+  aliases: [ 'lead_enrichment', 'enrich_lead' ],
+  inputSchema: LeadInput,
+  outputSchema: LeadOutput,
+  fn: async (input) => {
+    const company = await lookupCompany(input.domain);
+    return { summary: await generateSummary(company) };
+  },
+});
+```
+
+Callers using `lead_enrichment` or `enrich_lead` are resolved to `lead_enrichment_v2` before execution. The workflow runs under its canonical name, keeping execution history consistent.
+
+Alias names follow the same naming rules as workflow names (letters, numbers, underscores). Uniqueness is enforced case-insensitively at startup — an alias cannot conflict with any workflow name or another alias.
 
 ## Workflow Context
 

--- a/sdk/core/src/interface/validations/static.js
+++ b/sdk/core/src/interface/validations/static.js
@@ -64,6 +64,7 @@ const baseSchema = z.strictObject( {
 const stepSchema = baseSchema;
 
 const workflowSchema = baseSchema.extend( {
+  aliases: z.array( z.string().regex( /^[a-z_][a-z0-9_]*$/i ) ).optional().default( [] ),
   options: baseSchema.shape.options.unwrap().extend( {
     disableTrace: z.boolean().optional().default( false )
   } ).optional()

--- a/sdk/core/src/interface/validations/static.spec.js
+++ b/sdk/core/src/interface/validations/static.spec.js
@@ -189,6 +189,37 @@ describe( 'interface/validator', () => {
     it( 'rejects non-boolean options.disableTrace', () => {
       expect( () => validateWorkflow( { ...validArgs, options: { disableTrace: 'yes' } } ) ).toThrow( StaticValidationError );
     } );
+
+    it( 'passes with valid aliases array', () => {
+      expect( () => validateWorkflow( { ...validArgs, aliases: [ 'old_name', 'legacy_v1' ] } ) ).not.toThrow();
+    } );
+
+    it( 'passes with empty aliases array', () => {
+      expect( () => validateWorkflow( { ...validArgs, aliases: [] } ) ).not.toThrow();
+    } );
+
+    it( 'passes without aliases (optional)', () => {
+      expect( () => validateWorkflow( { ...validArgs } ) ).not.toThrow();
+    } );
+
+    it( 'rejects aliases with invalid name pattern', () => {
+      expect( () => validateWorkflow( { ...validArgs, aliases: [ '-bad' ] } ) ).toThrow( StaticValidationError );
+    } );
+
+    it( 'rejects non-array aliases', () => {
+      expect( () => validateWorkflow( { ...validArgs, aliases: 'not_array' } ) ).toThrow( StaticValidationError );
+    } );
+  } );
+
+  describe( 'aliases rejected on steps and evaluators', () => {
+    it( 'validateStep rejects aliases due to strictObject', () => {
+      expect( () => validateStep( { ...validArgs, aliases: [ 'alias' ] } ) ).toThrow( StaticValidationError );
+    } );
+
+    it( 'validateEvaluator rejects aliases due to strictObject', () => {
+      const { outputSchema, ...evalArgs } = validArgs;
+      expect( () => validateEvaluator( { ...evalArgs, aliases: [ 'alias' ] } ) ).toThrow( StaticValidationError );
+    } );
   } );
 
   describe( 'validateEvaluator', () => {

--- a/sdk/core/src/interface/workflow.d.ts
+++ b/sdk/core/src/interface/workflow.d.ts
@@ -270,4 +270,10 @@ export declare function workflow<
   outputSchema?: OutputSchema;
   fn: WorkflowFunction<InputSchema, OutputSchema>;
   options?: WorkflowOptions;
+
+  /**
+   * Alternative names that resolve to this workflow. Useful when renaming a workflow
+   * while maintaining backward compatibility with existing callers.
+   */
+  aliases?: string[];
 } ): WorkflowFunctionWrapper<WorkflowFunction<InputSchema, OutputSchema>>;

--- a/sdk/core/src/interface/workflow.js
+++ b/sdk/core/src/interface/workflow.js
@@ -22,8 +22,8 @@ const defaultOptions = {
   disableTrace: false
 };
 
-export function workflow( { name, description, inputSchema, outputSchema, fn, options = {} } ) {
-  validateWorkflow( { name, description, inputSchema, outputSchema, fn, options } );
+export function workflow( { name, description, inputSchema, outputSchema, fn, options = {}, aliases = [] } ) {
+  validateWorkflow( { name, description, inputSchema, outputSchema, fn, options, aliases } );
 
   const { disableTrace, activityOptions } = deepMerge( defaultOptions, options );
   const steps = proxyActivities( activityOptions );
@@ -123,6 +123,6 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
     }
   };
 
-  setMetadata( wrapper, { name, description, inputSchema, outputSchema } );
+  setMetadata( wrapper, { name, description, inputSchema, outputSchema, aliases } );
   return wrapper;
 };

--- a/sdk/core/src/interface/workflow.spec.js
+++ b/sdk/core/src/interface/workflow.spec.js
@@ -140,7 +140,7 @@ describe( 'workflow()', () => {
       const symbols = Object.getOwnPropertySymbols( wf );
       expect( symbols ).toHaveLength( 1 );
       const meta = wf[symbols[0]];
-      expect( meta ).toEqual( { name: 'meta_wf', description: 'Meta workflow', inputSchema, outputSchema } );
+      expect( meta ).toEqual( { name: 'meta_wf', description: 'Meta workflow', inputSchema, outputSchema, aliases: [] } );
     } );
   } );
 

--- a/sdk/core/src/worker/catalog_workflow/catalog.js
+++ b/sdk/core/src/worker/catalog_workflow/catalog.js
@@ -97,6 +97,11 @@ export class CatalogWorkflow extends CatalogEntry {
    * @type {Array<CatalogActivity>}
    */
   activities;
+  /**
+   * Alternative names that resolve to this workflow.
+   * @type {Array<string>}
+   */
+  aliases;
 
   /**
    * @param {Object} params - Entry parameters.
@@ -106,9 +111,11 @@ export class CatalogWorkflow extends CatalogEntry {
    * @param {object} [params.outputSchema] - JSON schema describing the produced output.
    * @param {string} params.path - Absolute path of the entity in the file system.
    * @param {Array<CatalogActivity>} params.activities - Each activity of this workflow
+   * @param {Array<string>} [params.aliases] - Alternative names for this workflow
    */
-  constructor( { activities, ...args } ) {
+  constructor( { activities, aliases = [], ...args } ) {
     super( args );
     this.activities = activities;
+    this.aliases = aliases;
   };
 };

--- a/sdk/core/src/worker/catalog_workflow/index.spec.js
+++ b/sdk/core/src/worker/catalog_workflow/index.spec.js
@@ -193,4 +193,27 @@ describe( 'createCatalog', () => {
     expect( workflows[0].path ).toBe( '/flows/flow1/workflow.js' );
     expect( workflows[1].path ).toBe( '/flows/flow2/workflow.js' );
   } );
+
+  it( 'includes aliases in catalog workflow entries', async () => {
+    const { createCatalog } = await import( './index.js' );
+
+    const workflows = [
+      {
+        name: 'flow1',
+        path: '/flows/flow1/workflow.js',
+        description: 'desc-flow1',
+        aliases: [ 'flow1_old', 'flow1_legacy' ]
+      },
+      {
+        name: 'flow2',
+        path: '/flows/flow2/workflow.js',
+        description: 'desc-flow2'
+      }
+    ];
+
+    const catalog = createCatalog( { workflows, activities: {} } );
+
+    expect( catalog.workflows[0].aliases ).toEqual( [ 'flow1_old', 'flow1_legacy' ] );
+    expect( catalog.workflows[1].aliases ).toEqual( [] );
+  } );
 } );

--- a/sdk/core/src/worker/interceptors/activity.js
+++ b/sdk/core/src/worker/interceptors/activity.js
@@ -39,15 +39,16 @@ export class ActivityExecutionInterceptor {
     const { workflowExecution: { workflowId }, activityId: id, activityType: name, workflowType: workflowName } = Context.current().info;
     const { executionContext } = headersToObject( input.headers );
     const { type: kind } = this.activities?.[name]?.[METADATA_ACCESS_SYMBOL];
+
+    messageBus.emit( BusEventType.ACTIVITY_START, { id, name, kind, workflowId, workflowName } );
+    Tracing.addEventStart( { id, name, kind, parentId: workflowId, details: input.args[0], executionContext } );
+
     const workflowEntry = this.workflowsMap.get( workflowName );
     if ( !workflowEntry ) {
       const availableWorkflows = [ ...this.workflowsMap.keys() ].join( ', ' );
       throw new Error( `Activity interceptor: workflow "${workflowName}" not found in workflowsMap. Available: [${availableWorkflows}]` );
     }
     const workflowFilename = workflowEntry.path;
-
-    messageBus.emit( BusEventType.ACTIVITY_START, { id, name, kind, workflowId, workflowName } );
-    Tracing.addEventStart( { id, name, kind, parentId: workflowId, details: input.args[0], executionContext } );
 
     const intervals = { heartbeat: null };
     try {

--- a/sdk/core/src/worker/interceptors/activity.js
+++ b/sdk/core/src/worker/interceptors/activity.js
@@ -39,7 +39,12 @@ export class ActivityExecutionInterceptor {
     const { workflowExecution: { workflowId }, activityId: id, activityType: name, workflowType: workflowName } = Context.current().info;
     const { executionContext } = headersToObject( input.headers );
     const { type: kind } = this.activities?.[name]?.[METADATA_ACCESS_SYMBOL];
-    const workflowFilename = this.workflowsMap.get( workflowName ).path;
+    const workflowEntry = this.workflowsMap.get( workflowName );
+    if ( !workflowEntry ) {
+      const availableWorkflows = [ ...this.workflowsMap.keys() ].join( ', ' );
+      throw new Error( `Activity interceptor: workflow "${workflowName}" not found in workflowsMap. Available: [${availableWorkflows}]` );
+    }
+    const workflowFilename = workflowEntry.path;
 
     messageBus.emit( BusEventType.ACTIVITY_START, { id, name, kind, workflowId, workflowName } );
     Tracing.addEventStart( { id, name, kind, parentId: workflowId, details: input.args[0], executionContext } );

--- a/sdk/core/src/worker/interceptors/activity.js
+++ b/sdk/core/src/worker/interceptors/activity.js
@@ -25,7 +25,13 @@ import { messageBus } from '#bus';
 export class ActivityExecutionInterceptor {
   constructor( { activities, workflows } ) {
     this.activities = activities;
-    this.workflowsMap = workflows.reduce( ( map, w ) => map.set( w.name, w ), new Map() );
+    this.workflowsMap = workflows.reduce( ( map, w ) => {
+      map.set( w.name, w );
+      for ( const alias of w.aliases ?? [] ) {
+        map.set( alias, w );
+      }
+      return map;
+    }, new Map() );
   };
 
   async execute( input, next ) {

--- a/sdk/core/src/worker/interceptors/activity.spec.js
+++ b/sdk/core/src/worker/interceptors/activity.spec.js
@@ -191,6 +191,29 @@ describe( 'ActivityExecutionInterceptor', () => {
     expect( heartbeatMock ).not.toHaveBeenCalled();
   } );
 
+  it( 'resolves workflow alias in workflowsMap', async () => {
+    const { ActivityExecutionInterceptor } = await import( './activity.js' );
+    const workflows = [ { name: 'myWorkflow', path: '/workflows/myWorkflow.js', aliases: [ 'myWorkflowOld' ] } ];
+    const interceptor = new ActivityExecutionInterceptor( { activities: makeActivities(), workflows } );
+
+    // Override context to use alias as workflowType
+    contextInfoMock.workflowType = 'myWorkflowOld';
+    const next = vi.fn().mockResolvedValue( { result: 'ok' } );
+
+    const promise = interceptor.execute( makeInput(), next );
+    vi.advanceTimersByTime( 0 );
+    await promise;
+
+    // Should resolve to the correct path despite using the alias
+    expect( runWithContextMock ).toHaveBeenCalledWith(
+      expect.any( Function ),
+      expect.objectContaining( { workflowFilename: '/workflows/myWorkflow.js' } )
+    );
+
+    // Restore for other tests
+    contextInfoMock.workflowType = 'myWorkflow';
+  } );
+
   it( 'does not heartbeat when OUTPUT_ACTIVITY_HEARTBEAT_ENABLED is false', async () => {
     vi.stubEnv( 'OUTPUT_ACTIVITY_HEARTBEAT_ENABLED', 'false' );
     const { ActivityExecutionInterceptor } = await import( './activity.js' );

--- a/sdk/core/src/worker/loader.js
+++ b/sdk/core/src/worker/loader.js
@@ -138,7 +138,7 @@ export async function loadHooks( rootDir ) {
  * @param {object[]} workflows
  * @throws {Error} If any alias conflicts with a workflow name or another alias
  */
-function validateAliasUniqueness( workflows ) {
+function validateWorkflowNames( workflows ) {
   const allNames = new Map();
 
   // Register primary names (case-insensitive to prevent confusing collisions)
@@ -151,15 +151,17 @@ function validateAliasUniqueness( workflows ) {
 
   // Check aliases against all names
   for ( const { name, aliases = [] } of workflows ) {
+    const lowerCaseName = name.toLowerCase();
     for ( const alias of aliases ) {
-      if ( alias.toLowerCase() === name.toLowerCase() ) {
+      const lowerAliasName = alias.toLowerCase();
+      if ( lowerAliasName === lowerCaseName ) {
         throw new Error( `Workflow "${name}" has an alias identical to its own name` );
       }
-      const conflict = allNames.get( alias.toLowerCase() );
+      const conflict = allNames.get( lowerAliasName );
       if ( conflict ) {
         throw new Error( `Alias "${alias}" on workflow "${name}" conflicts with ${conflict}` );
       }
-      allNames.set( alias.toLowerCase(), `alias "${alias}" on workflow "${name}"` );
+      allNames.set( lowerAliasName, `alias "${alias}" on workflow "${name}"` );
     }
   }
 }
@@ -171,7 +173,7 @@ function validateAliasUniqueness( workflows ) {
  * @returns
  */
 export function createWorkflowsEntryPoint( workflows ) {
-  validateAliasUniqueness( workflows );
+  validateWorkflowNames( workflows );
 
   const path = join( __dirname, 'temp', WORKFLOWS_INDEX_FILENAME );
 

--- a/sdk/core/src/worker/loader.js
+++ b/sdk/core/src/worker/loader.js
@@ -141,25 +141,25 @@ export async function loadHooks( rootDir ) {
 function validateAliasUniqueness( workflows ) {
   const allNames = new Map();
 
-  // Register primary names
+  // Register primary names (case-insensitive to prevent confusing collisions)
   for ( const { name } of workflows ) {
-    allNames.set( name, `workflow "${name}"` );
+    allNames.set( name.toLowerCase(), `workflow "${name}"` );
   }
 
   // Check the reserved catalog name
-  allNames.set( WORKFLOW_CATALOG, 'system workflow "$catalog"' );
+  allNames.set( WORKFLOW_CATALOG.toLowerCase(), 'system workflow "$catalog"' );
 
   // Check aliases against all names
   for ( const { name, aliases = [] } of workflows ) {
     for ( const alias of aliases ) {
-      if ( alias === name ) {
+      if ( alias.toLowerCase() === name.toLowerCase() ) {
         throw new Error( `Workflow "${name}" has an alias identical to its own name` );
       }
-      const conflict = allNames.get( alias );
+      const conflict = allNames.get( alias.toLowerCase() );
       if ( conflict ) {
         throw new Error( `Alias "${alias}" on workflow "${name}" conflicts with ${conflict}` );
       }
-      allNames.set( alias, `alias "${alias}" on workflow "${name}"` );
+      allNames.set( alias.toLowerCase(), `alias "${alias}" on workflow "${name}"` );
     }
   }
 }

--- a/sdk/core/src/worker/loader.js
+++ b/sdk/core/src/worker/loader.js
@@ -133,17 +133,54 @@ export async function loadHooks( rootDir ) {
 };
 
 /**
+ * Validates that all workflow names and aliases are unique across the project.
+ *
+ * @param {object[]} workflows
+ * @throws {Error} If any alias conflicts with a workflow name or another alias
+ */
+function validateAliasUniqueness( workflows ) {
+  const allNames = new Map();
+
+  // Register primary names
+  for ( const { name } of workflows ) {
+    allNames.set( name, `workflow "${name}"` );
+  }
+
+  // Check the reserved catalog name
+  allNames.set( WORKFLOW_CATALOG, 'system workflow "$catalog"' );
+
+  // Check aliases against all names
+  for ( const { name, aliases = [] } of workflows ) {
+    for ( const alias of aliases ) {
+      if ( alias === name ) {
+        throw new Error( `Workflow "${name}" has an alias identical to its own name` );
+      }
+      const conflict = allNames.get( alias );
+      if ( conflict ) {
+        throw new Error( `Alias "${alias}" on workflow "${name}" conflicts with ${conflict}` );
+      }
+      allNames.set( alias, `alias "${alias}" on workflow "${name}"` );
+    }
+  }
+}
+
+/**
  * Creates a temporary index file importing all workflows for Temporal.
  *
  * @param {object[]} workflows
  * @returns
  */
 export function createWorkflowsEntryPoint( workflows ) {
+  validateAliasUniqueness( workflows );
+
   const path = join( __dirname, 'temp', WORKFLOWS_INDEX_FILENAME );
 
   // default system catalog workflow
   const catalog = { name: WORKFLOW_CATALOG, path: join( __dirname, './catalog_workflow/workflow.js' ) };
-  const content = [ ... workflows, catalog ].map( ( { name, path } ) => `export { default as ${name} } from '${path}';` ).join( EOL );
+  const aliasExports = workflows.flatMap( ( { aliases = [], path } ) =>
+    aliases.map( alias => ( { name: alias, path } ) )
+  );
+  const content = [ ...workflows, ...aliasExports, catalog ].map( ( { name, path } ) => `export { default as ${name} } from '${path}';` ).join( EOL );
 
   mkdirSync( dirname( path ), { recursive: true } );
   writeFileSync( path, content, 'utf-8' );

--- a/sdk/core/src/worker/loader.spec.js
+++ b/sdk/core/src/worker/loader.spec.js
@@ -111,6 +111,45 @@ describe( 'worker/loader', () => {
     expect( fsMocks.mkdirSync ).toHaveBeenCalledTimes( 1 );
   } );
 
+  it( 'createWorkflowsEntryPoint generates alias exports', async () => {
+    const { createWorkflowsEntryPoint } = await import( './loader.js' );
+
+    const workflows = [ { name: 'W', path: '/abs/wf.js', aliases: [ 'W_old', 'W_legacy' ] } ];
+    createWorkflowsEntryPoint( workflows );
+
+    const [ , contents ] = fsMocks.writeFileSync.mock.calls[0];
+    expect( contents ).toContain( 'export { default as W } from \'/abs/wf.js\';' );
+    expect( contents ).toContain( 'export { default as W_old } from \'/abs/wf.js\';' );
+    expect( contents ).toContain( 'export { default as W_legacy } from \'/abs/wf.js\';' );
+  } );
+
+  it( 'createWorkflowsEntryPoint throws on alias conflicting with primary name', async () => {
+    const { createWorkflowsEntryPoint } = await import( './loader.js' );
+
+    const workflows = [
+      { name: 'alpha', path: '/a.js', aliases: [] },
+      { name: 'beta', path: '/b.js', aliases: [ 'alpha' ] }
+    ];
+    expect( () => createWorkflowsEntryPoint( workflows ) ).toThrow( /Alias "alpha" on workflow "beta" conflicts with workflow "alpha"/ );
+  } );
+
+  it( 'createWorkflowsEntryPoint throws on alias conflicting with another alias', async () => {
+    const { createWorkflowsEntryPoint } = await import( './loader.js' );
+
+    const workflows = [
+      { name: 'alpha', path: '/a.js', aliases: [ 'shared_alias' ] },
+      { name: 'beta', path: '/b.js', aliases: [ 'shared_alias' ] }
+    ];
+    expect( () => createWorkflowsEntryPoint( workflows ) ).toThrow( /Alias "shared_alias" on workflow "beta" conflicts with/ );
+  } );
+
+  it( 'createWorkflowsEntryPoint throws on alias identical to own name', async () => {
+    const { createWorkflowsEntryPoint } = await import( './loader.js' );
+
+    const workflows = [ { name: 'alpha', path: '/a.js', aliases: [ 'alpha' ] } ];
+    expect( () => createWorkflowsEntryPoint( workflows ) ).toThrow( /Workflow "alpha" has an alias identical to its own name/ );
+  } );
+
   it( 'loadActivities uses folder-based matchers for steps/evaluators and shared', async () => {
     const { loadActivities } = await import( './loader.js' );
     // First call (workflow dir): no results

--- a/sdk/core/src/worker/loader.spec.js
+++ b/sdk/core/src/worker/loader.spec.js
@@ -150,6 +150,26 @@ describe( 'worker/loader', () => {
     expect( () => createWorkflowsEntryPoint( workflows ) ).toThrow( /Workflow "alpha" has an alias identical to its own name/ );
   } );
 
+  it( 'createWorkflowsEntryPoint catches case-insensitive alias collision with primary name', async () => {
+    const { createWorkflowsEntryPoint } = await import( './loader.js' );
+
+    const workflows = [
+      { name: 'Alpha', path: '/a.js', aliases: [] },
+      { name: 'beta', path: '/b.js', aliases: [ 'alpha' ] }
+    ];
+    expect( () => createWorkflowsEntryPoint( workflows ) ).toThrow( /Alias "alpha" on workflow "beta" conflicts with workflow "Alpha"/ );
+  } );
+
+  it( 'createWorkflowsEntryPoint catches case-insensitive alias-to-alias collision', async () => {
+    const { createWorkflowsEntryPoint } = await import( './loader.js' );
+
+    const workflows = [
+      { name: 'alpha', path: '/a.js', aliases: [ 'Legacy' ] },
+      { name: 'beta', path: '/b.js', aliases: [ 'legacy' ] }
+    ];
+    expect( () => createWorkflowsEntryPoint( workflows ) ).toThrow( /Alias "legacy" on workflow "beta" conflicts with/ );
+  } );
+
   it( 'loadActivities uses folder-based matchers for steps/evaluators and shared', async () => {
     const { loadActivities } = await import( './loader.js' );
     // First call (workflow dir): no results

--- a/test_workflows/src/workflows/simple_alias/steps.spec.ts
+++ b/test_workflows/src/workflows/simple_alias/steps.spec.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { sumValues } from './steps.js';
+
+describe( 'simple_alias steps', () => {
+  it( 'should sum all received values', async () => {
+    const result = await sumValues( [ 10, 15, 20 ] );
+
+    expect( result ).toBe( 45 );
+  } );
+} );

--- a/test_workflows/src/workflows/simple_alias/steps.ts
+++ b/test_workflows/src/workflows/simple_alias/steps.ts
@@ -1,0 +1,16 @@
+import { step, z } from '@outputai/core';
+
+export const sumValues = step( {
+  name: 'sumValues',
+  description: 'Sum all values',
+  inputSchema: z.array( z.number() ),
+  outputSchema: z.number(),
+  fn: async numbers => numbers.reduce( ( v, n ) => v + n, 0 ),
+  options: {
+    activityOptions: {
+      retry: {
+        initialInterval: '5s'
+      }
+    }
+  }
+} );

--- a/test_workflows/src/workflows/simple_alias/tests/datasets/basic_input.yml
+++ b/test_workflows/src/workflows/simple_alias/tests/datasets/basic_input.yml
@@ -1,0 +1,14 @@
+name: basic_input
+input:
+  values:
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+last_output:
+  output:
+    result: 15
+    workflowId: test-cached
+  executionTimeMs: 100
+  date: '2026-02-13T00:00:00.000Z'

--- a/test_workflows/src/workflows/simple_alias/tests/evals/evaluators.ts
+++ b/test_workflows/src/workflows/simple_alias/tests/evals/evaluators.ts
@@ -1,0 +1,12 @@
+import { verify, Verdict } from '@outputai/evals';
+import { z } from '@outputai/core';
+
+export const evaluateSum = verify(
+  {
+    name: 'evaluate_sum',
+    input: z.object( { values: z.array( z.number() ) } ),
+    output: z.object( { result: z.number() } )
+  },
+  ( { input, output } ) =>
+    Verdict.equals( output.result, input.values.reduce( ( a, b ) => a + b, 0 ) )
+);

--- a/test_workflows/src/workflows/simple_alias/tests/evals/workflow.ts
+++ b/test_workflows/src/workflows/simple_alias/tests/evals/workflow.ts
@@ -1,0 +1,13 @@
+import { evalWorkflow } from '@outputai/evals';
+import { evaluateSum } from './evaluators.js';
+
+export default evalWorkflow( {
+  name: 'simple_alias_eval',
+  evals: [
+    {
+      evaluator: evaluateSum,
+      criticality: 'required',
+      interpret: { type: 'boolean' }
+    }
+  ]
+} );

--- a/test_workflows/src/workflows/simple_alias/workflow.spec.ts
+++ b/test_workflows/src/workflows/simple_alias/workflow.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { sumValues } from './steps.js';
+
+vi.mock( './steps.js', () => ( {
+  sumValues: vi.fn()
+} ) );
+
+import simpleAlias from './workflow.js';
+
+describe( 'simple_alias workflow', () => {
+  beforeEach( () => {
+    vi.clearAllMocks();
+  } );
+
+  it( 'should call sumValues step and return the sum result', async () => {
+    const sum = 45;
+    vi.mocked( sumValues ).mockResolvedValue( sum );
+
+    const context = {
+      info: {
+        workflowId: 'foo'
+      }
+    };
+    const input = { values: [ 10, 15, 20 ] };
+    const result = await simpleAlias( input, { context } );
+
+    expect( sumValues ).toHaveBeenCalledWith( input.values );
+    expect( sumValues ).toHaveBeenCalledTimes( 1 );
+    expect( result.workflowId ).toBe( 'foo' );
+    expect( result.result ).toBe( sum );
+  } );
+} );

--- a/test_workflows/src/workflows/simple_alias/workflow.ts
+++ b/test_workflows/src/workflows/simple_alias/workflow.ts
@@ -1,0 +1,27 @@
+import { workflow, z } from '@outputai/core';
+import { sumValues } from './steps.js';
+
+export default workflow( {
+  name: 'simple_alias',
+  description: 'Demonstrates workflow aliases for backward-compatible renaming',
+  aliases: [ 'simple_v1', 'simple_original' ],
+  inputSchema: z.object( {
+    values: z.array( z.number() )
+  } ),
+  outputSchema: z.object( {
+    result: z.number(),
+    workflowId: z.string()
+  } ),
+  fn: async ( input, context ) => {
+    const result = await sumValues( input.values );
+    return { result, workflowId: context.info.workflowId };
+  },
+  options: {
+    activityOptions: {
+      scheduleToCloseTimeout: '2m',
+      retry: {
+        maximumAttempts: 99
+      }
+    }
+  }
+} );


### PR DESCRIPTION
# Problem

I ran into an inconvenience earlier where I wanted to rename a workflow.  If there are callers to the workflow in the wild, you need a multi-step process coordinated across your project and the callers and must duplicate the workflow for a period to avoid errors.

# Solution

Allow workflows to declare alternative names via an `aliases` property, eliminating the 3-deploy rename process. Aliases are registered as additional Temporal workflow types and resolved to the canonical name by the API, keeping execution history consistent.