### PR TITLE
fix(changeset): prevent unintended v1.0.0 release

### DIFF
--- a/.changeset/plain-suns-decide.md
+++ b/.changeset/plain-suns-decide.md
@@ -1,6 +1,6 @@
 ---
-"@outputai/core": minor
-"output-api": minor
+"@outputai/core": patch
+"output-api": patch
 ---
 
 Add support for Workflow alias names


### PR DESCRIPTION
## Summary

- Downgrades the workflow aliases changeset (`plain-suns-decide.md`) from `minor` to `patch`

## Why

Changesets v3 treats a `minor` bump on `0.x` packages as a **major version graduation to `1.0.0`**. This caused the automated release PR (#106) to propose bumping all packages from `0.1.x` → `1.0.0`, which is not intentional.

By changing the bump type to `patch`, the next release will be `0.1.12` instead. When we're ready to graduate to v1, we should do so deliberately — not as a side effect of a changeset bump type.

## Test plan

- [ ] Verify the changesets release action regenerates PR #106 targeting `0.1.12`