### PR TITLE
feat(claude): enhance eval skills

### DIFF
--- a/coding_assistants/claude/plugins/outputai/.claude-plugin/plugin.json
+++ b/coding_assistants/claude/plugins/outputai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "outputai",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "Workflow development tools",
     "author": {
       "name": "Output.ai",

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-eval-testing/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-eval-testing/SKILL.md
@@ -154,6 +154,8 @@ All deterministic helpers return results with confidence `1.0`.
 
 ## LLM Judge Evaluators
 
+Before writing a judge prompt, identify the specific failure mode via error analysis (`output-eval-error-analysis`). Design the judge following `output-eval-judge-prompt`. After writing it, validate against human labels using `output-eval-validate-judge`.
+
 For subjective quality assessments, use judge functions with `.prompt` files:
 
 ```typescript
@@ -305,6 +307,8 @@ export default evalWorkflow({
 The eval workflow name **must** end in `_eval` and match the pattern `{workflow_name}_eval`. The CLI resolves this automatically — `output workflow test blog_generator` looks for `blog_generator_eval`.
 
 ## Dataset Files
+
+For methodology on designing diverse datasets that cover failure-prone regions, see `output-eval-dataset-design`.
 
 Datasets are YAML files in `tests/datasets/`. Each file represents one test case.
 
@@ -459,3 +463,8 @@ output workflow dataset list blog_generator
 - `output-dev-scenario-file` — Creating scenario JSON files for workflow execution
 - `output-dev-folder-structure` — Understanding project directory layout
 - `output-dev-prompt-file` — Creating `.prompt` files for LLM operations
+- `output-eval-error-analysis` — Identify failure modes before building evaluators
+- `output-eval-judge-prompt` — Design effective LLM judge prompts
+- `output-eval-dataset-design` — Generate diverse test datasets
+- `output-eval-validate-judge` — Validate LLM judges against human labels
+- `output-eval-audit` — Audit an existing eval suite for trustworthiness

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-evaluator-function/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-evaluator-function/SKILL.md
@@ -732,3 +732,4 @@ dimensions: [
 - `output-dev-types-file` - Defining evaluator input schemas
 - `output-dev-prompt-file` - Creating prompt files for LLM-powered evaluators
 - `output-dev-folder-structure` - Understanding project layout
+- `output-eval-error-analysis` — Identify what to evaluate before writing evaluators

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
@@ -524,3 +524,4 @@ Requirements:
 - `output-dev-evaluator-function` - Using prompts in evaluators
 - `output-dev-folder-structure` - Understanding prompts folder location
 - `output-dev-workflow-function` - Orchestrating LLM-powered steps
+- `output-eval-judge-prompt` — Methodology for designing effective LLM judge prompts

--- a/coding_assistants/claude/plugins/outputai/skills/output-eval-audit/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-eval-audit/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: output-eval-audit
+description: Audit an existing eval suite for trustworthiness. Use when inheriting evals, suspecting evals miss real failures, or after significant pipeline changes.
+allowed-tools: [Bash, Read]
+---
+
+# Auditing an Eval Suite
+
+## Overview
+
+Audit your eval suite to determine whether it actually catches real failures. This skill provides a structured diagnostic that identifies gaps in error analysis, evaluator design, judge validation, and dataset coverage, with concrete remediation steps for each finding.
+
+## When to Use
+
+- Inheriting an eval suite from another team or developer
+- Suspecting that evals pass but production quality is poor
+- After switching models, rewriting prompts, or changing pipeline logic
+- Periodic health check (quarterly or after major releases)
+
+## Step 1: Gather Artifacts
+
+Read the eval infrastructure files for the workflow being audited:
+
+```
+src/workflows/<workflow_name>/
+├── tests/
+│   ├── datasets/           # YAML dataset files
+│   │   ├── *.yml
+│   │   └── ...
+│   └── evals/
+│       ├── evaluators.ts   # Evaluator definitions
+│       ├── workflow.ts      # Eval workflow definition
+│       └── *.prompt         # Judge prompt files
+```
+
+Inventory what exists:
+
+| Artifact | File(s) | Count |
+|----------|---------|-------|
+| Evaluators | `tests/evals/evaluators.ts` | ? |
+| Eval workflow | `tests/evals/workflow.ts` | ? entries in `evals` array |
+| Judge prompts | `tests/evals/*.prompt` | ? |
+| Datasets | `tests/datasets/*.yml` | ? |
+| Datasets with ground_truth | ? of above | ? |
+| Datasets with last_output | ? of above | ? |
+
+If any of these are missing entirely, note it and skip to "Starting From Zero" at the bottom.
+
+## Step 2: Run the Diagnostic
+
+Evaluate each of the four areas below. For each, assign a status:
+
+- **Pass** — Meets the standard
+- **Warn** — Partially meets the standard, improvements needed
+- **Fail** — Does not meet the standard, significant risk
+
+---
+
+### Area 1: Error Analysis Grounding
+
+**Question:** Were the evaluators derived from observed failure modes in real workflow traces?
+
+**Check:**
+- Do failure categories exist (documented in a file, comments, or commit history)?
+- Does each evaluator map to a specific failure category?
+- Or are evaluators measuring generic qualities ("quality score", "overall rating")?
+
+**Pass criteria:**
+- Each evaluator targets a named failure mode (e.g., "check_tone" targets tone mismatch, not "evaluate general quality")
+- Failure categories were derived from reviewing real traces (not brainstormed)
+
+**Common failures:**
+- Evaluators named `evaluate_quality`, `check_overall`, `rate_output` — generic, not grounded in observed failures
+- Evaluators were written based on what seemed important, not what actually fails
+- No evidence of trace review before evaluator creation
+
+**Remediation:** `output-eval-error-analysis` — Review 50+ traces and categorize actual failure modes before modifying evaluators
+
+---
+
+### Area 2: Evaluator Design
+
+**Question:** Are the evaluators well-designed for reliable automated evaluation?
+
+**Check each evaluator in `tests/evals/evaluators.ts`:**
+
+| Check | What to look for |
+|-------|------------------|
+| One failure mode per judge | Each `judgeVerdict()` evaluator targets exactly one criterion |
+| Binary verdicts | Judge prompts use pass/fail, not Likert scales (1-5) or multi-axis ratings |
+| Code-based where possible | Objective checks use `Verdict.*` helpers, not LLM judges |
+| Few-shot examples in judges | Judge `.prompt` files include pass, fail, and borderline examples |
+| Critique before verdict | Judge prompts request critique/reasoning before the verdict in structured output |
+| Appropriate criticality | `required` for blocking failures, `informational` for nice-to-have checks |
+| Correct interpret type | `interpret` config matches what the evaluator returns |
+
+**Pass criteria:**
+- All checks above are met for every evaluator
+
+**Common failures:**
+- A single judge prompt evaluates 3+ criteria simultaneously ("Rate tone, accuracy, and completeness")
+- Judge prompts have no few-shot examples
+- Deterministic checks (length, string contains, regex) use LLM judges instead of `Verdict.*`
+- `interpret` type doesn't match evaluator return type (e.g., `judgeVerdict()` with `interpret: { type: 'boolean' }`)
+
+**Remediation:** `output-eval-judge-prompt` — Redesign judge prompts following the four-component structure
+
+---
+
+### Area 3: Judge Validation
+
+**Question:** Have LLM judges been validated against human labels?
+
+**Check for each LLM-based evaluator (those using `judgeVerdict()`, `judgeScore()`, `judgeLabel()`):**
+
+| Check | What to look for |
+|-------|------------------|
+| Human labels exist | Datasets have `ground_truth.evals.<evaluator_name>.verdict` populated |
+| TPR/TNR measured | Validation results documented (file, comment, or commit) |
+| Train/dev/test split | Few-shot examples in the judge prompt come from a designated train split, not from the same data used for measurement |
+| Metrics meet threshold | TPR > 80% and TNR > 80% (target: > 90%) |
+
+**Pass criteria:**
+- Every LLM judge has documented TPR/TNR metrics above 80%
+- Train/dev/test split was used (no data leakage)
+
+**Common failures:**
+- No validation at all — judges were written and immediately deployed
+- Few-shot examples in the judge prompt are the same examples used to measure metrics (data leakage)
+- "It seems to work" without quantitative measurement
+- Only raw accuracy reported (masks class imbalance)
+
+**Remediation:** `output-eval-validate-judge` — Calibrate each judge against human labels using TPR/TNR
+
+---
+
+### Area 4: Dataset Coverage
+
+**Question:** Do the datasets adequately cover the failure space?
+
+**Check:**
+
+| Check | What to look for |
+|-------|------------------|
+| Dataset count | Minimum 10 for simple workflows, 20+ for complex ones |
+| Diversity | Datasets vary across multiple input dimensions, not just happy paths |
+| Failure representation | At least 30% of datasets have `human_verdict: fail` in ground_truth |
+| Ground truth populated | Most datasets have `ground_truth` with per-evaluator labels |
+| Real + synthetic mix | Includes production traces alongside synthetic test cases |
+| No near-duplicates | Each dataset tests a meaningfully different scenario |
+
+**Pass criteria:**
+- 20+ diverse datasets with ground truth
+- Both pass and fail cases represented (not 95% passes)
+- Datasets cover different input dimensions
+
+**Common failures:**
+- Only 3-5 datasets, all happy-path variations
+- 100% of datasets pass (no failure cases to validate judges against)
+- Datasets are synthetic-only with no real production traces
+- Ground truth fields are empty or missing
+
+**Remediation:** `output-eval-dataset-design` — Design diverse datasets using dimension-based variation
+
+---
+
+## Step 3: Compile the Report
+
+Summarize findings in a structured format:
+
+```markdown
+# Eval Audit: <workflow_name>
+# Date: YYYY-MM-DD
+# Auditor: <name>
+
+## Summary
+
+| Area | Status | Key Finding |
+|------|--------|-------------|
+| Error Analysis Grounding | Warn | Evaluators seem reasonable but no documented trace review |
+| Evaluator Design | Fail | Single judge evaluates 3 criteria simultaneously |
+| Judge Validation | Fail | No validation performed on any LLM judge |
+| Dataset Coverage | Warn | 12 datasets but only 2 are failure cases |
+
+## Findings
+
+### 1. Error Analysis Grounding — WARN
+Evaluators target reasonable criteria (tone, topic, length) but there is no evidence
+that these were derived from observed failures. The eval suite may be missing the
+workflow's actual top failure modes.
+
+**Next step:** Run error analysis on 50+ production traces (`output-eval-error-analysis`)
+
+### 2. Evaluator Design — FAIL
+`evaluate_overall_quality` in evaluators.ts uses a single judgeVerdict() call that
+assesses tone, accuracy, and completeness simultaneously. This makes failures
+unactionable — when it fails, you don't know which criterion failed.
+
+**Next step:** Split into three focused judges (`output-eval-judge-prompt`)
+
+### 3. Judge Validation — FAIL
+No TPR/TNR metrics exist for any LLM judge. The judge_quality@v1.prompt has no
+few-shot examples.
+
+**Next step:** Label 100 datasets, validate each judge (`output-eval-validate-judge`)
+
+### 4. Dataset Coverage — WARN
+12 datasets exist with cached output. Only 2 have ground_truth.human_verdict: fail.
+All inputs are simple topics with no edge cases.
+
+**Next step:** Design 20+ diverse datasets (`output-eval-dataset-design`)
+
+## Priority Order
+1. Error analysis (foundational — may change which evaluators are needed)
+2. Split holistic judge into focused judges
+3. Expand datasets to 30+ with balanced pass/fail
+4. Validate all LLM judges
+```
+
+## Starting From Zero
+
+If the workflow has no eval infrastructure at all:
+
+1. **Start with error analysis** — `output-eval-error-analysis`. Review 50+ workflow traces.
+2. **Build datasets** — `output-eval-dataset-design`. Create 20+ diverse datasets.
+3. **Implement evaluators** — `output-dev-eval-testing`. Write `verify()` evaluators and `evalWorkflow()`.
+4. **Design judge prompts** — `output-eval-judge-prompt`. For subjective criteria only.
+5. **Validate judges** — `output-eval-validate-judge`. Before trusting any LLM judge.
+
+Do not skip error analysis. Building evaluators without understanding how the workflow fails wastes effort on the wrong things.
+
+## Related Skills
+
+- `output-eval-error-analysis` — Systematic trace review and failure categorization
+- `output-eval-judge-prompt` — Design effective LLM judge prompts
+- `output-eval-dataset-design` — Generate diverse test datasets
+- `output-eval-validate-judge` — Calibrate LLM judges against human labels
+- `output-dev-eval-testing` — Implementation reference for offline eval testing
+- `output-dev-evaluator-function` — Implementation reference for runtime evaluators

--- a/coding_assistants/claude/plugins/outputai/skills/output-eval-dataset-design/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-eval-dataset-design/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: output-eval-dataset-design
+description: Design diverse eval datasets using dimension-based variation. Use when bootstrapping eval datasets, when real traces are sparse, or when existing datasets miss edge cases.
+allowed-tools: [Bash, Read, Write, Edit]
+---
+
+# Designing Eval Datasets
+
+## Overview
+
+Diverse datasets catch more failures. This skill teaches dimension-based dataset design — systematically varying inputs along axes that target failure-prone regions of your workflow. The output is a set of YAML dataset files ready for `output workflow test`.
+
+## When to Use
+
+- Bootstrapping an eval dataset for a new workflow
+- Existing datasets only cover happy paths
+- Real production traces are sparse (fewer than 50)
+- Stress-testing specific failure hypotheses from error analysis
+
+## When NOT to Use
+
+- You already have 100+ representative real traces — use stratified sampling from those instead of generating synthetic data
+- You haven't done error analysis yet — do that first (`output-eval-error-analysis`) so your dimensions target real failure modes, not guesses
+
+## Step 1: Define Dimensions
+
+Identify 3+ axes of input variation that target **anticipated failure modes**. Each dimension should vary one aspect of the input that you expect to influence output quality.
+
+### Deriving dimensions from error analysis
+
+Map failure categories to input properties that trigger them:
+
+| Failure Category | Triggering Input Property | Dimension |
+|-----------------|---------------------------|-----------|
+| Off-topic drift | Ambiguous or broad topics | Topic specificity: specific / broad / ambiguous |
+| Tone mismatch | Conflicting tone signals | Tone difficulty: simple / nuanced / contradictory |
+| Too short | Short or vague input | Input detail: minimal / moderate / comprehensive |
+| Missing sections | Many explicit requirements | Requirement count: 0 / 1-2 / 5+ |
+| Hallucinated URLs | Technical topics with real entities | Entity density: none / few / many |
+
+### Example dimensions for a blog generation workflow
+
+| Dimension | Values | Why |
+|-----------|--------|-----|
+| Topic complexity | simple, technical, ambiguous | Technical and ambiguous topics trigger more hallucination and drift |
+| Tone request | none, formal, casual, contradictory | Explicit tone requests reveal tone-matching failures |
+| Length constraint | none, short (100w), long (1000w) | Extreme length constraints trigger truncation and padding |
+| Required sections | none, 1 section, 3+ sections | Multiple required sections stress structural compliance |
+
+Aim for 3-5 dimensions. More than 5 creates an unmanageable combinatorial space.
+
+## Step 2: Draft Tuples
+
+Create ~20 combinations of dimension values. Cover the extremes and the combinations most likely to cause failures.
+
+### Tuple selection strategy
+
+1. **Cover every dimension value at least twice** — ensures no blind spots
+2. **Pair difficult values together** — "ambiguous topic + contradictory tone + 3+ required sections" is where failures cluster
+3. **Include a few easy combinations** — confirms the workflow works under normal conditions
+4. **Avoid near-duplicates** — each tuple should test a distinct scenario
+
+### Example tuples
+
+| # | Topic Complexity | Tone | Length | Required Sections |
+|---|-----------------|------|--------|-------------------|
+| 1 | simple | none | none | none |
+| 2 | simple | formal | short | 1 section |
+| 3 | technical | formal | long | 3+ sections |
+| 4 | technical | casual | short | none |
+| 5 | ambiguous | formal | long | 1 section |
+| 6 | ambiguous | contradictory | none | 3+ sections |
+| 7 | simple | contradictory | long | none |
+| 8 | technical | none | none | 3+ sections |
+| 9 | ambiguous | casual | short | 1 section |
+| 10 | simple | casual | long | 3+ sections |
+| 11 | technical | formal | short | 1 section |
+| 12 | ambiguous | none | long | none |
+| 13 | simple | formal | none | 3+ sections |
+| 14 | technical | contradictory | long | 1 section |
+| 15 | ambiguous | formal | short | 3+ sections |
+| 16 | simple | none | short | 1 section |
+| 17 | technical | casual | long | 3+ sections |
+| 18 | ambiguous | contradictory | short | none |
+| 19 | technical | formal | none | none |
+| 20 | ambiguous | casual | long | 3+ sections |
+
+Review each tuple and ask: "Is this a realistic scenario a user might create?" Discard any that aren't.
+
+## Step 3: Convert Tuples to Workflow Inputs
+
+Transform each tuple into a JSON object matching the workflow's `inputSchema` from `types.ts`.
+
+### Read the schema first
+
+```bash
+# Find the input schema
+cat src/workflows/<workflow_name>/types.ts
+```
+
+### Manual conversion (small datasets)
+
+For each tuple, write the corresponding JSON input:
+
+**Tuple 3:** technical + formal + long + 3+ sections
+
+```json
+{
+  "topic": "Quantum error correction techniques in superconducting qubit architectures",
+  "tone": "formal",
+  "min_length": 1000,
+  "required_sections": ["Introduction", "Technical Background", "Current Approaches", "Challenges", "Conclusion"]
+}
+```
+
+**Tuple 6:** ambiguous + contradictory + none + 3+ sections
+
+```json
+{
+  "topic": "Things that matter",
+  "tone": "Write in a formal academic style but keep it super casual and fun",
+  "required_sections": ["Overview", "Deep Dive", "Takeaways"]
+}
+```
+
+Use realistic, natural-sounding inputs. Avoid test-looking data like "Test topic 1" or "Lorem ipsum."
+
+### LLM-assisted conversion (larger datasets)
+
+For 20+ tuples, use an LLM to batch-convert tuples into realistic inputs. Create a prompt that takes the tuple values and the `inputSchema`, then generates a natural JSON input. Review every generated input for realism before using it.
+
+## Step 4: Generate Dataset Files
+
+Run each input through the workflow to capture real output:
+
+```bash
+# Generate datasets one at a time
+npx output workflow dataset generate blog_generator \
+  --input '{"topic": "Quantum error correction", "tone": "formal", "min_length": 1000}' \
+  --name technical_formal_long
+
+npx output workflow dataset generate blog_generator \
+  --input '{"topic": "Things that matter", "tone": "Write formally but keep it casual"}' \
+  --name ambiguous_contradictory
+```
+
+Each command creates a YAML file in `tests/datasets/` with `input` and `last_output` populated.
+
+### Naming convention
+
+Use names that encode the key dimensions:
+
+```
+tests/datasets/
+├── simple_no_constraints.yml
+├── simple_formal_short.yml
+├── technical_formal_long_sections.yml
+├── technical_casual_short.yml
+├── ambiguous_formal_long.yml
+├── ambiguous_contradictory_sections.yml
+└── ...
+```
+
+### Batch generation
+
+For many datasets, create a shell script:
+
+```bash
+#!/bin/bash
+# generate_datasets.sh
+
+inputs=(
+  '{"topic": "Solar panels", "tone": "formal"}|simple_formal'
+  '{"topic": "Quantum error correction in superconducting qubits", "tone": "casual", "min_length": 1000}|technical_casual_long'
+  '{"topic": "Things that matter", "required_sections": ["Overview", "Dive", "Takeaways"]}|ambiguous_sections'
+)
+
+for entry in "${inputs[@]}"; do
+  IFS='|' read -r input name <<< "$entry"
+  echo "Generating: $name"
+  npx output workflow dataset generate blog_generator --input "$input" --name "$name"
+done
+```
+
+## Step 5: Add Ground Truth
+
+After generation, edit each dataset YAML to add `ground_truth` labels. Review the `last_output` and assign verdicts per evaluator.
+
+```yaml
+name: ambiguous_contradictory_sections
+input:
+  topic: "Things that matter"
+  tone: "Write in a formal academic style but keep it super casual and fun"
+  required_sections: ["Overview", "Deep Dive", "Takeaways"]
+last_output:
+  output:
+    title: "Things That Matter: A Casual Academic Exploration"
+    blog_post: "So here's the thing about stuff that matters..."
+  executionTimeMs: 4200
+  date: '2026-03-25T00:00:00.000Z'
+ground_truth:
+  human_verdict: fail
+  notes: "Contradictory tone caused drift; missing 'Deep Dive' section"
+  evals:
+    check_tone:
+      expected_tone: "formal academic style"
+      verdict: fail
+    check_topic:
+      required_topic: "Things that matter"
+      verdict: partial
+    check_sections:
+      required_sections: ["Overview", "Deep Dive", "Takeaways"]
+      verdict: fail
+    check_length:
+      min_length: 100
+      verdict: pass
+```
+
+### Labeling tips
+
+- Label the **global `human_verdict`** for every dataset (pass/fail)
+- Label the **top 3 evaluators** by failure rate first
+- For borderline cases, decide and commit — don't leave ambiguous labels
+- Record `notes` explaining your reasoning for future reference
+
+## Step 6: Supplement with Real Data
+
+If you have production traces available, use them to fill coverage gaps.
+
+```bash
+# Download production traces
+npx output workflow dataset generate blog_generator --download --limit 30
+```
+
+### Stratified sampling
+
+After downloading, check which dimensions are underrepresented:
+
+1. Review the downloaded datasets
+2. Tag each with its approximate dimension values
+3. Identify gaps (e.g., no ambiguous topics, no contradictory tones)
+4. Generate synthetic datasets specifically for the missing combinations
+
+### Mixing real and synthetic
+
+A good eval dataset combines both:
+- **Real traces** (60-70%) — capture authentic user behavior and edge cases you didn't anticipate
+- **Synthetic traces** (30-40%) — fill coverage gaps and stress-test specific failure regions
+
+## Step 7: Quality Filter
+
+Review every dataset before using it in evals.
+
+### Discard datasets where
+
+- The input is unrealistic or test-looking
+- The input is nearly identical to another dataset (redundant)
+- The workflow errored out entirely (test infrastructure issues, not quality issues)
+- The ground truth labels are ambiguous or contested
+
+### Target dataset count
+
+| Workflow Complexity | Minimum Datasets | Target |
+|--------------------|-----------------|--------|
+| Simple (1-2 steps, narrow input) | 10 | 20 |
+| Medium (3-5 steps, moderate variation) | 20 | 40 |
+| Complex (5+ steps, wide input space) | 40 | 80+ |
+
+More datasets improve eval reliability. Aim for at least 5 datasets per failure category to get meaningful failure rates.
+
+## Verification
+
+```bash
+# List all datasets
+npx output workflow dataset list blog_generator
+
+# Run evals on all datasets with cached output
+npx output workflow test blog_generator --cached
+
+# Run evals on a subset
+npx output workflow test blog_generator --cached --dataset technical_formal_long,ambiguous_contradictory
+```
+
+Check that:
+- [ ] All datasets load without errors
+- [ ] Dataset names are descriptive and encode key dimensions
+- [ ] Every dataset has a `human_verdict` in `ground_truth`
+- [ ] The top 3 evaluators have per-evaluator ground truth in most datasets
+- [ ] Datasets cover all dimension values from your tuple table
+- [ ] No two datasets are near-duplicates
+- [ ] Mix of real and synthetic traces (if production data is available)
+
+## Related Skills
+
+- `output-eval-error-analysis` — Identify failure modes that inform dimension selection
+- `output-dev-eval-testing` — Dataset YAML format, CLI commands, `evalWorkflow()` setup
+- `output-dev-scenario-file` — Scenario JSON files as seed inputs for dataset generation
+- `output-eval-validate-judge` — Split datasets into train/dev/test for judge validation
+- `output-eval-judge-prompt` — Design LLM judge prompts that consume these datasets

--- a/coding_assistants/claude/plugins/outputai/skills/output-eval-error-analysis/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-eval-error-analysis/SKILL.md
@@ -1,0 +1,259 @@
+---
+name: output-eval-error-analysis
+description: Systematically review workflow traces to identify failure modes before building evaluators. Use when starting an eval project, after significant pipeline changes, or when production quality drops.
+allowed-tools: [Bash, Read, Write, Edit]
+---
+
+# Error Analysis for Workflow Evaluation
+
+## Overview
+
+Review real workflow traces and categorize how your workflow fails **before** writing any evaluators. Evaluators built without error analysis target generic qualities ("is this good?") instead of the specific ways your workflow actually breaks. This skill walks you through the process.
+
+## When to Use
+
+- Starting a new eval project for an existing workflow
+- Production quality has dropped and you need to understand why
+- After significant prompt, model, or pipeline changes
+- Before building your first evaluator for a workflow
+
+## Step 1: Collect Traces
+
+Gather 50-100 representative workflow executions. More traces = more reliable failure categories.
+
+### From recent runs
+
+List recent workflow executions and pull their traces:
+
+```bash
+# List recent runs for a workflow
+npx output workflow runs list <workflowName>
+
+# Pull a specific trace as JSON
+npx output workflow debug <workflowId> --format json
+```
+
+### From production (bulk download)
+
+Download production traces directly into dataset YAML files:
+
+```bash
+# Download up to 20 recent traces as dataset files
+npx output workflow dataset generate <workflowName> --download --limit 20
+```
+
+This creates YAML files in `tests/datasets/` with the `input` and `last_output` fields populated from real executions.
+
+### From scenario-driven generation
+
+If production traces are sparse, generate traces from scenario inputs:
+
+```bash
+# Generate a dataset from a scenario file
+npx output workflow dataset generate <workflowName> basic --name basic_trace
+
+# Generate from inline JSON
+npx output workflow dataset generate <workflowName> --input '{"topic": "AI safety"}' --name ai_safety_trace
+```
+
+Run enough inputs to get 50+ traces. Prioritize diversity over volume — vary inputs across the dimensions you expect to matter.
+
+## Step 2: Review Traces Individually
+
+Review each trace one at a time. For each trace, record:
+
+| Field | What to write |
+|-------|---------------|
+| **Trace ID** | The workflow execution ID |
+| **Verdict** | Pass or Fail (binary — no "partial" at this stage) |
+| **Root cause** | If Fail: what specifically went wrong and why |
+| **Notes** | Anything surprising or worth remembering |
+
+### Review template
+
+Create a file to track your reviews. A simple markdown table works:
+
+```markdown
+# Error Analysis: <workflow_name>
+# Date: YYYY-MM-DD
+# Traces reviewed: 0 / 50
+
+| # | Trace ID | Verdict | Root Cause | Notes |
+|---|----------|---------|------------|-------|
+| 1 | abc-123  | Fail    | Hallucinated a URL that doesn't exist | Common with technical topics |
+| 2 | def-456  | Pass    | — | Clean output |
+| 3 | ghi-789  | Fail    | Ignored the "formal tone" requirement | Input had conflicting signals |
+```
+
+### What to look for in each trace
+
+Open the JSON trace and examine:
+
+1. **Final output** — Does it meet the user's intent? Is it correct?
+2. **Step-by-step data flow** — Did each step receive the right input and produce reasonable output?
+3. **LLM responses** — Did the model follow instructions? Did it hallucinate?
+4. **Error states** — Did any step fail, retry, or produce unexpected errors?
+
+### Critical rule: read first, categorize second
+
+Review at least 30 traces before naming any failure categories. Premature categorization causes you to see patterns that aren't there and miss patterns that are. Just record what you observe.
+
+## Step 3: Group Into Failure Categories
+
+After reviewing 30+ traces, patterns will emerge. Group your failures into 5-10 categories based on **root cause**, not surface symptoms.
+
+### Good categories (root cause)
+
+- "Hallucinated URLs" — model invents links that don't exist
+- "Tone mismatch" — output tone doesn't match the requested persona
+- "Missing required section" — output omits a section the input explicitly requested
+- "Factual error" — output contains verifiably wrong claims
+- "Prompt injection leak" — user input manipulates the system prompt
+
+### Bad categories (surface symptoms)
+
+- "Bad output" — too vague, not actionable
+- "LLM error" — doesn't identify the specific failure
+- "Quality issue" — could mean anything
+
+### Splitting and merging
+
+- If a category has fewer than 3 examples, merge it into a broader category or note it as rare
+- If a category has 15+ examples and contains distinct sub-patterns, split it
+- Categories should be **mutually exclusive** — each failure belongs to exactly one category
+
+### Example categorization
+
+For a blog generation workflow after reviewing 60 traces:
+
+| Category | Count | Rate | Example |
+|----------|-------|------|---------|
+| Hallucinated URLs | 8 | 13% | Invented links to non-existent pages |
+| Tone mismatch | 6 | 10% | Casual tone when formal was requested |
+| Off-topic drift | 5 | 8% | Blog about "AI" drifted to unrelated ML history |
+| Missing sections | 4 | 7% | Skipped "conclusion" when explicitly requested |
+| Too short | 3 | 5% | Under 200 words when 500+ requested |
+| **Total failures** | **26** | **43%** | |
+| **Passes** | **34** | **57%** | |
+
+## Step 4: Label Datasets
+
+Add `ground_truth` labels to your dataset YAML files so evaluators can validate against them. Each failure category maps to a future evaluator name.
+
+### YAML structure
+
+```yaml
+name: ai_safety_trace
+input:
+  topic: "AI safety"
+  tone: "formal"
+  min_length: 500
+last_output:
+  output:
+    title: "Understanding AI Safety"
+    blog_post: "AI safety is super important and stuff..."
+  executionTimeMs: 3200
+  date: '2026-03-25T00:00:00.000Z'
+ground_truth:
+  # Global ground truth (available to all evaluators)
+  human_verdict: fail
+  failure_categories:
+    - tone_mismatch
+  notes: "Used casual language despite formal tone request"
+  # Per-evaluator ground truth
+  evals:
+    check_tone:
+      expected_tone: formal
+      verdict: fail
+    check_length:
+      min_length: 500
+      verdict: pass
+    check_hallucinated_urls:
+      verdict: pass
+```
+
+The `ground_truth.evals.<evaluator_name>` fields map directly to the evaluator names you'll use in `verify()`. Each evaluator receives its own ground truth merged with the top-level ground truth via `context.ground_truth`.
+
+### Labeling efficiently
+
+You don't need to label every dataset for every category. Focus on:
+
+1. Label **all** datasets with the global `human_verdict` (pass/fail)
+2. Label datasets for the **top 3 failure categories** by rate
+3. Add per-evaluator labels as you build each evaluator
+
+## Step 5: Decide What to Fix vs. Evaluate
+
+Not every failure category needs an evaluator. Use this decision tree:
+
+```
+Is this failure caused by a fixable prompt/tool gap?
+├─ YES → Fix the prompt or add the missing tool first
+│        Re-run error analysis after the fix
+└─ NO  → Will this failure recur and need ongoing monitoring?
+         ├─ YES → Build an evaluator
+         │        Can it be checked with deterministic code?
+         │        ├─ YES → Use Verdict.* helpers (contains, matches, gte, etc.)
+         │        └─ NO  → Use judgeVerdict() with an LLM judge prompt
+         └─ NO  → Document it and move on (rare edge case)
+```
+
+### Prioritize by failure rate
+
+Build evaluators for the highest-rate failure categories first. A failure at 13% matters more than one at 2%.
+
+### Code-based checks first
+
+Many failures that seem subjective have objective proxies:
+
+| Failure | Seems like... | But you can check with... |
+|---------|---------------|---------------------------|
+| "Too short" | Subjective | `Verdict.gte(output.length, threshold)` |
+| "Missing section" | Needs LLM | `Verdict.contains(output, "## Conclusion")` |
+| "Hallucinated URLs" | Needs LLM | Extract URLs with regex, verify with HTTP HEAD |
+| "Wrong format" | Needs LLM | `Verdict.matches(output, expectedPattern)` |
+
+Reserve LLM judges for genuinely subjective criteria: tone, relevance, faithfulness, coherence.
+
+## Step 6: Map Categories to Evaluators
+
+Create a mapping document that connects your failure categories to planned evaluators:
+
+```markdown
+# Evaluator Plan: blog_generator
+
+| Category | Rate | Evaluator Type | Evaluator Name | Criticality |
+|----------|------|----------------|----------------|-------------|
+| Hallucinated URLs | 13% | Code (URL extraction + HTTP check) | check_urls | required |
+| Tone mismatch | 10% | LLM judge | check_tone | required |
+| Off-topic drift | 8% | LLM judge | check_topic | required |
+| Missing sections | 7% | Code (string contains) | check_sections | required |
+| Too short | 5% | Code (length check) | check_length | informational |
+```
+
+This becomes your implementation roadmap. Use `criticality: 'required'` for failure categories that should block a passing verdict. Use `'informational'` for nice-to-have checks.
+
+## Next Steps
+
+- **Build evaluators** — Follow `output-dev-eval-testing` to implement each evaluator with `verify()` and wire them into `evalWorkflow()`
+- **Design judge prompts** — For LLM-based evaluators, follow `output-eval-judge-prompt` to write effective `.prompt` files
+- **Expand datasets** — If your traces don't cover enough failure regions, follow `output-eval-dataset-design` to generate diverse test cases
+- **Re-run after changes** — After fixing prompts, switching models, or modifying pipeline logic, repeat this error analysis to find new failure modes
+
+## Anti-Patterns
+
+- **Building evaluators without error analysis** — You'll evaluate the wrong things
+- **Categorizing before reviewing 30+ traces** — Premature categories cause confirmation bias
+- **Surface-level categories** ("bad output", "LLM error") — Split by root cause
+- **One giant evaluator** — One evaluator per failure mode, not one evaluator for everything
+- **Skipping code-based checks** — Don't use an LLM judge when `Verdict.contains()` works
+- **Never re-running** — Error analysis is not a one-time activity; repeat after significant changes
+
+## Related Skills
+
+- `output-dev-eval-testing` — Implement evaluators with `verify()`, `Verdict`, and `evalWorkflow()`
+- `output-eval-judge-prompt` — Design LLM judge prompts for subjective failure modes
+- `output-eval-dataset-design` — Generate diverse datasets when real traces are sparse
+- `output-eval-validate-judge` — Validate LLM judges against human labels
+- `output-eval-audit` — Audit an existing eval suite for trustworthiness
+- `output-workflow-trace` — Retrieve and analyze workflow execution traces

--- a/coding_assistants/claude/plugins/outputai/skills/output-eval-judge-prompt/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-eval-judge-prompt/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: output-eval-judge-prompt
+description: Design effective LLM judge .prompt files for evaluators. Use when creating judgeVerdict/judgeScore/judgeLabel prompts, or when existing judges produce unreliable results.
+allowed-tools: [Read, Write, Edit]
+---
+
+# Designing LLM Judge Prompts
+
+## Overview
+
+An LLM judge evaluates workflow output for a **single, specific failure mode** identified during error analysis. This skill covers how to design the `.prompt` file that powers `judgeVerdict()`, `judgeScore()`, or `judgeLabel()` calls. For the file format basics, see `output-dev-prompt-file`. For error analysis, see `output-eval-error-analysis`.
+
+## Prerequisites
+
+Before writing a judge prompt:
+
+1. **Error analysis is complete** — You have identified the specific failure mode this judge targets (from `output-eval-error-analysis`)
+2. **20+ labeled examples** — At least 20 pass and 20 fail traces for this failure mode, with `ground_truth` labels in dataset YAML files
+3. **Code-based check ruled out** — Confirmed that `Verdict.*` helpers (contains, matches, gte, etc.) cannot reliably detect this failure
+
+## The Four Components
+
+Every effective judge prompt has exactly four components.
+
+### 1. Task and Criterion
+
+State the single failure mode being evaluated. Be specific and observable.
+
+**Good criteria (specific, observable):**
+- "Does the blog post maintain a formal tone throughout, or does it slip into casual language?"
+- "Does the output contain any URLs that are fabricated rather than drawn from the input?"
+- "Does the summary faithfully represent the source material without adding claims not present in the original?"
+
+**Bad criteria (vague, holistic):**
+- "Is this output high quality?"
+- "Rate the overall effectiveness of this response"
+- "How good is this content?"
+
+### 2. Pass/Fail Definitions
+
+Define exactly what constitutes pass and fail. **Always binary** — no Likert scales, no 1-5 ratings, no "partially meets criteria."
+
+```
+PASS: The blog post uses formal language throughout. Professional vocabulary,
+complete sentences, no slang, no contractions, no first-person casual asides.
+
+FAIL: The blog post contains one or more instances of casual language: slang,
+contractions ("don't", "can't"), informal asides ("pretty cool", "super important"),
+or conversational filler ("honestly", "basically").
+```
+
+Why binary: Likert scales create ambiguous boundaries (what's the difference between a 3 and a 4?). Binary forces precise definitions that LLMs can apply consistently and that you can validate against human labels.
+
+### 3. Few-Shot Examples
+
+Include at least three labeled examples: one clear pass, one clear fail, and one borderline case. **Borderline examples are the most valuable** — they teach the judge where the decision boundary lies.
+
+Draw examples from your **training split only** (see `output-eval-validate-judge`). Never use dev or test examples as few-shot — that's data leakage.
+
+Each example must include:
+- The relevant input/output excerpt
+- A detailed critique explaining the reasoning
+- The verdict (pass or fail)
+
+### 4. Structured Output
+
+Request JSON output with **critique before verdict**. This forces the judge to reason before deciding, which improves accuracy.
+
+```json
+{
+  "critique": "Detailed analysis of the output against the criterion...",
+  "verdict": "pass"
+}
+```
+
+Always put `critique` first in the schema. If `verdict` comes first, the judge commits to a decision before reasoning.
+
+## Full `.prompt` File Example
+
+A judge for the "tone mismatch" failure mode:
+
+```
+# tests/evals/judge_tone@v1.prompt
+---
+provider: anthropic
+model: claude-haiku-4-5-20251001
+temperature: 0
+maxTokens: 1500
+---
+
+<system>
+You are an evaluation judge. Your task is to determine whether a blog post maintains the requested tone throughout.
+
+## Criterion
+
+Assess whether the blog post consistently uses the requested tone. A single paragraph that breaks tone is a failure.
+
+## Definitions
+
+PASS: The blog post maintains the requested tone in every paragraph. Word choice, sentence structure, and rhetorical style all align with the requested tone.
+
+FAIL: The blog post contains one or more paragraphs where the tone shifts away from what was requested. Common failures include:
+- Formal request but casual language appears ("pretty cool", "super important", contractions)
+- Professional request but opinionated editorializing appears
+- Technical request but oversimplified explanations appear
+
+## Examples
+
+### Example 1: PASS
+Requested tone: formal
+Blog excerpt: "The implications of quantum computing for cryptographic security are substantial. Current encryption standards rely on the computational infeasibility of factoring large prime numbers, a guarantee that quantum algorithms may undermine."
+Critique: The excerpt uses professional vocabulary ("implications", "computational infeasibility"), complete sentences, no contractions, and maintains an academic register. Consistent formal tone throughout.
+Verdict: pass
+
+### Example 2: FAIL
+Requested tone: formal
+Blog excerpt: "Quantum computing is basically going to break all our encryption. It's pretty wild when you think about it — everything we thought was secure might not be."
+Critique: The excerpt contains multiple casual markers: "basically", "pretty wild", contractions ("It's", "might not be"), and conversational filler ("when you think about it"). This directly violates the formal tone request.
+Verdict: fail
+
+### Example 3: BORDERLINE (fail)
+Requested tone: formal
+Blog excerpt: "Quantum computing represents a paradigm shift in computational capability. The technology is incredibly promising, though it's important to note the current limitations in qubit stability and error correction."
+Critique: Mostly formal, but contains "incredibly promising" (informal intensifier) and "it's" (contraction). While the overall register is professional, these lapses break the formal tone requirement. Even minor inconsistencies constitute a failure.
+Verdict: fail
+
+## Output Format
+
+Return a JSON object with exactly two fields:
+- "critique": A detailed analysis (3-5 sentences) citing specific evidence from the blog post
+- "verdict": Either "pass" or "fail"
+</system>
+
+<user>
+Requested tone: {{ requested_tone }}
+
+Blog title: {{ blog_title }}
+
+Blog post:
+{{ blog_post }}
+
+Evaluate whether this blog post consistently maintains the requested tone.
+</user>
+```
+
+## Wiring to `judgeVerdict()`
+
+After creating the `.prompt` file, wire it to an evaluator using `verify()` and `judgeVerdict()`:
+
+```typescript
+// tests/evals/evaluators.ts
+import { verify, judgeVerdict } from '@outputai/evals';
+import { z } from '@outputai/core';
+import { blogInput, blogOutput } from './schemas.js';
+
+export const checkTone = verify(
+  {
+    name: 'check_tone',
+    input: blogInput,
+    output: blogOutput
+  },
+  async ({ input, output, context }) =>
+    judgeVerdict({
+      prompt: 'judge_tone@v1',
+      variables: {
+        requested_tone: String(context.ground_truth.expected_tone ?? input.tone ?? 'professional'),
+        blog_title: output.title,
+        blog_post: output.blog_post
+      }
+    })
+);
+```
+
+Then add it to the eval workflow:
+
+```typescript
+// tests/evals/workflow.ts
+import { evalWorkflow } from '@outputai/evals';
+import { checkTone } from './evaluators.js';
+
+export default evalWorkflow({
+  name: 'blog_generator_eval',
+  evals: [
+    {
+      evaluator: checkTone,
+      criticality: 'required',
+      interpret: { type: 'verdict' }
+    }
+  ]
+});
+```
+
+## Choosing What Context to Pass
+
+Feed the judge only what it needs to evaluate the criterion. Extra context adds noise and cost.
+
+| Failure Mode | Required Variables | Not Needed |
+|-------------|-------------------|------------|
+| Tone mismatch | requested_tone, blog_post | topic, input constraints |
+| Off-topic drift | topic, blog_post | tone, length requirements |
+| Hallucinated claims | blog_post, source_material | topic, tone |
+| Faithfulness | summary, original_document | formatting requirements |
+| Missing requirements | requirements_list, blog_post | topic (unless relevant) |
+
+Use `context.ground_truth` for expected values that vary per dataset. Use `input.*` for values from the workflow input. Use `output.*` for the workflow output being evaluated.
+
+## `judgeScore()` Variant
+
+Use `judgeScore()` when you need a numeric quality score rather than binary pass/fail. Apply the same four-component design.
+
+### `.prompt` file for scoring
+
+```
+# tests/evals/judge_quality@v1.prompt
+---
+provider: anthropic
+model: claude-haiku-4-5-20251001
+temperature: 0
+maxTokens: 1500
+---
+
+<system>
+You are an evaluation judge. Score the overall writing quality of a blog post on a scale of 0.0 to 1.0.
+
+## Scoring Criteria
+
+- 0.0-0.3: Major issues — incoherent, riddled with errors, or completely off-topic
+- 0.4-0.6: Mediocre — readable but has significant quality issues (poor structure, weak arguments, factual gaps)
+- 0.7-0.8: Good — well-structured, clear, minor issues only
+- 0.9-1.0: Excellent — polished, engaging, publication-ready
+
+## Output Format
+
+Return a JSON object with:
+- "critique": Detailed analysis of quality strengths and weaknesses (3-5 sentences)
+- "score": A number between 0.0 and 1.0
+</system>
+
+<user>
+Topic: {{ topic }}
+
+Blog title: {{ blog_title }}
+
+Blog post:
+{{ blog_post }}
+
+Score the writing quality of this blog post.
+</user>
+```
+
+### Wiring to `judgeScore()`
+
+```typescript
+export const checkQuality = verify(
+  { name: 'check_quality', input: blogInput, output: blogOutput },
+  async ({ input, output }) =>
+    judgeScore({
+      prompt: 'judge_quality@v1',
+      variables: {
+        topic: input.topic,
+        blog_title: output.title,
+        blog_post: output.blog_post
+      }
+    })
+);
+```
+
+In the eval workflow, use `interpret: { type: 'number' }` with thresholds:
+
+```typescript
+{
+  evaluator: checkQuality,
+  criticality: 'required',
+  interpret: { type: 'number', pass: 0.7, partial: 0.4 }
+}
+```
+
+## `judgeLabel()` Variant
+
+Use `judgeLabel()` when you need classification into named categories.
+
+```typescript
+export const checkToneLabel = verify(
+  { name: 'check_tone_label', input: blogInput, output: blogOutput },
+  async ({ output }) =>
+    judgeLabel({
+      prompt: 'judge_tone_label@v1',
+      variables: {
+        blog_title: output.title,
+        blog_post: output.blog_post
+      }
+    })
+);
+```
+
+In the eval workflow, use `interpret: { type: 'string' }` with label lists:
+
+```typescript
+{
+  evaluator: checkToneLabel,
+  criticality: 'informational',
+  interpret: { type: 'string', pass: ['professional', 'formal'], partial: ['casual'] }
+}
+```
+
+## Model Selection
+
+| Model | When to Use | Cost |
+|-------|-------------|------|
+| `claude-haiku-4-5-20251001` | Default for most judges. Fast, cheap, good at following structured instructions. | Low |
+| `claude-sonnet-4-6` | Complex reasoning required (faithfulness checking, multi-step logical analysis). | Medium |
+| `claude-opus-4-6` | Only if Sonnet fails validation. Rarely needed. | High |
+
+Always set `temperature: 0` for judges. Reproducibility matters more than creativity.
+
+Start with Haiku. If the judge fails validation (TPR/TNR below 80%), move to Sonnet before rewriting the prompt — the model upgrade alone often fixes it.
+
+## Anti-Patterns
+
+- **Vague criteria** ("Is this good?") — Target one specific, observable failure mode
+- **Holistic judges** ("Rate overall quality on 5 dimensions") — One judge per failure mode
+- **No few-shot examples** — Always include pass, fail, and borderline examples
+- **Likert scales** (1-5 ratings) — Use binary pass/fail for verdict judges; use 0.0-1.0 with defined bands for score judges
+- **Verdict before critique** — Put critique first in the JSON schema to force reasoning
+- **Skipping validation** — Always validate judges against human labels (`output-eval-validate-judge`)
+- **Kitchen-sink context** — Pass only the variables the judge needs for its criterion
+- **Few-shot from dev/test set** — Only use training-split examples to avoid data leakage
+
+## Related Skills
+
+- `output-eval-error-analysis` — Identify the failure mode this judge targets
+- `output-dev-eval-testing` — Implementation reference for `verify()`, `judgeVerdict()`, `evalWorkflow()`
+- `output-dev-prompt-file` — `.prompt` file format, Liquid.js templating, provider configuration
+- `output-eval-validate-judge` — Validate this judge against human labels after writing it
+- `output-eval-dataset-design` — Generate diverse datasets for judge validation

--- a/coding_assistants/claude/plugins/outputai/skills/output-eval-validate-judge/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-eval-validate-judge/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: output-eval-validate-judge
+description: Validate LLM judges against human labels using TPR/TNR metrics and train/dev/test splits. Use after writing a judge prompt to verify it agrees with human judgment.
+allowed-tools: [Bash, Read, Write, Edit]
+---
+
+# Validating LLM Judges
+
+## Overview
+
+An LLM judge is only useful if it agrees with human judgment. This skill walks you through calibrating a judge against human-labeled data using True Positive Rate (TPR) and True Negative Rate (TNR) metrics. Do this **before** trusting any `judgeVerdict()`, `judgeScore()`, or `judgeLabel()` evaluator in your eval suite.
+
+## Prerequisites
+
+1. **A judge `.prompt` file** — Written following `output-eval-judge-prompt`
+2. **~100 human-labeled traces** — With binary pass/fail labels for the failure mode this judge targets. Aim for ~50 pass and ~50 fail. Minimum: 20 pass and 20 fail.
+3. **Labels stored in dataset YAML** — Each dataset has `ground_truth.evals.<evaluator_name>.verdict: pass` or `fail`
+
+This process applies **only to LLM-based judges**. For code-based `Verdict.*` evaluators, write unit tests instead.
+
+## Step 1: Create Data Splits
+
+Split your labeled datasets into three groups:
+
+| Split | % of Data | Purpose | Example (100 datasets) |
+|-------|-----------|---------|----------------------|
+| **Train** | 10-20% | Source of few-shot examples in the judge prompt | 15 datasets |
+| **Dev** | 40-45% | Iterate on judge prompt, measure TPR/TNR | 42 datasets |
+| **Test** | 40-45% | Final held-out measurement, run once | 43 datasets |
+
+### Organizing splits
+
+Use a naming convention or subdirectories to separate splits:
+
+**Option A: Name prefixes**
+```
+tests/datasets/
+├── train_formal_pass_01.yml
+├── train_casual_fail_01.yml
+├── dev_technical_pass_01.yml
+├── dev_ambiguous_fail_01.yml
+├── test_simple_pass_01.yml
+├── test_contradictory_fail_01.yml
+└── ...
+```
+
+**Option B: Subdirectories**
+```
+tests/datasets/
+├── train/
+│   ├── formal_pass_01.yml
+│   └── casual_fail_01.yml
+├── dev/
+│   ├── technical_pass_01.yml
+│   └── ambiguous_fail_01.yml
+└── test/
+    ├── simple_pass_01.yml
+    └── contradictory_fail_01.yml
+```
+
+### Splitting rules
+
+- **Balance pass/fail in each split** — Don't put all failures in dev and all passes in test
+- **Randomize** — Don't sort by difficulty or topic
+- **Training examples in the prompt** — Use only train-split examples as few-shot in the judge `.prompt` file. Never use dev or test examples — that's data leakage
+- **Lock the test split** — Once created, do not look at test data until final measurement
+
+## Step 2: Run the Judge on Dev Set
+
+Execute the eval workflow against only the dev-split datasets:
+
+```bash
+# Run with cached output on dev datasets
+npx output workflow test <workflowName> --cached \
+  --dataset dev_technical_pass_01,dev_ambiguous_fail_01,dev_formal_pass_02,...
+```
+
+Or if using subdirectories, list the dev dataset names:
+
+```bash
+npx output workflow test <workflowName> --cached \
+  --dataset $(ls tests/datasets/dev/ | sed 's/.yml//' | tr '\n' ',')
+```
+
+Save the output. You need the judge's verdict for each dataset to compare against ground truth.
+
+### Extracting results
+
+Use `--format json` to get machine-readable results:
+
+```bash
+npx output workflow test <workflowName> --cached --dataset <dev_datasets> --format json
+```
+
+The output includes per-dataset, per-evaluator verdicts that you can compare against `ground_truth.evals.<evaluator_name>.verdict`.
+
+## Step 3: Compute TPR and TNR
+
+For the evaluator you're validating, build a confusion matrix from the dev results.
+
+### Definitions
+
+Using "fail" as the positive class (what you're trying to detect):
+
+| | Judge says Fail | Judge says Pass |
+|---|---|---|
+| **Human says Fail** | True Positive (TP) | False Negative (FN) |
+| **Human says Pass** | False Positive (FP) | True Negative (TN) |
+
+**TPR (True Positive Rate)** = TP / (TP + FN)
+- "Of all the real failures, what fraction did the judge catch?"
+- Low TPR means the judge **misses real failures** (dangerous)
+
+**TNR (True Negative Rate)** = TN / (TN + FP)
+- "Of all the real passes, what fraction did the judge correctly approve?"
+- Low TNR means the judge **flags passing traces as failures** (noisy)
+
+### Example computation
+
+Dev set results for `check_tone` evaluator (42 datasets):
+
+| | Judge: Fail | Judge: Pass |
+|---|---|---|
+| **Human: Fail** | 18 (TP) | 3 (FN) |
+| **Human: Pass** | 2 (FP) | 19 (TN) |
+
+- TPR = 18 / (18 + 3) = **85.7%**
+- TNR = 19 / (19 + 2) = **90.5%**
+
+### Why not raw accuracy?
+
+Raw accuracy = (TP + TN) / total = (18 + 19) / 42 = 88.1%
+
+This looks fine, but masks problems. If your dataset were 90% pass (class imbalance), a judge that always says "pass" would get 90% accuracy while catching zero failures (TPR = 0%). TPR and TNR measure what actually matters: catching failures and not crying wolf.
+
+## Step 4: Inspect Disagreements
+
+For every case where the judge disagrees with the human label, determine the root cause.
+
+### False Negatives (judge missed a real failure)
+
+The judge said "pass" but the human said "fail." For each:
+
+1. Read the trace and the judge's critique
+2. Determine why the judge missed it:
+   - **Criterion too narrow** — The prompt defines failure too narrowly. Broaden the fail definition.
+   - **Missing few-shot example** — The failure pattern isn't represented in examples. Add a similar borderline example from the train split.
+   - **Insufficient context** — The judge doesn't have the information needed to detect this failure. Add the missing variable to the prompt.
+
+### False Positives (judge flagged a passing trace)
+
+The judge said "fail" but the human said "pass." For each:
+
+1. Read the trace and the judge's critique
+2. Determine why the judge flagged it:
+   - **Criterion too broad** — The prompt defines failure too broadly. Tighten the fail definition.
+   - **Misleading few-shot example** — A borderline example is being overgeneralized. Clarify or replace it.
+   - **Overly strict** — The judge applies the criterion more strictly than intended. Add explicit exceptions to the prompt.
+
+### Logging disagreements
+
+Track each disagreement to guide prompt iteration:
+
+| Dataset | Human | Judge | Root Cause | Fix |
+|---------|-------|-------|------------|-----|
+| dev_technical_pass_03 | pass | fail | Judge flagged "it's" as casual but context was a direct quote | Add exception: "Contractions within direct quotes are acceptable" |
+| dev_ambiguous_fail_02 | fail | pass | Judge missed subtle tone shift in paragraph 3 | Add borderline few-shot example showing mid-text tone drift |
+
+## Step 5: Iterate
+
+Apply the fixes from Step 4 to the judge `.prompt` file. Then re-run on the dev set:
+
+```bash
+npx output workflow test <workflowName> --cached --dataset <dev_datasets>
+```
+
+Recompute TPR and TNR. Repeat until both metrics meet the target.
+
+### Targets
+
+| Metric | Target | Minimum Acceptable |
+|--------|--------|--------------------|
+| TPR | > 90% | > 80% |
+| TNR | > 90% | > 80% |
+
+If you can't reach 80%/80% after 3-4 iterations:
+
+1. **Upgrade the model** — Switch from Haiku to Sonnet in the `.prompt` frontmatter
+2. **Split the criterion** — The failure mode may contain two distinct sub-failures that need separate judges
+3. **Revisit the labels** — Some human labels may be inconsistent. Re-label disagreements with a second reviewer
+
+### Iteration checklist
+
+Each iteration:
+- [ ] Identified root cause for each disagreement
+- [ ] Applied targeted fix to `.prompt` file (not random changes)
+- [ ] Re-ran on dev set
+- [ ] Recomputed TPR and TNR
+- [ ] Logged the iteration number, changes made, and resulting metrics
+
+## Step 6: Final Measurement on Test Set
+
+Once dev metrics meet the target, run the judge on the held-out test set **exactly once**:
+
+```bash
+npx output workflow test <workflowName> --cached --dataset <test_datasets> --format json
+```
+
+Compute TPR and TNR on the test results. Record these as the final metrics.
+
+### Interpreting final results
+
+- **Test metrics close to dev metrics** — The judge generalizes well. Ship it.
+- **Test metrics significantly lower** — The judge may be overfit to dev set patterns. Do not iterate on the test set. Instead, gather more labeled data, re-split, and restart from Step 2.
+
+### Recording results
+
+Document the final validation results alongside the judge prompt:
+
+```markdown
+# Validation: check_tone (judge_tone@v1.prompt)
+# Date: 2026-03-25
+# Model: claude-haiku-4-5-20251001
+
+## Dev Set (42 datasets)
+- TPR: 90.5% (19/21)
+- TNR: 95.2% (20/21)
+
+## Test Set (43 datasets)
+- TPR: 88.0% (22/25)
+- TNR: 94.4% (17/18)
+
+## Conclusion: APPROVED — both metrics above 80% minimum
+```
+
+Store this in a `VALIDATION.md` file next to the judge prompt or in the evaluator's documentation.
+
+## Anti-Patterns
+
+- **Assuming judges work without validation** — An unvalidated judge may consistently miss failures or flag passing traces
+- **Using dev/test examples as few-shot** — Data leakage inflates metrics and hides real performance
+- **Optimizing for raw accuracy** — Use TPR and TNR instead; accuracy hides class imbalance problems
+- **Iterating on the test set** — Test is held-out. If test metrics are bad, gather more data and re-split
+- **Skipping disagreement analysis** — Random prompt tweaks without understanding root causes don't converge
+- **Too few labeled examples** — Below 40 total (20 pass + 20 fail), metrics are unreliable due to small sample size
+
+## Related Skills
+
+- `output-eval-judge-prompt` — Design the judge prompt being validated
+- `output-eval-error-analysis` — Source of human-labeled data for validation
+- `output-eval-dataset-design` — Generate additional labeled datasets if you need more data
+- `output-dev-eval-testing` — `output workflow test` CLI, `--cached` and `--dataset` flags
+- `output-eval-audit` — Audit whether existing judges have been validated


### PR DESCRIPTION
## Overview

- Add 5 new eval methodology skills (`output-eval-error-analysis`, `output-eval-judge-prompt`, `output-eval-dataset-design`, `output-eval-validate-judge`, `output-eval-audit`) inspired by [hamelsmu/evals-skills](https://github.com/hamelsmu/evals-skills)
- Teach the *process* of building trustworthy evals (when/why/how to design evaluators) complementing the existing API reference skills
- Cover the full eval lifecycle: trace review, judge prompt design, dataset generation, judge validation, and suite auditing
- Add cross-references from 3 existing skills (`output-dev-eval-testing`, `output-dev-evaluator-function`, `output-dev-prompt-file`) to the new methodology skills
- All skills are directive, under 500 lines, and use Output.ai's actual APIs and CLI commands in examples