### PR TITLE
Pin template to the version of Output that generates it

### DIFF
--- a/.changeset/hungry-mails-fail.md
+++ b/.changeset/hungry-mails-fail.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+update package.json template to pin output to specific version, and not a range

--- a/sdk/cli/src/templates/project/package.json.template
+++ b/sdk/cli/src/templates/project/package.json.template
@@ -13,7 +13,7 @@
     "output:dev": "output dev"
   },
   "dependencies": {
-    "@outputai/output": "^{{frameworkVersion}}"
+    "@outputai/output": "{{frameworkVersion}}"
   },
   "devDependencies": {
     "@types/node": "24.5.2",


### PR DESCRIPTION
I was trying out dev release `0.1.12-next.76bcede.0` for QA reasons and hit issues running the worker and getting errors like this:

```
> somedemo@0.0.1 output:worker:build
> rm -rf dist/* && tsc -p ./ && output-copy-assets

sh: 1: output-copy-assets: not found
[nodemon] failed to start process, "npm run output:worker" exec not found
[nodemon] Error
```

The scaffolded project's package.json had `"@outputai/output": "^{{frameworkVersion}}"`. For stable releases this is fine(?), but for pre-release dev builds
(e.g., `^0.1.12-next.76bcede.0`) the caret range breaks because:

1. Semver orders pre-release identifiers lexicographically, not chronologically. Commit hash ecd4dda sorts higher than 76bcede even though it's an older
commit
2. npm resolves `^0.1.12-next.76bcede.0` to `0.1.12-next.ecd4dda.0` (the "highest" match), which is from an older commit that predates `output-copy-assets`
being added
3. As a result, `output-copy-assets` is not found in the worker container

Those issues are specific to the `0.1.12-next.76bcede.0` release I was testing, but it demonstrates the issue is possible for future dev releases since those are the ones that will likely contain new things. 

Overall though, I think the template is an implementation detail of the CLI, and the generated project should be pinned to the exact version of the CLI that created it. Version upgrades happen by upgrading the CLI itself, which then scaffolds new projects with the new version, and we have a `fix` command/flag in the works to handle fixing anything that breaks between CLI version updates. The `^` was fighting that design.