### PR TITLE
chore: feedback/suggestions to improve our coding agents in how they generate workflows

### DIFF
--- a/.changeset/salty-meteors-invent.md
+++ b/.changeset/salty-meteors-invent.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": minor
+---
+
+Update the Claude plugin for Output to improve workflow code generation"

--- a/coding_assistants/claude/plugins/outputai/.claude-plugin/plugin.json
+++ b/coding_assistants/claude/plugins/outputai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "outputai",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "Workflow development tools",
     "author": {
       "name": "Output.ai",

--- a/coding_assistants/claude/plugins/outputai/agents/workflow_prompt_writer.md
+++ b/coding_assistants/claude/plugins/outputai/agents/workflow_prompt_writer.md
@@ -96,7 +96,9 @@ Each message role serves a specific purpose. Understanding when to use each is c
 
 ## System Message Structure
 
-Structure system messages with clear markdown headers for readability and maintainability:
+Structure system messages with clear markdown headers for readability and maintainability.
+
+This example is for a plain text output step (no `Output.object()`), so `## Output Format` is appropriate here. When using `Output.object()`, omit the Output Format section -- the schema handles structure.
 
 ```yaml
 <system>
@@ -139,7 +141,7 @@ Return a structured analysis with:
 | `## Expertise` | List specific knowledge areas |
 | `## Task` | Describe what the AI should accomplish |
 | `## Methodology` | Step-by-step approach to follow |
-| `## Output Format` | Specify expected response structure |
+| `## Output Format` | Specify expected response structure (**only when NOT using `Output.object()`** -- when using structured output, the schema handles format) |
 | `## Constraints` | Rules and limitations to follow |
 | `## Examples` | Few-shot examples (optional) |
 
@@ -449,26 +451,27 @@ Extract key metrics from this description:
 </user>
 ```
 
-### Structured Output Prompts
+### Structured Output Prompts (with Output.object())
 
-For `generateText` with `Output.object()`, specify format clearly:
+When `generateText` is called with `Output.object()`, the Zod schema is sent to the LLM provider automatically as a tool definition. **Do not duplicate the schema in the prompt.** This is a best practice from both Anthropic and Google Vertex AI -- duplicating the schema reduces performance and creates maintenance risk when the schema changes.
+
+Instead, use `.describe()` on schema fields (in `types.ts`) for field-level guidance, and use the prompt for **task framing, methodology, and quality standards**:
 
 ```yaml
 <system>
 ## Role
-You are a content extractor that outputs structured JSON.
+You are a content extractor that identifies the most important information.
 
-## Output Format
-Return a JSON object with exactly these fields:
-- title (string): The main title or headline
-- summary (string): A 1-2 sentence summary
-- keyPoints (array of strings): 3-5 key points
-- confidence (number): Your confidence score from 0.0 to 1.0
+## Methodology
+1. Read the content carefully to identify the central argument or topic
+2. Extract the main title -- prefer the author's own headline if present
+3. Write a summary that captures the "why it matters", not just the topic
+4. Select key points that are specific and actionable, not generic observations
+5. Rate your confidence based on content quality -- lower if the text is ambiguous or incomplete
 
 ## Constraints
-- All fields are required
-- keyPoints must have between 3 and 5 items
-- confidence must be between 0.0 and 1.0
+- Base conclusions only on provided content, do not add outside knowledge
+- If the text is too short or unclear for a confident extraction, reflect that in your confidence score
 </system>
 <user>
 Extract structured data from this text:
@@ -478,6 +481,19 @@ Extract structured data from this text:
 </content>
 </user>
 ```
+
+The corresponding schema in `types.ts` handles structure and field descriptions:
+
+```typescript
+const ContentExtractionSchema = z.object( {
+  title: z.string().describe( 'The main title or headline' ),
+  summary: z.string().describe( 'A 1-2 sentence summary' ),
+  keyPoints: z.array( z.string() ).describe( '3-5 key points' ),
+  confidence: z.number().describe( 'Confidence score from 0.0 to 1.0' )
+} );
+```
+
+**When Output.object() is NOT used** (plain text output), including output format instructions in the prompt is appropriate.
 
 ## Skills System
 
@@ -622,6 +638,9 @@ Writing system prompts as walls of text instead of using `## Headers`.
 
 ### 7. Missing Semantic Tags
 Dumping data without wrapping in `<data>`, `<context>`, etc.
+
+### 8. Duplicating Schema in Prompt
+Including `## Output Format` with JSON examples when the step uses `Output.object()`. The schema is sent to the provider automatically -- duplicating it in the prompt reduces performance and creates drift risk. Use `.describe()` on schema fields instead.
 
 ## Example Interactions
 

--- a/coding_assistants/claude/plugins/outputai/agents/workflow_prompt_writer.md
+++ b/coding_assistants/claude/plugins/outputai/agents/workflow_prompt_writer.md
@@ -406,7 +406,9 @@ Please work through each step of the methodology, showing your reasoning at each
 
 ### Few-Shot Prompting
 
-Provide examples in the system message for consistent output:
+Provide examples in the system message for consistent output.
+
+**Note**: This technique is for plain-text output steps (no `Output.object()`). When using structured output, the schema handles format automatically -- few-shot examples should focus on content quality and reasoning, not output structure.
 
 ```yaml
 <system>
@@ -491,6 +493,7 @@ const ContentExtractionSchema = z.object( {
   keyPoints: z.array( z.string() ).describe( '3-5 key points' ),
   confidence: z.number().describe( 'Confidence score from 0.0 to 1.0' )
 } );
+
 ```
 
 **When Output.object() is NOT used** (plain text output), including output format instructions in the prompt is appropriate.
@@ -528,12 +531,12 @@ Prompts work with both `generateText` (single-shot) and the `Agent` class (multi
 ```typescript
 import { Agent, Output } from '@outputai/llm';
 
-const agent = new Agent({
+const agent = new Agent( {
   prompt: 'writing_assistant@v1',
   variables: { content_type: 'documentation', focus: 'clarity', content: input.content },
-  output: Output.object({ schema: reviewSchema }),
+  output: Output.object( { schema: reviewSchema } ),
   maxSteps: 5
-});
+} );
 const { output } = await agent.generate();
 ```
 
@@ -610,10 +613,10 @@ src/workflows/{name}/
 Reference prompts by name and version in code:
 
 ```typescript
-const { result } = await generateText({
+const { result } = await generateText( {
   prompt: 'analyze@v1',
   variables: { companyData, competitors }
-});
+} );
 ```
 
 ## Common Pitfalls

--- a/coding_assistants/claude/plugins/outputai/agents/workflow_prompt_writer.md
+++ b/coding_assistants/claude/plugins/outputai/agents/workflow_prompt_writer.md
@@ -243,15 +243,39 @@ Variables use double curly braces with spaces:
 {{ x }}              # Wrong - unclear name
 ```
 
-### Nested Object Access
+### CRITICAL: Variable Type Constraint
 
-Access nested properties with dot notation:
+The `variables` field in `generateText` and `Agent` only accepts **`string | number | boolean`** values. You cannot pass arrays or objects directly -- this causes TypeScript compilation errors.
 
-```liquid
-{{ company.name }}
-{{ company.location.city }}
-{{ user.profile.preferences.theme }}
+When a step has complex data (arrays, objects), it must pre-format them into strings before passing as variables. The prompt then uses the pre-formatted string directly instead of Liquid loops:
+
+```typescript
+// In the step: pre-format before passing
+const itemsText = items.map( i => `- ${i.name}: ${i.value}` ).join( '\n' );
+const tagsText = tags.join( ', ' );
+
+const { result } = await generateText( {
+  prompt: 'process@v1',
+  variables: {
+    items: itemsText,   // string - OK
+    tags: tagsText,     // string - OK
+    count: items.length // number - OK
+  }
+} );
 ```
+
+```yaml
+# In the prompt: use the pre-formatted string directly
+<user>
+Process these items:
+{{ items }}
+
+Tags: {{ tags }}
+Total: {{ count }}
+</user>
+```
+
+Do NOT use Liquid loops (`{% for %}`) or nested object access (`{{ item.name }}`) in prompts -- the data should already be formatted as a string by the step.
 
 ### Conditionals with Fallbacks
 
@@ -278,10 +302,6 @@ Provide a standard analysis.
 Combine conditions with `and`, `or`:
 
 ```liquid
-{% if company and company.name %}
-Company: {{ company.name }}
-{% endif %}
-
 {% if includeFinancials or includeMetrics %}
 Include quantitative analysis.
 {% endif %}
@@ -289,36 +309,6 @@ Include quantitative analysis.
 {% if status == "active" and priority == "high" %}
 Urgent: Requires immediate attention.
 {% endif %}
-```
-
-### Loops with Defensive Checks
-
-Always check array existence AND size before looping:
-
-```liquid
-{% if competitors and competitors.size > 0 %}
-Known competitors:
-{% for competitor in competitors %}
-- {{ competitor.name }}{% if competitor.website %} ({{ competitor.website }}){% endif %}
-{% endfor %}
-{% else %}
-No known competitors provided.
-{% endif %}
-```
-
-### Loop Helpers
-
-Access loop metadata:
-
-```liquid
-{% for item in items %}
-{{ forloop.index }}. {{ item.name }}{% if forloop.last == false %},{% endif %}
-{% endfor %}
-
-{% for item in items %}
-{% if forloop.first %}First item: {% endif %}
-{{ item }}
-{% endfor %}
 ```
 
 ### Filters
@@ -330,7 +320,6 @@ Transform variables with filters:
 {{ text | downcase }}                  # lowercase
 {{ text | capitalize }}                # Capitalize
 {{ text | truncate: 100 }}             # Truncate to 100 chars
-{{ items | size }}                     # Array length
 {{ text | strip }}                     # Trim whitespace
 {{ value | default: "fallback" }}      # Default if nil/empty
 ```
@@ -340,11 +329,9 @@ Transform variables with filters:
 ```liquid
 # Wrong - Handlebars syntax
 {{#if condition}}...{{/if}}
-{{#each items}}...{{/each}}
 
 # Correct - Liquid.js syntax
 {% if condition %}...{% endif %}
-{% for item in items %}...{% endfor %}
 
 # Wrong - missing spaces in variables
 {{variable}}
@@ -352,13 +339,11 @@ Transform variables with filters:
 # Correct - spaces required
 {{ variable }}
 
-# Wrong - no array check before loop
-{% for item in items %}...{{ item }}...{% endfor %}
+# Wrong - passing arrays/objects as variables (causes TS2322)
+variables: { items: itemArray, user: userObject }
 
-# Correct - defensive array check
-{% if items and items.size > 0 %}
-{% for item in items %}...{{ item }}...{% endfor %}
-{% endif %}
+# Correct - pre-format complex data in the step
+variables: { items: itemsText, userName: user.name }
 ```
 
 ## Prompt Engineering Techniques
@@ -584,7 +569,7 @@ Add comments at the top of complex prompts:
 #
 # Variables:
 #   - companyData (string, required): Company information to analyze
-#   - competitors (array, optional): Known competitor names
+#   - competitors (string, optional): Comma-separated competitor names (pre-formatted in step)
 #   - focusAreas (string, optional): Specific areas to focus on
 #   - analysisDepth (string, optional): "summary" | "standard" | "comprehensive"
 #
@@ -613,9 +598,12 @@ src/workflows/{name}/
 Reference prompts by name and version in code:
 
 ```typescript
+// Pre-format array into string before passing as variable
+const competitorsText = competitors ? competitors.join( ', ' ) : '';
+
 const { result } = await generateText( {
   prompt: 'analyze@v1',
-  variables: { companyData, competitors }
+  variables: { companyData, competitors: competitorsText }
 } );
 ```
 

--- a/coding_assistants/claude/plugins/outputai/agents/workflow_prompt_writer.md
+++ b/coding_assistants/claude/plugins/outputai/agents/workflow_prompt_writer.md
@@ -48,9 +48,15 @@ maxTokens: 2000
 | `temperature` | number | Creativity (0.0-1.0, lower = more deterministic) |
 | `maxTokens` | number | Maximum response length |
 
+### Provider Consistency
+
+All prompt files in a workflow **must use the same provider** unless the user explicitly requests otherwise. Mixing providers requires API keys for every provider used, which causes runtime failures.
+
+Default to `anthropic` with `claude-sonnet-4-6` when no preference is specified. If the user or the workflow plan specifies a provider, use that for all prompts in the workflow.
+
 ### Recommended Models
 
-**Anthropic:**
+**Anthropic (default):**
 - `claude-sonnet-4-6` - Balanced performance (default)
 - `claude-opus-4-5` - Complex reasoning tasks
 - `claude-haiku-4-5` - Fast, simple tasks

--- a/coding_assistants/claude/plugins/outputai/agents/workflow_quality.md
+++ b/coding_assistants/claude/plugins/outputai/agents/workflow_quality.md
@@ -247,6 +247,15 @@ Always define inputSchema and outputSchema for type safety and validation.
 ### 6. Credentials Usage
 Never use `process.env` for secrets. Use `credentials.require()` from `@outputai/credentials` for mandatory secrets and `credentials.get()` with a default for optional values. See `output-dev-credentials` skill for setup and migration guidance.
 
+### 7. Inline LLM Schemas
+Define schemas for `Output.object()` in `types.ts` and import them. Never define schemas inline in step functions -- this causes duplication and drift.
+
+### 8. Redundant JSON in Prompts
+When a step uses `Output.object()`, the schema is sent to the LLM automatically. Do not describe JSON output format in the prompt -- it duplicates the schema and can conflict or drift over time. Use prompts for quality/content guidance, not structural format.
+
+### 9. Code Style
+All generated code must follow project style conventions. Key rules: no trailing commas, no `let` (use `const` only), arrow parens only when needed, operator linebreak after. See `output-dev-code-style` skill for the full list.
+
 ## Evaluator Quality Checks
 
 When reviewing evaluator implementations:

--- a/coding_assistants/claude/plugins/outputai/agents/workflow_quality.md
+++ b/coding_assistants/claude/plugins/outputai/agents/workflow_quality.md
@@ -259,6 +259,9 @@ All generated code must follow project style conventions. Key rules: no trailing
 ### 10. Arrays/Objects as Prompt Variables
 The `variables` field in `generateText` and `Agent` only accepts `string | number | boolean`. Passing arrays or objects causes TypeScript compilation errors (TS2322). Pre-format complex data into strings in the step before passing as variables.
 
+### 11. Mixed LLM Providers
+All prompt files in a workflow should use the same provider unless the user explicitly requests otherwise. Mixing providers (e.g., some prompts using anthropic and others using openai) requires API keys for every provider used, causing runtime failures when keys are missing. Default to anthropic.
+
 ## Evaluator Quality Checks
 
 When reviewing evaluator implementations:

--- a/coding_assistants/claude/plugins/outputai/agents/workflow_quality.md
+++ b/coding_assistants/claude/plugins/outputai/agents/workflow_quality.md
@@ -256,6 +256,9 @@ When a step uses `Output.object()`, the schema is sent to the LLM automatically.
 ### 9. Code Style
 All generated code must follow project style conventions. Key rules: no trailing commas, no `let` (use `const` only), arrow parens only when needed, operator linebreak after. See `output-dev-code-style` skill for the full list.
 
+### 10. Arrays/Objects as Prompt Variables
+The `variables` field in `generateText` and `Agent` only accepts `string | number | boolean`. Passing arrays or objects causes TypeScript compilation errors (TS2322). Pre-format complex data into strings in the step before passing as variables.
+
 ## Evaluator Quality Checks
 
 When reviewing evaluator implementations:

--- a/coding_assistants/claude/plugins/outputai/agents/workflow_quality.md
+++ b/coding_assistants/claude/plugins/outputai/agents/workflow_quality.md
@@ -51,7 +51,7 @@ const apiKey = process.env.SERVICE_API_KEY;
 
 // Correct
 import { credentials } from '@outputai/credentials';
-const apiKey = credentials.require('service.api_key');
+const apiKey = credentials.require( 'service.api_key' );
 ```
 
 ### Workflow Determinism
@@ -72,21 +72,21 @@ Workflows must NOT contain:
 All I/O operations must be wrapped in steps:
 ```typescript
 // Wrong - I/O in workflow
-export default workflow({
-  fn: async (input) => {
-    const data = await fetch('https://api.example.com'); // ❌
+export default workflow( {
+  fn: async input => {
+    const data = await fetch( 'https://api.example.com' ); // ❌
     return { data };
   }
-});
+} );
 
 // Correct - I/O in step
-export const fetchData = step({
+export const fetchData = step( {
   name: 'fetchData',
-  fn: async (input) => {
-    const client = httpClient({ prefixUrl: 'https://api.example.com' });
-    return client.get('endpoint').json();
+  fn: async input => {
+    const client = httpClient( { prefixUrl: 'https://api.example.com' } );
+    return client.get( 'endpoint' ).json();
   }
-});
+} );
 ```
 
 ### No Try-Catch Wrapping
@@ -94,18 +94,18 @@ export const fetchData = step({
 Don't wrap step calls in try-catch blocks. Allow failures to propagate:
 ```typescript
 // Wrong
-fn: async (input) => {
+fn: async input => {
   try {
-    const result = await myStep(input);
+    const result = await myStep( input );
     return result;
-  } catch (error) {
-    throw new FatalError(error.message);
+  } catch ( error ) {
+    throw new FatalError( error.message );
   }
 }
 
 // Correct
-fn: async (input) => {
-  const result = await myStep(input);
+fn: async input => {
+  const result = await myStep( input );
   return result;
 }
 ```
@@ -116,17 +116,17 @@ Never use axios directly. Use `@outputai/http`:
 ```typescript
 import { httpClient } from '@outputai/http';
 
-const client = httpClient({
+const client = httpClient( {
   prefixUrl: 'https://api.example.com',
   timeout: 30000,
   retry: { limit: 3 }
-});
+} );
 
 // GET request
-const data = await client.get('endpoint').json();
+const data = await client.get( 'endpoint' ).json();
 
 // POST request
-const result = await client.post('endpoint', { json: payload }).json();
+const result = await client.post( 'endpoint', { json: payload } ).json();
 ```
 
 ### LLM Integration
@@ -136,19 +136,19 @@ Never call LLM APIs directly. Use `@outputai/llm`:
 import { generateText, Output } from '@outputai/llm';
 
 // Text generation
-const { result: text } = await generateText({
+const { result: text } = await generateText( {
   prompt: 'prompts/my_prompt@v1',
   variables: { topic: 'AI' }
-});
+} );
 
 // Structured output
-const { output: data } = await generateText({
+const { output: data } = await generateText( {
   prompt: 'prompts/extract@v1',
   variables: { text },
-  output: Output.object({
-    schema: z.object({ title: z.string(), summary: z.string() })
-  })
-});
+  output: Output.object( {
+    schema: z.object( { title: z.string(), summary: z.string() } )
+  } )
+} );
 ```
 
 ### Schema Definitions
@@ -157,30 +157,30 @@ Define input/output schemas with Zod:
 ```typescript
 import { step, z } from '@outputai/core';
 
-export const processData = step({
+export const processData = step( {
   name: 'processData',
-  inputSchema: z.object({
+  inputSchema: z.object( {
     id: z.string(),
     count: z.number().optional()
-  }),
-  outputSchema: z.object({
+  } ),
+  outputSchema: z.object( {
     result: z.string(),
     processed: z.boolean()
-  }),
-  fn: async (input) => {
+  } ),
+  fn: async input => {
     // input is typed as { id: string, count?: number }
     return { result: input.id, processed: true };
   }
-});
+} );
 ```
 
 ### Retry Policies
 
 Configure retry policies in step options:
 ```typescript
-export const riskyStep = step({
+export const riskyStep = step( {
   name: 'riskyStep',
-  fn: async (input) => { /* ... */ },
+  fn: async input => { /* ... */ },
   options: {
     retry: {
       maximumAttempts: 3,
@@ -190,7 +190,7 @@ export const riskyStep = step({
     },
     startToCloseTimeout: '30s'
   }
-});
+} );
 ```
 
 ### Error Types
@@ -200,10 +200,10 @@ Use appropriate error types:
 import { FatalError, ValidationError } from '@outputai/core';
 
 // Non-retryable error (workflow fails immediately)
-throw new FatalError('Critical failure - do not retry');
+throw new FatalError( 'Critical failure - do not retry' );
 
 // Validation error (schema/input validation)
-throw new ValidationError('Invalid input format');
+throw new ValidationError( 'Invalid input format' );
 ```
 
 ## File Structure

--- a/coding_assistants/claude/plugins/outputai/commands/build_workflow.md
+++ b/coding_assistants/claude/plugins/outputai/commands/build_workflow.md
@@ -151,21 +151,21 @@ If the plan includes evaluator functions, implement them in `$3/evaluators.ts`.
 ```typescript
 import { evaluator, z, EvaluationBooleanResult } from '@outputai/core';
 
-export const evaluateName = evaluator({
+export const evaluateName = evaluator( {
   name: 'evaluate_name',
   description: 'Description from plan',
-  inputSchema: z.object({
+  inputSchema: z.object( {
     // Define based on plan
-  }),
-  fn: async (input) => {
+  } ),
+  fn: async input => {
     // Implement evaluation logic from plan
-    return new EvaluationBooleanResult({
+    return new EvaluationBooleanResult( {
       value: true,
       confidence: 0.95,
       reasoning: 'Explanation of evaluation'
-    });
+    } );
   }
-});
+} );
 ```
 </evaluator_template>
 
@@ -271,10 +271,10 @@ Create at least one scenario file in `$3/scenarios/` for testing the workflow.
 <example>
 For a workflow with inputSchema:
 ```typescript
-z.object({
+z.object( {
   topic: z.string(),
   maxLength: z.number().optional()
-})
+} )
 ```
 
 Create `scenarios/test_input.json`:

--- a/coding_assistants/claude/plugins/outputai/commands/plan_workflow.md
+++ b/coding_assistants/claude/plugins/outputai/commands/plan_workflow.md
@@ -76,6 +76,12 @@ Clarify scope boundaries and technical considerations by asking numbered questio
     - UI/UX requirements
     - integration points
   </technical>
+  <llm_provider>
+    - Ask which LLM provider the user wants to use (anthropic, openai, or vertex)
+    - Default to anthropic if the user has no preference
+    - All prompt files in the workflow must use the same provider unless the user explicitly requests otherwise
+    - Record the chosen provider so it flows through to prompt engineering (step 6) and implementation
+  </llm_provider>
 </clarification_areas>
 
 <decision_tree>

--- a/coding_assistants/claude/plugins/outputai/commands/plan_workflow.md
+++ b/coding_assistants/claude/plugins/outputai/commands/plan_workflow.md
@@ -1,6 +1,6 @@
 ---
 argument-hint: [workflow-description-and-additional-instructions]
-description: Workflow Planning Command for Output SDK
+description: Use when the user asks to create, build, generate, scaffold, or plan a new workflow. Orchestrates the full planning process including architecture, steps, prompts, evaluators, and testing strategy using specialized subagents.
 version: 0.1.3
 model: opus
 ---

--- a/coding_assistants/claude/plugins/outputai/hooks/SESSION_START_CONTEXT.md
+++ b/coding_assistants/claude/plugins/outputai/hooks/SESSION_START_CONTEXT.md
@@ -8,9 +8,13 @@ This project uses the Output.ai framework for building durable, LLM-powered work
 
 1. **`output-meta-project-context`** - Load complete Output SDK documentation, patterns, conventions, and available tools inventory (5 agents, 3 commands, 33 skills)
 
-Please make sure to conciously use appropriate skills and agents for the task at hand.
+Please make sure to consciously use appropriate skills and agents for the task at hand.
 
 There will be a skill and/or agent for every task you will need to complete.
+
+## Workflow Creation Routing
+
+When a user asks to create, build, generate, or scaffold a new workflow, ALWAYS use `/outputai:plan_workflow` with the user's description as arguments. Do not plan or build workflows manually. This command orchestrates specialized subagents for architecture, step design, prompt engineering, and testing strategy.
 
 ---
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-agent-class/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-agent-class/SKILL.md
@@ -32,17 +32,17 @@ import { z } from '@outputai/core';
 The prompt file is loaded and rendered at construction time. Variables, skills, and tools are fixed at construction. The agent is ready to call `generate()` or `stream()` immediately.
 
 ```typescript
-const agent = new Agent({
+const agent = new Agent( {
   prompt: 'writing_assistant@v1',
   variables: {
     content_type: input.contentType,
     focus: input.focus,
     content: input.content
   },
-  skills: [audienceSkill],
-  output: Output.object({ schema: reviewSchema }),
+  skills: [ audienceSkill ],
+  output: Output.object( { schema: reviewSchema } ),
   maxSteps: 5
-});
+} );
 ```
 
 ### Constructor Options
@@ -67,9 +67,9 @@ Run the agent and return when complete:
 
 ```typescript
 const result = await agent.generate();
-console.log(result.text);   // Generated text
-console.log(result.output); // Structured output (when using Output.object)
-console.log(result.usage);  // Token counts
+console.log( result.text );   // Generated text
+console.log( result.output ); // Structured output (when using Output.object)
+console.log( result.usage );  // Token counts
 ```
 
 The result has the same shape as `generateText`: `text`, `result` (alias for `text`), `output`, `usage`, `finishReason`, `toolCalls`, etc.
@@ -79,9 +79,9 @@ The result has the same shape as `generateText`: `text`, `result` (alias for `te
 Extend the conversation with extra messages:
 
 ```typescript
-const result = await agent.generate({
-  messages: [{ role: 'user', content: 'Focus on the introduction section.' }]
-});
+const result = await agent.generate( {
+  messages: [ { role: 'user', content: 'Focus on the introduction section.' } ]
+} );
 ```
 
 Messages are appended after the initial prompt messages (and any conversation store history).
@@ -93,8 +93,8 @@ Stream the agent's response:
 ```typescript
 const stream = await agent.stream();
 
-for await (const chunk of stream.textStream) {
-  process.stdout.write(chunk);
+for await ( const chunk of stream.textStream ) {
+  process.stdout.write( chunk );
 }
 ```
 
@@ -107,19 +107,19 @@ Like `streamText`, the stream result provides `textStream` and `fullStream` iter
 Use `Output.object()` to get typed responses:
 
 ```typescript
-const reviewSchema = z.object({
-  issues: z.array(z.string()).describe('List of issues found'),
-  suggestions: z.array(z.string()).describe('Actionable suggestions'),
-  score: z.number().describe('Quality score 0-100'),
-  summary: z.string().describe('Brief overall assessment')
-});
+const reviewSchema = z.object( {
+  issues: z.array( z.string() ).describe( 'List of issues found' ),
+  suggestions: z.array( z.string() ).describe( 'Actionable suggestions' ),
+  score: z.number().describe( 'Quality score 0-100' ),
+  summary: z.string().describe( 'Brief overall assessment' )
+} );
 
-const agent = new Agent({
+const agent = new Agent( {
   prompt: 'writing_assistant@v1',
   variables: { content_type: 'documentation', focus: 'clarity', content: markdownContent },
-  output: Output.object({ schema: reviewSchema }),
+  output: Output.object( { schema: reviewSchema } ),
   maxSteps: 5
-});
+} );
 
 const { output } = await agent.generate();
 // output: { issues: string[], suggestions: string[], score: number, summary: string }
@@ -135,19 +135,19 @@ By default, Agent is stateless. Each `generate()` call starts fresh with only th
 import { Agent, createMemoryConversationStore } from '@outputai/llm';
 
 const store = createMemoryConversationStore();
-const chatbot = new Agent({
+const chatbot = new Agent( {
   prompt: 'chatbot@v1',
   conversationStore: store
-});
+} );
 
-const r1 = await chatbot.generate({
-  messages: [{ role: 'user', content: 'Hello, tell me about Output.' }]
-});
+const r1 = await chatbot.generate( {
+  messages: [ { role: 'user', content: 'Hello, tell me about Output.' } ]
+} );
 // r1.text: "Output is an AI framework for..."
 
-const r2 = await chatbot.generate({
-  messages: [{ role: 'user', content: 'How does it handle retries?' }]
-});
+const r2 = await chatbot.generate( {
+  messages: [ { role: 'user', content: 'How does it handle retries?' } ]
+} );
 // r2 sees the full conversation history from r1
 ```
 
@@ -172,33 +172,33 @@ In workflow steps, construct a new Agent per invocation. Variables come from the
 import { step, z } from '@outputai/core';
 import { Agent, Output } from '@outputai/llm';
 
-const reviewSchema = z.object({
-  summary: z.string().describe('Brief assessment'),
-  issues: z.array(z.string()).describe('Problems found'),
-  suggestions: z.array(z.string()).describe('Improvements'),
-  score: z.number().describe('Quality score 0-100')
-});
+const reviewSchema = z.object( {
+  summary: z.string().describe( 'Brief assessment' ),
+  issues: z.array( z.string() ).describe( 'Problems found' ),
+  suggestions: z.array( z.string() ).describe( 'Improvements' ),
+  score: z.number().describe( 'Quality score 0-100' )
+} );
 
-export const reviewContent = step({
+export const reviewContent = step( {
   name: 'reviewContent',
   description: 'Review technical content using Agent with structured output',
-  inputSchema: z.object({
-    content: z.string().describe('The content to review'),
-    content_type: z.string().describe('Type of content'),
-    focus: z.string().describe('Review focus areas')
-  }),
+  inputSchema: z.object( {
+    content: z.string().describe( 'The content to review' ),
+    content_type: z.string().describe( 'Type of content' ),
+    focus: z.string().describe( 'Review focus areas' )
+  } ),
   outputSchema: reviewSchema,
-  fn: async (input) => {
-    const agent = new Agent({
+  fn: async input => {
+    const agent = new Agent( {
       prompt: 'writing_assistant@v1',
       variables: input,
-      output: Output.object({ schema: reviewSchema }),
+      output: Output.object( { schema: reviewSchema } ),
       maxSteps: 5
-    });
+    } );
     const { output } = await agent.generate();
     return output;
   }
-});
+} );
 ```
 
 This is the standard pattern. Each step invocation is independent, and Agent construction is cheap.
@@ -210,7 +210,7 @@ Combine inline skills with Agent for dynamic expertise:
 ```typescript
 import { Agent, skill, Output } from '@outputai/llm';
 
-const audienceSkill = skill({
+const audienceSkill = skill( {
   name: 'audience_adaptation',
   description: 'Tailor feedback for the specified expertise level',
   instructions: `# Audience Adaptation
@@ -219,15 +219,15 @@ When the target audience is specified, adjust your feedback:
 **Beginner**: Flag jargon as high-priority issues.
 **Expert**: Focus on accuracy and completeness.
 Always mention the audience level in your summary.`
-});
+} );
 
-const agent = new Agent({
+const agent = new Agent( {
   prompt: 'writing_assistant@v1',
   variables: input,
-  skills: [audienceSkill],
-  output: Output.object({ schema: reviewSchema }),
+  skills: [ audienceSkill ],
+  output: Output.object( { schema: reviewSchema } ),
   maxSteps: 5
-});
+} );
 const { output } = await agent.generate();
 ```
 
@@ -251,13 +251,13 @@ Start with `generateText`. Move to `Agent` when you need conversation state or a
 ```typescript
 import { generateText } from '@outputai/llm';
 
-const { result } = await generateText({
+const { result } = await generateText( {
   prompt: 'generate_summary@v1',
   variables: {
     company_name: input.name,
     website_content: input.websiteContent
   }
-});
+} );
 ```
 
 ## Verification Checklist

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-code-style/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-code-style/SKILL.md
@@ -27,16 +27,16 @@ Never use trailing commas in objects, arrays, function parameters, or type defin
 const config = {
   name: 'workflow',
   timeout: 30000
-}
+};
 
-const items = [ 'a', 'b', 'c' ]
+const items = [ 'a', 'b', 'c' ];
 
 export const myStep = step( {
   name: 'myStep',
   inputSchema: MyInputSchema,
   outputSchema: MyOutputSchema,
   fn: async input => {
-    return { result: input.value }
+    return { result: input.value };
   }
 } );
 ```
@@ -107,7 +107,7 @@ fn: async input => { ... }
 
 // Parens required for these cases:
 items.reduce( ( acc, item ) => acc + item, 0 )
-const run = ( { name, id } ) => `${ name }-${ id }`;
+const run = ( { name, id } ) => `${name}-${id}`;
 const noop = () => {};
 ```
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-code-style/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-code-style/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: output-dev-code-style
+description: Code style conventions for Output SDK projects. Use when writing or reviewing any TypeScript/JavaScript code to ensure it follows project formatting rules.
+allowed-tools: [Read]
+---
+
+# Code Style Conventions
+
+## Overview
+
+All Output SDK projects enforce a consistent code style via ESLint. Generated code must follow these rules so it passes linting without manual cleanup.
+
+## When to Use This Skill
+
+- Writing any TypeScript or JavaScript code in a workflow project
+- Reviewing generated code before delivery
+- Fixing lint errors after generation
+
+## Rules
+
+### No Trailing Commas
+
+Never use trailing commas in objects, arrays, function parameters, or type definitions.
+
+```typescript
+// CORRECT
+const config = {
+  name: 'workflow',
+  timeout: 30000
+}
+
+const items = [ 'a', 'b', 'c' ]
+
+export const myStep = step( {
+  name: 'myStep',
+  inputSchema: MyInputSchema,
+  outputSchema: MyOutputSchema,
+  fn: async input => {
+    return { result: input.value }
+  }
+} );
+```
+
+```typescript
+// WRONG - trailing commas
+const config = {
+  name: 'workflow',
+  timeout: 30000,  // <-- not allowed
+}
+
+const items = [ 'a', 'b', 'c', ]  // <-- not allowed
+```
+
+### No `let` Declarations
+
+`let` is banned. Use `const` exclusively. When a value needs conditional assignment, use a ternary, an IIFE, or restructure the logic.
+
+```typescript
+// CORRECT - ternary
+const label = count > 1 ? 'items' : 'item';
+
+// CORRECT - IIFE for complex cases
+const content = await ( async () => {
+  try {
+    return await fetchContent( url );
+  } catch {
+    return '[Content unavailable]';
+  }
+} )();
+
+// CORRECT - early return in a function
+function resolve( input ) {
+  if ( input.mode === 'fast' ) {
+    return fastPath( input );
+  }
+  return standardPath( input );
+}
+```
+
+```typescript
+// WRONG
+let content;  // <-- banned
+try {
+  content = await fetchContent( url );
+} catch {
+  content = '[Content unavailable]';
+}
+
+let label;  // <-- banned
+if ( count > 1 ) {
+  label = 'items';
+} else {
+  label = 'item';
+}
+```
+
+### Arrow Parens Only When Needed
+
+Single-parameter arrow functions must not have parentheses. Use parens only for zero, multiple, or destructured parameters.
+
+```typescript
+// CORRECT
+items.map( item => item.id )
+items.filter( s => s.url )
+items.forEach( x => console.log( x ) )
+fn: async input => { ... }
+
+// Parens required for these cases:
+items.reduce( ( acc, item ) => acc + item, 0 )
+const run = ( { name, id } ) => `${ name }-${ id }`;
+const noop = () => {};
+```
+
+```typescript
+// WRONG - unnecessary parens on single param
+items.map( ( item ) => item.id )
+items.filter( ( s ) => s.url )
+fn: async ( input ) => { ... }
+```
+
+### `prefer-const`
+
+Always use `const`. If a binding is never reassigned, it must be `const`.
+
+### Operator Linebreak After
+
+When an expression spans multiple lines, the operator stays on the first line.
+
+```typescript
+// CORRECT
+const result = longExpression +
+  anotherExpression;
+
+const isValid = conditionA &&
+  conditionB &&
+  conditionC;
+
+const value = condition ?
+  trueResult :
+  falseResult;
+```
+
+```typescript
+// WRONG - operator on next line
+const result = longExpression
+  + anotherExpression;
+```
+
+### Spacing
+
+- **Space in parens**: `fn( x )` not `fn(x)`, except empty parens `fn()`
+- **Space in brackets**: `[ 'a', 'b' ]` not `['a', 'b']`
+- **Space in braces**: `{ key: value }` not `{key: value}`
+- **Indent**: 2 spaces
+- **Quotes**: single quotes
+- **Semicolons**: always
+
+### File and Folder Naming
+
+- All file names: `snake_case` (e.g., `fetch_data.ts`, `html_renderer.ts`)
+- All folder names: `snake_case` (e.g., `ai_hn_digest`, `shared_utils`)
+- Exceptions: config files (`vitest.config.js`, `eslint.config.js`)
+
+## Quick Reference
+
+| Rule | Correct | Wrong |
+|------|---------|-------|
+| Trailing comma | `{ a: 1 }` | `{ a: 1, }` |
+| Variable declaration | `const x = 1` | `let x = 1` |
+| Single-param arrow | `x => x.id` | `( x ) => x.id` |
+| Operator linebreak | `a +\n  b` | `a\n  + b` |
+| Parens spacing | `fn( x )` | `fn(x)` |
+
+## Verification
+
+Run `npm run lint` to check all style rules. Run `npm run lint:fix` to auto-fix most violations.

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-code-style/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-code-style/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: output-dev-code-style
-description: Code style conventions for Output SDK projects. Use when writing or reviewing any TypeScript/JavaScript code to ensure it follows project formatting rules.
-allowed-tools: [Read]
+description: Code style conventions for Output SDK workflow projects. Use when writing or reviewing any TypeScript/JavaScript code. Discovers the project's own linting rules first; falls back to Output SDK conventions when no linter is configured.
+allowed-tools: [Read, Bash, Glob, Grep]
 ---
 
 # Code Style Conventions
 
 ## Overview
 
-All Output SDK projects enforce a consistent code style via ESLint. Generated code must follow these rules so it passes linting without manual cleanup.
+Generated code must match the style of the project it lives in. Many projects use their own linter or formatter (ESLint, Prettier, Biome, etc.) with rule sets that differ from Output's defaults. **Always discover and follow the project's rules first.** Only fall back to the Output SDK conventions below when the project has no linter or formatter configured.
 
 ## When to Use This Skill
 
@@ -16,7 +16,29 @@ All Output SDK projects enforce a consistent code style via ESLint. Generated co
 - Reviewing generated code before delivery
 - Fixing lint errors after generation
 
-## Rules
+## Rules Discovery (do this first)
+
+Before writing or reviewing code, determine the project's style rules:
+
+1. **Check for a linter config.** Look for `eslint.config.js`, `.eslintrc.*`, `biome.json`, `deno.json`, or similar in the project root.
+2. **Check for a formatter config.** Look for `.prettierrc*`, `.editorconfig`, or formatter settings in `package.json`.
+3. **Check for lint/format scripts.** Look in `package.json` for `lint`, `lint:fix`, `format`, or similar scripts.
+4. **Read existing source files.** If no config exists, infer conventions from the existing code (comma style, quote style, indentation, semicolons, spacing).
+
+### If the project has a linter or formatter
+
+- Follow its rules. Do not apply Output SDK conventions that conflict.
+- Run the project's lint/format command after generating code.
+- If a rule is ambiguous, match the patterns in existing source files.
+
+### If the project has no linter or formatter
+
+- Apply the Output SDK Default Conventions below.
+- Match any conventions already present in existing source files -- consistency with the repo takes priority over the defaults below.
+
+## Output SDK Default Conventions
+
+These rules reflect the Output SDK's own ESLint config. Apply them only when the project has no linter configured and no conflicting conventions are evident in existing code.
 
 ### No Trailing Commas
 
@@ -59,14 +81,15 @@ const items = [ 'a', 'b', 'c', ]  // <-- not allowed
 // CORRECT - ternary
 const label = count > 1 ? 'items' : 'item';
 
-// CORRECT - IIFE for complex cases
-const content = await ( async () => {
+// CORRECT - named helper for complex cases
+const fetchWithFallback = async url => {
   try {
     return await fetchContent( url );
   } catch {
     return '[Content unavailable]';
   }
-} )();
+};
+const content = await fetchWithFallback( url );
 
 // CORRECT - early return in a function
 function resolve( input ) {
@@ -96,7 +119,7 @@ if ( count > 1 ) {
 
 ### Arrow Parens Only When Needed
 
-Single-parameter arrow functions must not have parentheses. Use parens only for zero, multiple, or destructured parameters.
+Single-parameter arrow functions must not have parentheses. Use parens only for zero, multiple, destructured parameters, or when a TypeScript return type annotation is present.
 
 ```typescript
 // CORRECT
@@ -109,6 +132,7 @@ fn: async input => { ... }
 items.reduce( ( acc, item ) => acc + item, 0 )
 const run = ( { name, id } ) => `${name}-${id}`;
 const noop = () => {};
+fn: async ( input ): Promise<WorkflowOutput> => { ... }  // return type annotation
 ```
 
 ```typescript
@@ -161,7 +185,7 @@ const result = longExpression
 - All folder names: `snake_case` (e.g., `ai_hn_digest`, `shared_utils`)
 - Exceptions: config files (`vitest.config.js`, `eslint.config.js`)
 
-## Quick Reference
+## Quick Reference (Output SDK defaults)
 
 | Rule | Correct | Wrong |
 |------|---------|-------|
@@ -173,4 +197,6 @@ const result = longExpression
 
 ## Verification
 
-Run `npm run lint` to check all style rules. Run `npm run lint:fix` to auto-fix most violations.
+1. If the project has a lint command (`npm run lint`, `npx eslint`, etc.), run it and fix any violations.
+2. If the project has a format command (`npm run format`, `npx prettier --write`, etc.), run it.
+3. If neither exists, review the generated code against existing source files in the repo for consistency.

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-create-skeleton/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-create-skeleton/SKILL.md
@@ -71,16 +71,16 @@ import { workflow, z } from '@outputai/core';
 import { exampleStep } from './steps.js';
 import { WorkflowInputSchema } from './types.js';
 
-export default workflow({
+export default workflow( {
   name: 'workflowName',
   description: 'Workflow description',
   inputSchema: WorkflowInputSchema,
-  outputSchema: z.object({ result: z.string() }),
-  fn: async (input) => {
-    const result = await exampleStep(input);
+  outputSchema: z.object( { result: z.string() } ),
+  fn: async input => {
+    const result = await exampleStep( input );
     return { result };
   }
-});
+} );
 ```
 
 **steps.ts** - Contains example step template:
@@ -88,25 +88,25 @@ export default workflow({
 import { step, z } from '@outputai/core';
 import { ExampleStepInputSchema } from './types.js';
 
-export const exampleStep = step({
+export const exampleStep = step( {
   name: 'exampleStep',
   description: 'Example step description',
   inputSchema: ExampleStepInputSchema,
-  outputSchema: z.object({ result: z.string() }),
-  fn: async (input) => {
+  outputSchema: z.object( { result: z.string() } ),
+  fn: async input => {
     // Implement step logic here
     return { result: 'example' };
   }
-});
+} );
 ```
 
 **types.ts** - Contains schema definitions:
 ```typescript
 import { z } from '@outputai/core';
 
-export const WorkflowInputSchema = z.object({
+export const WorkflowInputSchema = z.object( {
   // Define input fields
-});
+} );
 
 export type WorkflowInput = z.infer<typeof WorkflowInputSchema>;
 ```
@@ -126,12 +126,12 @@ In `types.ts`, define your actual input/output schemas:
 ```typescript
 import { z } from '@outputai/core';
 
-export const WorkflowInputSchema = z.object({
-  content: z.string().describe('Content to process'),
-  options: z.object({
-    format: z.enum(['json', 'text']).default('json')
-  }).optional()
-});
+export const WorkflowInputSchema = z.object( {
+  content: z.string().describe( 'Content to process' ),
+  options: z.object( {
+    format: z.enum( [ 'json', 'text' ] ).default( 'json' )
+  } ).optional()
+} );
 
 export type WorkflowInput = z.infer<typeof WorkflowInputSchema>;
 export type WorkflowOutput = { processed: string };
@@ -148,16 +148,16 @@ import { step, z, FatalError, ValidationError } from '@outputai/core';
 import { httpClient } from '@outputai/http';
 import { ProcessContentInputSchema } from './types.js';
 
-export const processContent = step({
+export const processContent = step( {
   name: 'processContent',
   description: 'Process the input content',
   inputSchema: ProcessContentInputSchema,
-  outputSchema: z.object({ processed: z.string() }),
-  fn: async ({ content }) => {
+  outputSchema: z.object( { processed: z.string() } ),
+  fn: async ( { content } ) => {
     // Implement your logic
     return { processed: content.toUpperCase() };
   }
-});
+} );
 ```
 
 **Related Skill**: `output-dev-step-function`
@@ -171,16 +171,16 @@ import { workflow, z } from '@outputai/core';
 import { processContent } from './steps.js';
 import { WorkflowInputSchema } from './types.js';
 
-export default workflow({
+export default workflow( {
   name: 'contentProcessor',
   description: 'Process content with custom logic',
   inputSchema: WorkflowInputSchema,
-  outputSchema: z.object({ processed: z.string() }),
-  fn: async (input) => {
-    const result = await processContent({ content: input.content });
+  outputSchema: z.object( { processed: z.string() } ),
+  fn: async input => {
+    const result = await processContent( { content: input.content } );
     return result;
   }
-});
+} );
 ```
 
 **Related Skill**: `output-dev-workflow-function`
@@ -258,32 +258,32 @@ Common issues after skeleton generation:
 
 ```typescript
 // steps.ts
-export const stepOne = step({ ... });
-export const stepTwo = step({ ... });
-export const stepThree = step({ ... });
+export const stepOne = step( { ... } );
+export const stepTwo = step( { ... } );
+export const stepThree = step( { ... } );
 
 // workflow.ts
-const resultOne = await stepOne(input);
-const resultTwo = await stepTwo(resultOne);
-const resultThree = await stepThree(resultTwo);
+const resultOne = await stepOne( input );
+const resultTwo = await stepTwo( resultOne );
+const resultThree = await stepThree( resultTwo );
 ```
 
 ### Parallel Step Execution
 
 ```typescript
 // workflow.ts
-const [resultA, resultB] = await Promise.all([
-  stepA(input),
-  stepB(input)
-]);
+const [ resultA, resultB ] = await Promise.all( [
+  stepA( input ),
+  stepB( input )
+] );
 ```
 
 ### Conditional Steps
 
 ```typescript
 // workflow.ts
-if (input.processImages) {
-  await processImages(input);
+if ( input.processImages ) {
+  await processImages( input );
 }
 ```
 
@@ -325,4 +325,5 @@ After generating and customizing the skeleton:
 - `output-dev-prompt-file` - Adding LLM prompts
 - `output-dev-scenario-file` - Creating test scenarios
 - `output-workflow-run` - Running workflows
+- `output-dev-code-style` - Code style conventions
 - `output-workflow-list` - Listing available workflows

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-evaluator-function/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-evaluator-function/SKILL.md
@@ -125,18 +125,18 @@ import { BlogContent } from './types';
 ```typescript
 import { evaluator, z, EvaluationBooleanResult } from '@outputai/core';
 
-export const myEvaluator = evaluator({
+export const myEvaluator = evaluator( {
   name: 'my_evaluator',
   description: 'Description of what this evaluator assesses',
-  inputSchema: z.object({ /* input schema */ }),
-  fn: async (input) => {
+  inputSchema: z.object( { /* input schema */ } ),
+  fn: async input => {
     // Evaluation logic
-    return new EvaluationBooleanResult({
+    return new EvaluationBooleanResult( {
       value: true,
       confidence: 0.95
-    });
+    } );
   }
-});
+} );
 ```
 
 ## Required Properties
@@ -159,22 +159,22 @@ description: 'Evaluate the quality and completeness of generated content'
 Schema for validating evaluator input.
 
 ```typescript
-inputSchema: z.object({
+inputSchema: z.object( {
   content: z.string(),
   expectedLength: z.number()
-})
+} )
 ```
 
 ### fn (async function)
 The evaluator execution function. Returns an evaluation result with value and confidence.
 
 ```typescript
-fn: async (input) => {
+fn: async input => {
   const isValid = input.content.length >= input.expectedLength;
-  return new EvaluationBooleanResult({
+  return new EvaluationBooleanResult( {
     value: isValid,
     confidence: 0.95
-  });
+  } );
 }
 ```
 
@@ -187,11 +187,11 @@ Use for pass/fail or true/false evaluations:
 ```typescript
 import { EvaluationBooleanResult } from '@outputai/core';
 
-return new EvaluationBooleanResult({
+return new EvaluationBooleanResult( {
   value: true,           // boolean result
   confidence: 0.95,      // 0.0 to 1.0
   reasoning: 'Optional explanation of the evaluation'
-});
+} );
 ```
 
 ### EvaluationNumberResult
@@ -201,11 +201,11 @@ Use for numeric scores or ratings:
 ```typescript
 import { EvaluationNumberResult } from '@outputai/core';
 
-return new EvaluationNumberResult({
+return new EvaluationNumberResult( {
   value: 85,             // numeric result (e.g., 0-100 score)
   confidence: 0.85,      // 0.0 to 1.0
   reasoning: 'Optional explanation of the score'
-});
+} );
 ```
 
 ### EvaluationStringResult
@@ -215,11 +215,11 @@ Use for categorical or text-based evaluations:
 ```typescript
 import { EvaluationStringResult } from '@outputai/core';
 
-return new EvaluationStringResult({
+return new EvaluationStringResult( {
   value: 'positive',     // string result (e.g., category, sentiment, label)
   confidence: 0.9,       // 0.0 to 1.0
   reasoning: 'Optional explanation of the classification'
-});
+} );
 ```
 
 ## Result Properties
@@ -240,25 +240,25 @@ return new EvaluationStringResult({
 ```typescript
 import { evaluator, z, EvaluationBooleanResult } from '@outputai/core';
 
-export const evaluateCompleteness = evaluator({
+export const evaluateCompleteness = evaluator( {
   name: 'evaluate_completeness',
   description: 'Check if content meets minimum length requirements',
-  inputSchema: z.object({
+  inputSchema: z.object( {
     content: z.string(),
-    minLength: z.number().default(100)
-  }),
-  fn: async ({ content, minLength }) => {
+    minLength: z.number().default( 100 )
+  } ),
+  fn: async ( { content, minLength } ) => {
     const isComplete = content.length >= minLength;
 
-    return new EvaluationBooleanResult({
+    return new EvaluationBooleanResult( {
       value: isComplete,
       confidence: 1.0,
       reasoning: isComplete
         ? `Content has ${content.length} characters, meets minimum of ${minLength}`
         : `Content has ${content.length} characters, below minimum of ${minLength}`
-    });
+    } );
   }
-});
+} );
 ```
 
 ### Boolean Evaluator - Pattern Detection
@@ -266,20 +266,20 @@ export const evaluateCompleteness = evaluator({
 ```typescript
 import { evaluator, z, EvaluationBooleanResult } from '@outputai/core';
 
-export const evaluateGibberish = evaluator({
+export const evaluateGibberish = evaluator( {
   name: 'evaluate_gibberish',
   description: 'Check if a given string is gibberish',
   inputSchema: z.string(),
   fn: async content => {
-    const gibberishPatterns = ['foo', 'bar', 'lorem', 'ipsum'];
-    const isGibberish = gibberishPatterns.some(p => content.toLowerCase().includes(p));
+    const gibberishPatterns = [ 'foo', 'bar', 'lorem', 'ipsum' ];
+    const isGibberish = gibberishPatterns.some( p => content.toLowerCase().includes( p ) );
 
-    return new EvaluationBooleanResult({
+    return new EvaluationBooleanResult( {
       value: !isGibberish,
       confidence: 0.95
-    });
+    } );
   }
-});
+} );
 ```
 
 ### Number Evaluator - Quality Score
@@ -287,27 +287,27 @@ export const evaluateGibberish = evaluator({
 ```typescript
 import { evaluator, z, EvaluationNumberResult } from '@outputai/core';
 
-export const evaluateReadability = evaluator({
+export const evaluateReadability = evaluator( {
   name: 'evaluate_readability',
   description: 'Calculate readability score based on sentence structure',
-  inputSchema: z.object({
+  inputSchema: z.object( {
     content: z.string()
-  }),
-  fn: async ({ content }) => {
-    const sentences = content.split(/[.!?]+/).filter(s => s.trim());
-    const words = content.split(/\s+/).filter(w => w.trim());
-    const avgWordsPerSentence = words.length / Math.max(sentences.length, 1);
+  } ),
+  fn: async ( { content } ) => {
+    const sentences = content.split( /[.!?]+/ ).filter( s => s.trim() );
+    const words = content.split( /\s+/ ).filter( w => w.trim() );
+    const avgWordsPerSentence = words.length / Math.max( sentences.length, 1 );
 
     // Simple readability score (lower avg words = more readable)
-    const score = Math.max(0, Math.min(100, 100 - (avgWordsPerSentence - 15) * 5));
+    const score = Math.max( 0, Math.min( 100, 100 - ( avgWordsPerSentence - 15 ) * 5 ) );
 
-    return new EvaluationNumberResult({
-      value: Math.round(score),
+    return new EvaluationNumberResult( {
+      value: Math.round( score ),
       confidence: 0.8,
-      reasoning: `Average ${avgWordsPerSentence.toFixed(1)} words per sentence`
-    });
+      reasoning: `Average ${avgWordsPerSentence.toFixed( 1 )} words per sentence`
+    } );
   }
-});
+} );
 ```
 
 ### String Evaluator - Sentiment Classification
@@ -315,41 +315,33 @@ export const evaluateReadability = evaluator({
 ```typescript
 import { evaluator, z, EvaluationStringResult } from '@outputai/core';
 
-export const evaluateSentiment = evaluator({
+export const evaluateSentiment = evaluator( {
   name: 'evaluate_sentiment',
   description: 'Classify the sentiment of content',
-  inputSchema: z.object({
+  inputSchema: z.object( {
     content: z.string()
-  }),
-  fn: async ({ content }) => {
-    const positiveWords = ['great', 'excellent', 'amazing', 'good', 'love'];
-    const negativeWords = ['bad', 'terrible', 'awful', 'hate', 'poor'];
+  } ),
+  fn: async ( { content } ) => {
+    const positiveWords = [ 'great', 'excellent', 'amazing', 'good', 'love' ];
+    const negativeWords = [ 'bad', 'terrible', 'awful', 'hate', 'poor' ];
 
     const lowerContent = content.toLowerCase();
-    const positiveCount = positiveWords.filter(w => lowerContent.includes(w)).length;
-    const negativeCount = negativeWords.filter(w => lowerContent.includes(w)).length;
+    const positiveCount = positiveWords.filter( w => lowerContent.includes( w ) ).length;
+    const negativeCount = negativeWords.filter( w => lowerContent.includes( w ) ).length;
 
-    let sentiment: string;
-    let confidence: number;
+    const { sentiment, confidence } = positiveCount > negativeCount
+      ? { sentiment: 'positive', confidence: Math.min( 0.95, 0.6 + positiveCount * 0.1 ) }
+      : negativeCount > positiveCount
+        ? { sentiment: 'negative', confidence: Math.min( 0.95, 0.6 + negativeCount * 0.1 ) }
+        : { sentiment: 'neutral', confidence: 0.7 };
 
-    if (positiveCount > negativeCount) {
-      sentiment = 'positive';
-      confidence = Math.min(0.95, 0.6 + positiveCount * 0.1);
-    } else if (negativeCount > positiveCount) {
-      sentiment = 'negative';
-      confidence = Math.min(0.95, 0.6 + negativeCount * 0.1);
-    } else {
-      sentiment = 'neutral';
-      confidence = 0.7;
-    }
-
-    return new EvaluationStringResult({
+    return new EvaluationStringResult( {
       value: sentiment,
       confidence,
       reasoning: `Found ${positiveCount} positive and ${negativeCount} negative indicators`
-    });
+    } );
   }
-});
+} );
 ```
 
 ## LLM-Powered Evaluator Examples
@@ -360,33 +352,33 @@ export const evaluateSentiment = evaluator({
 import { evaluator, z, EvaluationNumberResult } from '@outputai/core';
 import { generateText, Output } from '@outputai/llm';
 
-export const evaluateSignalToNoise = evaluator({
+export const evaluateSignalToNoise = evaluator( {
   name: 'evaluate_signal_to_noise',
   description: 'Evaluate the signal-to-noise ratio of content',
-  inputSchema: z.object({
+  inputSchema: z.object( {
     title: z.string(),
     content: z.string()
-  }),
-  fn: async ({ title, content }) => {
-    const { output } = await generateText({
+  } ),
+  fn: async ( { title, content } ) => {
+    const { output } = await generateText( {
       prompt: 'signal_noise@v1',  // References prompts/signal_noise@v1.prompt
       variables: {
         title,
         content
       },
-      output: Output.object({
-        schema: z.object({
-          score: z.number().describe('Signal-to-noise score 0-100')
-        })
-      })
-    });
+      output: Output.object( {
+        schema: z.object( {
+          score: z.number().describe( 'Signal-to-noise score 0-100' )
+        } )
+      } )
+    } );
 
-    return new EvaluationNumberResult({
+    return new EvaluationNumberResult( {
       value: output.score,
       confidence: 0.85
-    });
+    } );
   }
-});
+} );
 ```
 
 ### LLM Boolean Evaluation
@@ -395,35 +387,35 @@ export const evaluateSignalToNoise = evaluator({
 import { evaluator, z, EvaluationBooleanResult } from '@outputai/core';
 import { generateText, Output } from '@outputai/llm';
 
-export const evaluateFactualAccuracy = evaluator({
+export const evaluateFactualAccuracy = evaluator( {
   name: 'evaluate_factual_accuracy',
   description: 'Check if content contains factual claims that can be verified',
-  inputSchema: z.object({
+  inputSchema: z.object( {
     content: z.string(),
     topic: z.string()
-  }),
-  fn: async ({ content, topic }) => {
-    const { output } = await generateText({
+  } ),
+  fn: async ( { content, topic } ) => {
+    const { output } = await generateText( {
       prompt: 'factual_check@v1',
       variables: { content, topic },
-      output: Output.object({
-        schema: z.object({
-          isFactual: z.boolean().describe('Whether content appears factually accurate'),
-          confidence: z.number().describe('Confidence in assessment 0-1'),
-          issues: z.array(z.string()).optional().describe('Any factual issues found')
-        })
-      })
-    });
+      output: Output.object( {
+        schema: z.object( {
+          isFactual: z.boolean().describe( 'Whether content appears factually accurate' ),
+          confidence: z.number().describe( 'Confidence in assessment 0-1' ),
+          issues: z.array( z.string() ).optional().describe( 'Any factual issues found' )
+        } )
+      } )
+    } );
 
-    return new EvaluationBooleanResult({
+    return new EvaluationBooleanResult( {
       value: output.isFactual,
       confidence: output.confidence,
       reasoning: output.issues?.length
-        ? `Issues found: ${output.issues.join(', ')}`
+        ? `Issues found: ${output.issues.join( ', ' )}`
         : 'No factual issues detected'
-    });
+    } );
   }
-});
+} );
 ```
 
 ### LLM String Evaluation - Content Classification
@@ -432,36 +424,36 @@ export const evaluateFactualAccuracy = evaluator({
 import { evaluator, z, EvaluationStringResult } from '@outputai/core';
 import { generateText, Output } from '@outputai/llm';
 
-export const evaluateContentCategory = evaluator({
+export const evaluateContentCategory = evaluator( {
   name: 'evaluate_content_category',
   description: 'Classify content into a category',
-  inputSchema: z.object({
+  inputSchema: z.object( {
     content: z.string(),
-    categories: z.array(z.string())
-  }),
-  fn: async ({ content, categories }) => {
-    const { output } = await generateText({
+    categories: z.array( z.string() )
+  } ),
+  fn: async ( { content, categories } ) => {
+    const { output } = await generateText( {
       prompt: 'categorize_content@v1',
       variables: {
         content,
-        categories: categories.join(', ')
+        categories: categories.join( ', ' )
       },
-      output: Output.object({
-        schema: z.object({
-          category: z.string().describe('The best matching category'),
-          confidence: z.number().describe('Confidence in classification 0-1'),
-          explanation: z.string().describe('Why this category was chosen')
-        })
-      })
-    });
+      output: Output.object( {
+        schema: z.object( {
+          category: z.string().describe( 'The best matching category' ),
+          confidence: z.number().describe( 'Confidence in classification 0-1' ),
+          explanation: z.string().describe( 'Why this category was chosen' )
+        } )
+      } )
+    } );
 
-    return new EvaluationStringResult({
+    return new EvaluationStringResult( {
       value: output.category,
       confidence: output.confidence,
       reasoning: output.explanation
-    });
+    } );
   }
-});
+} );
 ```
 
 ## EvaluationResult with Feedback
@@ -471,28 +463,28 @@ Use the `feedback` field to provide actionable improvement suggestions alongside
 ```typescript
 import { evaluator, z, EvaluationStringResult, EvaluationFeedback } from '@outputai/core';
 
-export const evaluateWithFeedback = evaluator({
+export const evaluateWithFeedback = evaluator( {
   name: 'evaluate_with_feedback',
   description: 'Evaluate content quality and provide actionable feedback',
   inputSchema: z.string(),
-  fn: async (response) => {
+  fn: async response => {
     const feedback = [];
 
-    if (response.length < 50) {
-      feedback.push(new EvaluationFeedback({
+    if ( response.length < 50 ) {
+      feedback.push( new EvaluationFeedback( {
         issue: 'Response is too short',
         suggestion: 'Expand the response with more detail',
         priority: 'medium'
-      }));
+      } ) );
     }
 
-    return new EvaluationStringResult({
+    return new EvaluationStringResult( {
       value: feedback.length === 0 ? 'good' : 'needs_improvement',
       confidence: 0.85,
       feedback: feedback
-    });
+    } );
   }
-});
+} );
 ```
 
 ### EvaluationFeedback Properties
@@ -510,33 +502,33 @@ Use the `dimensions` field to nest `EvaluationResult` instances for sub-scores. 
 ```typescript
 import { evaluator, z, EvaluationStringResult, EvaluationNumberResult } from '@outputai/core';
 
-export const evaluateMultiDimensional = evaluator({
+export const evaluateMultiDimensional = evaluator( {
   name: 'evaluate_multi_dimensional',
   description: 'Evaluate content across multiple quality dimensions',
   inputSchema: z.string(),
-  fn: async (response) => {
-    const coherenceScore = calculateCoherence(response);
-    const relevanceScore = calculateRelevance(response);
-    const overallScore = (coherenceScore + relevanceScore) / 2;
+  fn: async response => {
+    const coherenceScore = calculateCoherence( response );
+    const relevanceScore = calculateRelevance( response );
+    const overallScore = ( coherenceScore + relevanceScore ) / 2;
 
-    return new EvaluationStringResult({
+    return new EvaluationStringResult( {
       value: overallScore > 0.7 ? 'high_quality' : 'low_quality',
       confidence: 0.9,
       dimensions: [
-        new EvaluationNumberResult({
+        new EvaluationNumberResult( {
           value: coherenceScore,
           confidence: 0.85,
           name: 'coherence'
-        }),
-        new EvaluationNumberResult({
+        } ),
+        new EvaluationNumberResult( {
           value: relevanceScore,
           confidence: 0.88,
           name: 'relevance'
-        })
+        } )
       ]
-    });
+    } );
   }
-});
+} );
 ```
 
 ## Complete Example
@@ -550,77 +542,77 @@ import { blogContentSchema } from './types.js';
 import type { BlogContent, QualityMetrics } from './types.js';
 
 // Simple boolean evaluator
-export const evaluateMinimumLength = evaluator({
+export const evaluateMinimumLength = evaluator( {
   name: 'evaluate_minimum_length',
   description: 'Check if blog content meets minimum length requirements',
   inputSchema: blogContentSchema,
-  fn: async (input: BlogContent) => {
+  fn: async ( input: BlogContent ) => {
     const MIN_TOKENS = 500;
     const meetsRequirement = input.tokenCount >= MIN_TOKENS;
 
-    return new EvaluationBooleanResult({
+    return new EvaluationBooleanResult( {
       value: meetsRequirement,
       confidence: 1.0,
       reasoning: `Content has ${input.tokenCount} tokens (minimum: ${MIN_TOKENS})`
-    });
+    } );
   }
-});
+} );
 
 // LLM-powered number evaluator
-export const evaluateSignalToNoise = evaluator({
+export const evaluateSignalToNoise = evaluator( {
   name: 'evaluate_signal_to_noise',
   description: 'Evaluate the signal-to-noise ratio of blog content',
   inputSchema: blogContentSchema,
-  fn: async (input: BlogContent) => {
-    const { output } = await generateText({
+  fn: async ( input: BlogContent ) => {
+    const { output } = await generateText( {
       prompt: 'signal_noise@v1',
       variables: {
         title: input.title,
         content: input.content
       },
-      output: Output.object({
-        schema: z.object({
-          score: z.number().describe('Signal-to-noise score 0-100')
-        })
-      })
-    });
+      output: Output.object( {
+        schema: z.object( {
+          score: z.number().describe( 'Signal-to-noise score 0-100' )
+        } )
+      } )
+    } );
 
-    return new EvaluationNumberResult({
+    return new EvaluationNumberResult( {
       value: output.score,
       confidence: 0.85
-    });
+    } );
   }
-});
+} );
 
 // LLM-powered boolean evaluator
-export const evaluateRelevance = evaluator({
+export const evaluateRelevance = evaluator( {
   name: 'evaluate_relevance',
   description: 'Check if content is relevant to the stated topic',
-  inputSchema: z.object({
+  inputSchema: z.object( {
     content: z.string(),
     topic: z.string(),
-    keywords: z.array(z.string())
-  }),
-  fn: async ({ content, topic, keywords }) => {
-    const { output } = await generateText({
+    keywords: z.array( z.string() )
+  } ),
+  fn: async ( { content, topic, keywords } ) => {
+    const { output } = await generateText( {
       prompt: 'relevance_check@v1',
-      variables: { content, topic, keywords: keywords.join(', ') },
-      output: Output.object({
-        schema: z.object({
+      variables: { content, topic, keywords: keywords.join( ', ' ) },
+      output: Output.object( {
+        schema: z.object( {
           isRelevant: z.boolean(),
-          relevanceScore: z.number().describe('Relevance score 0-1'),
+          relevanceScore: z.number().describe( 'Relevance score 0-1' ),
           explanation: z.string()
-        })
-      })
-    });
+        } )
+      } )
+    } );
 
-    return new EvaluationBooleanResult({
+    return new EvaluationBooleanResult( {
       value: output.isRelevant,
       confidence: output.relevanceScore,
       reasoning: output.explanation
-    });
+    } );
   }
-});
+} );
 ```
 
 ## Best Practices
@@ -629,13 +621,13 @@ export const evaluateRelevance = evaluator({
 
 ```typescript
 // Boolean for pass/fail decisions
-return new EvaluationBooleanResult({ value: true, confidence: 0.9 });
+return new EvaluationBooleanResult( { value: true, confidence: 0.9 } );
 
 // Number for scores and ratings
-return new EvaluationNumberResult({ value: 85, confidence: 0.85 });
+return new EvaluationNumberResult( { value: 85, confidence: 0.85 } );
 
 // String for categories, labels, or classifications
-return new EvaluationStringResult({ value: 'positive', confidence: 0.9 });
+return new EvaluationStringResult( { value: 'positive', confidence: 0.9 } );
 ```
 
 ### 2. Provide Meaningful Confidence Scores
@@ -654,23 +646,23 @@ confidence: 0.7  // e.g., subjective quality judgments
 ### 3. Include Reasoning for Transparency
 
 ```typescript
-return new EvaluationBooleanResult({
+return new EvaluationBooleanResult( {
   value: false,
   confidence: 0.95,
   reasoning: `Content contains ${errorCount} grammatical errors, exceeding threshold of ${maxErrors}`
-});
+} );
 ```
 
 ### 4. Keep Evaluators Focused
 
 ```typescript
 // Good - single responsibility
-export const evaluateGrammar = evaluator({ ... });
-export const evaluateReadability = evaluator({ ... });
-export const evaluateTone = evaluator({ ... });
+export const evaluateGrammar = evaluator( { ... } );
+export const evaluateReadability = evaluator( { ... } );
+export const evaluateTone = evaluator( { ... } );
 
 // Avoid - doing too much in one evaluator
-export const evaluateEverything = evaluator({ ... });
+export const evaluateEverything = evaluator( { ... } );
 ```
 
 ### 5. Use Descriptive Names
@@ -691,11 +683,11 @@ name: 'evaluate_stuff'
 
 ```typescript
 feedback: [
-  new EvaluationFeedback({
+  new EvaluationFeedback( {
     issue: 'Missing conclusion paragraph',
     suggestion: 'Add a summary paragraph at the end',
     priority: 'high'
-  })
+  } )
 ]
 ```
 
@@ -703,8 +695,8 @@ feedback: [
 
 ```typescript
 dimensions: [
-  new EvaluationNumberResult({ value: 8, confidence: 0.9, name: 'coherence' }),
-  new EvaluationNumberResult({ value: 6, confidence: 0.85, name: 'relevance' })
+  new EvaluationNumberResult( { value: 8, confidence: 0.9, name: 'coherence' } ),
+  new EvaluationNumberResult( { value: 6, confidence: 0.85, name: 'relevance' } )
 ]
 ```
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-evaluator-function/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-evaluator-function/SKILL.md
@@ -253,9 +253,9 @@ export const evaluateCompleteness = evaluator( {
     return new EvaluationBooleanResult( {
       value: isComplete,
       confidence: 1.0,
-      reasoning: isComplete
-        ? `Content has ${content.length} characters, meets minimum of ${minLength}`
-        : `Content has ${content.length} characters, below minimum of ${minLength}`
+      reasoning: isComplete ?
+        `Content has ${content.length} characters, meets minimum of ${minLength}` :
+        `Content has ${content.length} characters, below minimum of ${minLength}`
     } );
   }
 } );
@@ -329,11 +329,11 @@ export const evaluateSentiment = evaluator( {
     const positiveCount = positiveWords.filter( w => lowerContent.includes( w ) ).length;
     const negativeCount = negativeWords.filter( w => lowerContent.includes( w ) ).length;
 
-    const { sentiment, confidence } = positiveCount > negativeCount
-      ? { sentiment: 'positive', confidence: Math.min( 0.95, 0.6 + positiveCount * 0.1 ) }
-      : negativeCount > positiveCount
-        ? { sentiment: 'negative', confidence: Math.min( 0.95, 0.6 + negativeCount * 0.1 ) }
-        : { sentiment: 'neutral', confidence: 0.7 };
+    const { sentiment, confidence } = positiveCount > negativeCount ?
+      { sentiment: 'positive', confidence: Math.min( 0.95, 0.6 + positiveCount * 0.1 ) } :
+      negativeCount > positiveCount ?
+        { sentiment: 'negative', confidence: Math.min( 0.95, 0.6 + negativeCount * 0.1 ) } :
+        { sentiment: 'neutral', confidence: 0.7 };
 
     return new EvaluationStringResult( {
       value: sentiment,
@@ -345,6 +345,8 @@ export const evaluateSentiment = evaluator( {
 ```
 
 ## LLM-Powered Evaluator Examples
+
+**Note**: Evaluators are self-contained components that don't share schemas across steps, so defining `Output.object()` schemas inline is acceptable here. For workflow steps that share schemas, define them in `types.ts` instead.
 
 ### Using generateText with Output.object() for Evaluation
 
@@ -410,9 +412,9 @@ export const evaluateFactualAccuracy = evaluator( {
     return new EvaluationBooleanResult( {
       value: output.isFactual,
       confidence: output.confidence,
-      reasoning: output.issues?.length
-        ? `Issues found: ${output.issues.join( ', ' )}`
-        : 'No factual issues detected'
+      reasoning: output.issues?.length ?
+        `Issues found: ${output.issues.join( ', ' )}` :
+        'No factual issues detected'
     } );
   }
 } );

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
@@ -77,6 +77,12 @@ model: claude-sonnet-4-6  # Model identifier
 ---
 ```
 
+### Provider Consistency
+
+All prompt files in a workflow should use the **same provider** unless the user explicitly requests otherwise. Mixing providers (e.g., some prompts using anthropic and others using openai) requires the user to have API keys for all providers, which causes runtime failures if they don't.
+
+Default to `anthropic` with `claude-sonnet-4-6` when no provider preference is specified. If the user has stated a preferred provider during planning, use that for all prompts.
+
 ### Optional Fields
 
 ```yaml

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
@@ -290,7 +290,7 @@ Focus on the most important concepts that would benefit from visual explanation.
 import { generateText, Output } from '@outputai/llm';
 import { z } from '@outputai/core';
 
-const { output } = await generateText({
+const { output } = await generateText( {
   prompt: 'generateImageIdeas@v1',  // References prompts/generateImageIdeas@v1.prompt
   variables: {
     content: 'Solar panel technology explained...',
@@ -298,12 +298,12 @@ const { output } = await generateText({
     colorPalette: 'blue and green tones',
     artDirection: 'minimalist style'
   },
-  output: Output.object({
-    schema: z.object({
-      ideas: z.array(z.string())
-    })
-  })
-});
+  output: Output.object( {
+    schema: z.object( {
+      ideas: z.array( z.string() )
+    } )
+  } )
+} );
 // output contains { ideas: [...] }
 ```
 
@@ -312,13 +312,13 @@ const { output } = await generateText({
 ```typescript
 import { generateText } from '@outputai/llm';
 
-const { result } = await generateText({
+const { result } = await generateText( {
   prompt: 'summarize@v1',
   variables: {
     content: 'Long article text...',
     maxLength: 200
   }
-});
+} );
 // result contains the generated text string
 ```
 
@@ -355,16 +355,16 @@ Prompts work with both `generateText` and the `Agent` class. Use `Agent` for mul
 ```typescript
 import { Agent, Output } from '@outputai/llm';
 
-const agent = new Agent({
+const agent = new Agent( {
   prompt: 'writing_assistant@v1',
   variables: {
     content_type: 'documentation',
     focus: 'clarity',
     content: input.content
   },
-  output: Output.object({ schema: reviewSchema }),
+  output: Output.object( { schema: reviewSchema } ),
   maxSteps: 5
-});
+} );
 const { output } = await agent.generate();
 ```
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
@@ -368,6 +368,40 @@ const agent = new Agent({
 const { output } = await agent.generate();
 ```
 
+## Common Mistakes
+
+### Do Not Duplicate Output Format When Using Output.object()
+
+When a step uses `Output.object()` with `generateText`, the Zod schema is automatically sent to the LLM provider as a tool definition. The LLM already knows the exact JSON shape it must return.
+
+**Do not** include "Output Format" sections, JSON examples, or structural instructions in the prompt -- they duplicate what the schema already provides and can drift out of sync.
+
+```
+<!-- WRONG - prompt duplicates what Output.object() already sends -->
+<system>
+## Output Format
+Return a JSON object with this shape:
+{
+  "title": "string",
+  "summary": "string",
+  "tags": ["string"]
+}
+</system>
+```
+
+Instead, use the prompt to describe **quality expectations and content guidance**, not structural format:
+
+```
+<!-- CORRECT - prompt focuses on content, not structure -->
+<system>
+Write a concise, specific title (under 80 characters).
+The summary should capture the main argument, not just the topic.
+Choose tags from the reader's domain -- avoid generic terms like "technology".
+</system>
+```
+
+The schema in `types.ts` handles structure; the prompt handles quality.
+
 ## Best Practices
 
 ### 1. Be Explicit About Requirements
@@ -515,6 +549,7 @@ Requirements:
 - [ ] Conditionals use `{% if %}...{% endif %}` syntax
 - [ ] All required variables are documented or have defaults
 - [ ] Step code references correct prompt name
+- [ ] No JSON output format instructions when step uses `Output.object()` (schema handles structure)
 
 ## Related Skills
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
@@ -368,13 +368,31 @@ const agent = new Agent({
 const { output } = await agent.generate();
 ```
 
-## Common Mistakes
+## CRITICAL: Prompts and Structured Output Schemas
 
-### Do Not Duplicate Output Format When Using Output.object()
+### Do Not Duplicate the Schema in the Prompt
 
-When a step uses `Output.object()` with `generateText`, the Zod schema is automatically sent to the LLM provider as a tool definition. The LLM already knows the exact JSON shape it must return.
+When a step uses `Output.object()` with `generateText`, the Zod schema is automatically sent to the LLM provider as a tool definition. The LLM already knows the exact JSON shape it must return. **Do not also specify the schema in the prompt.**
 
-**Do not** include "Output Format" sections, JSON examples, or structural instructions in the prompt -- they duplicate what the schema already provides and can drift out of sync.
+This is a best practice documented by multiple LLM providers:
+
+- **Anthropic**: The schema is sent as a tool definition; `.describe()` on fields is how you guide the model's output. The SDK automatically transforms unsupported constraints into field descriptions.
+- **Google Vertex AI**: "Only specify the schema in the schema object. Don't also specify the schema in the prompt. Doing both can reduce performance." If you must discuss the schema in the prompt, match the exact field order from the schema.
+
+**Why this matters:**
+1. **Performance**: Redundant schema instructions can confuse the model and reduce output quality
+2. **Maintenance**: When the schema changes, you must update both the schema AND the prompt, or they drift apart
+3. **Correctness**: The prompt's JSON examples can contradict the actual schema (wrong field names, missing fields, wrong types)
+
+### What NOT to Include in Prompts
+
+When `Output.object()` is used, do not include any of these in the prompt:
+
+- `## Output Format` sections describing the JSON shape
+- JSON examples showing the expected response structure
+- Field-by-field descriptions that mirror the schema
+- Instructions like "Return a JSON object with exactly these fields"
+- Instructions like "Return only the JSON object with no surrounding explanation"
 
 ```
 <!-- WRONG - prompt duplicates what Output.object() already sends -->
@@ -389,10 +407,12 @@ Return a JSON object with this shape:
 </system>
 ```
 
-Instead, use the prompt to describe **quality expectations and content guidance**, not structural format:
+### What TO Include in Prompts
+
+Use the prompt for **quality expectations, domain knowledge, and content guidance** -- things the schema cannot express:
 
 ```
-<!-- CORRECT - prompt focuses on content, not structure -->
+<!-- CORRECT - prompt focuses on content quality, not structure -->
 <system>
 Write a concise, specific title (under 80 characters).
 The summary should capture the main argument, not just the topic.
@@ -400,7 +420,24 @@ Choose tags from the reader's domain -- avoid generic terms like "technology".
 </system>
 ```
 
-The schema in `types.ts` handles structure; the prompt handles quality.
+### Use `.describe()` on Schema Fields Instead
+
+The right place to communicate field-level expectations is on the schema itself, using `.describe()`. LLM providers use these descriptions when generating output:
+
+```typescript
+// In types.ts -- .describe() guides the LLM on each field
+const ArticleSummarySchema = z.object( {
+  title: z.string().describe( 'Concise title under 80 characters' ),
+  summary: z.string().describe( 'One-sentence summary capturing the main argument' ),
+  tags: z.array( z.string() ).describe( '3-5 domain-specific tags, avoid generic terms' )
+} );
+```
+
+The schema handles structure AND field-level guidance; the prompt handles task framing, methodology, and quality standards.
+
+### When the Step Does NOT Use Output.object()
+
+If `generateText` is called **without** `Output.object()` (plain text output), then including output format instructions in the prompt is appropriate since no schema is sent to the provider.
 
 ## Best Practices
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
@@ -282,6 +282,39 @@ Focus on the most important concepts that would benefit from visual explanation.
 </user>
 ```
 
+## CRITICAL: Variable Type Constraint
+
+The `variables` field in `generateText` and `Agent` only accepts **`string | number | boolean`** values. You cannot pass arrays or objects as variables -- TypeScript will reject them.
+
+When your step has complex data (arrays, objects), pre-format it into a string before passing it as a variable:
+
+```typescript
+// WRONG - arrays/objects as variables cause TS2322
+const { output } = await generateText( {
+  prompt: 'rank@v1',
+  variables: {
+    stories: storyArray,       // Type error: not assignable to string | number | boolean
+    interests: interestArray   // Type error: not assignable to string | number | boolean
+  }
+} );
+
+// CORRECT - pre-format complex data into strings
+const storiesText = stories.map( s =>
+  `- ${s.title} (score: ${s.score}, by: ${s.author})`
+).join( '\n' );
+const interestsText = interests.join( ', ' );
+
+const { output } = await generateText( {
+  prompt: 'rank@v1',
+  variables: {
+    stories: storiesText,     // string - OK
+    interests: interestsText  // string - OK
+  }
+} );
+```
+
+The prompt template then uses the pre-formatted string directly with `{{ stories }}` instead of Liquid loops. This is simpler and avoids the type constraint entirely.
+
 ## Using Prompts in Steps
 
 ### With generateText and Output.object()

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-skill-file/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-skill-file/SKILL.md
@@ -133,7 +133,7 @@ Create skills programmatically with the `skill()` function from `@outputai/llm`:
 ```typescript
 import { skill } from '@outputai/llm';
 
-const audienceSkill = skill({
+const audienceSkill = skill( {
   name: 'audience_adaptation',
   description: 'Tailor feedback for the specified expertise level',
   instructions: `# Audience Adaptation
@@ -144,18 +144,18 @@ When the target audience is specified, adjust your feedback:
 **Expert**: Focus on accuracy and completeness.
 
 Always mention the audience level in your summary.`
-});
+} );
 ```
 
 Pass inline skills to `generateText` or `Agent`:
 
 ```typescript
-const { result } = await generateText({
+const { result } = await generateText( {
   prompt: 'writing_assistant@v1',
   variables: { content_type: 'documentation', focus: 'clarity', content: input.content },
-  skills: [audienceSkill],
+  skills: [ audienceSkill ],
   maxSteps: 5
-});
+} );
 ```
 
 Inline skills are merged with any file-based skills.
@@ -237,38 +237,38 @@ Content:
 import { step, z } from '@outputai/core';
 import { Agent, Output } from '@outputai/llm';
 
-export const reviewContent = step({
+export const reviewContent = step( {
   name: 'reviewContent',
   description: 'Review content using skills for specialized expertise',
-  inputSchema: z.object({
+  inputSchema: z.object( {
     content: z.string(),
     content_type: z.string(),
     focus: z.string()
-  }),
-  outputSchema: z.object({
+  } ),
+  outputSchema: z.object( {
     summary: z.string(),
-    issues: z.array(z.string()),
-    suggestions: z.array(z.string()),
+    issues: z.array( z.string() ),
+    suggestions: z.array( z.string() ),
     score: z.number()
-  }),
-  fn: async (input) => {
-    const agent = new Agent({
+  } ),
+  fn: async input => {
+    const agent = new Agent( {
       prompt: 'writing_assistant@v1',
       variables: input,
-      output: Output.object({
-        schema: z.object({
-          summary: z.string().describe('2-3 sentence overview'),
-          issues: z.array(z.string()).describe('Specific problems found'),
-          suggestions: z.array(z.string()).describe('Actionable improvements'),
-          score: z.number().describe('Quality score 0-100')
-        })
-      }),
+      output: Output.object( {
+        schema: z.object( {
+          summary: z.string().describe( '2-3 sentence overview' ),
+          issues: z.array( z.string() ).describe( 'Specific problems found' ),
+          suggestions: z.array( z.string() ).describe( 'Actionable improvements' ),
+          score: z.number().describe( 'Quality score 0-100' )
+        } )
+      } ),
       maxSteps: 5
-    });
+    } );
     const { output } = await agent.generate();
     return output;
   }
-});
+} );
 ```
 
 ## Best Practices

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-step-function/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-step-function/SKILL.md
@@ -134,16 +134,16 @@ import { generateText, Output } from '@outputai/llm';
 
 import { StepInputSchema, StepOutputSchema } from './types.js';
 
-export const myStep = step({
+export const myStep = step( {
   name: 'myStep',
   description: 'Description of what this step does',
   inputSchema: StepInputSchema,
   outputSchema: StepOutputSchema,
-  fn: async (input) => {
+  fn: async input => {
     // Implementation with I/O operations
     return { /* output matching outputSchema */ };
   }
-});
+} );
 ```
 
 ## Required Properties
@@ -163,29 +163,28 @@ description: 'Generate creative infographic prompt ideas using Claude'
 ```
 
 ### inputSchema (Zod schema)
-Schema for validating step input.
+Schema for validating step input. Define in `types.ts` and import.
 
 ```typescript
-inputSchema: z.object({
+inputSchema: z.object( {
   content: z.string(),
   numberOfIdeas: z.number()
-})
+} )
 ```
 
 ### outputSchema (Zod schema)
-Schema for validating step output.
+Schema for validating step output. Define in `types.ts` and import.
 
 ```typescript
-outputSchema: z.array(z.string())
+outputSchema: z.array( z.string() )
 ```
 
 ### fn (async function)
 The step execution function. This is where I/O operations happen.
 
 ```typescript
-fn: async (input) => {
-  // I/O operations allowed here
-  const result = await someExternalService(input);
+fn: async input => {
+  const result = await someExternalService( input );
   return result;
 }
 ```
@@ -198,10 +197,10 @@ fn: async (input) => {
 import { httpClient } from '@outputai/http';
 import { FatalError, ValidationError } from '@outputai/core';
 
-const RETRY_STATUS_CODES = [408, 429, 500, 502, 503, 504];
-const FATAL_STATUS_CODES = [401, 403, 404];
+const RETRY_STATUS_CODES = [ 408, 429, 500, 502, 503, 504 ];
+const FATAL_STATUS_CODES = [ 401, 403, 404 ];
 
-const httpClientInstance = httpClient({
+const httpClientInstance = httpClient( {
   timeout: 30000,
   retry: {
     limit: 3,
@@ -213,89 +212,113 @@ const httpClientInstance = httpClient({
         const status = error.response?.status;
         const message = error.message;
 
-        if (status && FATAL_STATUS_CODES.includes(status)) {
+        if ( status && FATAL_STATUS_CODES.includes( status ) ) {
           throw new FatalError(
-            `HTTP ${status} error: ${message}. This is a permanent error.`
+            `HTTP ${ status } error: ${ message }. This is a permanent error.`
           );
         }
 
         throw new ValidationError(
-          `HTTP request failed: ${message}`
+          `HTTP request failed: ${ message }`
         );
       }
     ]
   }
-});
+} );
 ```
 
 ### Making HTTP Requests
 
 ```typescript
 // GET request
-const response = await httpClientInstance.get('https://api.example.com/data');
+const response = await httpClientInstance.get( 'https://api.example.com/data' );
 const data = await response.json();
 
 // POST request with JSON body
-const response = await httpClientInstance.post('https://api.example.com/submit', {
+const response = await httpClientInstance.post( 'https://api.example.com/submit', {
   json: { field: 'value' }
-});
+} );
 
 // HEAD request (check URL accessibility)
-const response = await httpClientInstance.head(url);
-const contentType = response.headers.get('content-type');
+const response = await httpClientInstance.head( url );
+const contentType = response.headers.get( 'content-type' );
 ```
 
 **Related Skill**: `output-dev-http-client-create` for creating shared clients
 
 ## LLM Operations
 
+### Important: Define LLM Schemas in types.ts
+
+Schemas used in `Output.object()` **must** be defined in `types.ts` and imported -- never defined inline in step functions. Inline schemas lead to duplication, drift between the step's `outputSchema` and the LLM schema, and make it harder to maintain types.
+
+```typescript
+// WRONG - inline schema in Output.object()
+output: Output.object( {
+  schema: z.object( {
+    analysis: z.string()
+  } )
+} )
+
+// CORRECT - import from types.ts
+import { AnalysisLlmSchema } from './types.js';
+// ...
+output: Output.object( {
+  schema: AnalysisLlmSchema
+} )
+```
+
 ### Using generateText with Output.object()
 
 ```typescript
 import { generateText, Output } from '@outputai/llm';
+import {
+  AnalyzeContentInputSchema,
+  AnalyzeContentOutputSchema,
+  AnalysisLlmSchema
+} from './types.js';
 
-export const analyzeContent = step({
+export const analyzeContent = step( {
   name: 'analyzeContent',
   description: 'Analyze content using Claude',
-  inputSchema: z.object({ content: z.string() }),
-  outputSchema: z.object({ analysis: z.string() }),
-  fn: async ({ content }) => {
-    const { output } = await generateText({
-      prompt: 'analyzeContent@v1',  // References prompts/analyzeContent@v1.prompt
+  inputSchema: AnalyzeContentInputSchema,
+  outputSchema: AnalyzeContentOutputSchema,
+  fn: async ( { content } ) => {
+    const { output } = await generateText( {
+      prompt: 'analyzeContent@v1',
       variables: {
         content
       },
-      output: Output.object({
-        schema: z.object({
-          analysis: z.string()
-        })
-      })
-    });
+      output: Output.object( {
+        schema: AnalysisLlmSchema
+      } )
+    } );
 
     return { analysis: output.analysis };
   }
-});
+} );
 ```
 
 ### Using generateText
 
 ```typescript
 import { generateText } from '@outputai/llm';
+import { SummarizeInputSchema, SummarizeOutputSchema } from './types.js';
 
-export const generateSummary = step({
+export const generateSummary = step( {
   name: 'generateSummary',
   description: 'Generate a text summary',
-  inputSchema: z.object({ content: z.string() }),
-  outputSchema: z.object({ summary: z.string() }),
-  fn: async ({ content }) => {
-    const { result } = await generateText({
+  inputSchema: SummarizeInputSchema,
+  outputSchema: SummarizeOutputSchema,
+  fn: async ( { content } ) => {
+    const { result } = await generateText( {
       prompt: 'summarize@v1',
       variables: { content }
-    });
+    } );
 
     return { summary: result };
   }
-});
+} );
 ```
 
 **Related Skill**: `output-dev-prompt-file` for creating prompt files
@@ -310,23 +333,23 @@ Use FatalError for permanent failures that should not be retried:
 import { FatalError } from '@outputai/core';
 
 // Authentication failures
-if (response.status === 401) {
-  throw new FatalError('Invalid API key');
+if ( response.status === 401 ) {
+  throw new FatalError( 'Invalid API key' );
 }
 
 // Invalid input that cannot be fixed by retry
-if (!input.requiredField) {
-  throw new FatalError('Missing required field: requiredField');
+if ( !input.requiredField ) {
+  throw new FatalError( 'Missing required field: requiredField' );
 }
 
 // Resource not found
-if (response.status === 404) {
-  throw new FatalError(`Resource not found: ${resourceId}`);
+if ( response.status === 404 ) {
+  throw new FatalError( `Resource not found: ${ resourceId }` );
 }
 
 // Configuration errors
-if (!process.env.API_KEY) {
-  throw new FatalError('API_KEY environment variable not set');
+if ( !process.env.API_KEY ) {
+  throw new FatalError( 'API_KEY environment variable not set' );
 }
 ```
 
@@ -338,25 +361,25 @@ Use ValidationError for temporary failures that may succeed on retry:
 import { ValidationError } from '@outputai/core';
 
 // Rate limiting
-if (response.status === 429) {
-  throw new ValidationError('Rate limit exceeded, will retry');
+if ( response.status === 429 ) {
+  throw new ValidationError( 'Rate limit exceeded, will retry' );
 }
 
 // Temporary service unavailability
-if (response.status === 503) {
-  throw new ValidationError('Service temporarily unavailable');
+if ( response.status === 503 ) {
+  throw new ValidationError( 'Service temporarily unavailable' );
 }
 
 // Network errors
 try {
-  const response = await httpClientInstance.get(url);
-} catch (error) {
-  throw new ValidationError(`Network error: ${error.message}`);
+  const response = await httpClientInstance.get( url );
+} catch ( error ) {
+  throw new ValidationError( `Network error: ${ error.message }` );
 }
 
 // Empty response that might be temporary
-if (results.length === 0) {
-  throw new ValidationError('No results returned, will retry');
+if ( results.length === 0 ) {
+  throw new ValidationError( 'No results returned, will retry' );
 }
 ```
 
@@ -378,10 +401,10 @@ import {
   ImageIdeasSchema
 } from './types.js';
 
-const RETRY_STATUS_CODES = [408, 429, 500, 502, 503, 504];
-const FATAL_STATUS_CODES = [401, 403, 404];
+const RETRY_STATUS_CODES = [ 408, 429, 500, 502, 503, 504 ];
+const FATAL_STATUS_CODES = [ 401, 403, 404 ];
 
-const httpClientInstance = httpClient({
+const httpClientInstance = httpClient( {
   timeout: 30000,
   retry: {
     limit: 3,
@@ -393,24 +416,24 @@ const httpClientInstance = httpClient({
         const status = error.response?.status;
         const message = error.message;
 
-        if (status && FATAL_STATUS_CODES.includes(status)) {
-          throw new FatalError(`HTTP ${status} error: ${message}`);
+        if ( status && FATAL_STATUS_CODES.includes( status ) ) {
+          throw new FatalError( `HTTP ${ status } error: ${ message }` );
         }
 
-        throw new ValidationError(`HTTP request failed: ${message}`);
+        throw new ValidationError( `HTTP request failed: ${ message }` );
       }
     ]
   }
-});
+} );
 
 // Step 1: Generate Ideas using LLM
-export const generateImageIdeas = step({
+export const generateImageIdeas = step( {
   name: 'generateImageIdeas',
   description: 'Generate creative infographic prompt ideas using Claude',
   inputSchema: GenerateImageIdeasInputSchema,
-  outputSchema: z.array(z.string()),
-  fn: async ({ content, numberOfIdeas, colorPalette, artDirection }) => {
-    const { output } = await generateText({
+  outputSchema: z.array( z.string() ),
+  fn: async ( { content, numberOfIdeas, colorPalette, artDirection } ) => {
+    const { output } = await generateText( {
       prompt: 'generateImageIdeas@v1',
       variables: {
         content,
@@ -418,66 +441,66 @@ export const generateImageIdeas = step({
         colorPalette: colorPalette || '',
         artDirection: artDirection || ''
       },
-      output: Output.object({
+      output: Output.object( {
         schema: ImageIdeasSchema
-      })
-    });
+      } )
+    } );
 
     return output.ideas;
   }
-});
+} );
 
 // Step 2: Generate Images using external API
-export const generateImages = step({
+export const generateImages = step( {
   name: 'generateImages',
   description: 'Generate images using Gemini API',
   inputSchema: GenerateImagesInputSchema,
-  outputSchema: z.array(z.string()),
-  fn: async ({ input, prompt }) => {
+  outputSchema: z.array( z.string() ),
+  fn: async ( { input, prompt } ) => {
     const geminiImageService = new GeminiImageService();
 
-    const generatedImages = await geminiImageService.generateImage({
+    const generatedImages = await geminiImageService.generateImage( {
       prompt,
       aspectRatio: input.aspectRatio,
       resolution: input.resolution,
       numberOfImages: input.numberOfGenerations
-    });
+    } );
 
-    if (generatedImages.length === 0) {
-      throw new ValidationError('No images were generated by Gemini');
+    if ( generatedImages.length === 0 ) {
+      throw new ValidationError( 'No images were generated by Gemini' );
     }
 
     return generatedImages;
   }
-});
+} );
 
 // Step 3: Validate URLs using HTTP client
-export const validateReferenceImages = step({
+export const validateReferenceImages = step( {
   name: 'validateReferenceImages',
   description: 'Validates that all provided reference image URLs are accessible',
-  inputSchema: z.object({
-    referenceImageUrls: z.array(z.string()).optional()
-  }),
+  inputSchema: z.object( {
+    referenceImageUrls: z.array( z.string() ).optional()
+  } ),
   outputSchema: z.boolean(),
-  fn: async ({ referenceImageUrls }) => {
-    if (!referenceImageUrls || referenceImageUrls.length === 0) {
+  fn: async ( { referenceImageUrls } ) => {
+    if ( !referenceImageUrls || referenceImageUrls.length === 0 ) {
       return true;
     }
 
-    for (const [index, url] of referenceImageUrls.entries()) {
-      const response = await httpClientInstance.head(url);
-      const contentType = response.headers.get('content-type');
+    for ( const [ index, url ] of referenceImageUrls.entries() ) {
+      const response = await httpClientInstance.head( url );
+      const contentType = response.headers.get( 'content-type' );
 
-      if (contentType && !contentType.startsWith('image/')) {
+      if ( contentType && !contentType.startsWith( 'image/' ) ) {
         throw new FatalError(
-          `Reference URL ${index + 1} (${url}) is not an image file`
+          `Reference URL ${ index + 1 } (${ url }) is not an image file`
         );
       }
     }
 
     return true;
   }
-});
+} );
 ```
 
 ## Best Practices
@@ -512,14 +535,12 @@ throw new FatalError('Error occurred');
 ### 3. Validate Input Early
 
 ```typescript
-fn: async (input) => {
-  // Validate early
-  if (!input.url.startsWith('https://')) {
-    throw new FatalError('URL must use HTTPS protocol');
+fn: async input => {
+  if ( !input.url.startsWith( 'https://' ) ) {
+    throw new FatalError( 'URL must use HTTPS protocol' );
   }
 
-  // Then proceed with operation
-  const response = await httpClientInstance.get(input.url);
+  const response = await httpClientInstance.get( input.url );
   // ...
 }
 ```
@@ -530,6 +551,7 @@ fn: async (input) => {
 - [ ] `httpClient` imported from `@outputai/http` (not axios)
 - [ ] `generateText` and `Output` imported from `@outputai/llm` (not direct provider)
 - [ ] Structured output uses `Output.object()` with `.describe()` (not `.min()/.max()/.length()`) on number and array schemas
+- [ ] Schemas for `Output.object()` are defined in `types.ts` and imported, not inline
 - [ ] All imports use `.js` extension
 - [ ] Named exports used for each step
 - [ ] Each step has `name`, `description`, `inputSchema`, `outputSchema`, `fn`
@@ -538,12 +560,14 @@ fn: async (input) => {
 - [ ] No bare try-catch blocks that swallow errors
 - [ ] Steps only import allowed dependencies (local files, shared code)
 - [ ] No imports of other steps, evaluators, or workflows
+- [ ] Code follows style conventions (see `output-dev-code-style`)
 
 ## Related Skills
 
 - `output-dev-workflow-function` - Orchestrating steps in workflow.ts
 - `output-dev-evaluator-function` - Using steps in evaluator functions
 - `output-dev-types-file` - Defining step input/output schemas
+- `output-dev-code-style` - Code formatting and style conventions
 - `output-dev-http-client-create` - Creating shared HTTP clients
 - `output-dev-prompt-file` - Creating prompt files for LLM operations
 - `output-error-try-catch` - Proper error handling patterns

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-step-function/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-step-function/SKILL.md
@@ -214,12 +214,12 @@ const httpClientInstance = httpClient( {
 
         if ( status && FATAL_STATUS_CODES.includes( status ) ) {
           throw new FatalError(
-            `HTTP ${ status } error: ${ message }. This is a permanent error.`
+            `HTTP ${status} error: ${message}. This is a permanent error.`
           );
         }
 
         throw new ValidationError(
-          `HTTP request failed: ${ message }`
+          `HTTP request failed: ${message}`
         );
       }
     ]
@@ -344,7 +344,7 @@ if ( !input.requiredField ) {
 
 // Resource not found
 if ( response.status === 404 ) {
-  throw new FatalError( `Resource not found: ${ resourceId }` );
+  throw new FatalError( `Resource not found: ${resourceId}` );
 }
 
 // Configuration errors
@@ -374,7 +374,7 @@ if ( response.status === 503 ) {
 try {
   const response = await httpClientInstance.get( url );
 } catch ( error ) {
-  throw new ValidationError( `Network error: ${ error.message }` );
+  throw new ValidationError( `Network error: ${error.message}` );
 }
 
 // Empty response that might be temporary
@@ -417,10 +417,10 @@ const httpClientInstance = httpClient( {
         const message = error.message;
 
         if ( status && FATAL_STATUS_CODES.includes( status ) ) {
-          throw new FatalError( `HTTP ${ status } error: ${ message }` );
+          throw new FatalError( `HTTP ${status} error: ${message}` );
         }
 
-        throw new ValidationError( `HTTP request failed: ${ message }` );
+        throw new ValidationError( `HTTP request failed: ${message}` );
       }
     ]
   }
@@ -493,7 +493,7 @@ export const validateReferenceImages = step( {
 
       if ( contentType && !contentType.startsWith( 'image/' ) ) {
         throw new FatalError(
-          `Reference URL ${ index + 1 } (${ url }) is not an image file`
+          `Reference URL ${index + 1} (${url}) is not an image file`
         );
       }
     }
@@ -509,27 +509,27 @@ export const validateReferenceImages = step( {
 
 ```typescript
 // Good - focused step
-export const fetchUserData = step({
+export const fetchUserData = step( {
   name: 'fetchUserData',
-  description: 'Fetch user data from the API',
+  description: 'Fetch user data from the API'
   // ...
-});
+} );
 
 // Avoid - step doing too much
-export const fetchAndProcessAndSaveUserData = step({
-  name: 'fetchAndProcessAndSaveUserData',
+export const fetchAndProcessAndSaveUserData = step( {
+  name: 'fetchAndProcessAndSaveUserData'
   // ...
-});
+} );
 ```
 
 ### 2. Clear Error Messages
 
 ```typescript
 // Good - specific error message
-throw new FatalError(`Invalid API key for service: ${serviceName}`);
+throw new FatalError( `Invalid API key for service: ${serviceName}` );
 
 // Avoid - generic error message
-throw new FatalError('Error occurred');
+throw new FatalError( 'Error occurred' );
 ```
 
 ### 3. Validate Input Early

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-step-function/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-step-function/SKILL.md
@@ -270,6 +270,8 @@ output: Output.object( {
 
 ### Using generateText with Output.object()
 
+**Important**: The `variables` field only accepts `string | number | boolean` values. Arrays and objects must be pre-formatted into strings in the step before passing. See `output-dev-prompt-file` for the full constraint and examples.
+
 ```typescript
 import { generateText, Output } from '@outputai/llm';
 import {

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-types-file/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-types-file/SKILL.md
@@ -70,6 +70,10 @@ Schemas passed to `Output.object()` are sent to LLM providers as tool definition
 
 ### Use `.describe()` Instead
 
+`.describe()` is the primary mechanism for guiding LLM output quality. LLM providers use field names and descriptions from the schema to understand what each field should contain. Write clear, specific descriptions that communicate your intent.
+
+**Important**: `.describe()` replaces both unsupported constraints AND prompt-based format instructions. Do not also describe the schema in the prompt -- the schema is sent to the provider automatically, and duplicating it reduces performance and creates drift risk. See `output-dev-prompt-file` for details.
+
 ```typescript
 // LLM output schema (sent to provider via Output.object()) -- .describe() ONLY
 const llmOutputSchema = z.object( {

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-types-file/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-types-file/SKILL.md
@@ -37,27 +37,67 @@ import { z } from 'zod';
 import { z } from '@outputai/core';
 
 // 1. Workflow Input Schema
-export const WorkflowInputSchema = z.object({
+export const WorkflowInputSchema = z.object( {
   // Define input fields
-});
+} );
 
 // 2. Workflow Output Type
 export type WorkflowInput = z.infer<typeof WorkflowInputSchema>;
 export type WorkflowOutput = /* output type */;
 
 // 3. Step Schemas (for each step)
-export const StepNameInputSchema = z.object({
+export const StepNameInputSchema = z.object( {
   // Step input fields
-});
+} );
 
-export const StepNameOutputSchema = z.object({
+export const StepNameOutputSchema = z.object( {
   // Step output fields
-});
+} );
 
 // 4. Type Exports
 export type StepNameInput = z.infer<typeof StepNameInputSchema>;
 export type StepNameOutput = z.infer<typeof StepNameOutputSchema>;
 ```
+
+## CRITICAL: Schema Constraints for LLM Output
+
+Schemas passed to `Output.object()` are sent to LLM providers as tool definitions. **Anthropic rejects several JSON Schema constraints** that Zod methods produce. Getting this wrong causes runtime errors.
+
+### What Is NOT Allowed in LLM Output Schemas
+
+- **Numbers**: `.min()`, `.max()` on `z.number()` produce `minimum`/`maximum` -- rejected by Anthropic.
+- **Arrays**: `.min()`, `.max()`, `.length()` on `z.array()` produce `minItems`/`maxItems` -- Anthropic only supports `minItems` of `0` or `1`. Values like `.length( 3 )` or `.min( 2 )` will be rejected.
+
+### Use `.describe()` Instead
+
+```typescript
+// LLM output schema (sent to provider via Output.object()) -- .describe() ONLY
+const llmOutputSchema = z.object( {
+  score: z.number().describe( 'Quality score 0-100' ),
+  confidence: z.number().describe( 'Confidence 0-1' ),
+  predictions: z.array( predictionSchema ).describe( 'Exactly 3 predictions' )
+} );
+
+// Workflow/step validation schema (Zod-only, NOT sent to LLM) -- .min()/.max()/.length() OK
+const workflowOutputSchema = z.object( {
+  score: z.number().min( 0 ).max( 100 ).describe( 'Quality score 0-100' ),
+  confidence: z.number().min( 0 ).max( 1 ).describe( 'Confidence 0-1' ),
+  predictions: z.array( predictionSchema ).length( 3 ).describe( 'Exactly 3 predictions' )
+} );
+```
+
+### When to Use Which
+
+| Context | `.min()/.max()/.length()` | `.describe()` |
+|---------|:-:|:-:|
+| Schema passed to `Output.object()` | **No** (numbers or arrays) | Yes |
+| `inputSchema` / `outputSchema` on steps | OK | Optional |
+| `inputSchema` / `outputSchema` on workflows | OK | Optional |
+| `outputSchema` on evaluators | OK | Optional |
+
+### LLM Schemas Must Live in types.ts
+
+Define all schemas used in `Output.object()` in `types.ts` and import them in step functions. Never define them inline -- this causes duplication and makes it harder to verify they follow the constraints above.
 
 ## Common Schema Patterns
 
@@ -69,21 +109,21 @@ import { z } from '@outputai/core';
 // Strings
 const stringField = z.string();
 const optionalString = z.string().optional();
-const stringWithDefault = z.string().default('default value');
-const describedString = z.string().describe('Field description');
+const stringWithDefault = z.string().default( 'default value' );
+const describedString = z.string().describe( 'Field description' );
 
 // Numbers
 const numberField = z.number();
 const integerField = z.number().int();
-const rangedNumber = z.number().min(1).max(100); // runtime only — NOT safe for Output.object() schemas
+const rangedNumber = z.number().min( 1 ).max( 100 ); // runtime only — NOT safe for Output.object() schemas
 
 // Booleans
 const booleanField = z.boolean();
-const defaultBoolean = z.boolean().default(false);
+const defaultBoolean = z.boolean().default( false );
 
 // Enums
-const enumField = z.enum(['option1', 'option2', 'option3']);
-const enumWithDefault = z.enum(['small', 'medium', 'large']).default('medium');
+const enumField = z.enum( [ 'option1', 'option2', 'option3' ] );
+const enumWithDefault = z.enum( [ 'small', 'medium', 'large' ] ).default( 'medium' );
 ```
 
 ### Complex Types
@@ -92,28 +132,28 @@ const enumWithDefault = z.enum(['small', 'medium', 'large']).default('medium');
 import { z } from '@outputai/core';
 
 // Arrays
-const stringArray = z.array(z.string());
-const objectArray = z.array(z.object({ id: z.string(), name: z.string() }));
+const stringArray = z.array( z.string() );
+const objectArray = z.array( z.object( { id: z.string(), name: z.string() } ) );
 
 // Objects
-const nestedObject = z.object({
-  user: z.object({
+const nestedObject = z.object( {
+  user: z.object( {
     id: z.string(),
     email: z.string().email()
-  }),
-  settings: z.object({
+  } ),
+  settings: z.object( {
     notifications: z.boolean()
-  })
-});
+  } )
+} );
 
 // Union Types
-const flexibleInput = z.union([
+const flexibleInput = z.union( [
   z.string(),
-  z.array(z.string())
-]);
+  z.array( z.string() )
+] );
 
 // Records
-const keyValueMap = z.record(z.string(), z.number());
+const keyValueMap = z.record( z.string(), z.number() );
 ```
 
 ### Validation Patterns
@@ -125,43 +165,18 @@ import { z } from '@outputai/core';
 const emailField = z.string().email();
 const urlField = z.string().url();
 const uuidField = z.string().uuid();
-const minLengthString = z.string().min(1);
-const maxLengthString = z.string().max(1000);
+const minLengthString = z.string().min( 1 );
+const maxLengthString = z.string().max( 1000 );
 
 // Number Validations
 const positiveNumber = z.number().positive();
 const nonNegativeNumber = z.number().nonnegative();
-const percentageNumber = z.number().min(0).max(100);
+const percentageNumber = z.number().min( 0 ).max( 100 );
 
 // Array Validations (runtime only — NOT safe for Output.object() schemas)
-const nonEmptyArray = z.array(z.string()).min(1);
-const limitedArray = z.array(z.string()).max(10);
-const fixedLengthArray = z.array(z.string()).length(3);
-```
-
-### Schema Constraints for LLM Output
-
-**Important**: Schemas passed to `Output.object()` (sent to LLM providers) have constraints that Anthropic rejects:
-
-- **Numbers**: `.min()`, `.max()` on `z.number()` produce `minimum`/`maximum` — rejected.
-- **Arrays**: `.min()`, `.max()`, `.length()` on `z.array()` produce `minItems`/`maxItems` — Anthropic only supports `minItems` of `0` or `1`. Values like `.length(3)` or `.min(2)` will fail.
-
-Use `.describe()` instead to guide the LLM on expected ranges and counts.
-
-```typescript
-// Schema for Output.object() (sent to LLM) - use .describe() only
-const llmOutputSchema = z.object({
-  score: z.number().describe('Quality score 0-100'),
-  confidence: z.number().describe('Confidence 0-1'),
-  predictions: z.array(predictionSchema).describe('Exactly 3 predictions')
-});
-
-// Schema for workflow/step input/output (Zod validation only) - .min()/.max()/.length() OK
-const workflowOutputSchema = z.object({
-  score: z.number().min(0).max(100).describe('Quality score 0-100'),
-  confidence: z.number().min(0).max(1).describe('Confidence 0-1'),
-  predictions: z.array(predictionSchema).length(3).describe('Exactly 3 predictions')
-});
+const nonEmptyArray = z.array( z.string() ).min( 1 );
+const limitedArray = z.array( z.string() ).max( 10 );
+const fixedLengthArray = z.array( z.string() ).length( 3 );
 ```
 
 ## Complete Example
@@ -175,21 +190,21 @@ import { z } from '@outputai/core';
 // Workflow Schemas
 // ============================================
 
-export const WorkflowInputSchema = z.object({
-  content: z.string().describe('Text content to generate image ideas from'),
-  mode: z.enum(['infographic']).default('infographic').describe('Type of image to generate'),
-  colorPalette: z.string().optional().describe('Color palette preference for the images'),
-  artDirection: z.string().optional().describe('Art direction or style preference'),
-  numberOfIdeas: z.number().min(1).max(10).default(1).describe('Number of image concepts to generate'),
-  referenceImageUrls: z.union([
+export const WorkflowInputSchema = z.object( {
+  content: z.string().describe( 'Text content to generate image ideas from' ),
+  mode: z.enum( [ 'infographic' ] ).default( 'infographic' ).describe( 'Type of image to generate' ),
+  colorPalette: z.string().optional().describe( 'Color palette preference for the images' ),
+  artDirection: z.string().optional().describe( 'Art direction or style preference' ),
+  numberOfIdeas: z.number().min( 1 ).max( 10 ).default( 1 ).describe( 'Number of image concepts to generate' ),
+  referenceImageUrls: z.union( [
     z.string(),
-    z.array(z.string())
-  ]).optional().describe('Reference image URLs for style guidance (max 14)'),
-  aspectRatio: z.enum(['1:1', '16:9', '9:16', '4:3', '3:4']).default('1:1').describe('Aspect ratio for generated images'),
-  resolution: z.enum(['1K', '2K', '4K']).default('1K').describe('Resolution for generated images'),
-  numberOfGenerations: z.number().min(1).max(10).default(1).describe('Number of images to generate per concept'),
-  storageNamespace: z.string().optional().describe('S3 folder path for storing images')
-});
+    z.array( z.string() )
+  ] ).optional().describe( 'Reference image URLs for style guidance (max 14)' ),
+  aspectRatio: z.enum( [ '1:1', '16:9', '9:16', '4:3', '3:4' ] ).default( '1:1' ).describe( 'Aspect ratio for generated images' ),
+  resolution: z.enum( [ '1K', '2K', '4K' ] ).default( '1K' ).describe( 'Resolution for generated images' ),
+  numberOfGenerations: z.number().min( 1 ).max( 10 ).default( 1 ).describe( 'Number of images to generate per concept' ),
+  storageNamespace: z.string().optional().describe( 'S3 folder path for storing images' )
+} );
 
 export type WorkflowInput = z.infer<typeof WorkflowInputSchema>;
 export type WorkflowOutput = string[];
@@ -198,32 +213,32 @@ export type WorkflowOutput = string[];
 // Step Schemas
 // ============================================
 
-export const ValidateReferenceImagesInputSchema = z.object({
-  referenceImageUrls: z.array(z.string()).optional()
-});
+export const ValidateReferenceImagesInputSchema = z.object( {
+  referenceImageUrls: z.array( z.string() ).optional()
+} );
 
-export const GenerateImageIdeasInputSchema = z.object({
+export const GenerateImageIdeasInputSchema = z.object( {
   content: z.string(),
   numberOfIdeas: z.number(),
   colorPalette: z.string().optional(),
   artDirection: z.string().optional()
-});
+} );
 
-export const GenerateImagesInputSchema = z.object({
-  input: z.object({
-    referenceImageUrls: z.union([z.string(), z.array(z.string())]).optional(),
-    aspectRatio: z.enum(['1:1', '16:9', '9:16', '4:3', '3:4']),
-    resolution: z.enum(['1K', '2K', '4K']),
+export const GenerateImagesInputSchema = z.object( {
+  input: z.object( {
+    referenceImageUrls: z.union( [ z.string(), z.array( z.string() ) ] ).optional(),
+    aspectRatio: z.enum( [ '1:1', '16:9', '9:16', '4:3', '3:4' ] ),
+    resolution: z.enum( [ '1K', '2K', '4K' ] ),
     numberOfGenerations: z.number(),
     storageNamespace: z.string().optional()
-  }),
+  } ),
   prompt: z.string()
-});
+} );
 
 // Schema for LLM response validation
-export const ImageIdeasSchema = z.object({
-  ideas: z.array(z.string()).describe('Array of detailed image prompts for Gemini')
-});
+export const ImageIdeasSchema = z.object( {
+  ideas: z.array( z.string() ).describe( 'Array of detailed image prompts for Gemini' )
+} );
 
 // ============================================
 // Type Exports
@@ -240,7 +255,7 @@ export type ImageIdeas = z.infer<typeof ImageIdeasSchema>;
 ### 1. Use Descriptive Field Descriptions
 ```typescript
 // Good - helps with documentation and error messages
-z.string().describe('User email address for notifications')
+z.string().describe( 'User email address for notifications' )
 
 // Avoid - no context for errors
 z.string()
@@ -249,25 +264,25 @@ z.string()
 ### 2. Provide Sensible Defaults
 ```typescript
 // Good - workflow works without optional fields
-numberOfIdeas: z.number().min(1).max(10).default(1)
+numberOfIdeas: z.number().min( 1 ).max( 10 ).default( 1 )
 
 // Avoid - forces users to provide every field
-numberOfIdeas: z.number().min(1).max(10)
+numberOfIdeas: z.number().min( 1 ).max( 10 )
 ```
 
 ### 3. Separate Workflow and Step Schemas
 ```typescript
 // Workflow input schema (what the user provides)
-export const WorkflowInputSchema = z.object({ ... });
+export const WorkflowInputSchema = z.object( { ... } );
 
 // Step schemas (internal data shapes)
-export const StepNameInputSchema = z.object({ ... });
+export const StepNameInputSchema = z.object( { ... } );
 ```
 
 ### 4. Export Both Schemas and Types
 ```typescript
 // Export schema for runtime validation
-export const UserSchema = z.object({ ... });
+export const UserSchema = z.object( { ... } );
 
 // Export type for TypeScript type checking
 export type User = z.infer<typeof UserSchema>;
@@ -283,6 +298,7 @@ export type User = z.infer<typeof UserSchema>;
 - [ ] All schemas have `.describe()` for important fields
 - [ ] Optional fields use `.optional()` or `.default()`
 - [ ] Numeric fields have appropriate constraints (`.min()/.max()` for runtime schemas, `.describe()` for `Output.object()` schemas)
+- [ ] Code follows style conventions (see output-dev-code-style)
 
 ## Related Skills
 
@@ -291,3 +307,4 @@ export type User = z.infer<typeof UserSchema>;
 - `output-dev-evaluator-function` - Using schemas in evaluator definitions
 - `output-dev-folder-structure` - Where types.ts belongs in the project
 - `output-error-zod-import` - Troubleshooting schema import issues
+- `output-dev-code-style` - Code style conventions

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-workflow-function/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-workflow-function/SKILL.md
@@ -49,22 +49,22 @@ import { WorkflowInputSchema } from './types';
 
 ```typescript
 // WRONG - Direct I/O in workflow
-export default workflow({
+export default workflow( {
   // ...
-  fn: async (input) => {
-    const response = await fetch('https://api.example.com'); // NEVER do this!
+  fn: async input => {
+    const response = await fetch( 'https://api.example.com' ); // NEVER do this!
     return response.json();
   }
-});
+} );
 
 // CORRECT - Delegate I/O to steps
-export default workflow({
+export default workflow( {
   // ...
-  fn: async (input) => {
-    const result = await fetchDataStep(input); // Steps handle I/O
+  fn: async input => {
+    const result = await fetchDataStep( input ); // Steps handle I/O
     return result;
   }
-});
+} );
 ```
 
 **Related Skill**: `output-error-nondeterminism`
@@ -77,18 +77,18 @@ import { workflow, z } from '@outputai/core';
 import { stepOne, stepTwo } from './steps.js';
 import { WorkflowInputSchema, WorkflowOutput } from './types.js';
 
-export default workflow({
+export default workflow( {
   name: 'workflowName',
   description: 'Brief description of what the workflow does',
   inputSchema: WorkflowInputSchema,
-  outputSchema: z.object({ /* output shape */ }),
-  fn: async (input): Promise<WorkflowOutput> => {
+  outputSchema: z.object( { /* output shape */ } ),
+  fn: async ( input ): Promise<WorkflowOutput> => {
     // Orchestrate step calls
-    const result = await stepOne(input);
-    const final = await stepTwo(result);
+    const result = await stepOne( input );
+    const final = await stepTwo( result );
     return final;
   }
-});
+} );
 ```
 
 ## Required Properties
@@ -120,21 +120,21 @@ inputSchema: WorkflowInputSchema
 Schema for validating workflow output.
 
 ```typescript
-outputSchema: z.object({
-  results: z.array(z.string()),
-  metadata: z.object({
+outputSchema: z.object( {
+  results: z.array( z.string() ),
+  metadata: z.object( {
     processedAt: z.string()
-  })
-})
+  } )
+} )
 ```
 
 ### fn (async function)
 The workflow execution function. Must be deterministic.
 
 ```typescript
-fn: async (input): Promise<WorkflowOutput> => {
+fn: async ( input ): Promise<WorkflowOutput> => {
   // Step orchestration only - no direct I/O
-  const result = await processStep(input);
+  const result = await processStep( input );
   return result;
 }
 ```
@@ -158,37 +158,37 @@ import {
 } from './types.js';
 import { normalizeReferenceImageUrls } from './utils.js';
 
-export default workflow({
+export default workflow( {
   name: 'contentUtilsImageInfographicNano',
   description: 'Generate high-quality infographic images using Google Gemini 3 Pro Image model with AI-powered ideation',
   inputSchema: WorkflowInputSchema,
-  outputSchema: z.array(z.string()),
-  fn: async (rawInput: WorkflowInput): Promise<WorkflowOutput> => {
+  outputSchema: z.array( z.string() ),
+  fn: async ( rawInput: WorkflowInput ): Promise<WorkflowOutput> => {
     // Pre-process input (pure function - OK in workflow)
     const input = {
       ...rawInput,
-      referenceImageUrls: normalizeReferenceImageUrls(rawInput.referenceImageUrls)
+      referenceImageUrls: normalizeReferenceImageUrls( rawInput.referenceImageUrls )
     };
 
     // Conditional step execution
-    if (input.referenceImageUrls && input.referenceImageUrls.length > 0) {
-      await validateReferenceImages({
+    if ( input.referenceImageUrls && input.referenceImageUrls.length > 0 ) {
+      await validateReferenceImages( {
         referenceImageUrls: input.referenceImageUrls as string[]
-      });
+      } );
     }
 
     // Sequential step execution
-    const ideas = await generateImageIdeas({
+    const ideas = await generateImageIdeas( {
       content: input.content,
       numberOfIdeas: input.numberOfIdeas,
       colorPalette: input.colorPalette,
       artDirection: input.artDirection
-    });
+    } );
 
     // Parallel step execution
     const generations = await Promise.all(
-      ideas.map(idea =>
-        generateImages({
+      ideas.map( idea =>
+        generateImages( {
           input: {
             referenceImageUrls: input.referenceImageUrls,
             aspectRatio: input.aspectRatio,
@@ -197,13 +197,13 @@ export default workflow({
             storageNamespace: input.storageNamespace
           },
           prompt: idea
-        })
+        } )
       )
     );
 
     return generations.flat();
   }
-});
+} );
 ```
 
 ## Orchestration Patterns
@@ -213,10 +213,10 @@ export default workflow({
 Execute steps one after another:
 
 ```typescript
-fn: async (input) => {
-  const step1Result = await stepOne(input);
-  const step2Result = await stepTwo(step1Result);
-  const step3Result = await stepThree(step2Result);
+fn: async input => {
+  const step1Result = await stepOne( input );
+  const step2Result = await stepTwo( step1Result );
+  const step3Result = await stepThree( step2Result );
   return step3Result;
 }
 ```
@@ -226,12 +226,12 @@ fn: async (input) => {
 Execute independent steps concurrently:
 
 ```typescript
-fn: async (input) => {
-  const [resultA, resultB, resultC] = await Promise.all([
-    stepA(input),
-    stepB(input),
-    stepC(input)
-  ]);
+fn: async input => {
+  const [ resultA, resultB, resultC ] = await Promise.all( [
+    stepA( input ),
+    stepB( input ),
+    stepC( input )
+  ] );
   return { resultA, resultB, resultC };
 }
 ```
@@ -241,14 +241,14 @@ fn: async (input) => {
 Execute steps based on conditions:
 
 ```typescript
-fn: async (input) => {
-  if (input.includeImages) {
-    await processImages(input);
+fn: async input => {
+  if ( input.includeImages ) {
+    await processImages( input );
   }
 
   const result = input.mode === 'fast'
-    ? await quickProcess(input)
-    : await detailedProcess(input);
+    ? await quickProcess( input )
+    : await detailedProcess( input );
 
   return result;
 }
@@ -259,9 +259,9 @@ fn: async (input) => {
 Process multiple items in parallel:
 
 ```typescript
-fn: async (input) => {
+fn: async input => {
   const results = await Promise.all(
-    input.items.map(item => processItem({ item }))
+    input.items.map( item => processItem( { item } ) )
   );
   return { processedItems: results };
 }
@@ -272,11 +272,11 @@ fn: async (input) => {
 Chain multiple transformations:
 
 ```typescript
-fn: async (input) => {
-  const extracted = await extractData(input);
-  const transformed = await transformData(extracted);
-  const validated = await validateData(transformed);
-  const enriched = await enrichData(validated);
+fn: async input => {
+  const extracted = await extractData( input );
+  const transformed = await transformData( extracted );
+  const validated = await validateData( transformed );
+  const enriched = await enrichData( validated );
   return enriched;
 }
 ```
@@ -312,6 +312,7 @@ fn: async (input) => {
 - [ ] `outputSchema` matches actual return type
 - [ ] `fn` is deterministic (no direct I/O)
 - [ ] All I/O delegated to step functions
+- [ ] Code follows style conventions (see output-dev-code-style)
 
 ## Related Skills
 
@@ -321,3 +322,4 @@ fn: async (input) => {
 - `output-dev-folder-structure` - Where workflow.ts belongs
 - `output-error-nondeterminism` - Fixing determinism violations
 - `output-error-zod-import` - Fixing schema import issues
+- `output-dev-code-style`

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-workflow-function/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-workflow-function/SKILL.md
@@ -246,9 +246,9 @@ fn: async input => {
     await processImages( input );
   }
 
-  const result = input.mode === 'fast'
-    ? await quickProcess( input )
-    : await detailedProcess( input );
+  const result = input.mode === 'fast' ?
+    await quickProcess( input ) :
+    await detailedProcess( input );
 
   return result;
 }

--- a/coding_assistants/claude/plugins/outputai/skills/output-error-direct-io/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-error-direct-io/SKILL.md
@@ -34,25 +34,25 @@ Workflow functions must be **deterministic** - they should only orchestrate step
 
 ```typescript
 // WRONG: I/O directly in workflow
-export default workflow({
-  fn: async (input) => {
-    const response = await fetch('https://api.example.com/data');  // BAD!
+export default workflow( {
+  fn: async input => {
+    const response = await fetch( 'https://api.example.com/data' );  // BAD!
     const data = await response.json();
     return { data };
   }
-});
+} );
 ```
 
 ### Direct Database Calls
 
 ```typescript
 // WRONG: Database I/O in workflow
-export default workflow({
-  fn: async (input) => {
-    const user = await db.users.findById(input.userId);  // BAD!
+export default workflow( {
+  fn: async input => {
+    const user = await db.users.findById( input.userId );  // BAD!
     return { user };
   }
-});
+} );
 ```
 
 ### File System Operations
@@ -61,12 +61,12 @@ export default workflow({
 // WRONG: File I/O in workflow
 import fs from 'fs/promises';
 
-export default workflow({
-  fn: async (input) => {
-    const data = await fs.readFile(input.path, 'utf-8');  // BAD!
+export default workflow( {
+  fn: async input => {
+    const data = await fs.readFile( input.path, 'utf-8' );  // BAD!
     return { data };
   }
-});
+} );
 ```
 
 ## Solution
@@ -76,13 +76,13 @@ Move ALL I/O operations to step functions. Steps are designed to handle non-dete
 ### Before (Wrong)
 
 ```typescript
-export default workflow({
-  fn: async (input) => {
-    const response = await fetch('https://api.example.com/data');
+export default workflow( {
+  fn: async input => {
+    const response = await fetch( 'https://api.example.com/data' );
     const data = await response.json();
     return { data };
   }
-});
+} );
 ```
 
 ### After (Correct)
@@ -92,30 +92,30 @@ import { z, step, workflow } from '@outputai/core';
 import { httpClient } from '@outputai/http';
 
 // Create a step for the I/O operation
-export const fetchData = step({
+export const fetchData = step( {
   name: 'fetchData',
-  inputSchema: z.object({
-    endpoint: z.string(),
-  }),
-  outputSchema: z.object({
-    data: z.unknown(),
-  }),
-  fn: async (input) => {
-    const client = httpClient({ prefixUrl: 'https://api.example.com' });
-    const data = await client.get(input.endpoint).json();
+  inputSchema: z.object( {
+    endpoint: z.string()
+  } ),
+  outputSchema: z.object( {
+    data: z.unknown()
+  } ),
+  fn: async input => {
+    const client = httpClient( { prefixUrl: 'https://api.example.com' } );
+    const data = await client.get( input.endpoint ).json();
     return { data };
-  },
-});
+  }
+} );
 
 // Workflow only orchestrates steps
-export default workflow({
-  inputSchema: z.object({}),
-  outputSchema: z.object({ data: z.unknown() }),
-  fn: async (input) => {
-    const result = await fetchData({ endpoint: 'data' });
+export default workflow( {
+  inputSchema: z.object( {} ),
+  outputSchema: z.object( { data: z.unknown() } ),
+  fn: async input => {
+    const result = await fetchData( { endpoint: 'data' } );
     return result;
-  },
-});
+  }
+} );
 ```
 
 ## Complete Example: Database Operation
@@ -123,17 +123,17 @@ export default workflow({
 ### Before (Wrong)
 
 ```typescript
-export default workflow({
-  fn: async (input) => {
-    const user = await prisma.user.findUnique({
+export default workflow( {
+  fn: async input => {
+    const user = await prisma.user.findUnique( {
       where: { id: input.userId }
-    });
-    const orders = await prisma.order.findMany({
+    } );
+    const orders = await prisma.order.findMany( {
       where: { userId: input.userId }
-    });
+    } );
     return { user, orders };
   }
-});
+} );
 ```
 
 ### After (Correct)
@@ -142,53 +142,53 @@ export default workflow({
 import { z, step, workflow } from '@outputai/core';
 import { prisma } from '../lib/db';
 
-export const fetchUser = step({
+export const fetchUser = step( {
   name: 'fetchUser',
-  inputSchema: z.object({ userId: z.string() }),
-  outputSchema: z.object({
-    user: z.object({
+  inputSchema: z.object( { userId: z.string() } ),
+  outputSchema: z.object( {
+    user: z.object( {
       id: z.string(),
       name: z.string(),
-      email: z.string(),
-    }).nullable(),
-  }),
-  fn: async (input) => {
-    const user = await prisma.user.findUnique({
+      email: z.string()
+    } ).nullable()
+  } ),
+  fn: async input => {
+    const user = await prisma.user.findUnique( {
       where: { id: input.userId }
-    });
+    } );
     return { user };
-  },
-});
+  }
+} );
 
-export const fetchOrders = step({
+export const fetchOrders = step( {
   name: 'fetchOrders',
-  inputSchema: z.object({ userId: z.string() }),
-  outputSchema: z.object({
-    orders: z.array(z.object({
+  inputSchema: z.object( { userId: z.string() } ),
+  outputSchema: z.object( {
+    orders: z.array( z.object( {
       id: z.string(),
-      total: z.number(),
-    })),
-  }),
-  fn: async (input) => {
-    const orders = await prisma.order.findMany({
+      total: z.number()
+    } ) )
+  } ),
+  fn: async input => {
+    const orders = await prisma.order.findMany( {
       where: { userId: input.userId }
-    });
+    } );
     return { orders };
-  },
-});
+  }
+} );
 
-export default workflow({
-  inputSchema: z.object({ userId: z.string() }),
-  outputSchema: z.object({
+export default workflow( {
+  inputSchema: z.object( { userId: z.string() } ),
+  outputSchema: z.object( {
     user: z.unknown(),
-    orders: z.array(z.unknown()),
-  }),
-  fn: async (input) => {
-    const { user } = await fetchUser({ userId: input.userId });
-    const { orders } = await fetchOrders({ userId: input.userId });
+    orders: z.array( z.unknown() )
+  } ),
+  fn: async input => {
+    const { user } = await fetchUser( { userId: input.userId } );
+    const { orders } = await fetchOrders( { userId: input.userId } );
     return { user, orders };
-  },
-});
+  }
+} );
 ```
 
 ## Finding Direct I/O in Workflows
@@ -214,7 +214,7 @@ Then review each match to see if it's in a workflow function vs a step function.
 ## What CAN Be in Workflow Functions
 
 Workflow functions should contain:
-- **Step calls**: `await myStep(input)`
+- **Step calls**: `await myStep( input )`
 - **Orchestration logic**: conditionals, loops (over step calls)
 - **Data transformation**: Pure functions on step results
 - **Constants**: Static values and configuration

--- a/coding_assistants/claude/plugins/outputai/skills/output-error-http-client/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-error-http-client/SKILL.md
@@ -35,26 +35,26 @@ Using axios, fetch, or other HTTP clients directly bypasses Output SDK's:
 // WRONG: Using axios
 import axios from 'axios';
 
-export const fetchData = step({
+export const fetchData = step( {
   name: 'fetchData',
-  fn: async (input) => {
-    const response = await axios.get('https://api.example.com/data');
+  fn: async input => {
+    const response = await axios.get( 'https://api.example.com/data' );
     return response.data;
-  },
-});
+  }
+} );
 ```
 
 ### Using fetch Directly
 
 ```typescript
 // WRONG: Using fetch
-export const fetchData = step({
+export const fetchData = step( {
   name: 'fetchData',
-  fn: async (input) => {
-    const response = await fetch('https://api.example.com/data');
+  fn: async input => {
+    const response = await fetch( 'https://api.example.com/data' );
     return response.json();
-  },
-});
+  }
+} );
 ```
 
 ## Solution
@@ -67,23 +67,23 @@ Use `httpClient` from `@outputai/http`:
 import { z, step } from '@outputai/core';
 import { httpClient } from '@outputai/http';
 
-export const fetchData = step({
+export const fetchData = step( {
   name: 'fetchData',
-  inputSchema: z.object({
-    endpoint: z.string(),
-  }),
-  outputSchema: z.object({
-    data: z.unknown(),
-  }),
-  fn: async (input) => {
-    const client = httpClient({
-      prefixUrl: 'https://api.example.com',
-    });
+  inputSchema: z.object( {
+    endpoint: z.string()
+  } ),
+  outputSchema: z.object( {
+    data: z.unknown()
+  } ),
+  fn: async input => {
+    const client = httpClient( {
+      prefixUrl: 'https://api.example.com'
+    } );
 
-    const data = await client.get(input.endpoint).json();
+    const data = await client.get( input.endpoint ).json();
     return { data };
-  },
-});
+  }
+} );
 ```
 
 ### With Full Configuration
@@ -91,19 +91,19 @@ export const fetchData = step({
 ```typescript
 import { httpClient } from '@outputai/http';
 
-const client = httpClient({
+const client = httpClient( {
   prefixUrl: 'https://api.example.com',
   timeout: 30000,  // 30 second timeout
   retry: {
     limit: 3,      // Retry up to 3 times
-    methods: ['GET', 'POST'],  // Which methods to retry
-    statusCodes: [408, 500, 502, 503, 504],  // Which status codes trigger retry
+    methods: [ 'GET', 'POST' ],  // Which methods to retry
+    statusCodes: [ 408, 500, 502, 503, 504 ]  // Which status codes trigger retry
   },
   headers: {
     'Authorization': `Bearer ${apiKey}`,
-    'Content-Type': 'application/json',
-  },
-});
+    'Content-Type': 'application/json'
+  }
+} );
 ```
 
 ## HTTP Methods
@@ -111,45 +111,45 @@ const client = httpClient({
 ### GET Request
 
 ```typescript
-const data = await client.get('users/123').json();
+const data = await client.get( 'users/123' ).json();
 ```
 
 ### POST Request
 
 ```typescript
-const result = await client.post('users', {
+const result = await client.post( 'users', {
   json: {
     name: 'John',
-    email: 'john@example.com',
-  },
-}).json();
+    email: 'john@example.com'
+  }
+} ).json();
 ```
 
 ### PUT Request
 
 ```typescript
-const updated = await client.put('users/123', {
+const updated = await client.put( 'users/123', {
   json: {
-    name: 'John Updated',
-  },
-}).json();
+    name: 'John Updated'
+  }
+} ).json();
 ```
 
 ### DELETE Request
 
 ```typescript
-await client.delete('users/123');
+await client.delete( 'users/123' );
 ```
 
 ### With Query Parameters
 
 ```typescript
-const data = await client.get('search', {
+const data = await client.get( 'search', {
   searchParams: {
     q: 'query',
-    limit: 10,
-  },
-}).json();
+    limit: 10
+  }
+} ).json();
 ```
 
 ## Complete Migration Example
@@ -160,27 +160,27 @@ const data = await client.get('search', {
 import axios from 'axios';
 import { step } from '@outputai/core';
 
-export const createUser = step({
+export const createUser = step( {
   name: 'createUser',
-  fn: async (input) => {
+  fn: async input => {
     try {
       const response = await axios.post(
         'https://api.example.com/users',
         { name: input.name, email: input.email },
         {
           headers: { 'Authorization': `Bearer ${process.env.API_KEY}` },
-          timeout: 30000,
+          timeout: 30000
         }
       );
       return response.data;
-    } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(`API Error: ${error.response?.data?.message}`);
+    } catch ( error ) {
+      if ( axios.isAxiosError( error ) ) {
+        throw new Error( `API Error: ${error.response?.data?.message}` );
       }
       throw error;
     }
-  },
-});
+  }
+} );
 ```
 
 ### After (Correct - using httpClient)
@@ -189,37 +189,37 @@ export const createUser = step({
 import { z, step } from '@outputai/core';
 import { httpClient } from '@outputai/http';
 
-export const createUser = step({
+export const createUser = step( {
   name: 'createUser',
-  inputSchema: z.object({
+  inputSchema: z.object( {
     name: z.string(),
-    email: z.string().email(),
-  }),
-  outputSchema: z.object({
+    email: z.string().email()
+  } ),
+  outputSchema: z.object( {
     id: z.string(),
     name: z.string(),
-    email: z.string(),
-  }),
-  fn: async (input) => {
-    const client = httpClient({
+    email: z.string()
+  } ),
+  fn: async input => {
+    const client = httpClient( {
       prefixUrl: 'https://api.example.com',
       timeout: 30000,
       retry: { limit: 3 },
       headers: {
-        'Authorization': `Bearer ${process.env.API_KEY}`,
-      },
-    });
+        'Authorization': `Bearer ${process.env.API_KEY}`
+      }
+    } );
 
-    const user = await client.post('users', {
+    const user = await client.post( 'users', {
       json: {
         name: input.name,
-        email: input.email,
-      },
-    }).json();
+        email: input.email
+      }
+    } ).json();
 
     return user;
-  },
-});
+  }
+} );
 ```
 
 ## Error Handling
@@ -229,24 +229,24 @@ The httpClient provides structured error handling:
 ```typescript
 import { httpClient, HTTPError } from '@outputai/http';
 
-export const fetchData = step({
+export const fetchData = step( {
   name: 'fetchData',
-  fn: async (input) => {
-    const client = httpClient({ prefixUrl: 'https://api.example.com' });
+  fn: async input => {
+    const client = httpClient( { prefixUrl: 'https://api.example.com' } );
 
     try {
-      return await client.get('data').json();
-    } catch (error) {
-      if (error instanceof HTTPError) {
+      return await client.get( 'data' ).json();
+    } catch ( error ) {
+      if ( error instanceof HTTPError ) {
         // Access response details
         const status = error.response.status;
         const body = await error.response.json();
-        throw new Error(`API returned ${status}: ${body.message}`);
+        throw new Error( `API returned ${status}: ${body.message}` );
       }
       throw error;
     }
-  },
-});
+  }
+} );
 ```
 
 ## Finding axios/fetch Usage

--- a/coding_assistants/claude/plugins/outputai/skills/output-error-missing-schemas/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-error-missing-schemas/SKILL.md
@@ -33,41 +33,41 @@ Steps without explicit schemas:
 
 ```typescript
 // WRONG: No input validation
-export const processData = step({
+export const processData = step( {
   name: 'processData',
   // inputSchema: missing!
-  outputSchema: z.object({ result: z.string() }),
-  fn: async (input) => {
+  outputSchema: z.object( { result: z.string() } ),
+  fn: async input => {
     return { result: input.value };  // input.value might be undefined!
   }
-});
+} );
 ```
 
 ### Missing Output Schema
 
 ```typescript
 // WRONG: No output validation
-export const fetchData = step({
+export const fetchData = step( {
   name: 'fetchData',
-  inputSchema: z.object({ id: z.string() }),
+  inputSchema: z.object( { id: z.string() } ),
   // outputSchema: missing!
-  fn: async (input) => {
-    return { data: await getFromApi(input.id) };  // Output shape not validated
+  fn: async input => {
+    return { data: await getFromApi( input.id ) };  // Output shape not validated
   }
-});
+} );
 ```
 
 ### Both Schemas Missing
 
 ```typescript
 // WRONG: No validation at all
-export const transformData = step({
+export const transformData = step( {
   name: 'transformData',
   // No schemas!
-  fn: async (input) => {
-    return transform(input);
+  fn: async input => {
+    return transform( input );
   }
-});
+} );
 ```
 
 ## Solution
@@ -79,26 +79,26 @@ Always define both `inputSchema` and `outputSchema` for every step:
 ```typescript
 import { z, step } from '@outputai/core';
 
-export const processData = step({
+export const processData = step( {
   name: 'processData',
-  inputSchema: z.object({
+  inputSchema: z.object( {
     id: z.string(),
     value: z.number(),
-    optional: z.string().optional(),
-  }),
-  outputSchema: z.object({
+    optional: z.string().optional()
+  } ),
+  outputSchema: z.object( {
     result: z.string(),
-    processedAt: z.number(),
-  }),
-  fn: async (input) => {
+    processedAt: z.number()
+  } ),
+  fn: async input => {
     // input is fully typed: { id: string, value: number, optional?: string }
     return {
       result: `Processed ${input.id}`,
-      processedAt: Date.now(),
+      processedAt: Date.now()
     };
     // output is validated against outputSchema
-  },
-});
+  }
+} );
 ```
 
 ## Schema Definition Best Practices
@@ -107,54 +107,54 @@ export const processData = step({
 
 ```typescript
 // Good: Clear, descriptive schema
-inputSchema: z.object({
+inputSchema: z.object( {
   userId: z.string().uuid(),
   email: z.string().email(),
-  age: z.number().int().positive(),
-})
+  age: z.number().int().positive()
+} )
 ```
 
 ### Handle Optional Fields
 
 ```typescript
-inputSchema: z.object({
+inputSchema: z.object( {
   required: z.string(),
   optional: z.string().optional(),
-  withDefault: z.string().default('fallback'),
-})
+  withDefault: z.string().default( 'fallback' )
+} )
 ```
 
 ### Use Schema Composition
 
 ```typescript
 // Define reusable schemas
-const userSchema = z.object({
+const userSchema = z.object( {
   id: z.string(),
-  name: z.string(),
-});
+  name: z.string()
+} );
 
-const addressSchema = z.object({
+const addressSchema = z.object( {
   street: z.string(),
-  city: z.string(),
-});
+  city: z.string()
+} );
 
 // Compose in step
-inputSchema: z.object({
+inputSchema: z.object( {
   user: userSchema,
-  address: addressSchema,
-})
+  address: addressSchema
+} )
 ```
 
 ### Handle Arrays and Nested Objects
 
 ```typescript
-inputSchema: z.object({
-  items: z.array(z.object({
+inputSchema: z.object( {
+  items: z.array( z.object( {
     id: z.string(),
-    quantity: z.number(),
-  })),
-  metadata: z.record(z.string()),
-})
+    quantity: z.number()
+  } ) ),
+  metadata: z.record( z.string() )
+} )
 ```
 
 ## Finding Steps Without Schemas
@@ -188,46 +188,46 @@ Review each step definition to ensure both schemas are present.
 ### API Response Steps
 
 ```typescript
-export const fetchUser = step({
+export const fetchUser = step( {
   name: 'fetchUser',
-  inputSchema: z.object({
-    userId: z.string(),
-  }),
-  outputSchema: z.object({
-    user: z.object({
+  inputSchema: z.object( {
+    userId: z.string()
+  } ),
+  outputSchema: z.object( {
+    user: z.object( {
       id: z.string(),
       name: z.string(),
-      email: z.string(),
-    }).nullable(),  // Handle not found
-    found: z.boolean(),
-  }),
-  fn: async (input) => {
-    const user = await api.getUser(input.userId);
+      email: z.string()
+    } ).nullable(),  // Handle not found
+    found: z.boolean()
+  } ),
+  fn: async input => {
+    const user = await api.getUser( input.userId );
     return { user, found: user !== null };
-  },
-});
+  }
+} );
 ```
 
 ### Transformation Steps
 
 ```typescript
-export const transformData = step({
+export const transformData = step( {
   name: 'transformData',
-  inputSchema: z.object({
-    raw: z.array(z.unknown()),
-  }),
-  outputSchema: z.object({
-    processed: z.array(z.object({
+  inputSchema: z.object( {
+    raw: z.array( z.unknown() )
+  } ),
+  outputSchema: z.object( {
+    processed: z.array( z.object( {
       id: z.string(),
-      value: z.number(),
-    })),
-    count: z.number(),
-  }),
-  fn: async (input) => {
-    const processed = input.raw.map(transformItem);
+      value: z.number()
+    } ) ),
+    count: z.number()
+  } ),
+  fn: async input => {
+    const processed = input.raw.map( transformItem );
     return { processed, count: processed.length };
-  },
-});
+  }
+} );
 ```
 
 ### Void Output Steps
@@ -235,20 +235,20 @@ export const transformData = step({
 For steps that don't return meaningful data:
 
 ```typescript
-export const logEvent = step({
+export const logEvent = step( {
   name: 'logEvent',
-  inputSchema: z.object({
+  inputSchema: z.object( {
     event: z.string(),
-    data: z.record(z.unknown()),
-  }),
-  outputSchema: z.object({
-    logged: z.literal(true),
-  }),
-  fn: async (input) => {
-    await logger.log(input.event, input.data);
+    data: z.record( z.unknown() )
+  } ),
+  outputSchema: z.object( {
+    logged: z.literal( true )
+  } ),
+  fn: async input => {
+    await logger.log( input.event, input.data );
     return { logged: true };
-  },
-});
+  }
+} );
 ```
 
 ## Verification

--- a/coding_assistants/claude/plugins/outputai/skills/output-error-nondeterminism/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-error-nondeterminism/SKILL.md
@@ -33,39 +33,39 @@ Non-deterministic operations break this replay mechanism because they produce di
 
 ```typescript
 // WRONG: Non-deterministic
-export default workflow({
-  fn: async (input) => {
-    const id = Math.random().toString(36);  // Different each time!
-    return await processWithId({ id });
+export default workflow( {
+  fn: async input => {
+    const id = Math.random().toString( 36 );  // Different each time!
+    return await processWithId( { id } );
   }
-});
+} );
 ```
 
 **Solution**: Pass random values as workflow input or generate in a step.
 
 ```typescript
 // Option 1: Pass as input
-export default workflow({
-  inputSchema: z.object({
+export default workflow( {
+  inputSchema: z.object( {
     id: z.string()  // Generate ID before calling workflow
-  }),
-  fn: async (input) => {
-    return await processWithId({ id: input.id });
+  } ),
+  fn: async input => {
+    return await processWithId( { id: input.id } );
   }
-});
+} );
 
 // Option 2: Generate in a step (steps can be non-deterministic)
-export const generateId = step({
+export const generateId = step( {
   name: 'generateId',
-  fn: async () => ({ id: Math.random().toString(36) })
-});
+  fn: async () => ( { id: Math.random().toString( 36 ) } )
+} );
 
-export default workflow({
-  fn: async (input) => {
-    const { id } = await generateId({});
-    return await processWithId({ id });
+export default workflow( {
+  fn: async input => {
+    const { id } = await generateId( {} );
+    return await processWithId( { id } );
   }
-});
+} );
 ```
 
 ### 2. Date.now() / new Date()
@@ -74,32 +74,32 @@ export default workflow({
 
 ```typescript
 // WRONG: Non-deterministic
-export default workflow({
-  fn: async (input) => {
+export default workflow( {
+  fn: async input => {
     const timestamp = Date.now();  // Different each replay!
-    return await logEvent({ timestamp });
+    return await logEvent( { timestamp } );
   }
-});
+} );
 ```
 
 **Solution**: Pass timestamps as input or use Temporal's time API.
 
 ```typescript
 // Option 1: Pass as input
-export default workflow({
-  inputSchema: z.object({
+export default workflow( {
+  inputSchema: z.object( {
     timestamp: z.number()
-  }),
-  fn: async (input) => {
-    return await logEvent({ timestamp: input.timestamp });
+  } ),
+  fn: async input => {
+    return await logEvent( { timestamp: input.timestamp } );
   }
-});
+} );
 
 // Option 2: Generate in a step
-export const getTimestamp = step({
+export const getTimestamp = step( {
   name: 'getTimestamp',
-  fn: async () => ({ timestamp: Date.now() })
-});
+  fn: async () => ( { timestamp: Date.now() } )
+} );
 ```
 
 ### 3. crypto.randomUUID()
@@ -110,25 +110,25 @@ export const getTimestamp = step({
 // WRONG: Non-deterministic
 import { randomUUID } from 'crypto';
 
-export default workflow({
-  fn: async (input) => {
+export default workflow( {
+  fn: async input => {
     const requestId = randomUUID();  // Different each time!
-    return await makeRequest({ requestId });
+    return await makeRequest( { requestId } );
   }
-});
+} );
 ```
 
 **Solution**: Generate UUIDs as input or in steps.
 
 ```typescript
 // Correct: Generate in step
-export const generateRequestId = step({
+export const generateRequestId = step( {
   name: 'generateRequestId',
   fn: async () => {
-    const { randomUUID } = await import('crypto');
+    const { randomUUID } = await import( 'crypto' );
     return { requestId: randomUUID() };
   }
-});
+} );
 ```
 
 ### 4. Dynamic Imports
@@ -137,12 +137,12 @@ export const generateRequestId = step({
 
 ```typescript
 // WRONG: Non-deterministic import timing
-export default workflow({
-  fn: async (input) => {
-    const module = await import(`./handlers/${input.type}`);
-    return module.handle(input);
+export default workflow( {
+  fn: async input => {
+    const module = await import( `./handlers/${input.type}` );
+    return module.handle( input );
   }
-});
+} );
 ```
 
 **Solution**: Use static imports and conditional logic.
@@ -152,15 +152,15 @@ export default workflow({
 import { handleTypeA } from './handlers/typeA';
 import { handleTypeB } from './handlers/typeB';
 
-export default workflow({
-  fn: async (input) => {
-    if (input.type === 'A') {
-      return await handleTypeA(input);
+export default workflow( {
+  fn: async input => {
+    if ( input.type === 'A' ) {
+      return await handleTypeA( input );
     } else {
-      return await handleTypeB(input);
+      return await handleTypeB( input );
     }
   }
-});
+} );
 ```
 
 ### 5. Environment Variables
@@ -169,26 +169,26 @@ export default workflow({
 
 ```typescript
 // WRONG: Environment can change
-export default workflow({
-  fn: async (input) => {
+export default workflow( {
+  fn: async input => {
     const apiUrl = process.env.API_URL;  // May differ on different workers
-    return await callApi({ url: apiUrl });
+    return await callApi( { url: apiUrl } );
   }
-});
+} );
 ```
 
 **Solution**: Pass configuration as input or use constants.
 
 ```typescript
 // Correct: Pass as input
-export default workflow({
-  inputSchema: z.object({
+export default workflow( {
+  inputSchema: z.object( {
     apiUrl: z.string()
-  }),
-  fn: async (input) => {
-    return await callApi({ url: input.apiUrl });
+  } ),
+  fn: async input => {
+    return await callApi( { url: input.apiUrl } );
   }
-});
+} );
 ```
 
 ## How to Find Non-Deterministic Code

--- a/coding_assistants/claude/plugins/outputai/skills/output-error-try-catch/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-error-try-catch/SKILL.md
@@ -34,9 +34,9 @@ When you wrap step calls in try-catch blocks, you intercept errors before the Ou
 ```typescript
 // WRONG: Error is silently ignored
 try {
-  const result = await myStep(input);
-} catch (error) {
-  console.log('Step failed');  // Swallowed!
+  const result = await myStep( input );
+} catch ( error ) {
+  console.log( 'Step failed' );  // Swallowed!
   return { success: false };
 }
 ```
@@ -46,9 +46,9 @@ try {
 ```typescript
 // WRONG: Turns retryable errors into fatal errors
 try {
-  const result = await myStep(input);
-} catch (error) {
-  throw new FatalError(error.message);  // Prevents retries!
+  const result = await myStep( input );
+} catch ( error ) {
+  throw new FatalError( error.message );  // Prevents retries!
 }
 ```
 
@@ -57,9 +57,9 @@ try {
 ```typescript
 // WRONG: Loses error context and may affect retry behavior
 try {
-  const result = await myStep(input);
-} catch (error) {
-  throw new Error(`Step failed: ${error.message}`);
+  const result = await myStep( input );
+} catch ( error ) {
+  throw new Error( `Step failed: ${error.message}` );
 }
 ```
 
@@ -70,29 +70,29 @@ try {
 ### Before (Wrong)
 
 ```typescript
-export default workflow({
-  fn: async (input) => {
+export default workflow( {
+  fn: async input => {
     try {
-      const data = await fetchDataStep(input);
-      const result = await processDataStep(data);
+      const data = await fetchDataStep( input );
+      const result = await processDataStep( data );
       return result;
-    } catch (error) {
-      throw new FatalError(error.message);
+    } catch ( error ) {
+      throw new FatalError( error.message );
     }
   }
-});
+} );
 ```
 
 ### After (Correct)
 
 ```typescript
-export default workflow({
-  fn: async (input) => {
-    const data = await fetchDataStep(input);
-    const result = await processDataStep(data);
+export default workflow( {
+  fn: async input => {
+    const data = await fetchDataStep( input );
+    const result = await processDataStep( data );
     return result;
   }
-});
+} );
 ```
 
 ## When Try-Catch IS Appropriate
@@ -104,18 +104,18 @@ There are limited cases where catching errors in workflows is valid:
 When a step failure should trigger an alternative path:
 
 ```typescript
-export default workflow({
-  fn: async (input) => {
-    let data;
-    try {
-      data = await fetchFromPrimarySource(input);
-    } catch {
-      // Fallback to secondary source
-      data = await fetchFromSecondarySource(input);
-    }
-    return await processData(data);
+export default workflow( {
+  fn: async input => {
+    const data = await ( async () => {
+      try {
+        return await fetchFromPrimarySource( input );
+      } catch {
+        return await fetchFromSecondarySource( input );
+      }
+    } )();
+    return await processData( data );
   }
-});
+} );
 ```
 
 ### 2. Aggregate Results with Partial Failures
@@ -123,20 +123,20 @@ export default workflow({
 When processing multiple items where some may fail:
 
 ```typescript
-export default workflow({
-  fn: async (input) => {
+export default workflow( {
+  fn: async input => {
     const results = [];
-    for (const item of input.items) {
+    for ( const item of input.items ) {
       try {
-        const result = await processItem(item);
-        results.push({ item, result, success: true });
-      } catch (error) {
-        results.push({ item, error: error.message, success: false });
+        const result = await processItem( item );
+        results.push( { item, result, success: true } );
+      } catch ( error ) {
+        results.push( { item, error: error.message, success: false } );
       }
     }
     return results;  // Contains both successes and failures
   }
-});
+} );
 ```
 
 **Note**: Even in these cases, be careful not to swallow errors that should cause the whole workflow to fail.
@@ -178,7 +178,7 @@ When you DO catch errors:
 Instead of try-catch, configure retry policies on steps:
 
 ```typescript
-export const fetchData = step({
+export const fetchData = step( {
   name: 'fetchData',
   retry: {
     maxAttempts: 3,
@@ -186,11 +186,11 @@ export const fetchData = step({
     maxInterval: '30s',
     backoffCoefficient: 2
   },
-  fn: async (input) => {
+  fn: async input => {
     // If this fails, it will be retried according to policy
-    return await callApi(input);
+    return await callApi( input );
   }
-});
+} );
 ```
 
 ## Using FatalError Correctly
@@ -198,16 +198,16 @@ export const fetchData = step({
 FatalError is for errors that should NEVER be retried:
 
 ```typescript
-export const validateInput = step({
+export const validateInput = step( {
   name: 'validateInput',
-  fn: async (input) => {
-    if (!input.userId) {
+  fn: async input => {
+    if ( !input.userId ) {
       // This will never succeed on retry
-      throw new FatalError('userId is required');
+      throw new FatalError( 'userId is required' );
     }
     return input;
   }
-});
+} );
 ```
 
 Do NOT use FatalError to wrap other errors unless you're certain they shouldn't retry.

--- a/coding_assistants/claude/plugins/outputai/skills/output-error-try-catch/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-error-try-catch/SKILL.md
@@ -118,6 +118,25 @@ export default workflow( {
 } );
 ```
 
+For readability, you can extract the fallback logic into a named helper function instead of using an IIFE:
+
+```typescript
+const fetchWithFallback = async input => {
+  try {
+    return await fetchFromPrimarySource( input );
+  } catch {
+    return await fetchFromSecondarySource( input );
+  }
+};
+
+export default workflow( {
+  fn: async input => {
+    const data = await fetchWithFallback( input );
+    return await processData( data );
+  }
+} );
+```
+
 ### 2. Aggregate Results with Partial Failures
 
 When processing multiple items where some may fail:

--- a/coding_assistants/claude/plugins/outputai/skills/output-error-zod-import/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-error-zod-import/SKILL.md
@@ -41,9 +41,9 @@ TypeError: Cannot read property 'parse' of undefined
 // WRONG: Importing from 'zod' directly
 import { z } from 'zod';
 
-const inputSchema = z.object({
-  name: z.string(),
-});
+const inputSchema = z.object( {
+  name: z.string()
+} );
 ```
 
 ## Solution
@@ -92,18 +92,18 @@ All matches should show `@outputai/core`, not `zod`.
 import { z } from 'zod';  // Wrong!
 import { step } from '@outputai/core';
 
-export const processStep = step({
+export const processStep = step( {
   name: 'processData',
-  inputSchema: z.object({
-    id: z.string(),
-  }),
-  outputSchema: z.object({
-    result: z.string(),
-  }),
-  fn: async (input) => {
+  inputSchema: z.object( {
+    id: z.string()
+  } ),
+  outputSchema: z.object( {
+    result: z.string()
+  } ),
+  fn: async input => {
     return { result: `Processed ${input.id}` };
-  },
-});
+  }
+} );
 ```
 
 ### After (Correct)
@@ -112,18 +112,18 @@ export const processStep = step({
 // src/workflows/my-workflow/steps/process.ts
 import { z, step } from '@outputai/core';  // Correct!
 
-export const processStep = step({
+export const processStep = step( {
   name: 'processData',
-  inputSchema: z.object({
-    id: z.string(),
-  }),
-  outputSchema: z.object({
-    result: z.string(),
-  }),
-  fn: async (input) => {
+  inputSchema: z.object( {
+    id: z.string()
+  } ),
+  outputSchema: z.object( {
+    result: z.string()
+  } ),
+  fn: async input => {
     return { result: `Processed ${input.id}` };
-  },
-});
+  }
+} );
 ```
 
 ## Verification Steps
@@ -158,12 +158,12 @@ Add a rule to prevent direct zod imports:
 // .eslintrc.js
 module.exports = {
   rules: {
-    'no-restricted-imports': ['error', {
-      paths: [{
+    'no-restricted-imports': [ 'error', {
+      paths: [ {
         name: 'zod',
         message: "Import { z } from '@outputai/core' instead of 'zod'"
-      }]
-    }]
+      } ]
+    } ]
   }
 };
 ```

--- a/coding_assistants/claude/plugins/outputai/skills/output-meta-post-flight/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-meta-post-flight/SKILL.md
@@ -23,13 +23,25 @@ Verify the following conventions were followed:
 #### Import Conventions
 - [ ] All TypeScript/JavaScript imports use `.js` extension for ES modules
 - [ ] No direct axios usage - HttpClient wrapper used throughout
-- [ ] Proper import paths for Output SDK packages (@flowsdk/core, @flowsdk/llm, etc.)
+- [ ] Proper import paths for Output SDK packages (@outputai/core, @outputai/llm, etc.)
 
 #### Workflow Structure
 - [ ] Workflow exported in entrypoint.ts: `export * from './path/to/workflow.js';`
 - [ ] All external operations wrapped in Temporal activities (steps)
 - [ ] Proper error handling with ApplicationFailure patterns
 - [ ] Retry policies configured appropriately
+
+#### Schema Placement
+- [ ] All schemas for `Output.object()` defined in `types.ts`, not inline in step functions
+- [ ] LLM output schemas use `.describe()` only -- no `.min()/.max()/.length()` on numbers or arrays
+- [ ] Prompt files do not contain JSON output format instructions when `Output.object()` is used
+
+#### Code Style (see `output-dev-code-style`)
+- [ ] No trailing commas in any generated code
+- [ ] No `let` declarations -- all variables use `const`
+- [ ] Arrow functions use parens only when needed (multi-param or destructured)
+- [ ] Operator linebreaks placed after the operator, not before
+- [ ] Space in parens: `fn( x )` not `fn(x)`
 
 #### Documentation & Testing
 - [ ] Comprehensive plan document created with all required sections

--- a/coding_assistants/claude/plugins/outputai/skills/output-meta-post-flight/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-meta-post-flight/SKILL.md
@@ -36,6 +36,10 @@ Verify the following conventions were followed:
 - [ ] LLM output schemas use `.describe()` only -- no `.min()/.max()/.length()` on numbers or arrays
 - [ ] Prompt files do not contain JSON output format instructions when `Output.object()` is used
 
+#### LLM Provider & Variables
+- [ ] All prompt files use the same provider (no mixing unless explicitly requested)
+- [ ] `generateText`/`Agent` variables are `string | number | boolean` only -- no arrays or objects
+
 #### Code Style (see `output-dev-code-style`)
 - [ ] No trailing commas in any generated code
 - [ ] No `let` declarations -- all variables use `const`

--- a/coding_assistants/claude/plugins/outputai/skills/output-meta-project-context/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-meta-project-context/SKILL.md
@@ -232,20 +232,20 @@ npx output credentials get <path>            # Get single credential value
 import { workflow, z } from '@outputai/core';
 import { fetchData, processData } from './steps.js';
 
-export const inputSchema = z.object({ url: z.string().url() });
-export const outputSchema = z.object({ result: z.string() });
+export const inputSchema = z.object( { url: z.string().url() } );
+export const outputSchema = z.object( { result: z.string() } );
 
-export default workflow({
+export default workflow( {
   name: 'my_workflow',
   description: 'Processes data from URL',
   inputSchema,
   outputSchema,
-  fn: async (input) => {
-    const data = await fetchData(input.url);
-    const result = await processData(data);
+  fn: async input => {
+    const data = await fetchData( input.url );
+    const result = await processData( data );
     return { result };
   }
-});
+} );
 ```
 
 See `output-dev-workflow-function` for comprehensive patterns.
@@ -257,9 +257,9 @@ import { httpClient } from '@outputai/http';
 
 export const fetchData = step(
   { name: 'fetchData', inputSchema: z.string(), outputSchema: z.any() },
-  async (url) => {
-    const client = httpClient({ prefixUrl: url });
-    const response = await client.get('');
+  async url => {
+    const client = httpClient( { prefixUrl: url } );
+    const response = await client.get( '' );
     return response.json();
   }
 );
@@ -277,26 +277,26 @@ import { FatalError, ValidationError } from '@outputai/core';
 import { httpClient } from '@outputai/http';
 import { credentials } from '@outputai/credentials';
 
-const API_KEY = credentials.require('example.api_key');
+const API_KEY = credentials.require( 'example.api_key' );
 
-const client = httpClient({
+const client = httpClient( {
   prefixUrl: 'https://api.example.com',
   headers: { Authorization: `Bearer ${API_KEY}` },
   timeout: 30000,
-  retry: { limit: 3, statusCodes: [408, 429, 500, 502, 503, 504] }
-});
+  retry: { limit: 3, statusCodes: [ 408, 429, 500, 502, 503, 504 ] }
+} );
 
-export async function fetchFromExample(query: string): Promise<ExampleResponse> {
+export async function fetchFromExample( query: string ): Promise<ExampleResponse> {
 
   try {
-    const response = await client.get('endpoint', { searchParams: { q: query } });
+    const response = await client.get( 'endpoint', { searchParams: { q: query } } );
     return response.json();
-  } catch (error: unknown) {
+  } catch ( error: unknown ) {
     const err = error as { status?: number; message?: string };
-    if (err.status === 401 || err.status === 403) {
-      throw new FatalError(`Auth failed: ${err.message}`);
+    if ( err.status === 401 || err.status === 403 ) {
+      throw new FatalError( `Auth failed: ${err.message}` );
     }
-    throw new ValidationError(`Request failed: ${err.message}`);
+    throw new ValidationError( `Request failed: ${err.message}` );
   }
 }
 ```
@@ -315,18 +315,18 @@ Evaluators return confidence-scored results. Three result types available:
 import { evaluator, z, EvaluationBooleanResult, EvaluationNumberResult, EvaluationStringResult } from '@outputai/core';
 
 // Boolean evaluator - pass/fail checks
-export const evaluateCompleteness = evaluator({
+export const evaluateCompleteness = evaluator( {
   name: 'evaluate_completeness',
   description: 'Check if content meets minimum length',
-  inputSchema: z.object({ content: z.string(), minLength: z.number() }),
-  fn: async ({ content, minLength }) => {
-    return new EvaluationBooleanResult({
+  inputSchema: z.object( { content: z.string(), minLength: z.number() } ),
+  fn: async ( { content, minLength } ) => {
+    return new EvaluationBooleanResult( {
       value: content.length >= minLength,
       confidence: 1.0,
       reasoning: `Content has ${content.length} chars (min: ${minLength})`
-    });
+    } );
   }
-});
+} );
 ```
 
 See `output-dev-evaluator-function` for comprehensive patterns.
@@ -368,19 +368,19 @@ import { generateText, Output } from '@outputai/llm';
 import { z } from '@outputai/core';
 
 // Structured output
-const { output } = await generateText({
+const { output } = await generateText( {
   prompt: 'analyze@v1',
   variables: { content: 'Article text...', numberOfPoints: 5 },
-  output: Output.object({
-    schema: z.object({ insights: z.array(z.string()) })
-  })
-});
+  output: Output.object( {
+    schema: z.object( { insights: z.array( z.string() ) } )
+  } )
+} );
 
 // Text output
-const { result } = await generateText({
+const { result } = await generateText( {
   prompt: 'summarize@v1',
   variables: { content: 'Article text...' }
-});
+} );
 ```
 
 **Provider options:**

--- a/coding_assistants/claude/plugins/outputai/skills/output-workflow-result/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-workflow-result/SKILL.md
@@ -53,11 +53,11 @@ A successful workflow returns the value from its `fn` function:
 
 ```typescript
 // Workflow code
-export default workflow({
-  fn: async (input) => {
+export default workflow( {
+  fn: async input => {
     return { processed: true, count: 42 };
   }
-});
+} );
 ```
 
 ```bash

--- a/sdk/cli/src/templates/agent_instructions/dotclaude/settings.json.template
+++ b/sdk/cli/src/templates/agent_instructions/dotclaude/settings.json.template
@@ -4,8 +4,8 @@
       "WebFetch",
       "Bash(npx output:*)",
       "Bash(npm run output:*)",
-      "Skills(output*)",
-      "Skills(flow*)"
+      "Skill(output*)",
+      "Skill(outputai:*)"
     ]
   },
   "enabledPlugins": {


### PR DESCRIPTION
Updates coding assistant plugin files to improve AI-generated workflow code quality and command routing. These changes are intended to improve the code generated when users ask Claude to create or iterate on workflows. These changes add things like structured output guidance, schema placement rules, a new code style skill, and try to add consistent formatting across all plugin files. Also adds an entirely new skill around code style called `output-dev-code-style`.

- Add `output-dev-code-style` skill covering project ESLint rules (trailing commas, const-only, arrow parens, operator linebreak, spacing)
- Add guidance against duplicating `Output.object()` schemas in prompts (grounded in Anthropic and Google Vertex AI best practices)
- Add rule requiring LLM schemas to be defined in `types.ts`, not inline in steps
- Update prompt writer agent with correct structured output patterns and pitfall documentation
- Add schema placement and code style checks to the post-flight checklist
- Apply consistent code style (space-in-parens, no trailing commas, `fn: async input =>`) across all plugin files
- Improve `plan_workflow` command description with trigger phrases for better semantic matching
- Add workflow creation routing directive to `SESSION_START_CONTEXT.md` so Claude always uses `/outputai:plan_workflow` instead of manual planning
- Apply style sweep to 7 remaining plugin files not covered in initial pass (error skills, workflow-result, skill-file, project-context, build command)
- Document `generateText` variable type constraint (`string | number | boolean` only) -- arrays/objects must be pre-formatted in steps
- Remove Liquid loop/nested object patterns from prompt writer agent that conflict with the variable type constraint
- Add provider preference question to `plan_workflow` planning flow
- Add LLM provider consistency rule -- all prompts in a workflow should use the same provider, default to Anthropic, unless specified in the `plan_workflow` step
- Fixes templated `.claude/settings.json` for running Output skills (was `Skills()` but it should be `Skill()`)
