### PR TITLE
fix(core,ci): catalog TERMINATE_EXISTING + publish-dev ref fallback

### DIFF
--- a/.changeset/catalog-startup-fix.md
+++ b/.changeset/catalog-startup-fix.md
@@ -1,0 +1,5 @@
+---
+"@outputai/core": patch
+---
+
+Fix catalog workflow startup race condition by using TERMINATE_EXISTING conflict policy

--- a/.github/workflows/publish_dev.yml
+++ b/.github/workflows/publish_dev.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Git ref to checkout and publish (branch, tag, or full SHA). Must exist in this repository.'
+        description: 'Git ref to checkout and publish (branch, tag, or full SHA). Defaults to the dispatched ref.'
         required: false
-        default: 'main'
         type: string
 
 concurrency: ${{ github.workflow }}
@@ -21,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Enable pnpm
         run: corepack enable

--- a/sdk/core/src/worker/start_catalog.js
+++ b/sdk/core/src/worker/start_catalog.js
@@ -1,4 +1,4 @@
-import { Client, WorkflowNotFoundError } from '@temporalio/client';
+import { Client } from '@temporalio/client';
 import { WorkflowIdConflictPolicy } from '@temporalio/common';
 import { WORKFLOW_CATALOG } from '#consts';
 import { catalogId, taskQueue } from './configs.js';
@@ -8,29 +8,12 @@ const log = createChildLogger( 'Catalog' );
 
 export const startCatalog = async ( { connection, namespace, catalog } ) => {
   const client = new Client( { connection, namespace } );
-  const catalogWorkflowHandle = client.workflow.getHandle( catalogId );
-
-  try {
-    const catalogWorkflowDescription = await catalogWorkflowHandle.describe();
-    if ( !catalogWorkflowDescription.closeTime ) {
-      log.info( 'Completing previous catalog workflow...' );
-      await catalogWorkflowHandle.executeUpdate( 'complete', { args: [] } );
-    }
-  } catch ( error ) {
-    // When "not found", it's either a cold start or the catalog was already stopped/terminated, ignore it.
-    // Otherwise, create a log and try the next operation:
-    // A. If the workflow is still running, the start() will fail and throw;
-    // B. If the workflow is no running, the start() will succeed, and the error was transient;
-    if ( !( error instanceof WorkflowNotFoundError ) ) {
-      log.warn( 'Error interacting with previous catalog workflow', { error } );
-    }
-  }
 
   log.info( 'Starting catalog workflow...' );
   await client.workflow.start( WORKFLOW_CATALOG, {
     taskQueue,
-    workflowId: catalogId, // use the name of the task queue as the catalog name, ensuring uniqueness
-    workflowIdConflictPolicy: WorkflowIdConflictPolicy.FAIL,
+    workflowId: catalogId,
+    workflowIdConflictPolicy: WorkflowIdConflictPolicy.TERMINATE_EXISTING,
     args: [ catalog ]
   } );
 };

--- a/sdk/core/src/worker/start_catalog.spec.js
+++ b/sdk/core/src/worker/start_catalog.spec.js
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { WorkflowNotFoundError } from '@temporalio/client';
 
 const mockLog = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
 vi.mock( '#logger', () => ( { createChildLogger: () => mockLog } ) );
@@ -10,25 +9,18 @@ const catalogId = 'test-catalog';
 const taskQueue = 'test-queue';
 vi.mock( './configs.js', () => ( { catalogId, taskQueue } ) );
 
-const describeMock = vi.fn();
-const executeUpdateMock = vi.fn();
 const workflowStartMock = vi.fn().mockResolvedValue( undefined );
 vi.mock( '@temporalio/client', async importOriginal => {
   const actual = await importOriginal();
   return {
     ...actual,
     Client: vi.fn().mockImplementation( function () {
-      return {
-        workflow: {
-          start: workflowStartMock,
-          getHandle: () => ( { describe: describeMock, executeUpdate: executeUpdateMock } )
-        }
-      };
+      return { workflow: { start: workflowStartMock } };
     } )
   };
 } );
 
-vi.mock( '@temporalio/common', () => ( { WorkflowIdConflictPolicy: { FAIL: 'FAIL' } } ) );
+vi.mock( '@temporalio/common', () => ( { WorkflowIdConflictPolicy: { TERMINATE_EXISTING: 'TERMINATE_EXISTING' } } ) );
 
 describe( 'worker/start_catalog', () => {
   const mockConnection = {};
@@ -40,79 +32,24 @@ describe( 'worker/start_catalog', () => {
     workflowStartMock.mockResolvedValue( undefined );
   } );
 
-  it( 'when previous catalog still running: completes it then starts catalog workflow', async () => {
-    describeMock.mockResolvedValue( { closeTime: undefined } );
-    executeUpdateMock.mockResolvedValue( undefined );
-
+  it( 'starts catalog workflow with TERMINATE_EXISTING policy', async () => {
     const { startCatalog } = await import( './start_catalog.js' );
     await startCatalog( { connection: mockConnection, namespace, catalog } );
 
-    expect( describeMock ).toHaveBeenCalled();
-    expect( mockLog.info ).toHaveBeenCalledWith( 'Completing previous catalog workflow...' );
-    expect( executeUpdateMock ).toHaveBeenCalledWith( 'complete', { args: [] } );
     expect( mockLog.info ).toHaveBeenCalledWith( 'Starting catalog workflow...' );
     expect( workflowStartMock ).toHaveBeenCalledWith( 'catalog', {
       taskQueue,
       workflowId: catalogId,
-      workflowIdConflictPolicy: 'FAIL',
+      workflowIdConflictPolicy: 'TERMINATE_EXISTING',
       args: [ catalog ]
     } );
   } );
 
-  it( 'when no previous catalog: ignores and starts catalog workflow', async () => {
-    describeMock.mockRejectedValue( new WorkflowNotFoundError( 'not found' ) );
+  it( 'propagates errors from workflow.start', async () => {
+    workflowStartMock.mockRejectedValue( new Error( 'Connection refused' ) );
 
     const { startCatalog } = await import( './start_catalog.js' );
-    await startCatalog( { connection: mockConnection, namespace, catalog } );
-
-    expect( describeMock ).toHaveBeenCalled();
-    expect( mockLog.warn ).not.toHaveBeenCalled();
-    expect( mockLog.info ).toHaveBeenCalledWith( 'Starting catalog workflow...' );
-    expect( executeUpdateMock ).not.toHaveBeenCalled();
-    expect( workflowStartMock ).toHaveBeenCalledWith( 'catalog', {
-      taskQueue,
-      workflowId: catalogId,
-      workflowIdConflictPolicy: 'FAIL',
-      args: [ catalog ]
-    } );
-  } );
-
-  it( 'when previous catalog already closed: skips complete and starts catalog workflow', async () => {
-    describeMock.mockResolvedValue( { closeTime: '2024-01-01T00:00:00Z' } );
-
-    const { startCatalog } = await import( './start_catalog.js' );
-    await startCatalog( { connection: mockConnection, namespace, catalog } );
-
-    expect( describeMock ).toHaveBeenCalled();
-    expect( mockLog.info ).not.toHaveBeenCalledWith( 'Completing previous catalog workflow...' );
-    expect( executeUpdateMock ).not.toHaveBeenCalled();
-    expect( mockLog.info ).toHaveBeenCalledWith( 'Starting catalog workflow...' );
-    expect( workflowStartMock ).toHaveBeenCalledWith( 'catalog', {
-      taskQueue,
-      workflowId: catalogId,
-      workflowIdConflictPolicy: 'FAIL',
-      args: [ catalog ]
-    } );
-  } );
-
-  it( 'when describe or complete fails with other error: logs warn and still starts catalog workflow', async () => {
-    describeMock.mockResolvedValue( { closeTime: undefined } );
-    executeUpdateMock.mockRejectedValue( new Error( 'Connection refused' ) );
-
-    const { startCatalog } = await import( './start_catalog.js' );
-    await startCatalog( { connection: mockConnection, namespace, catalog } );
-
-    expect( describeMock ).toHaveBeenCalled();
-    expect( executeUpdateMock ).toHaveBeenCalledWith( 'complete', { args: [] } );
-    expect( mockLog.warn ).toHaveBeenCalledWith( 'Error interacting with previous catalog workflow', {
-      error: expect.any( Error )
-    } );
-    expect( mockLog.info ).toHaveBeenCalledWith( 'Starting catalog workflow...' );
-    expect( workflowStartMock ).toHaveBeenCalledWith( 'catalog', {
-      taskQueue,
-      workflowId: catalogId,
-      workflowIdConflictPolicy: 'FAIL',
-      args: [ catalog ]
-    } );
+    await expect( startCatalog( { connection: mockConnection, namespace, catalog } ) )
+      .rejects.toThrow( 'Connection refused' );
   } );
 } );


### PR DESCRIPTION
## Overview

Trims the original sandbox-prototype PR down to the two changes that have **not** yet shipped to main via separate, more polished PRs. Branch history was reset onto current `main` and the two remaining fixes re-applied as small focused commits.

## What's changing

### `fix(core)` — catalog workflow startup uses TERMINATE_EXISTING

Replace `WorkflowIdConflictPolicy.FAIL` + the `describe()` / `executeUpdate('complete')` dance with a single `client.workflow.start(...)` call using `TERMINATE_EXISTING`. Temporal handles old-workflow termination atomically, eliminating the `WorkflowExecutionAlreadyStartedError` race when restarting a worker before the prior catalog has fully closed.

Files:
- `sdk/core/src/worker/start_catalog.js`
- `sdk/core/src/worker/start_catalog.spec.js` (simplified — drops `describe`/`executeUpdate` mocks)
- `.changeset/catalog-startup-fix.md`

### `fix(ci)` — publish_dev workflow checks out the dispatched ref

The `Checkout` step used `inputs.ref` which defaults to `main` when not explicitly provided. Dispatching via `gh workflow run --ref <branch>` populates `github.ref` but **not** `inputs.ref`, so dev builds always silently checked out `main`. Drop the `main` default and fall back to `github.ref` when `inputs.ref` is empty.

Files:
- `.github/workflows/publish_dev.yml`

## Why the diff shrank

Everything else from the original prototype landed on main separately:

| Prototype change | Landed on main via |
|---|---|
| Non-interactive CLI (`--yes`, TTY autodetect) | #137 |
| HTTP fetch proxy (worker + CLI) | #140 |
| Temporal gRPC proxy (`TEMPORAL_GRPC_PROXY`) | #140 |
| `output credentials set` | #136 |
| `OUTPUT_CATALOG_ID` auto-forward | #139 (renamed `--catalog` in #151) |
| `GET /workflow/runs` catalog filter | #151 |

Ref: [OUT-411](https://linear.app/growthx/issue/OUT-411)

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build:packages` passes
- [x] `start_catalog.spec.js` — 2/2 tests pass
- [ ] CI validation pipeline green
- [ ] Dispatch `publish_dev.yml` against this branch and confirm the Checkout step logs the branch ref (not `main`)
- [ ] Smoke test: `npm run start:worker`, kill mid-run, restart immediately — should not throw `WorkflowExecutionAlreadyStartedError`