### PR TITLE
Moving output from peer to actual dependency at the credentials lib

### DIFF
--- a/sdk/credentials/package.json
+++ b/sdk/credentials/package.json
@@ -21,9 +21,7 @@
   },
   "dependencies": {
     "@noble/ciphers": "2.1.1",
-    "js-yaml": "catalog:"
-  },
-  "peerDependencies": {
+    "js-yaml": "catalog:",
     "@outputai/core": "workspace:"
   },
   "devDependencies": {


### PR DESCRIPTION
Having "core" as peer dependency in "credentials" is causing changeset to treat minor releases as major: https://github.com/changesets/changesets/issues/1011.

This PR moves it to a normal dependency!
