### PR TITLE
feat(cli): auto-forward OUTPUT_CATALOG_ID as default task queue

### DIFF
--- a/.changeset/taskqueue-env-forwarding.md
+++ b/.changeset/taskqueue-env-forwarding.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Auto-forward OUTPUT_CATALOG_ID as default task queue for workflow run/start commands

--- a/sdk/cli/src/commands/workflow/run.spec.ts
+++ b/sdk/cli/src/commands/workflow/run.spec.ts
@@ -17,6 +17,7 @@ vi.mock( '#utils/sleep.js', () => ( {
 describe( 'workflow run command', () => {
   beforeEach( async () => {
     vi.clearAllMocks();
+    delete process.env.OUTPUT_CATALOG_ID;
     const { resolveInput } = await import( '#utils/resolve_input.js' );
     const { sleep } = await import( '#utils/sleep.js' );
     vi.mocked( resolveInput ).mockResolvedValue( {} );

--- a/sdk/cli/src/commands/workflow/run.ts
+++ b/sdk/cli/src/commands/workflow/run.ts
@@ -70,7 +70,8 @@ export default class WorkflowRun extends Command {
     } ),
     'task-queue': Flags.string( {
       char: 'q',
-      description: 'Task queue name for workflow execution'
+      description: 'Task queue name for workflow execution (defaults to OUTPUT_CATALOG_ID)',
+      env: 'OUTPUT_CATALOG_ID'
     } ),
     format: Flags.string( {
       char: 'f',

--- a/sdk/cli/src/commands/workflow/start.spec.ts
+++ b/sdk/cli/src/commands/workflow/start.spec.ts
@@ -7,6 +7,7 @@ vi.mock( '../../api/generated/api.js', () => ( {
 describe( 'workflow start command', () => {
   beforeEach( () => {
     vi.clearAllMocks();
+    delete process.env.OUTPUT_CATALOG_ID;
   } );
 
   describe( 'command definition', () => {

--- a/sdk/cli/src/commands/workflow/start.ts
+++ b/sdk/cli/src/commands/workflow/start.ts
@@ -32,7 +32,8 @@ export default class WorkflowStart extends Command {
     } ),
     'task-queue': Flags.string( {
       char: 'q',
-      description: 'Task queue name for workflow execution'
+      description: 'Task queue name for workflow execution (defaults to OUTPUT_CATALOG_ID)',
+      env: 'OUTPUT_CATALOG_ID'
     } )
   };
 


### PR DESCRIPTION
## Summary

- The `--task-queue` flag on `workflow run` and `workflow start` now reads from `OUTPUT_CATALOG_ID` env var via oclif's `env` option
- Precedence: explicit `--task-queue` flag > `OUTPUT_CATALOG_ID` env var > API server default
- No more need to pass `--task-queue` every time when `OUTPUT_CATALOG_ID` is in `.env`

Ref: [OUT-411](https://linear.app/growthx/issue/OUT-411)

## Test plan

- [x] `npm run lint` passes
- [x] `run.spec.ts` and `start.spec.ts` tests pass
- [ ] Smoke test: Set `OUTPUT_CATALOG_ID=my-catalog` in `.env`, run `npx output workflow run simple` without `--task-queue`