### PR TITLE
feat(evals): support multi-case dataset files

### DIFF
--- a/.changeset/multi-case-datasets.md
+++ b/.changeset/multi-case-datasets.md
@@ -2,4 +2,6 @@
 "@outputai/evals": minor
 ---
 
-Switch dataset files to multi-case format where each top-level YAML key is the case name. Allows grouping multiple test cases into a single file. The old single-case format with a top-level `name:` field is no longer supported — existing files must be migrated.
+Switch dataset files to multi-case format where each top-level YAML key is the case name. Allows grouping multiple test cases into a single file instead of one file per case.
+
+The old single-case format (with a top-level `name:` field) is no longer supported — existing files must be migrated to the new format. Treated as minor rather than major because adoption is still early and the migration is mechanical.

--- a/.changeset/multi-case-datasets.md
+++ b/.changeset/multi-case-datasets.md
@@ -1,0 +1,5 @@
+---
+"@outputai/evals": major
+---
+
+Switch dataset files to multi-case format where each top-level YAML key is the case name. Allows grouping multiple test cases into a single file. The old single-case format with a top-level `name:` field is no longer supported — existing files must be migrated.

--- a/.changeset/multi-case-datasets.md
+++ b/.changeset/multi-case-datasets.md
@@ -1,5 +1,5 @@
 ---
-"@outputai/evals": major
+"@outputai/evals": minor
 ---
 
 Switch dataset files to multi-case format where each top-level YAML key is the case name. Allows grouping multiple test cases into a single file. The old single-case format with a top-level `name:` field is no longer supported — existing files must be migrated.

--- a/docs/guides/packages/evals.mdx
+++ b/docs/guides/packages/evals.mdx
@@ -373,31 +373,50 @@ Informational evaluators never affect the case verdict.
 
 ## Datasets
 
-Datasets are YAML files that live in `tests/datasets/` within your workflow directory. Each file defines one test case:
+Datasets are YAML files that live in `tests/datasets/` within your workflow directory. Each file contains one or more test cases — the top-level key is the case name.
 
-```yaml tests/datasets/basic_input.yml
-name: basic_input
-input:
-  values:
-    - 1
-    - 2
-    - 3
-    - 4
-    - 5
-last_output:
-  output:
-    result: 15
-  executionTimeMs: 100
-  date: '2026-02-13T00:00:00.000Z'
+```yaml tests/datasets/core_cases.yml
+basic_sum:
+  input:
+    values:
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+  ground_truth:
+    notes: "Simple sum test"
+
+edge_case_empty:
+  input:
+    values: []
+  ground_truth:
+    notes: "Empty input should return 0"
 ```
+
+The key is the case name — no separate `name:` field inside. Every case must have an `input` field; the framework throws if one is missing.
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `name` | Yes | Unique name for this test case |
 | `input` | Yes | The workflow input |
 | `ground_truth` | No | Expected values for evaluators to check against |
 | `last_output` | No | Cached workflow output (used with `--cached` flag) |
 | `last_eval` | No | Cached evaluation results from the last run |
+
+Organise files however makes sense for your project — by topic, test suite version, or importance level:
+
+```
+tests/datasets/
+├── core_cases.yml       # happy path coverage
+├── edge_cases.yml       # edge cases and error paths
+└── v2_regression.yml    # cases added for v2
+```
+
+The `--dataset` flag filters by case name regardless of which file it lives in:
+
+```bash
+output workflow test my_workflow --dataset basic_sum,edge_case_empty
+```
 
 You can write datasets by hand, or generate them from workflow executions using the CLI — see [Dataset Commands](/packages/cli#dataset-commands).
 
@@ -441,9 +460,8 @@ src/workflows/
         │   ├── judge_topic@v1.prompt
         │   └── judge_quality@v1.prompt
         └── datasets/
-            ├── happy_path.yml
-            ├── edge_case.yml
-            └── stripe_blog.yml
+            ├── core_cases.yml
+            └── edge_cases.yml
 ```
 
 The eval workflow file (`tests/evals/workflow.ts`) is discovered automatically by the worker alongside your regular workflow.

--- a/sdk/cli/src/commands/workflow/test_eval.ts
+++ b/sdk/cli/src/commands/workflow/test_eval.ts
@@ -155,7 +155,7 @@ export default class WorkflowTest extends Command {
       };
 
       if ( save ) {
-        const filePath = join( dir, `${dataset.name}.yml` );
+        const filePath = dataset._source ?? join( dir, `${dataset.name}.yml` );
         await writeDataset( updated, filePath );
         this.log( `    Saved output to ${filePath}` );
       }
@@ -188,7 +188,7 @@ export default class WorkflowTest extends Command {
         }
       };
 
-      const filePath = join( dir, `${dataset.name}.yml` );
+      const filePath = dataset._source ?? join( dir, `${dataset.name}.yml` );
       await writeDataset( updated, filePath );
       this.log( `  Saved eval result to ${filePath}` );
     }

--- a/sdk/cli/src/services/datasets.test.ts
+++ b/sdk/cli/src/services/datasets.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, writeFile, readFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import yaml from 'js-yaml';
+import { readDatasetFile, readAllDatasets, writeDataset, listDatasets } from './datasets.js';
+
+const ctx = { tmpDir: '' };
+
+beforeEach( async () => {
+  ctx.tmpDir = await mkdtemp( join( tmpdir(), 'output-datasets-test-' ) );
+} );
+
+afterEach( async () => {
+  await rm( ctx.tmpDir, { recursive: true, force: true } );
+} );
+
+function writeYaml( filePath: string, obj: unknown ) {
+  return writeFile( filePath, yaml.dump( obj, { lineWidth: 120, noRefs: true, sortKeys: false } ), 'utf-8' );
+}
+
+// ---------------------------------------------------------------------------
+// readDatasetFile
+// ---------------------------------------------------------------------------
+
+describe( 'readDatasetFile', () => {
+  it( 'parses a multi-case file and returns all cases', async () => {
+    const filePath = join( ctx.tmpDir, 'cases.yml' );
+    await writeYaml( filePath, {
+      case_a: { input: { query: 'foo' }, ground_truth: { expected: 1 } },
+      case_b: { input: { query: 'bar' } },
+      case_c: { input: { query: 'baz' }, ground_truth: { expected: 3 } }
+    } );
+
+    const datasets = await readDatasetFile( filePath );
+
+    expect( datasets ).toHaveLength( 3 );
+    expect( datasets.map( d => d.name ) ).toEqual( [ 'case_a', 'case_b', 'case_c' ] );
+    expect( datasets[0].input ).toEqual( { query: 'foo' } );
+    expect( datasets[0].ground_truth ).toEqual( { expected: 1 } );
+  } );
+
+  it( 'attaches _source with the absolute file path to each dataset', async () => {
+    const filePath = join( ctx.tmpDir, 'cases.yml' );
+    await writeYaml( filePath, {
+      my_case: { input: { x: 1 } }
+    } );
+
+    const [ dataset ] = await readDatasetFile( filePath );
+
+    expect( dataset._source ).toBe( filePath );
+  } );
+
+  it( 'throws when a case is missing input', async () => {
+    const filePath = join( ctx.tmpDir, 'bad.yml' );
+    await writeYaml( filePath, {
+      good_case: { input: { x: 1 } },
+      bad_case: { ground_truth: { expected: 42 } }
+    } );
+
+    await expect( readDatasetFile( filePath ) ).rejects.toThrow(
+      'Dataset case "bad_case" in'
+    );
+  } );
+
+  it( 'throws when file content is not an object', async () => {
+    const filePath = join( ctx.tmpDir, 'bad.yml' );
+    await writeFile( filePath, 'just a string', 'utf-8' );
+
+    await expect( readDatasetFile( filePath ) ).rejects.toThrow( 'Invalid dataset file' );
+  } );
+
+  it( 'throws with clear message when file content is a YAML array', async () => {
+    const filePath = join( ctx.tmpDir, 'bad.yml' );
+    await writeFile( filePath, '- foo\n- bar\n', 'utf-8' );
+
+    await expect( readDatasetFile( filePath ) ).rejects.toThrow( 'Invalid dataset file' );
+  } );
+
+  it( 'preserves last_output and last_eval fields', async () => {
+    const filePath = join( ctx.tmpDir, 'cases.yml' );
+    await writeYaml( filePath, {
+      cached_case: {
+        input: { q: 'hello' },
+        last_output: { output: { result: 42 }, executionTimeMs: 100, date: '2026-01-01T00:00:00.000Z' }
+      }
+    } );
+
+    const [ dataset ] = await readDatasetFile( filePath );
+
+    expect( dataset.last_output?.output ).toEqual( { result: 42 } );
+    expect( dataset.last_output?.executionTimeMs ).toBe( 100 );
+  } );
+} );
+
+// ---------------------------------------------------------------------------
+// readAllDatasets
+// ---------------------------------------------------------------------------
+
+describe( 'readAllDatasets', () => {
+  it( 'flattens cases from multiple files', async () => {
+    const datasetsDir = join( ctx.tmpDir, 'src', 'workflows', 'my_workflow', 'tests', 'datasets' );
+    await mkdir( datasetsDir, { recursive: true } );
+
+    await writeYaml( join( datasetsDir, 'group_a.yml' ), {
+      case_1: { input: { x: 1 } },
+      case_2: { input: { x: 2 } }
+    } );
+    await writeYaml( join( datasetsDir, 'group_b.yml' ), {
+      case_3: { input: { x: 3 } }
+    } );
+
+    const { datasets } = await readAllDatasets( 'my_workflow', undefined, ctx.tmpDir );
+
+    expect( datasets ).toHaveLength( 3 );
+    expect( datasets.map( d => d.name ).sort() ).toEqual( [ 'case_1', 'case_2', 'case_3' ] );
+  } );
+
+  it( 'filters by case name across files', async () => {
+    const datasetsDir = join( ctx.tmpDir, 'src', 'workflows', 'my_workflow', 'tests', 'datasets' );
+    await mkdir( datasetsDir, { recursive: true } );
+
+    await writeYaml( join( datasetsDir, 'group_a.yml' ), {
+      case_1: { input: { x: 1 } },
+      case_2: { input: { x: 2 } }
+    } );
+    await writeYaml( join( datasetsDir, 'group_b.yml' ), {
+      case_3: { input: { x: 3 } }
+    } );
+
+    const { datasets } = await readAllDatasets( 'my_workflow', [ 'case_2', 'case_3' ], ctx.tmpDir );
+
+    expect( datasets ).toHaveLength( 2 );
+    expect( datasets.map( d => d.name ).sort() ).toEqual( [ 'case_2', 'case_3' ] );
+  } );
+
+  it( 'returns empty datasets and a default dir when workflow has no datasets dir', async () => {
+    const { datasets, dir } = await readAllDatasets( 'nonexistent_workflow', undefined, ctx.tmpDir );
+
+    expect( datasets ).toHaveLength( 0 );
+    expect( dir ).toContain( 'nonexistent_workflow' );
+  } );
+
+  it( 'throws when the same case name appears in two different files', async () => {
+    const datasetsDir = join( ctx.tmpDir, 'src', 'workflows', 'my_workflow', 'tests', 'datasets' );
+    await mkdir( datasetsDir, { recursive: true } );
+
+    await writeYaml( join( datasetsDir, 'group_a.yml' ), { case_1: { input: { x: 1 } } } );
+    await writeYaml( join( datasetsDir, 'group_b.yml' ), { case_1: { input: { x: 2 } } } );
+
+    await expect( readAllDatasets( 'my_workflow', undefined, ctx.tmpDir ) ).rejects.toThrow(
+      'Duplicate dataset case name "case_1"'
+    );
+  } );
+} );
+
+// ---------------------------------------------------------------------------
+// writeDataset
+// ---------------------------------------------------------------------------
+
+describe( 'writeDataset', () => {
+  it( 'creates a new file with one case keyed by name', async () => {
+    const filePath = join( ctx.tmpDir, 'cases.yml' );
+    const dataset = { name: 'new_case', input: { q: 'hello' } };
+
+    await writeDataset( dataset, filePath );
+
+    const raw = yaml.load( await readFile( filePath, 'utf-8' ) ) as Record<string, unknown>;
+    expect( raw ).toHaveProperty( 'new_case' );
+    expect( ( raw.new_case as Record<string, unknown> ).input ).toEqual( { q: 'hello' } );
+    expect( raw.new_case ).not.toHaveProperty( 'name' );
+  } );
+
+  it( 'does not write _source into the file', async () => {
+    const filePath = join( ctx.tmpDir, 'cases.yml' );
+    const dataset = { name: 'my_case', input: { q: 'x' }, _source: '/some/path.yml' };
+
+    await writeDataset( dataset, filePath );
+
+    const raw = yaml.load( await readFile( filePath, 'utf-8' ) ) as Record<string, unknown>;
+    expect( ( raw.my_case as Record<string, unknown> ) ).not.toHaveProperty( '_source' );
+  } );
+
+  it( 'updates only the target case, leaving other cases untouched', async () => {
+    const filePath = join( ctx.tmpDir, 'cases.yml' );
+    await writeYaml( filePath, {
+      case_a: { input: { x: 1 }, ground_truth: { expected: 1 } },
+      case_b: { input: { x: 2 }, ground_truth: { expected: 2 } }
+    } );
+
+    await writeDataset(
+      { name: 'case_a', input: { x: 1 }, last_output: { output: { result: 1 }, date: '2026-01-01T00:00:00.000Z' } },
+      filePath
+    );
+
+    const raw = yaml.load( await readFile( filePath, 'utf-8' ) ) as Record<string, unknown>;
+    expect( raw ).toHaveProperty( 'case_b' );
+    expect( ( raw.case_b as Record<string, unknown> ).ground_truth ).toEqual( { expected: 2 } );
+  } );
+
+  it( 'preserves existing fields when writing last_output then last_eval', async () => {
+    const filePath = join( ctx.tmpDir, 'cases.yml' );
+    await writeYaml( filePath, {
+      my_case: { input: { q: 'hello' }, ground_truth: { expected: 42 } }
+    } );
+
+    await writeDataset(
+      { name: 'my_case', input: { q: 'hello' }, last_output: { output: { result: 42 }, executionTimeMs: 50, date: '2026-01-01T00:00:00.000Z' } },
+      filePath
+    );
+    await writeDataset(
+      {
+        name: 'my_case', input: { q: 'hello' },
+        last_eval: { output: { datasetName: 'my_case', verdict: 'pass', evaluators: [] }, date: '2026-01-01T00:01:00.000Z' }
+      },
+      filePath
+    );
+
+    const raw = yaml.load( await readFile( filePath, 'utf-8' ) ) as Record<string, unknown>;
+    const caseObj = raw.my_case as Record<string, unknown>;
+    expect( caseObj ).toHaveProperty( 'last_output' );
+    expect( caseObj ).toHaveProperty( 'last_eval' );
+    expect( caseObj ).toHaveProperty( 'ground_truth' );
+  } );
+
+  it( 'creates parent directories if they do not exist', async () => {
+    const filePath = join( ctx.tmpDir, 'deep', 'nested', 'cases.yml' );
+    await writeDataset( { name: 'my_case', input: { q: 'x' } }, filePath );
+
+    const raw = yaml.load( await readFile( filePath, 'utf-8' ) ) as Record<string, unknown>;
+    expect( raw ).toHaveProperty( 'my_case' );
+  } );
+
+  it( 'recovers gracefully when existing file contains non-object YAML', async () => {
+    const filePath = join( ctx.tmpDir, 'cases.yml' );
+    await writeFile( filePath, 'just a string', 'utf-8' );
+
+    await writeDataset( { name: 'my_case', input: { q: 'x' } }, filePath );
+
+    const raw = yaml.load( await readFile( filePath, 'utf-8' ) ) as Record<string, unknown>;
+    expect( raw ).toHaveProperty( 'my_case' );
+  } );
+} );
+
+// ---------------------------------------------------------------------------
+// listDatasets
+// ---------------------------------------------------------------------------
+
+describe( 'listDatasets', () => {
+  it( 'returns one DatasetInfo per case across all files', async () => {
+    const datasetsDir = join( ctx.tmpDir, 'src', 'workflows', 'my_workflow', 'tests', 'datasets' );
+    await mkdir( datasetsDir, { recursive: true } );
+
+    await writeYaml( join( datasetsDir, 'core.yml' ), {
+      case_1: { input: { x: 1 }, last_output: { output: { r: 1 }, date: '2026-01-01T00:00:00.000Z' } },
+      case_2: { input: { x: 2 } }
+    } );
+
+    const infos = await listDatasets( 'my_workflow', ctx.tmpDir );
+
+    expect( infos ).toHaveLength( 2 );
+    const case1 = infos.find( i => i.name === 'case_1' )!;
+    expect( case1.hasLastOutput ).toBe( true );
+    expect( case1.path ).toContain( 'core.yml' );
+
+    const case2 = infos.find( i => i.name === 'case_2' )!;
+    expect( case2.hasLastOutput ).toBe( false );
+  } );
+
+  it( 'returns empty array when no datasets directory exists', async () => {
+    const infos = await listDatasets( 'nonexistent_workflow', ctx.tmpDir );
+    expect( infos ).toHaveLength( 0 );
+  } );
+} );

--- a/sdk/cli/src/services/datasets.ts
+++ b/sdk/cli/src/services/datasets.ts
@@ -44,10 +44,21 @@ export function resolveDefaultDatasetsDir(
   return resolve( basePath, WORKFLOWS_PATHS[0], workflowName, DATASETS_DIR );
 }
 
-export async function readDataset( filePath: string ): Promise<Dataset> {
-  const content = await readFile( filePath, 'utf-8' );
-  const raw = yaml.load( content );
-  return DatasetSchema.parse( raw ) as Dataset;
+export async function readDatasetFile( filePath: string ): Promise<Dataset[]> {
+  const raw = yaml.load( await readFile( filePath, 'utf-8' ) );
+
+  if ( !raw || typeof raw !== 'object' || Array.isArray( raw ) ) {
+    throw new Error( `Invalid dataset file: ${filePath}` );
+  }
+
+  return Object.entries( raw as Record<string, unknown> ).map( ( [ name, body ] ) => {
+    if ( !body || typeof body !== 'object' || !( 'input' in body ) ) {
+      throw new Error( `Dataset case "${name}" in ${filePath} is missing required "input" field` );
+    }
+    const dataset = DatasetSchema.parse( { name, ...( body as object ) } ) as Dataset;
+    dataset._source = filePath;
+    return dataset;
+  } );
 }
 
 export async function readAllDatasets(
@@ -63,47 +74,41 @@ export async function readAllDatasets(
   const files = await readdir( dir );
   const ymlFiles = files.filter( f => f.endsWith( '.yml' ) || f.endsWith( '.yaml' ) );
 
+  const seen = new Set<string>();
   const datasets: Dataset[] = [];
   for ( const file of ymlFiles ) {
-    const dataset = await readDataset( join( dir, file ) );
-    if ( filterNames && !filterNames.includes( dataset.name ) ) {
-      continue;
+    const cases = await readDatasetFile( join( dir, file ) );
+    for ( const dataset of cases ) {
+      if ( seen.has( dataset.name ) ) {
+        throw new Error( `Duplicate dataset case name "${dataset.name}" found in ${file}` );
+      }
+      seen.add( dataset.name );
+      if ( filterNames && !filterNames.includes( dataset.name ) ) {
+        continue;
+      }
+      datasets.push( dataset );
     }
-    datasets.push( dataset );
   }
 
   return { datasets, dir };
 }
 
-async function mergeWithExisting( dataset: Dataset, filePath: string ): Promise<Dataset> {
-  if ( !existsSync( filePath ) ) {
-    return dataset;
-  }
-
-  try {
-    const existing = await readDataset( filePath );
-    return {
-      ...existing,
-      ...dataset,
-      ground_truth: dataset.ground_truth ?? existing.ground_truth,
-      last_output: dataset.last_output ?? existing.last_output,
-      last_eval: dataset.last_eval ?? existing.last_eval
-    };
-  } catch {
-    return dataset;
-  }
-}
-
 export async function writeDataset( dataset: Dataset, filePath: string ): Promise<void> {
-  const merged = await mergeWithExisting( dataset, filePath );
-
   const dir = resolve( filePath, '..' );
   if ( !existsSync( dir ) ) {
     await mkdir( dir, { recursive: true } );
   }
 
-  const content = yaml.dump( merged, { lineWidth: 120, noRefs: true, sortKeys: false } );
-  await writeFile( filePath, content, 'utf-8' );
+  const loaded = existsSync( filePath ) ? yaml.load( await readFile( filePath, 'utf-8' ) ) : null;
+  const fileObj: Record<string, unknown> =
+    ( loaded && typeof loaded === 'object' && !Array.isArray( loaded ) ) ?
+      loaded as Record<string, unknown> :
+      {};
+
+  const { name, _source, ...caseBody } = dataset;
+  fileObj[name] = { ...( fileObj[name] as object ), ...caseBody };
+
+  await writeFile( filePath, yaml.dump( fileObj, { lineWidth: 120, noRefs: true, sortKeys: false } ), 'utf-8' );
 }
 
 export async function listDatasets(
@@ -122,14 +127,16 @@ export async function listDatasets(
   for ( const file of ymlFiles ) {
     const filePath = join( dir, file );
     try {
-      const dataset = await readDataset( filePath );
-      results.push( {
-        name: dataset.name,
-        path: filePath,
-        hasLastOutput: dataset.last_output?.output !== undefined,
-        lastOutputDate: dataset.last_output?.date,
-        lastEvalDate: dataset.last_eval?.date
-      } );
+      const cases = await readDatasetFile( filePath );
+      for ( const dataset of cases ) {
+        results.push( {
+          name: dataset.name,
+          path: filePath,
+          hasLastOutput: dataset.last_output?.output !== undefined,
+          lastOutputDate: dataset.last_output?.date,
+          lastEvalDate: dataset.last_eval?.date
+        } );
+      }
     } catch {
       results.push( {
         name: file.replace( /\.(yml|yaml)$/, '' ),

--- a/sdk/evals/src/schemas.ts
+++ b/sdk/evals/src/schemas.ts
@@ -119,6 +119,7 @@ export interface Dataset {
   ground_truth?: GroundTruth;
   last_output?: LastOutput;
   last_eval?: LastEval;
+  _source?: string;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
Switches dataset files from one-case-per-file to a keyed multi-case format where each top-level YAML key is the case name. Allows grouping related test cases into a single file instead of maintaining one file per case at scale.

Breaking change: old single-case format (with top-level `name:` field) is no longer supported. Existing files must be migrated to the new format.

- Replace readDataset + mergeWithExisting with readDatasetFile returning Dataset[]
- Attach _source (typed) to each dataset so write-back targets the correct file
- writeDataset does a key-based upsert instead of full-file overwrite
- Throw on duplicate case names across files to prevent silent data loss
- Guard against YAML array files and non-object existing files
- Update evals.mdx Datasets section for the new format