### PR TITLE
docs: fix agent-score warnings (99 → 100)

### DIFF
--- a/docs/guides/api/index.mdx
+++ b/docs/guides/api/index.mdx
@@ -69,12 +69,12 @@ For remote traces, the API server needs AWS credentials (`OUTPUT_AWS_ACCESS_KEY_
 
 <CardGroup cols={2}>
   <Card title="Configuration" icon="gear" href="/api/configuration">
-    Base URL, ports, and environment variables for the API server.
+    **Configuration.** Base URL, ports, and environment variables for the API server.
   </Card>
   <Card title="Authentication" icon="lock" href="/api/authentication">
-    How auth works in development vs production.
+    **Authentication.** How auth works in development vs production.
   </Card>
   <Card title="Error Responses" icon="circle-exclamation" href="/api/errors">
-    Error codes, response format, and how to handle failures.
+    **Error Responses.** Error codes, response format, and how to handle failures.
   </Card>
 </CardGroup>

--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -2,6 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
   "name": "Output Framework",
+  "description": "Open-source TypeScript framework for building AI workflows and agents. Designed for Claude Code — ships with prompts, evals, tracing, cost tracking, credentials, and orchestration in one framework, so you stop stitching together SaaS subscriptions.",
   "colors": {
     "primary": "#999",
     "light": "#ccc",

--- a/docs/guides/evaluators/evaluator-step.mdx
+++ b/docs/guides/evaluators/evaluator-step.mdx
@@ -112,16 +112,19 @@ Evaluators must return an `EvaluationResult`. Three types are available dependin
 
 <CardGroup cols={3}>
   <Card title="EvaluationBooleanResult" icon="check-circle">
+    **EvaluationBooleanResult:**
     - Pass/fail judgments
     - `value: boolean`
     - Quality gates, compliance checks
   </Card>
   <Card title="EvaluationNumberResult" icon="hashtag">
+    **EvaluationNumberResult:**
     - Numeric scores
     - `value: number`
     - Ratings (1-10), percentages
   </Card>
   <Card title="EvaluationStringResult" icon="tag">
+    **EvaluationStringResult:**
     - Category assignments
     - `value: string`
     - Classifications, labels

--- a/docs/guides/evaluators/index.mdx
+++ b/docs/guides/evaluators/index.mdx
@@ -39,12 +39,12 @@ Both approaches use evaluators under the hood — the difference is _where_ they
 
 <CardGroup cols={2}>
   <Card title="Evaluator Step" icon="layer-group" href="/evaluators/evaluator-step">
-    Build evaluators and use them inside your workflows for self-correction
+    **Evaluator Step.** Build evaluators and use them inside your workflows for self-correction.
   </Card>
   <Card title="Evaluation Workflow" icon="flask-vial" href="/evaluators/workflow-evaluators">
-    Test workflow quality across datasets from the CLI
+    **Evaluation Workflow.** Test workflow quality across datasets from the CLI.
   </Card>
   <Card title="LLM-as-a-Judge Best Practices" icon="lightbulb" href="/evaluators/best-practices">
-    Writing effective judge prompts, grading scales, and common pitfalls
+    **LLM-as-a-Judge Best Practices.** Writing effective judge prompts, grading scales, and common pitfalls.
   </Card>
 </CardGroup>

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -96,25 +96,25 @@ export const summarizeContent = step({
 
 <CardGroup cols={2}>
   <Card title="Prompt Management" icon="file-code">
-    `.prompt` files with LiquidJS templating. Version-controlled, reviewable in PRs, deployed with your code.
+    **Prompt Management.** `.prompt` files with LiquidJS templating. Version-controlled, reviewable in PRs, deployed with your code.
   </Card>
   <Card title="Multi-Provider LLM" icon="brain">
-    Anthropic, OpenAI, Azure, Vertex AI, Bedrock. Switch providers by changing one line in your prompt file.
+    **Multi-Provider LLM.** Anthropic, OpenAI, Azure, Vertex AI, Bedrock. Switch providers by changing one line in your prompt file.
   </Card>
   <Card title="LLM-as-Judge Evals" icon="scale-balanced">
-    Built-in evaluators with confidence scores and reasoning. Test non-deterministic code programmatically.
+    **LLM-as-Judge Evals.** Built-in evaluators with confidence scores and reasoning. Test non-deterministic code programmatically.
   </Card>
   <Card title="Tracing and Cost Tracking" icon="chart-line">
-    Every operation traced automatically. Token counts, costs, latency. JSON on disk, zero config. You own your data.
+    **Tracing and Cost Tracking.** Every operation traced automatically. Token counts, costs, latency. JSON on disk, zero config. You own your data.
   </Card>
   <Card title="Durable Orchestration" icon="rotate">
-    Temporal under the hood. Automatic retries, workflow history, replay on failure. You don't think about it until you need it.
+    **Durable Orchestration.** Temporal under the hood. Automatic retries, workflow history, replay on failure. You don't think about it until you need it.
   </Card>
   <Card title="Encrypted Credentials" icon="lock">
-    AES-256-GCM encrypted secrets, scoped per environment and workflow. No more sharing `.env` files or external vault subscriptions.
+    **Encrypted Credentials.** AES-256-GCM encrypted secrets, scoped per environment and workflow. No more sharing `.env` files or external vault subscriptions.
   </Card>
 </CardGroup>
 
 <Card title="Get Started" icon="rocket" href="/start-here/getting-started">
-  Set up your first Output project in 5 minutes
+  **Get Started.** Set up your first Output project in 5 minutes.
 </Card>

--- a/docs/guides/operations/deployment.mdx
+++ b/docs/guides/operations/deployment.mdx
@@ -37,13 +37,13 @@ Choose your deployment platform:
 
 <CardGroup cols={3}>
   <Card title="Railway" icon="train" href="/operations/deployment/railway">
-    Simple Docker-based deployments with automatic scaling.
+    **Railway.** Simple Docker-based deployments with automatic scaling.
   </Card>
   <Card title="Render" icon="cloud" href="/operations/deployment/render">
-    Infrastructure-as-code deployments with a single render.yaml Blueprint.
+    **Render.** Infrastructure-as-code deployments with a single render.yaml Blueprint.
   </Card>
   <Card title="Advanced" icon="gear" href="/operations/deployment/advanced">
-    Remote tracing with Redis and S3 for production debugging.
+    **Advanced.** Remote tracing with Redis and S3 for production debugging.
   </Card>
 </CardGroup>
 
@@ -51,9 +51,9 @@ Choose your deployment platform:
 
 <CardGroup cols={2}>
   <Card title="Tracing" icon="magnifying-glass" href="/operations/tracing">
-    Configure production tracing and S3 storage
+    **Tracing.** Configure production tracing and S3 storage.
   </Card>
   <Card title="Error Handling" icon="triangle-exclamation" href="/operations/error-handling">
-    Handle failures gracefully in production
+    **Error Handling.** Handle failures gracefully in production.
   </Card>
 </CardGroup>

--- a/docs/guides/start-here/claude-code.mdx
+++ b/docs/guides/start-here/claude-code.mdx
@@ -85,9 +85,9 @@ You can see all skills, agents, commands, and hooks [here in our repo](https://g
 
 <CardGroup cols={2}>
   <Card title="Learning Path" icon="route" href="/start-here/learning-path">
-    A structured guide through the rest of the documentation.
+    **Learning Path.** A structured guide through the rest of the documentation.
   </Card>
   <Card title="Workflows" icon="diagram-project" href="/workflows">
-    Deep dive into workflow structure, patterns, and orchestration.
+    **Workflows.** Deep dive into workflow structure, patterns, and orchestration.
   </Card>
 </CardGroup>

--- a/docs/guides/start-here/getting-started.mdx
+++ b/docs/guides/start-here/getting-started.mdx
@@ -610,12 +610,12 @@ You've built your first real Output workflow. Here's where to go next:
 
 <CardGroup cols={2}>
   <Card title="CLI Reference" icon="terminal" href="/packages/cli">
-    All commands in depth—run, start, status, terminate, and more.
+    **CLI Reference.** All commands in depth—run, start, status, terminate, and more.
   </Card>
   <Card title="Workflows" icon="diagram-project" href="/workflows">
-    Control flow, child workflows, scenarios, and advanced patterns.
+    **Workflows.** Control flow, child workflows, scenarios, and advanced patterns.
   </Card>
   <Card title="Claude Code" icon="wand-magic-sparkles" href="/start-here/claude-code">
-    How Output's Claude Code plugin plans, builds, and debugs workflows for you.
+    **Claude Code.** How Output's Claude Code plugin plans, builds, and debugs workflows for you.
   </Card>
 </CardGroup>

--- a/docs/guides/steps/index.mdx
+++ b/docs/guides/steps/index.mdx
@@ -54,11 +54,13 @@ Steps are called from workflows like regular async functions — `await lookupCo
 
 <CardGroup cols={2}>
   <Card title="Workflows" icon="diagram-project">
+    **Workflows:**
     - Orchestrate steps in sequence or parallel
     - Must be deterministic (no I/O)
     - Replayed on failure to recover state
   </Card>
   <Card title="Steps" icon="list-check">
+    **Steps:**
     - Where I/O happens: APIs, databases, LLMs
     - Results cached — won't re-run on replay
     - Automatically retried on failure

--- a/docs/guides/workflows/index.mdx
+++ b/docs/guides/workflows/index.mdx
@@ -61,11 +61,13 @@ In practice this means:
 
 <CardGroup cols={2}>
   <Card title="Do" icon="check">
+    **Do:**
     - Call steps and evaluators
     - Use conditionals and loops
     - Import from allowed files
   </Card>
   <Card title="Don't" icon="xmark">
+    **Don't:**
     - Make API calls directly
     - Use `Date.now()` or `Math.random()`
     - Import component files from wrong locations


### PR DESCRIPTION
## Summary

Fixes both warnings flagged at [buildwithfern.com/agent-score/company/output](https://buildwithfern.com/agent-score/company/output#checks) to push the docs from **99/100** to a perfect **100/100**.

### 1. `llms.txt` blockquote summary
The generated `https://docs.output.ai/llms.txt` had a prose paragraph under the H1 rather than the `> blockquote` summary required by the [llms.txt spec](https://llmstxt.org/). Mintlify renders this blockquote from the top-level `description` field in `docs.json`, so I added one.

### 2. Markdown/HTML content parity (6/10 pages had drift)
The Fern check compares headings/code-blocks/paragraphs between the rendered HTML and the `.md` export. Mintlify's `.md` generator preserves `<Card>…</Card>` tags but drops the `title="…"` attribute, so card titles existed as headings in HTML but not in the `.md` export.

Fix: inline each card title as bold text inside the card body (e.g. `**Workflows.** …`). HTML still renders the title prominently (via the `title` attribute) and the body text also includes it — so headings/paragraph content now match across formats.

Pages touched:
- `index.mdx`
- `start-here/getting-started.mdx`, `start-here/claude-code.mdx`
- `workflows/index.mdx`
- `steps/index.mdx`
- `evaluators/index.mdx`, `evaluators/evaluator-step.mdx`
- `operations/deployment.mdx`
- `api/index.mdx`

## Test plan

- [ ] Preview the Mintlify build and confirm cards still render visually
- [ ] After deploy, verify `https://docs.output.ai/llms.txt` contains a `> blockquote` under the H1
- [ ] Re-run [buildwithfern.com/agent-score/company/output](https://buildwithfern.com/agent-score/company/output#checks) and confirm score is 100/100

🤖 Generated with [Claude Code](https://claude.com/claude-code)