### PR TITLE
chore: Migrate some Output plugin Commands to Skills

### DIFF
--- a/coding_assistants/claude/plugins/outputai/commands/build_workflow.md
+++ b/coding_assistants/claude/plugins/outputai/commands/build_workflow.md
@@ -1,6 +1,6 @@
 ---
 argument-hint: "[workflow-plan-file-path] [workflow-name] [workflow-directory]"
-description: Workflow Implementation Command for Output SDK
+description: Implement an Output SDK workflow from a plan document. Use after plan_workflow has produced a plan and the user is ready to build.
 version: 0.1.3
 model: opus
 ---
@@ -324,10 +324,6 @@ Verify the implementation is ready for use.
 </step>
 
 </process_flow>
-
-<post_flight_check>
-  EXECUTE: Claude Skill: `output-meta-post-flight`
-</post_flight_check>
 
 ---- START ----
 

--- a/coding_assistants/claude/plugins/outputai/commands/build_workflow.md
+++ b/coding_assistants/claude/plugins/outputai/commands/build_workflow.md
@@ -325,6 +325,10 @@ Verify the implementation is ready for use.
 
 </process_flow>
 
+<post_flight_check>
+  EXECUTE: Claude Skill: `output-meta-post-flight`
+</post_flight_check>
+
 ---- START ----
 
 Workflow Name: $2

--- a/coding_assistants/claude/plugins/outputai/skills/build-workflow/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/build-workflow/SKILL.md
@@ -1,6 +1,7 @@
 ---
+name: build-workflow
 argument-hint: "[workflow-plan-file-path] [workflow-name] [workflow-directory]"
-description: Implement an Output SDK workflow from a plan document. Use after plan_workflow has produced a plan and the user is ready to build.
+description: Implement an Output SDK workflow from a plan document. Use when the user asks to build, implement, or code a workflow from an existing plan, or after plan-workflow has produced a plan and the user is ready to build.
 version: 0.1.3
 model: opus
 ---

--- a/coding_assistants/claude/plugins/outputai/skills/debug-workflow/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/debug-workflow/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: debug-workflow
 argument-hint: [problem-description-and-optional-workflow-id]
 description: Debug Output SDK workflow issues
+when_to_use: When user reports a workflow failing, erroring, hanging, producing wrong results, or asks to debug, troubleshoot, or investigate a workflow execution
 version: 0.1.3
 model: opus
 ---

--- a/coding_assistants/claude/plugins/outputai/skills/debug-workflow/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/debug-workflow/SKILL.md
@@ -1,8 +1,7 @@
 ---
 name: debug-workflow
 argument-hint: [problem-description-and-optional-workflow-id]
-description: Debug Output SDK workflow issues
-when_to_use: When user reports a workflow failing, erroring, hanging, producing wrong results, or asks to debug, troubleshoot, or investigate a workflow execution
+description: Debug Output SDK workflow issues. Use when user reports a workflow failing, erroring, hanging, producing wrong results, or asks to debug, troubleshoot, or investigate a workflow execution.
 version: 0.1.3
 model: opus
 ---

--- a/coding_assistants/claude/plugins/outputai/skills/output-workflow-trace-file/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-workflow-trace-file/SKILL.md
@@ -1,6 +1,7 @@
 ---
+name: output-workflow-trace-file
 argument-hint: [workflow-name-or-run-id]
-description: Show the final result of a local trace file — clean readable markdown
+description: Read and render the output of a local Output SDK workflow trace file as clean readable markdown. Use when the user wants to view what a recent workflow produced, see the result from a local trace file, or render trace output as a document.
 version: 0.1.0
 ---
 

--- a/coding_assistants/claude/plugins/outputai/skills/plan-workflow/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/plan-workflow/SKILL.md
@@ -1,6 +1,8 @@
 ---
+name: plan-workflow
 argument-hint: [workflow-description-and-additional-instructions]
 description: Use when the user asks to create, build, generate, scaffold, or plan a new workflow. Orchestrates the full planning process including architecture, steps, prompts, evaluators, and testing strategy using specialized subagents.
+when_to_use: When user says "create a workflow", "build a workflow", "make a workflow", "generate a workflow", "scaffold a workflow", "plan a workflow", or describes workflow functionality they want built for the Output SDK
 version: 0.1.3
 model: opus
 ---

--- a/coding_assistants/claude/plugins/outputai/skills/plan-workflow/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/plan-workflow/SKILL.md
@@ -2,7 +2,6 @@
 name: plan-workflow
 argument-hint: [workflow-description-and-additional-instructions]
 description: Use when the user asks to create, build, generate, scaffold, or plan a new workflow. Orchestrates the full planning process including architecture, steps, prompts, evaluators, and testing strategy using specialized subagents.
-when_to_use: When user says "create a workflow", "build a workflow", "make a workflow", "generate a workflow", "scaffold a workflow", "plan a workflow", or describes workflow functionality they want built for the Output SDK
 version: 0.1.3
 model: opus
 ---


### PR DESCRIPTION
## Summary

Migrate `debug` and `plan` commands to be skills, which I think makes more sense than commands that are directly invoked. They can still be directly invoked, but skills are more likely to be loaded and used in the course of chat with Claude than if left as commands. 