### PR TITLE
(feat): Contributing guide and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Report a bug in Output
+title: "[Bug]: "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+<!-- A clear and concise description of the bug. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What did you expect to happen? -->
+
+## Actual behavior
+
+<!-- What actually happened? Include error messages and stack traces if any. -->
+
+## Environment
+
+- Output version:
+- Node.js version:
+- OS:
+- LLM provider (if relevant):
+
+## Additional context
+
+<!-- Logs, screenshots, links to traces in `logs/runs/`, etc. -->
+
+---
+
+> Before submitting a PR for this issue, please read [CONTRIBUTING.md](../../CONTRIBUTING.md). A maintainer must approve and assign the issue before work begins.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Propose a new feature or enhancement
+title: "[Feature]: "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+<!-- What problem are you trying to solve? Who is affected? -->
+
+## Proposed solution
+
+<!-- Describe the feature or behavior you'd like. -->
+
+## Alternatives considered
+
+<!-- Other approaches you've thought about and why you ruled them out. -->
+
+## Additional context
+
+<!-- Links, references, prior art, mockups, etc. -->
+
+---
+
+> Before submitting a PR for this issue, please read [CONTRIBUTING.md](../../CONTRIBUTING.md). A maintainer must approve and assign the issue before work begins.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+<!--
+Thanks for contributing to Output!
+
+Before opening this PR, please confirm:
+- [ ] An issue exists for this change and a maintainer has assigned it to you
+      (see CONTRIBUTING.md). PRs without an approved, assigned issue may be closed.
+-->
+
+## Related issue
+
+Closes #
+
+## Summary
+
+<!-- 1-3 bullets describing what this PR changes. Focus on the "what" and "why". -->
+
+-
+-
+
+## Problem
+
+<!-- Optional: what problem does this solve? Omit for trivial changes. -->
+
+## Solution
+
+<!-- Optional: how does this PR solve it? Highlight any non-obvious design decisions. -->
+
+## Test plan
+
+<!-- How can reviewers verify this works? Use checkboxes so the author can self-verify. -->
+
+- [ ] `npm run lint`
+- [ ] `npm test`
+- [ ] `npm run build:packages`
+- [ ] Manually verified:
+
+## Screenshots / traces
+
+<!-- Optional: screenshots for UI/CLI changes, or links to `logs/runs/` traces for workflow changes. -->
+
+## Checklist
+
+- [ ] I followed the conventions in [CLAUDE.md](../CLAUDE.md)
+- [ ] I added or updated tests where relevant
+- [ ] I added a changeset if this affects a published package (`pnpm changeset`)
+- [ ] Documentation updated (README / package READMEs / inline docs) if behavior changed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-Closes #
-
 ## Summary
 
 -

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,46 +1,9 @@
-<!--
-Thanks for contributing to Output!
-
-Before opening this PR, please confirm:
-- [ ] An issue exists for this change and a maintainer has assigned it to you
-      (see CONTRIBUTING.md). PRs without an approved, assigned issue may be closed.
--->
-
-## Related issue
-
 Closes #
 
 ## Summary
 
-<!-- 1-3 bullets describing what this PR changes. Focus on the "what" and "why". -->
-
 -
--
-
-## Problem
-
-<!-- Optional: what problem does this solve? Omit for trivial changes. -->
-
-## Solution
-
-<!-- Optional: how does this PR solve it? Highlight any non-obvious design decisions. -->
 
 ## Test plan
 
-<!-- How can reviewers verify this works? Use checkboxes so the author can self-verify. -->
-
-- [ ] `npm run lint`
-- [ ] `npm test`
-- [ ] `npm run build:packages`
-- [ ] Manually verified:
-
-## Screenshots / traces
-
-<!-- Optional: screenshots for UI/CLI changes, or links to `logs/runs/` traces for workflow changes. -->
-
-## Checklist
-
-- [ ] I followed the conventions in [CLAUDE.md](../CLAUDE.md)
-- [ ] I added or updated tests where relevant
-- [ ] I added a changeset if this affects a published package (`pnpm changeset`)
-- [ ] Documentation updated (README / package READMEs / inline docs) if behavior changed
+-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to Output
+
+Thanks for your interest in contributing to Output! We welcome contributions from the community.
+
+## Contribution Process
+
+To keep work coordinated and avoid duplicated effort, we require all contributions to follow this process:
+
+1. **Open an issue** describing the bug you want to fix or the feature you want to add.
+2. **Wait for maintainer approval.** A maintainer will review the issue and decide whether it fits the project's direction.
+3. **Get assigned to the issue.** Once approved, a maintainer will assign the issue to you.
+4. **Start working.** Only begin implementation after you've been assigned — this ensures your work will be reviewed and merged.
+5. **Open a pull request** referencing the issue.
+
+> Pull requests submitted without an approved, assigned issue may be closed without review.
+
+## Development Setup
+
+```bash
+git clone https://github.com/growthxai/output.git
+cd output
+pnpm install && npm run build:packages
+```
+
+Common commands:
+
+```bash
+npm run dev           # Start dev environment
+npm test              # Run tests
+npm run lint          # Lint code
+./run.sh validate     # Validate everything
+```
+
+## Code Guidelines
+
+- Follow existing code patterns and project structure.
+- Use ES modules and TypeScript definitions alongside JavaScript implementations.
+- Use `snake_case` for file and folder names.
+- Wrap all external operations inside Temporal activities (steps).
+- Prefer functional over object-oriented style.
+- Don't opt out of lint rules without discussion.
+
+See [CLAUDE.md](CLAUDE.md) for the full set of conventions.
+
+## Questions
+
+If you're unsure about anything, open an issue or start a discussion before writing code. We'd rather talk early than reject a PR late.

--- a/README.md
+++ b/README.md
@@ -229,9 +229,11 @@ OUTPUT_TRACE_REMOTE_S3_BUCKET=my-traces
 
 ## Contributing
 
+We welcome contributions! Please read [CONTRIBUTING.md](CONTRIBUTING.md) first — all contributions require an approved issue and maintainer assignment before work begins.
+
 ```bash
-git clone https://github.com/growthxai/output-sdk.git
-cd output-sdk
+git clone https://github.com/growthxai/output.git
+cd output
 pnpm install && npm run build:packages
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # Output
 
+[![GitHub stars](https://img.shields.io/github/stars/growthxai/output?style=social)](https://github.com/growthxai/output/stargazers)
+[![npm downloads](https://img.shields.io/npm/dm/@outputai/core)](https://www.npmjs.com/package/@outputai/core)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Build Status](https://github.com/growthxai/output/actions/workflows/validation.yml/badge.svg)](https://github.com/growthxai/output/actions/workflows/validation.yml)
+
 The open-source TypeScript framework for building AI workflows and agents. Designed for Claude Code — describe what you want, Claude builds it, with all the best practices already in place.
 
 One framework. Prompts, evals, tracing, cost tracking, orchestration, credentials. No SaaS fragmentation. No vendor lock-in. Everything in your codebase, everything your AI coding agent can reach.
+
+[![Star on GitHub](https://img.shields.io/github/stars/growthxai/output?style=social&label=%E2%AD%90%20If%20this%20helps%20you%2C%20star%20us%20on%20GitHub)](https://github.com/growthxai/output)
 
 <a href="https://output.ai/?autoplay=true"><img src="assets/home.png" alt="Output.ai Demo" /></a>
 


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` requiring an approved issue and maintainer assignment before contributions begin
- Add bug report and feature request issue templates (and disable blank issues)
- Add a minimal pull request template (Closes / Summary / Test plan)
- Link `CONTRIBUTING.md` from the README

## Test plan

- [x] `CONTRIBUTING.md` renders correctly on GitHub
- [x] Issue templates appear when opening a new issue
- [x] PR template pre-fills when opening a new PR