### PR TITLE
feat(cli): add credentials set command

### DIFF
--- a/.changeset/credentials-set-command.md
+++ b/.changeset/credentials-set-command.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Add `credentials set` command for programmatic credential updates by dot-notation path

--- a/.changeset/credentials-set-command.md
+++ b/.changeset/credentials-set-command.md
@@ -2,4 +2,4 @@
 "@outputai/cli": patch
 ---
 
-Add `credentials set` command for programmatic credential updates by dot-notation path
+Add `credentials set` command for programmatic credential updates by dot-notation path. Prompts for confirmation when the write would change a value's shape (primitive → object or object → primitive); pass `--yes` to skip in non-interactive environments.

--- a/sdk/cli/src/commands/credentials/set.spec.ts
+++ b/sdk/cli/src/commands/credentials/set.spec.ts
@@ -1,0 +1,121 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as credentialsService from '#services/credentials_service.js';
+import CredentialsSet from './set.js';
+
+vi.mock( '#services/credentials_service.js' );
+vi.mock( 'js-yaml', () => ( {
+  load: vi.fn( ( yaml: string ) => {
+    if ( yaml.includes( 'sk-existing' ) ) {
+      return { anthropic: { api_key: 'sk-existing' } };
+    }
+    return {};
+  } ),
+  dump: vi.fn( ( obj: any ) => JSON.stringify( obj ) )
+} ) );
+
+describe( 'credentials set command', () => {
+  beforeEach( () => {
+    vi.clearAllMocks();
+    vi.mocked( credentialsService.credentialsExist ).mockReturnValue( true );
+    vi.mocked( credentialsService.decryptCredentials ).mockReturnValue( 'anthropic:\n  api_key: sk-existing\n' );
+    vi.mocked( credentialsService.writeEncrypted ).mockImplementation( () => {} );
+  } );
+
+  afterEach( () => {
+    vi.restoreAllMocks();
+  } );
+
+  const createTestCommand = (
+    parsedArgs: Record<string, unknown> = {},
+    flags: Record<string, unknown> = {}
+  ) => {
+    const cmd = new CredentialsSet( [], {} as any );
+    cmd.log = vi.fn();
+    cmd.error = vi.fn( ( msg: string ) => {
+      throw new Error( msg );
+    } ) as any;
+    Object.defineProperty( cmd, 'parse', {
+      value: vi.fn().mockResolvedValue( {
+        args: { path: 'anthropic.api_key', value: 'sk-new-key', ...parsedArgs },
+        flags: { environment: undefined, workflow: undefined, ...flags }
+      } ),
+      configurable: true
+    } );
+    return cmd;
+  };
+
+  describe( 'command structure', () => {
+    it( 'should have correct description', () => {
+      expect( CredentialsSet.description ).toContain( 'credential value' );
+    } );
+
+    it( 'should have required path and value arguments', () => {
+      expect( CredentialsSet.args.path ).toBeDefined();
+      expect( CredentialsSet.args.path.required ).toBe( true );
+      expect( CredentialsSet.args.value ).toBeDefined();
+      expect( CredentialsSet.args.value.required ).toBe( true );
+    } );
+
+    it( 'should have environment and workflow flags', () => {
+      expect( CredentialsSet.flags.environment ).toBeDefined();
+      expect( CredentialsSet.flags.workflow ).toBeDefined();
+    } );
+  } );
+
+  describe( 'command execution', () => {
+    it( 'should decrypt, update, and re-encrypt credentials', async () => {
+      const cmd = createTestCommand();
+      await cmd.run();
+
+      expect( credentialsService.decryptCredentials ).toHaveBeenCalledWith( undefined, undefined );
+      expect( credentialsService.writeEncrypted ).toHaveBeenCalledWith(
+        undefined,
+        expect.any( String ),
+        undefined
+      );
+      expect( cmd.log ).toHaveBeenCalledWith( 'Set anthropic.api_key' );
+    } );
+
+    it( 'should create nested keys that do not exist', async () => {
+      vi.mocked( credentialsService.decryptCredentials ).mockReturnValue( '' );
+      const cmd = createTestCommand( { path: 'new.nested.key', value: 'my-value' } );
+      await cmd.run();
+
+      expect( credentialsService.writeEncrypted ).toHaveBeenCalledTimes( 1 );
+      expect( cmd.log ).toHaveBeenCalledWith( 'Set new.nested.key' );
+    } );
+
+    it( 'should pass environment flag to service functions', async () => {
+      const cmd = createTestCommand( {}, { environment: 'production' } );
+      await cmd.run();
+
+      expect( credentialsService.credentialsExist ).toHaveBeenCalledWith( 'production', undefined );
+      expect( credentialsService.decryptCredentials ).toHaveBeenCalledWith( 'production', undefined );
+      expect( credentialsService.writeEncrypted ).toHaveBeenCalledWith( 'production', expect.any( String ), undefined );
+    } );
+
+    it( 'should pass workflow flag to service functions', async () => {
+      const cmd = createTestCommand( {}, { workflow: 'my_workflow' } );
+      await cmd.run();
+
+      expect( credentialsService.credentialsExist ).toHaveBeenCalledWith( undefined, 'my_workflow' );
+      expect( credentialsService.decryptCredentials ).toHaveBeenCalledWith( undefined, 'my_workflow' );
+      expect( credentialsService.writeEncrypted ).toHaveBeenCalledWith( undefined, expect.any( String ), 'my_workflow' );
+    } );
+
+    it( 'should error when both environment and workflow are specified', async () => {
+      const cmd = createTestCommand( {}, { environment: 'production', workflow: 'my_workflow' } );
+
+      await expect( cmd.run() ).rejects.toThrow( 'Cannot specify both' );
+    } );
+
+    it( 'should error when credentials file does not exist', async () => {
+      vi.mocked( credentialsService.credentialsExist ).mockReturnValue( false );
+      vi.mocked( credentialsService.resolveCredentialsPath ).mockReturnValue( '/project/config/credentials.yml.enc' );
+      const cmd = createTestCommand();
+
+      await expect( cmd.run() ).rejects.toThrow( 'No credentials file found' );
+    } );
+  } );
+} );

--- a/sdk/cli/src/commands/credentials/set.spec.ts
+++ b/sdk/cli/src/commands/credentials/set.spec.ts
@@ -117,5 +117,23 @@ describe( 'credentials set command', () => {
 
       await expect( cmd.run() ).rejects.toThrow( 'No credentials file found' );
     } );
+
+    it( 'should surface a friendly error when decryption fails', async () => {
+      vi.mocked( credentialsService.decryptCredentials ).mockImplementation( () => {
+        throw new Error( 'Invalid key' );
+      } );
+      const cmd = createTestCommand();
+
+      await expect( cmd.run() ).rejects.toThrow( 'Failed to update credentials: Invalid key' );
+    } );
+
+    it( 'should surface a friendly error when encryption fails', async () => {
+      vi.mocked( credentialsService.writeEncrypted ).mockImplementation( () => {
+        throw new Error( 'Permission denied' );
+      } );
+      const cmd = createTestCommand();
+
+      await expect( cmd.run() ).rejects.toThrow( 'Failed to update credentials: Permission denied' );
+    } );
   } );
 } );

--- a/sdk/cli/src/commands/credentials/set.spec.ts
+++ b/sdk/cli/src/commands/credentials/set.spec.ts
@@ -1,11 +1,21 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { confirm } from '@inquirer/prompts';
 import * as credentialsService from '#services/credentials_service.js';
 import CredentialsSet from './set.js';
 
 vi.mock( '#services/credentials_service.js' );
+vi.mock( '@inquirer/prompts', () => ( {
+  confirm: vi.fn()
+} ) );
 vi.mock( 'js-yaml', () => ( {
   load: vi.fn( ( yaml: string ) => {
+    if ( yaml.includes( '__PRIMITIVE_AT_X_Y__' ) ) {
+      return { x: { y: 'FOO' } };
+    }
+    if ( yaml.includes( '__OBJECT_AT_X_Y__' ) ) {
+      return { x: { y: { z: 'FOO' } } };
+    }
     if ( yaml.includes( 'sk-existing' ) ) {
       return { anthropic: { api_key: 'sk-existing' } };
     }
@@ -20,6 +30,7 @@ describe( 'credentials set command', () => {
     vi.mocked( credentialsService.credentialsExist ).mockReturnValue( true );
     vi.mocked( credentialsService.decryptCredentials ).mockReturnValue( 'anthropic:\n  api_key: sk-existing\n' );
     vi.mocked( credentialsService.writeEncrypted ).mockImplementation( () => {} );
+    vi.mocked( confirm ).mockResolvedValue( true );
   } );
 
   afterEach( () => {
@@ -32,13 +43,14 @@ describe( 'credentials set command', () => {
   ) => {
     const cmd = new CredentialsSet( [], {} as any );
     cmd.log = vi.fn();
+    cmd.warn = vi.fn() as any;
     cmd.error = vi.fn( ( msg: string ) => {
       throw new Error( msg );
     } ) as any;
     Object.defineProperty( cmd, 'parse', {
       value: vi.fn().mockResolvedValue( {
         args: { path: 'anthropic.api_key', value: 'sk-new-key', ...parsedArgs },
-        flags: { environment: undefined, workflow: undefined, ...flags }
+        flags: { environment: undefined, workflow: undefined, yes: false, ...flags }
       } ),
       configurable: true
     } );
@@ -57,9 +69,10 @@ describe( 'credentials set command', () => {
       expect( CredentialsSet.args.value.required ).toBe( true );
     } );
 
-    it( 'should have environment and workflow flags', () => {
+    it( 'should have environment, workflow, and yes flags', () => {
       expect( CredentialsSet.flags.environment ).toBeDefined();
       expect( CredentialsSet.flags.workflow ).toBeDefined();
+      expect( CredentialsSet.flags.yes ).toBeDefined();
     } );
   } );
 
@@ -74,6 +87,7 @@ describe( 'credentials set command', () => {
         expect.any( String ),
         undefined
       );
+      expect( confirm ).not.toHaveBeenCalled();
       expect( cmd.log ).toHaveBeenCalledWith( 'Set anthropic.api_key' );
     } );
 
@@ -83,6 +97,7 @@ describe( 'credentials set command', () => {
       await cmd.run();
 
       expect( credentialsService.writeEncrypted ).toHaveBeenCalledTimes( 1 );
+      expect( confirm ).not.toHaveBeenCalled();
       expect( cmd.log ).toHaveBeenCalledWith( 'Set new.nested.key' );
     } );
 
@@ -134,6 +149,54 @@ describe( 'credentials set command', () => {
       const cmd = createTestCommand();
 
       await expect( cmd.run() ).rejects.toThrow( 'Failed to update credentials: Permission denied' );
+    } );
+  } );
+
+  describe( 'shape-change confirmation', () => {
+    it( 'should prompt before converting a primitive value into an object', async () => {
+      vi.mocked( credentialsService.decryptCredentials ).mockReturnValue( '__PRIMITIVE_AT_X_Y__' );
+      const cmd = createTestCommand( { path: 'x.y.z', value: 'BAR' } );
+
+      await cmd.run();
+
+      expect( cmd.warn ).toHaveBeenCalledWith( expect.stringContaining( 'convert "x.y" from a value into an object' ) );
+      expect( confirm ).toHaveBeenCalledTimes( 1 );
+      expect( credentialsService.writeEncrypted ).toHaveBeenCalledTimes( 1 );
+      expect( cmd.log ).toHaveBeenCalledWith( 'Set x.y.z' );
+    } );
+
+    it( 'should prompt before replacing an object with a primitive value', async () => {
+      vi.mocked( credentialsService.decryptCredentials ).mockReturnValue( '__OBJECT_AT_X_Y__' );
+      const cmd = createTestCommand( { path: 'x.y', value: 'BAR' } );
+
+      await cmd.run();
+
+      expect( cmd.warn ).toHaveBeenCalledWith( expect.stringContaining( 'replace the existing object' ) );
+      expect( confirm ).toHaveBeenCalledTimes( 1 );
+      expect( credentialsService.writeEncrypted ).toHaveBeenCalledTimes( 1 );
+    } );
+
+    it( 'should abort without writing when the user declines the prompt', async () => {
+      vi.mocked( credentialsService.decryptCredentials ).mockReturnValue( '__PRIMITIVE_AT_X_Y__' );
+      vi.mocked( confirm ).mockResolvedValue( false );
+      const cmd = createTestCommand( { path: 'x.y.z', value: 'BAR' } );
+
+      await cmd.run();
+
+      expect( credentialsService.writeEncrypted ).not.toHaveBeenCalled();
+      expect( cmd.log ).toHaveBeenCalledWith( 'Aborted.' );
+      expect( cmd.log ).not.toHaveBeenCalledWith( 'Set x.y.z' );
+    } );
+
+    it( 'should skip the prompt when --yes is passed', async () => {
+      vi.mocked( credentialsService.decryptCredentials ).mockReturnValue( '__PRIMITIVE_AT_X_Y__' );
+      const cmd = createTestCommand( { path: 'x.y.z', value: 'BAR' }, { yes: true } );
+
+      await cmd.run();
+
+      expect( confirm ).not.toHaveBeenCalled();
+      expect( credentialsService.writeEncrypted ).toHaveBeenCalledTimes( 1 );
+      expect( cmd.log ).toHaveBeenCalledWith( 'Set x.y.z' );
     } );
   } );
 } );

--- a/sdk/cli/src/commands/credentials/set.ts
+++ b/sdk/cli/src/commands/credentials/set.ts
@@ -1,0 +1,79 @@
+import { Args, Command, Flags } from '@oclif/core';
+import { load as parseYaml, dump as stringifyYaml } from 'js-yaml';
+import {
+  decryptCredentials,
+  credentialsExist,
+  writeEncrypted,
+  resolveCredentialsPath
+} from '#services/credentials_service.js';
+
+type CredentialsObject = Record<string, unknown>;
+
+const setNestedValue = ( obj: CredentialsObject, dotPath: string, value: string ): void => {
+  const parts = dotPath.split( '.' );
+  const parent = parts.slice( 0, -1 ).reduce<CredentialsObject>( ( current, key ) => {
+    if ( !current[key] || typeof current[key] !== 'object' ) {
+      current[key] = {};
+    }
+    return current[key] as CredentialsObject;
+  }, obj );
+
+  parent[parts[parts.length - 1]] = value;
+};
+
+export default class CredentialsSet extends Command {
+  static override description = 'Set a credential value by dot-notation path';
+
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> anthropic.api_key sk-ant-...',
+    '<%= config.bin %> <%= command.id %> openai.api_key sk-... --environment production',
+    '<%= config.bin %> <%= command.id %> stripe.key sk_live_... --workflow my_workflow'
+  ];
+
+  static override args = {
+    path: Args.string( {
+      description: 'Dot-notation path to the credential (e.g. anthropic.api_key)',
+      required: true
+    } ),
+    value: Args.string( {
+      description: 'Value to set',
+      required: true
+    } )
+  };
+
+  static override flags = {
+    environment: Flags.string( {
+      char: 'e',
+      description: 'Target environment (e.g. production, development)'
+    } ),
+    workflow: Flags.string( {
+      char: 'w',
+      description: 'Target a specific workflow directory'
+    } )
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse( CredentialsSet );
+    const environment = flags.environment;
+    const workflow = flags.workflow;
+
+    if ( environment && workflow ) {
+      this.error( 'Cannot specify both --environment and --workflow.' );
+    }
+
+    if ( !credentialsExist( environment, workflow ) ) {
+      this.error(
+        `No credentials file found at ${resolveCredentialsPath( environment, workflow )}. Run "output credentials init" first.`
+      );
+    }
+
+    const plaintext = decryptCredentials( environment, workflow );
+    const data = ( parseYaml( plaintext ) || {} ) as CredentialsObject;
+
+    setNestedValue( data, args.path, args.value );
+
+    writeEncrypted( environment, stringifyYaml( data ), workflow );
+
+    this.log( `Set ${args.path}` );
+  }
+}

--- a/sdk/cli/src/commands/credentials/set.ts
+++ b/sdk/cli/src/commands/credentials/set.ts
@@ -1,4 +1,5 @@
 import { Args, Command, Flags } from '@oclif/core';
+import { confirm } from '@inquirer/prompts';
 import { load as parseYaml, dump as stringifyYaml } from 'js-yaml';
 import { getErrorMessage } from '#utils/error_utils.js';
 import {
@@ -10,10 +11,58 @@ import {
 
 type CredentialsObject = Record<string, unknown>;
 
+type PathConflict =
+  { kind: 'primitive_to_object'; atPath: string; existingValue: unknown } |
+  { kind: 'object_to_primitive'; atPath: string; existingValue: unknown };
+
+type WalkState =
+  { done: false; cursor: CredentialsObject } |
+  { done: true; conflict: PathConflict | null };
+
+const isPlainObject = ( value: unknown ): value is CredentialsObject =>
+  typeof value === 'object' && value !== null && !Array.isArray( value );
+
+const detectPathConflict = ( obj: CredentialsObject, dotPath: string ): PathConflict | null => {
+  const parts = dotPath.split( '.' );
+  const intermediateKeys = parts.slice( 0, -1 );
+  const leafKey = parts[parts.length - 1];
+
+  const walked = intermediateKeys.reduce<WalkState>( ( state, key, i ) => {
+    if ( state.done ) {
+      return state;
+    }
+    const next = state.cursor[key];
+    if ( next === undefined ) {
+      return { done: true, conflict: null };
+    }
+    if ( !isPlainObject( next ) ) {
+      return {
+        done: true,
+        conflict: {
+          kind: 'primitive_to_object',
+          atPath: parts.slice( 0, i + 1 ).join( '.' ),
+          existingValue: next
+        }
+      };
+    }
+    return { done: false, cursor: next };
+  }, { done: false, cursor: obj } );
+
+  if ( walked.done ) {
+    return walked.conflict;
+  }
+
+  const leaf = walked.cursor[leafKey];
+  if ( leaf !== undefined && ( isPlainObject( leaf ) || Array.isArray( leaf ) ) ) {
+    return { kind: 'object_to_primitive', atPath: dotPath, existingValue: leaf };
+  }
+  return null;
+};
+
 const setNestedValue = ( obj: CredentialsObject, dotPath: string, value: string ): void => {
   const parts = dotPath.split( '.' );
   const parent = parts.slice( 0, -1 ).reduce<CredentialsObject>( ( current, key ) => {
-    if ( !current[key] || typeof current[key] !== 'object' ) {
+    if ( !isPlainObject( current[key] ) ) {
       current[key] = {};
     }
     return current[key] as CredentialsObject;
@@ -50,8 +99,28 @@ export default class CredentialsSet extends Command {
     workflow: Flags.string( {
       char: 'w',
       description: 'Target a specific workflow directory'
+    } ),
+    yes: Flags.boolean( {
+      char: 'y',
+      description: 'Skip confirmation prompts when overwriting a value of a different shape',
+      default: false
     } )
   };
+
+  private async confirmOverwrite( conflict: PathConflict, newPath: string ): Promise<boolean> {
+    if ( conflict.kind === 'primitive_to_object' ) {
+      this.warn(
+        `Writing to "${newPath}" will convert "${conflict.atPath}" from a value into an object, ` +
+        `discarding its current value (${JSON.stringify( conflict.existingValue )}).`
+      );
+    } else {
+      this.warn(
+        `Writing to "${newPath}" will replace the existing object at that path ` +
+        `(${JSON.stringify( conflict.existingValue )}) with a string value.`
+      );
+    }
+    return confirm( { message: 'Continue?', default: false } );
+  }
 
   async run(): Promise<void> {
     const { args, flags } = await this.parse( CredentialsSet );
@@ -72,10 +141,22 @@ export default class CredentialsSet extends Command {
       const plaintext = decryptCredentials( environment, workflow );
       const data = ( parseYaml( plaintext ) || {} ) as CredentialsObject;
 
+      const conflict = detectPathConflict( data, args.path );
+      if ( conflict && !flags.yes ) {
+        const shouldContinue = await this.confirmOverwrite( conflict, args.path );
+        if ( !shouldContinue ) {
+          this.log( 'Aborted.' );
+          return;
+        }
+      }
+
       setNestedValue( data, args.path, args.value );
 
       writeEncrypted( environment, stringifyYaml( data ), workflow );
     } catch ( error ) {
+      if ( error instanceof Error && error.constructor.name === 'ExitPromptError' ) {
+        return;
+      }
       this.error( `Failed to update credentials: ${getErrorMessage( error )}` );
     }
 

--- a/sdk/cli/src/commands/credentials/set.ts
+++ b/sdk/cli/src/commands/credentials/set.ts
@@ -1,5 +1,6 @@
 import { Args, Command, Flags } from '@oclif/core';
 import { load as parseYaml, dump as stringifyYaml } from 'js-yaml';
+import { getErrorMessage } from '#utils/error_utils.js';
 import {
   decryptCredentials,
   credentialsExist,
@@ -67,12 +68,16 @@ export default class CredentialsSet extends Command {
       );
     }
 
-    const plaintext = decryptCredentials( environment, workflow );
-    const data = ( parseYaml( plaintext ) || {} ) as CredentialsObject;
+    try {
+      const plaintext = decryptCredentials( environment, workflow );
+      const data = ( parseYaml( plaintext ) || {} ) as CredentialsObject;
 
-    setNestedValue( data, args.path, args.value );
+      setNestedValue( data, args.path, args.value );
 
-    writeEncrypted( environment, stringifyYaml( data ), workflow );
+      writeEncrypted( environment, stringifyYaml( data ), workflow );
+    } catch ( error ) {
+      this.error( `Failed to update credentials: ${getErrorMessage( error )}` );
+    }
 
     this.log( `Set ${args.path}` );
   }


### PR DESCRIPTION
## Summary

- Add `output credentials set KEY VALUE` command for programmatic credential updates
- Accepts dot-notation paths (e.g. `anthropic.api_key`) and creates nested keys as needed
- Decrypts, updates, and re-encrypts the credentials file
- Supports `--environment` and `--workflow` flags (same as other credentials commands)
- Useful in sandbox/CI environments where interactive `credentials edit` is not available

Ref: [OUT-411](https://linear.app/growthx/issue/OUT-411)

## Test plan

- [x] `npm run lint` passes
- [x] `set.spec.ts` tests pass (9 tests)
- [ ] Smoke test: `output credentials set anthropic.api_key sk-test && output credentials get anthropic.api_key`