### PR TITLE
chore(api): include input in GET /workflow/:id/result response

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -766,6 +766,9 @@
                       "type": "string",
                       "description": "The workflow execution id"
                     },
+                    "input": {
+                      "description": "The original input passed to the workflow, null if unavailable"
+                    },
                     "output": {
                       "description": "The result of workflow, null if workflow failed"
                     },

--- a/api/src/clients/temporal_client.js
+++ b/api/src/clients/temporal_client.js
@@ -1,4 +1,4 @@
-import { Client, Connection } from '@temporalio/client';
+import { Client, Connection, defaultPayloadConverter } from '@temporalio/client';
 import { temporal as temporalConfig } from '#configs';
 import { buildWorkflowId, extractTraceInfo, extractErrorMessage, takeFromAsyncIterable } from '#utils';
 import { logger } from '#logger';
@@ -129,17 +129,33 @@ export const resolveResetEventId = ( events, stepName ) => {
 };
 
 /**
+ * Extract the workflow input from a Temporal history object.
+ * The first event is always WorkflowExecutionStarted, which contains the input payloads.
+ *
+ * @param {object} history - Temporal History object from handle.fetchHistory()
+ * @returns {any} The decoded first input argument, or null if unavailable
+ */
+export const extractWorkflowInput = history => {
+  const payloads = history?.events?.[0]?.workflowExecutionStartedEventAttributes?.input?.payloads;
+  if ( !payloads?.length ) {
+    return null;
+  }
+  return defaultPayloadConverter.fromPayload( payloads[0] );
+};
+
+/**
  * Build a standardized workflow response object
  * @param {string} workflowId - The workflow execution id
  * @param {string} status - The workflow status
  * @param {Object} [options] - Optional fields
+ * @param {any} [options.input] - The original workflow input
  * @param {any} [options.output] - The workflow output
  * @param {object} [options.trace] - Trace information
  * @param {string} [options.error] - Error message if failed
  * @returns {Object} Standardized workflow response
  */
-const buildWorkflowResponse = ( workflowId, status, { output = null, trace = null, error = null } = {} ) =>
-  ( { workflowId, output, trace, status, error } );
+const buildWorkflowResponse = ( workflowId, status, { input = null, output = null, trace = null, error = null } = {} ) =>
+  ( { workflowId, status, input, output, trace, error } );
 
 export default {
   async init() {
@@ -323,7 +339,10 @@ export default {
        */
       async getWorkflowResult( workflowId ) {
         const handle = client.workflow.getHandle( workflowId );
-        const description = await handle.describe();
+        const [ description, history ] = await Promise.all( [
+          handle.describe(),
+          handle.fetchHistory()
+        ] );
 
         // Only throw if workflow is still running (not in a terminal state)
         if ( !TERMINAL_STATUS_CODES.has( description.status.code ) ) {
@@ -331,11 +350,13 @@ export default {
         }
 
         const status = mapWorkflowStatus( description.status.name );
+        const input = extractWorkflowInput( history );
 
         // For completed workflows, return the full result
         if ( description.status.code === TemporalStatus.COMPLETED ) {
           const result = await handle.result();
           return buildWorkflowResponse( workflowId, status, {
+            input,
             output: result.output ?? null,
             trace: result.trace ?? null
           } );
@@ -343,7 +364,7 @@ export default {
 
         // CONTINUED_AS_NEW is not an error - it means the workflow continued in a new execution
         if ( description.status.code === TemporalStatus.CONTINUED_AS_NEW ) {
-          return buildWorkflowResponse( workflowId, status );
+          return buildWorkflowResponse( workflowId, status, { input } );
         }
 
         // For other terminal statuses (failed, canceled, terminated, timed_out), extract trace from error details
@@ -365,6 +386,7 @@ export default {
           } );
 
         return buildWorkflowResponse( workflowId, status, {
+          input,
           trace: workflowError ? extractTraceInfo( workflowError ) ?? null : null,
           error: workflowError ? extractErrorMessage( workflowError ) : null
         } );

--- a/api/src/clients/temporal_client.spec.js
+++ b/api/src/clients/temporal_client.spec.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { WorkflowNotCompletedError, WorkflowExecutionTimedOutError, StepNotFoundError, StepNotCompletedError } from './errors.js';
-import { resolveResetEventId } from './temporal_client.js';
+import { resolveResetEventId, extractWorkflowInput } from './temporal_client.js';
 
 const {
   mockDescribe,
@@ -9,6 +9,7 @@ const {
   mockStart,
   mockGetHandle,
   mockConnect,
+  mockFetchHistory,
   mockLoggerInfo,
   mockLoggerError,
   mockLoggerWarn,
@@ -20,6 +21,7 @@ const {
   const mockStart = vi.fn();
   const mockGetHandle = vi.fn();
   const mockConnect = vi.fn();
+  const mockFetchHistory = vi.fn();
   const mockLoggerInfo = vi.fn();
   const mockLoggerError = vi.fn();
   const mockLoggerWarn = vi.fn();
@@ -40,6 +42,7 @@ const {
     mockStart,
     mockGetHandle,
     mockConnect,
+    mockFetchHistory,
     mockLoggerInfo,
     mockLoggerError,
     mockLoggerWarn,
@@ -58,6 +61,9 @@ vi.mock( '@temporalio/client', () => ( {
   } ),
   Connection: {
     connect: mockConnect
+  },
+  defaultPayloadConverter: {
+    fromPayload: vi.fn( p => p )
   },
   WorkflowNotFoundError: class WorkflowNotFoundError extends Error {
     constructor( message ) {
@@ -99,10 +105,12 @@ describe( 'temporal_client', () => {
   beforeEach( () => {
     vi.clearAllMocks();
     mockConnect.mockResolvedValue( {} );
+    mockFetchHistory.mockResolvedValue( { events: [] } );
     mockGetHandle.mockReturnValue( {
       describe: mockDescribe,
       result: mockResult,
-      query: mockQuery
+      query: mockQuery,
+      fetchHistory: mockFetchHistory
     } );
   } );
 
@@ -145,6 +153,7 @@ describe( 'temporal_client', () => {
       expect( result ).toEqual( {
         workflowId: 'test-uuid',
         status: 'failed',
+        input: null,
         output: null,
         trace: tracePayload,
         error: 'step error message'
@@ -173,6 +182,7 @@ describe( 'temporal_client', () => {
       expect( result ).toEqual( {
         workflowId: 'test-uuid',
         status: 'completed',
+        input: null,
         output: { data: 'result' },
         trace: { local: '/tmp/trace.json' },
         error: null
@@ -301,6 +311,7 @@ describe( 'temporal_client', () => {
       expect( result ).toEqual( {
         workflowId: 'workflow-123',
         status: 'completed',
+        input: null,
         output: { data: 'result' },
         trace: { local: '/tmp/trace.json' },
         error: null
@@ -326,6 +337,7 @@ describe( 'temporal_client', () => {
       expect( result ).toEqual( {
         workflowId: 'workflow-123',
         status: 'failed',
+        input: null,
         output: null,
         trace: tracePayload,
         error: 'step error message'
@@ -369,6 +381,7 @@ describe( 'temporal_client', () => {
       expect( result ).toEqual( {
         workflowId: 'workflow-123',
         status: 'continued',
+        input: null,
         output: null,
         trace: null,
         error: null
@@ -421,6 +434,61 @@ describe( 'temporal_client', () => {
 
       expect( result.status ).toBe( 'timed_out' );
       expect( result.error ).toBe( 'Workflow timed out' );
+    } );
+
+    it( 'should include workflow input from history when available', async () => {
+      const workflowInput = { url: 'https://example.com', options: { depth: 2 } };
+
+      mockDescribe.mockResolvedValue( {
+        status: { code: 2, name: 'COMPLETED' }
+      } );
+      mockResult.mockResolvedValue( { output: { data: 'result' }, trace: null } );
+      mockFetchHistory.mockResolvedValue( {
+        events: [ {
+          workflowExecutionStartedEventAttributes: {
+            input: { payloads: [ workflowInput ] }
+          }
+        } ]
+      } );
+
+      const temporalClient = ( await import( './temporal_client.js' ) ).default;
+      const client = await temporalClient.init();
+      const result = await client.getWorkflowResult( 'workflow-123' );
+
+      expect( result.input ).toEqual( workflowInput );
+    } );
+  } );
+
+  describe( 'extractWorkflowInput', () => {
+    it( 'returns null when history has no events', () => {
+      expect( extractWorkflowInput( { events: [] } ) ).toBeNull();
+    } );
+
+    it( 'returns null when history is null', () => {
+      expect( extractWorkflowInput( null ) ).toBeNull();
+    } );
+
+    it( 'returns null when payloads are empty', () => {
+      expect( extractWorkflowInput( {
+        events: [ { workflowExecutionStartedEventAttributes: { input: { payloads: [] } } } ]
+      } ) ).toBeNull();
+    } );
+
+    it( 'returns null when input attributes are missing', () => {
+      expect( extractWorkflowInput( {
+        events: [ { workflowExecutionStartedEventAttributes: {} } ]
+      } ) ).toBeNull();
+    } );
+
+    it( 'returns decoded payload when present', () => {
+      const payload = { values: [ 1, 2, 3 ] };
+      expect( extractWorkflowInput( {
+        events: [ {
+          workflowExecutionStartedEventAttributes: {
+            input: { payloads: [ payload ] }
+          }
+        } ]
+      } ) ).toEqual( payload );
     } );
   } );
 

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -627,6 +627,8 @@ app.post( '/workflow/:id/reset', async ( req, res ) => {
  *                 workflowId:
  *                   type: string
  *                   description: The workflow execution id
+ *                 input:
+ *                   description: The original input passed to the workflow, null if unavailable
  *                 output:
  *                   description: The result of workflow, null if workflow failed
  *                 trace:

--- a/api/src/index.spec.js
+++ b/api/src/index.spec.js
@@ -89,9 +89,10 @@ describe( 'API endpoints', () => {
     mockClient.resetWorkflow.mockResolvedValue( { workflowId: 'w1', runId: 'new-run-123' } );
     mockClient.getWorkflowResult.mockResolvedValue( {
       workflowId: 'w1',
+      status: 'completed',
+      input: { some: 'input' },
       output: { done: true },
       trace: { destinations: { local: '/tmp/trace.json', remote: null } },
-      status: 'completed',
       error: null
     } );
     mockClient.queryWorkflow.mockResolvedValue( { workflows: [] } );

--- a/docs/guides/openapi.json
+++ b/docs/guides/openapi.json
@@ -766,6 +766,9 @@
                       "type": "string",
                       "description": "The workflow execution id"
                     },
+                    "input": {
+                      "description": "The original input passed to the workflow, null if unavailable"
+                    },
                     "output": {
                       "description": "The result of workflow, null if workflow failed"
                     },

--- a/sdk/cli/src/api/generated/api.ts
+++ b/sdk/cli/src/api/generated/api.ts
@@ -347,6 +347,8 @@ export const GetWorkflowIdResult200Status = {
 export type GetWorkflowIdResult200 = {
   /** The workflow execution id */
   workflowId?: string;
+  /** The original input passed to the workflow, null if unavailable */
+  input?: unknown;
   /** The result of workflow, null if workflow failed */
   output?: unknown;
   trace?: TraceInfo;


### PR DESCRIPTION
## Overview

- Add `input` field to the `GET /workflow/:id/result` response so consumers can see what a workflow run was given without a separate call
- Extract the original input from Temporal's `WorkflowExecutionStarted` history event using `defaultPayloadConverter`
- Run `fetchHistory()` in parallel with `describe()` via `Promise.all` to avoid added latency
- Regenerate OpenAPI spec and CLI types to include the new field

Ref: [OUT-413](https://linear.app/growthx/issue/OUT-413)

## Test plan

- [x] Lint passes (`npm run lint`)
- [x] All 126 API tests pass (`npx vitest run api/`)
- [x] Build passes (`npm run build:packages`)
- [ ] Smoke test: start a workflow, poll `GET /workflow/:id/result`, verify `input` field contains the original payload