### PR TITLE
chore(dependabot): Adding dependabot cooldown period

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,6 @@ updates:
       minor-updates:
         update-types: ['patch', 'minor']
         applies-to: 'version-updates'
+    cooldown:
+      default-days: 3
+


### PR DESCRIPTION
## Summary

Adding dependabot cooldown period for dependencies updates, helping to strength against supply chain attacks

References:
- https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
- https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/
