### PR TITLE
chore(CLI): Add Docker Compose version check

### DIFF
--- a/.changeset/frank-teeth-think.md
+++ b/.changeset/frank-teeth-think.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Add Docker Compose version check to prevent silent hangs on versions older than v2.24.0

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,30 @@
 
 set -e
 
+check_docker_compose_version() {
+  local required_version="2.24.0"
+  local current_version
+  current_version=$(docker compose version --short 2>/dev/null) || {
+    echo "Error: Docker Compose is not installed. Please install Docker Compose."
+    echo "Visit: https://docs.docker.com/compose/install/"
+    exit 1
+  }
+
+  local current_major current_minor current_patch
+  IFS='.' read -r current_major current_minor current_patch <<< "$current_version"
+
+  local required_major required_minor required_patch
+  IFS='.' read -r required_major required_minor required_patch <<< "$required_version"
+
+  if [ "$current_major" -lt "$required_major" ] ||
+     { [ "$current_major" -eq "$required_major" ] && [ "$current_minor" -lt "$required_minor" ]; } ||
+     { [ "$current_major" -eq "$required_major" ] && [ "$current_minor" -eq "$required_minor" ] && [ "${current_patch%%[-+]*}" -lt "$required_patch" ]; }; then
+    echo "Error: Docker Compose >=${required_version} is required (found v${current_version})."
+    echo "Please update Docker Compose: https://docs.docker.com/compose/install/"
+    exit 1
+  fi
+}
+
 cmd=$1
 
 if [[ $cmd == 'validate' ]]; then
@@ -22,6 +46,7 @@ elif [[ $cmd == 'docs:mint' ]]; then
     -w /app mint -c "cd ./docs/guides; mint dev"
 
 elif [[ $cmd == 'dev' ]]; then
+  check_docker_compose_version
   docker run -it --rm \
     -v $(pwd):/app \
     -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
@@ -30,12 +55,15 @@ elif [[ $cmd == 'dev' ]]; then
   docker compose -f ./docker-compose.dev.yml up
 
 elif [[ $cmd == 'dev:destroy' ]]; then
+  check_docker_compose_version
   docker compose -f ./docker-compose.dev.yml down -v
 
 elif [[ $cmd == 'prod' ]]; then
+  check_docker_compose_version
   docker compose -f ./docker-compose.prod.yml up --build
 
 elif [[ $cmd == 'prod:destroy' ]]; then
+  check_docker_compose_version
   docker compose -f ./docker-compose.prod.yml down -v
 
 else

--- a/sdk/cli/src/services/docker.ts
+++ b/sdk/cli/src/services/docker.ts
@@ -2,6 +2,7 @@ import { execFileSync, execSync, spawn, type ChildProcess } from 'node:child_pro
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ux } from '@oclif/core';
+import semver from 'semver';
 
 const DEFAULT_COMPOSE_PATH = '../assets/docker/docker-compose-dev.yml';
 
@@ -67,39 +68,6 @@ const getCommandVersion = ( command: string, pattern: RegExp = /(\d+\.\d+\.\d+)/
   }
 };
 
-const parseSemver = ( version: string ): [number, number, number] | null => {
-  const match = version.match( /^(\d+)\.(\d+)\.(\d+)/ );
-  return match ? [ Number( match[1] ), Number( match[2] ), Number( match[3] ) ] : null;
-};
-
-const satisfiesSemver = ( version: string, range: string ): boolean => {
-  if ( range === '*' ) {
-    return true;
-  }
-
-  const gteMatch = range.match( /^>=(.+)$/ );
-  if ( !gteMatch ) {
-    return false;
-  }
-
-  const current = parseSemver( version );
-  const required = parseSemver( gteMatch[1] );
-  if ( !current || !required ) {
-    return false;
-  }
-
-  const [ currentMajor, currentMinor, currentPatch ] = current;
-  const [ requiredMajor, requiredMinor, requiredPatch ] = required;
-
-  if ( currentMajor !== requiredMajor ) {
-    return currentMajor > requiredMajor;
-  }
-  if ( currentMinor !== requiredMinor ) {
-    return currentMinor > requiredMinor;
-  }
-  return currentPatch >= requiredPatch;
-};
-
 const isDockerInstalled = (): boolean => checkDockerCommand( 'docker --version' );
 
 const PREREQUISITES: Prerequisite[] = [
@@ -132,13 +100,14 @@ const PREREQUISITES: Prerequisite[] = [
 
 export function validateDockerEnvironment(): void {
   for ( const prereq of PREREQUISITES ) {
-    const version = prereq.getVersion();
+    const raw = prereq.getVersion();
+    const version = raw ? semver.valid( semver.coerce( raw ) ) : null;
 
-    if ( version === null ) {
+    if ( !version ) {
       throw new DockerValidationError( prereq.errorMessage( null, prereq.semverRange ) );
     }
 
-    if ( !satisfiesSemver( version, prereq.semverRange ) ) {
+    if ( !semver.satisfies( version, prereq.semverRange ) ) {
       throw new DockerValidationError( prereq.errorMessage( version, prereq.semverRange ) );
     }
   }

--- a/sdk/cli/src/services/docker.ts
+++ b/sdk/cli/src/services/docker.ts
@@ -19,6 +19,13 @@ export const SERVICE_STATE = {
 
 class DockerValidationError extends Error {}
 
+interface Prerequisite {
+  name: string;
+  semverRange: string;
+  getVersion: () => string | null;
+  errorMessage: ( current: string | null, required: string ) => string;
+}
+
 export interface ServiceStatus {
   name: string;
   state: string;
@@ -50,29 +57,90 @@ const checkDockerCommand = ( command: string ): boolean => {
   }
 };
 
-const isDockerInstalled = (): boolean => checkDockerCommand( 'docker --version' );
-const isDockerComposeAvailable = (): boolean => checkDockerCommand( 'docker compose version' );
-const isDockerDaemonRunning = (): boolean => checkDockerCommand( 'docker ps' );
+const getCommandVersion = ( command: string, pattern: RegExp = /(\d+\.\d+\.\d+)/ ): string | null => {
+  try {
+    const output = execSync( command, { stdio: 'pipe', encoding: 'utf-8' } ).trim();
+    const match = output.match( pattern );
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+};
 
-const DOCKER_VALIDATIONS = [
+const parseSemver = ( version: string ): [number, number, number] | null => {
+  const match = version.match( /^(\d+)\.(\d+)\.(\d+)/ );
+  return match ? [ Number( match[1] ), Number( match[2] ), Number( match[3] ) ] : null;
+};
+
+const satisfiesSemver = ( version: string, range: string ): boolean => {
+  if ( range === '*' ) {
+    return true;
+  }
+
+  const gteMatch = range.match( /^>=(.+)$/ );
+  if ( !gteMatch ) {
+    return false;
+  }
+
+  const current = parseSemver( version );
+  const required = parseSemver( gteMatch[1] );
+  if ( !current || !required ) {
+    return false;
+  }
+
+  const [ currentMajor, currentMinor, currentPatch ] = current;
+  const [ requiredMajor, requiredMinor, requiredPatch ] = required;
+
+  if ( currentMajor !== requiredMajor ) {
+    return currentMajor > requiredMajor;
+  }
+  if ( currentMinor !== requiredMinor ) {
+    return currentMinor > requiredMinor;
+  }
+  return currentPatch >= requiredPatch;
+};
+
+const isDockerInstalled = (): boolean => checkDockerCommand( 'docker --version' );
+
+const PREREQUISITES: Prerequisite[] = [
   {
-    check: isDockerInstalled,
-    error: 'Docker is not installed. Please install Docker to use the dev command.\nVisit: https://docs.docker.com/get-docker/'
+    name: 'Docker',
+    semverRange: '>=20.0.0',
+    getVersion: () => getCommandVersion( 'docker --version' ),
+    errorMessage: ( current, required ) =>
+      current === null ?
+        'Docker is not installed. Please install Docker to use the dev command.\nVisit: https://docs.docker.com/get-docker/' :
+        `Docker version ${required} is required (found v${current}).\nVisit: https://docs.docker.com/get-docker/`
   },
   {
-    check: isDockerComposeAvailable,
-    error: 'Docker Compose is not installed. Please install Docker Compose to use the dev command.\nVisit: https://docs.docker.com/compose/install/'
+    name: 'Docker Compose',
+    semverRange: '>=2.24.0',
+    getVersion: () => getCommandVersion( 'docker compose version --short' ),
+    errorMessage: ( current, required ) =>
+      current === null ?
+        'Docker Compose is not installed. Please install Docker Compose to use the dev command.\nVisit: https://docs.docker.com/compose/install/' :
+        `Docker Compose ${required} is required (found v${current}).\nPlease update Docker Compose: https://docs.docker.com/compose/install/`
   },
   {
-    check: isDockerDaemonRunning,
-    error: 'Docker daemon is not running. Please start Docker and try again.'
+    name: 'Docker Daemon',
+    semverRange: '*',
+    getVersion: () => checkDockerCommand( 'docker ps' ) ? '0.0.0' : null,
+    errorMessage: () =>
+      'Docker daemon is not running. Please start Docker and try again.'
   }
 ];
 
 export function validateDockerEnvironment(): void {
-  const failedValidation = DOCKER_VALIDATIONS.find( v => !v.check() );
-  if ( failedValidation ) {
-    throw new DockerValidationError( failedValidation.error );
+  for ( const prereq of PREREQUISITES ) {
+    const version = prereq.getVersion();
+
+    if ( version === null ) {
+      throw new DockerValidationError( prereq.errorMessage( null, prereq.semverRange ) );
+    }
+
+    if ( !satisfiesSemver( version, prereq.semverRange ) ) {
+      throw new DockerValidationError( prereq.errorMessage( version, prereq.semverRange ) );
+    }
   }
 }
 
@@ -200,4 +268,4 @@ export async function stopDockerCompose( dockerComposePath: string ): Promise<vo
   );
 }
 
-export { isDockerInstalled, isDockerComposeAvailable, isDockerDaemonRunning, DockerValidationError };
+export { isDockerInstalled, DockerValidationError };


### PR DESCRIPTION
## Problem

- `output dev` silently hangs when Docker Compose is older than v2.24.0
- The previous validation only checked if Docker/Compose were installed, not their versions
- No actionable error message was shown to guide users toward a fix

## Solution

- Replaced ad-hoc validation with an extensible `PREREQUISITES` system that checks name, semver range, version detection, and error messaging uniformly
- Added a Docker Compose `>=2.24.0` version requirement that fails fast with upgrade instructions
- Added the same version check to `run.sh` before any `docker compose` call