### PR TITLE
docs: add badges and star CTA to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # Output
 
+[![GitHub stars](https://img.shields.io/github/stars/growthxai/output?style=social)](https://github.com/growthxai/output/stargazers)
+[![npm downloads](https://img.shields.io/npm/dm/@outputai/core)](https://www.npmjs.com/package/@outputai/core)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Build Status](https://github.com/growthxai/output/actions/workflows/validation.yml/badge.svg)](https://github.com/growthxai/output/actions/workflows/validation.yml)
+
 The open-source TypeScript framework for building AI workflows and agents. Designed for Claude Code — describe what you want, Claude builds it, with all the best practices already in place.
 
 One framework. Prompts, evals, tracing, cost tracking, orchestration, credentials. No SaaS fragmentation. No vendor lock-in. Everything in your codebase, everything your AI coding agent can reach.
+
+[![Star on GitHub](https://img.shields.io/github/stars/growthxai/output?style=social&label=%E2%AD%90%20If%20this%20helps%20you%2C%20star%20us%20on%20GitHub)](https://github.com/growthxai/output)
 
 <a href="https://output.ai/?autoplay=true"><img src="assets/home.png" alt="Output.ai Demo" /></a>
 


### PR DESCRIPTION
## Summary
- Add shields.io badges: GitHub stars, npm downloads (@outputai/core), Apache-2.0 license, TypeScript, build status
- Add clickable star CTA button linking to the repo

## Test plan
- [x] Badges render correctly on GitHub
- [x] Star CTA links to repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)