### PR TITLE
feat(api,cli): rename task-queue to catalog across workflow commands

### DIFF
--- a/.changeset/catalog-aware-runs-listing.md
+++ b/.changeset/catalog-aware-runs-listing.md
@@ -1,0 +1,12 @@
+---
+"@outputai/cli": patch
+"output-api": patch
+---
+
+Use `catalog` as the public name for the routing/filtering target across the CLI and HTTP API:
+
+- `output workflow runs list` gains `--catalog`/`-c` (with `OUTPUT_CATALOG_ID` env fallback) and `GET /workflow/runs` accepts `?catalog=...`, scoping listed runs to a single worker's catalog/session.
+- `output workflow run` and `output workflow start` rename the routing flag to `--catalog`/`-c`. The previous `--task-queue` and `-q` are kept as deprecated aliases (oclif emits a warning when used).
+- `POST /workflow/run` and `POST /workflow/start` accept a `catalog` body field; the previous `taskQueue` field is still accepted as a deprecated alias and the API logs a deprecation warning when it is used.
+
+Internally the value is still a Temporal task queue — only the user-facing name changes.

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -545,9 +545,14 @@
                     "type": "string",
                     "description": "(Optional) The workflowId to use. Must be unique"
                   },
+                  "catalog": {
+                    "type": "string",
+                    "description": "The catalog (Temporal task queue) to route the execution to. Falls back to the default catalog."
+                  },
                   "taskQueue": {
                     "type": "string",
-                    "description": "The name of the task queue to send the workflow to"
+                    "deprecated": true,
+                    "description": "Deprecated alias for `catalog`. If both are sent, `catalog` wins."
                   },
                   "timeout": {
                     "type": "number",
@@ -637,9 +642,14 @@
                     "type": "string",
                     "description": "(Optional) The workflowId to use. Must be unique"
                   },
+                  "catalog": {
+                    "type": "string",
+                    "description": "The catalog (Temporal task queue) to route the execution to. Falls back to the default catalog."
+                  },
                   "taskQueue": {
                     "type": "string",
-                    "description": "The name of the task queue to send the workflow to"
+                    "deprecated": true,
+                    "description": "Deprecated alias for `catalog`. If both are sent, `catalog` wins."
                   }
                 }
               }
@@ -1548,6 +1558,14 @@
               "type": "string"
             },
             "description": "Filter by workflow type/name"
+          },
+          {
+            "in": "query",
+            "name": "catalog",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by catalog ID (scopes runs to a single worker's catalog/session)"
           },
           {
             "in": "query",

--- a/api/src/clients/temporal_client.js
+++ b/api/src/clients/temporal_client.js
@@ -629,15 +629,21 @@ export default {
        *
        * @param {Object} [options] - Optional configuration
        * @param {string} [options.workflowType] - Filter by workflow type/name
+       * @param {string} [options.taskQueue] - Filter by Temporal task queue name
        * @param {number} [options.limit=100] - Maximum number of runs to return
        * @returns {WorkflowRunsListResult}
        */
       async listWorkflowRuns( options = {} ) {
-        const { workflowType, limit = 100 } = options;
+        const { workflowType, taskQueue, limit = 100 } = options;
 
-        const query = workflowType ?
-          `WorkflowType = "${workflowType}"` :
-          undefined;
+        const conditions = [];
+        if ( workflowType ) {
+          conditions.push( `WorkflowType = "${workflowType}"` );
+        }
+        if ( taskQueue ) {
+          conditions.push( `TaskQueue = "${taskQueue}"` );
+        }
+        const query = conditions.length > 0 ? conditions.join( ' AND ' ) : undefined;
 
         const executions = await takeFromAsyncIterable(
           client.workflow.list( { query } ),

--- a/api/src/clients/temporal_client.spec.js
+++ b/api/src/clients/temporal_client.spec.js
@@ -1222,5 +1222,37 @@ describe( 'temporal_client', () => {
         }
       ] );
     } );
+
+    it( 'sends only the TaskQueue clause when only taskQueue is provided', async () => {
+      mockList.mockReturnValue( asAsyncIterable( [] ) );
+      const temporalClient = ( await import( './temporal_client.js' ) ).default;
+      const client = await temporalClient.init();
+
+      await client.listWorkflowRuns( { taskQueue: 'sepcat' } );
+
+      expect( mockList ).toHaveBeenCalledWith( { query: 'TaskQueue = "sepcat"' } );
+    } );
+
+    it( 'AND-joins WorkflowType and TaskQueue when both are provided', async () => {
+      mockList.mockReturnValue( asAsyncIterable( [] ) );
+      const temporalClient = ( await import( './temporal_client.js' ) ).default;
+      const client = await temporalClient.init();
+
+      await client.listWorkflowRuns( { workflowType: 'factChecker', taskQueue: 'sepcat' } );
+
+      expect( mockList ).toHaveBeenCalledWith( {
+        query: 'WorkflowType = "factChecker" AND TaskQueue = "sepcat"'
+      } );
+    } );
+
+    it( 'sends no query (returns all runs) when neither filter is provided', async () => {
+      mockList.mockReturnValue( asAsyncIterable( [] ) );
+      const temporalClient = ( await import( './temporal_client.js' ) ).default;
+      const client = await temporalClient.init();
+
+      await client.listWorkflowRuns();
+
+      expect( mockList ).toHaveBeenCalledWith( { query: undefined } );
+    } );
   } );
 } );

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -16,6 +16,22 @@ import { readPinnedRunId } from './handlers/utils.js';
 // 90 days after the PR that introduces the pinned-run scheme.
 const PINNED_MUTATION_SUNSET = new Date( '2026-07-16T00:00:00Z' ).toUTCString();
 
+/**
+ * Resolve the catalog field on workflow run/start request bodies, accepting
+ * both `catalog` and the deprecated `taskQueue` alias. When `taskQueue` is
+ * supplied, log a deprecation warning so callers can migrate.
+ *
+ * @param {{ catalog?: string, taskQueue?: string }} body
+ * @param {string} route
+ * @returns {string|undefined}
+ */
+const resolveCatalogField = ( body, route ) => {
+  if ( body.taskQueue !== undefined ) {
+    logger.warn( 'Deprecated body field', { field: 'taskQueue', successor: 'catalog', route } );
+  }
+  return body.catalog ?? body.taskQueue;
+};
+
 const app = express();
 
 const client = await temporalClient.init().catch( e => {
@@ -434,9 +450,13 @@ app.use( ( req, res, next ) => {
  *               workflowId:
  *                 type: string
  *                 description: (Optional) The workflowId to use. Must be unique
+ *               catalog:
+ *                 type: string
+ *                 description: The catalog (Temporal task queue) to route the execution to. Falls back to the default catalog.
  *               taskQueue:
  *                 type: string
- *                 description: The name of the task queue to send the workflow to
+ *                 deprecated: true
+ *                 description: Deprecated alias for `catalog`. If both are sent, `catalog` wins.
  *               timeout:
  *                 type: number
  *                 description: (Optional) The max time to wait for the execution, defaults to 30s
@@ -475,14 +495,21 @@ app.use( ( req, res, next ) => {
  *         $ref: '#/components/responses/InternalServerError'
  */
 app.post( '/workflow/run', async ( req, res ) => {
-  const { workflowName, input, workflowId, taskQueue, timeout } = z.object( {
+  const parsed = z.object( {
     workflowName: z.string(),
     input: z.any().optional(),
     workflowId: z.string().optional(),
+    catalog: z.string().optional(),
     taskQueue: z.string().optional(),
     timeout: z.coerce.number().int().min( 250 ).optional()
   } ).parse( req.body );
-  res.json( await client.runWorkflow( workflowName, input, { workflowId, taskQueue, timeout } ) );
+  const catalog = resolveCatalogField( parsed, '/workflow/run' );
+  const result = await client.runWorkflow( parsed.workflowName, parsed.input, {
+    workflowId: parsed.workflowId,
+    taskQueue: catalog,
+    timeout: parsed.timeout
+  } );
+  res.json( result );
 } );
 
 /**
@@ -508,9 +535,13 @@ app.post( '/workflow/run', async ( req, res ) => {
  *               workflowId:
  *                 type: string
  *                 description: (Optional) The workflowId to use. Must be unique
+ *               catalog:
+ *                 type: string
+ *                 description: The catalog (Temporal task queue) to route the execution to. Falls back to the default catalog.
  *               taskQueue:
  *                 type: string
- *                 description: The name of the task queue to send the workflow to
+ *                 deprecated: true
+ *                 description: Deprecated alias for `catalog`. If both are sent, `catalog` wins.
  *     responses:
  *       200:
  *         description: The workflow start result
@@ -534,14 +565,16 @@ app.post( '/workflow/run', async ( req, res ) => {
  *         $ref: '#/components/responses/InternalServerError'
  */
 app.post( '/workflow/start', async ( req, res ) => {
-  const { workflowName, input, workflowId, taskQueue } = z.object( {
+  const parsed = z.object( {
     workflowName: z.string(),
     input: z.any().optional(),
     workflowId: z.string().optional(),
+    catalog: z.string().optional(),
     taskQueue: z.string().optional()
   } ).parse( req.body );
+  const catalog = resolveCatalogField( parsed, '/workflow/start' );
 
-  res.json( await client.startWorkflow( workflowName, input, { workflowId, taskQueue } ) );
+  res.json( await client.startWorkflow( parsed.workflowName, parsed.input, { workflowId: parsed.workflowId, taskQueue: catalog } ) );
 } );
 
 /**
@@ -1185,6 +1218,11 @@ app.get( '/workflow/catalog', async ( _req, res ) => {
  *           type: string
  *         description: Filter by workflow type/name
  *       - in: query
+ *         name: catalog
+ *         schema:
+ *           type: string
+ *         description: Filter by catalog ID (scopes runs to a single worker's catalog/session)
+ *       - in: query
  *         name: limit
  *         schema:
  *           type: integer
@@ -1205,11 +1243,12 @@ app.get( '/workflow/catalog', async ( _req, res ) => {
  *         $ref: '#/components/responses/InternalServerError'
  */
 app.get( '/workflow/runs', async ( req, res ) => {
-  const { workflowType, limit } = z.object( {
+  const { workflowType, catalog, limit } = z.object( {
     workflowType: z.string().optional(),
+    catalog: z.string().optional(),
     limit: z.coerce.number().int().min( 1 ).max( 1000 ).default( 100 )
   } ).parse( req.query );
-  res.json( await client.listWorkflowRuns( { workflowType, limit } ) );
+  res.json( await client.listWorkflowRuns( { workflowType, taskQueue: catalog, limit } ) );
 } );
 
 /**

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -16,6 +16,14 @@ import { readPinnedRunId } from './handlers/utils.js';
 // 90 days after the PR that introduces the pinned-run scheme.
 const PINNED_MUTATION_SUNSET = new Date( '2026-07-16T00:00:00Z' ).toUTCString();
 
+// Identifier shape for values that flow into Temporal visibility queries
+// (`catalog` and `workflowType`). Mirrors the `OUTPUT_CATALOG_ID` regex from
+// `@outputai/core` so a worker-routable id always satisfies the API too.
+// Restricting to `[a-z0-9_.@-]` prevents query injection via embedded quotes
+// or operators since the value is interpolated into the visibility query string.
+const QUERY_IDENTIFIER = /^[a-z0-9_.@-]+$/i;
+const queryIdentifier = z.string().regex( QUERY_IDENTIFIER );
+
 /**
  * Resolve the catalog field on workflow run/start request bodies, accepting
  * both `catalog` and the deprecated `taskQueue` alias. When `taskQueue` is
@@ -499,8 +507,8 @@ app.post( '/workflow/run', async ( req, res ) => {
     workflowName: z.string(),
     input: z.any().optional(),
     workflowId: z.string().optional(),
-    catalog: z.string().optional(),
-    taskQueue: z.string().optional(),
+    catalog: queryIdentifier.optional(),
+    taskQueue: queryIdentifier.optional(),
     timeout: z.coerce.number().int().min( 250 ).optional()
   } ).parse( req.body );
   const catalog = resolveCatalogField( parsed, '/workflow/run' );
@@ -569,8 +577,8 @@ app.post( '/workflow/start', async ( req, res ) => {
     workflowName: z.string(),
     input: z.any().optional(),
     workflowId: z.string().optional(),
-    catalog: z.string().optional(),
-    taskQueue: z.string().optional()
+    catalog: queryIdentifier.optional(),
+    taskQueue: queryIdentifier.optional()
   } ).parse( req.body );
   const catalog = resolveCatalogField( parsed, '/workflow/start' );
 
@@ -1244,8 +1252,8 @@ app.get( '/workflow/catalog', async ( _req, res ) => {
  */
 app.get( '/workflow/runs', async ( req, res ) => {
   const { workflowType, catalog, limit } = z.object( {
-    workflowType: z.string().optional(),
-    catalog: z.string().optional(),
+    workflowType: queryIdentifier.optional(),
+    catalog: queryIdentifier.optional(),
     limit: z.coerce.number().int().min( 1 ).max( 1000 ).default( 100 )
   } ).parse( req.query );
   res.json( await client.listWorkflowRuns( { workflowType, taskQueue: catalog, limit } ) );

--- a/api/src/index.spec.js
+++ b/api/src/index.spec.js
@@ -151,6 +151,14 @@ describe( 'API endpoints', () => {
       expect( res.body.issues ).toBeDefined();
       expect( mockClient.runWorkflow ).not.toHaveBeenCalled();
     } );
+
+    it( 'rejects catalog containing characters that could break the visibility query', async () => {
+      await request( `http://localhost:${PORT}` )
+        .post( '/workflow/run' )
+        .send( { workflowName: 'MyWorkflow', input: {}, catalog: 'sepcat" OR "x' } )
+        .expect( 400 );
+      expect( mockClient.runWorkflow ).not.toHaveBeenCalled();
+    } );
   } );
 
   describe( 'POST /workflow/start', () => {
@@ -475,6 +483,13 @@ describe( 'API endpoints', () => {
       const res = await request( `http://localhost:${PORT}` ).get( '/workflow/runs?limit=0' ).expect( 400 );
       expect( res.body ).toMatchObject( { error: 'ValidationError', message: 'Invalid Payload' } );
       expect( res.body.issues ).toBeDefined();
+      expect( mockClient.listWorkflowRuns ).not.toHaveBeenCalled();
+    } );
+
+    it( 'rejects catalog containing characters that could break the visibility query', async () => {
+      await request( `http://localhost:${PORT}` )
+        .get( '/workflow/runs?catalog=sepcat%22%20OR%20%22x' ) // sepcat" OR "x
+        .expect( 400 );
       expect( mockClient.listWorkflowRuns ).not.toHaveBeenCalled();
     } );
   } );

--- a/api/src/index.spec.js
+++ b/api/src/index.spec.js
@@ -117,6 +117,34 @@ describe( 'API endpoints', () => {
       expect( mockClient.runWorkflow ).toHaveBeenCalledWith( 'MyWorkflow', { x: 1 }, expect.any( Object ) );
     } );
 
+    it( 'forwards catalog body field as taskQueue to runWorkflow', async () => {
+      await request( `http://localhost:${PORT}` )
+        .post( '/workflow/run' )
+        .send( { workflowName: 'MyWorkflow', input: {}, catalog: 'sepcat' } )
+        .expect( 200 );
+      expect( mockClient.runWorkflow ).toHaveBeenCalledWith( 'MyWorkflow', {}, expect.objectContaining( { taskQueue: 'sepcat' } ) );
+    } );
+
+    it( 'accepts deprecated taskQueue body field, forwards as taskQueue, and warns', async () => {
+      await request( `http://localhost:${PORT}` )
+        .post( '/workflow/run' )
+        .send( { workflowName: 'MyWorkflow', input: {}, taskQueue: 'sepcat' } )
+        .expect( 200 );
+      expect( mockClient.runWorkflow ).toHaveBeenCalledWith( 'MyWorkflow', {}, expect.objectContaining( { taskQueue: 'sepcat' } ) );
+      expect( mockLogger.warn ).toHaveBeenCalledWith(
+        'Deprecated body field',
+        expect.objectContaining( { field: 'taskQueue', successor: 'catalog', route: '/workflow/run' } )
+      );
+    } );
+
+    it( 'prefers catalog over taskQueue when both are provided', async () => {
+      await request( `http://localhost:${PORT}` )
+        .post( '/workflow/run' )
+        .send( { workflowName: 'MyWorkflow', input: {}, catalog: 'wins', taskQueue: 'loses' } )
+        .expect( 200 );
+      expect( mockClient.runWorkflow ).toHaveBeenCalledWith( 'MyWorkflow', {}, expect.objectContaining( { taskQueue: 'wins' } ) );
+    } );
+
     it( 'validation error returns 400', async () => {
       const res = await request( `http://localhost:${PORT}` ).post( '/workflow/run' ).send( { input: { x: 1 } } ).expect( 400 );
       expect( res.body ).toMatchObject( { error: 'ValidationError', message: 'Invalid Payload' } );
@@ -133,6 +161,26 @@ describe( 'API endpoints', () => {
         .expect( 200 );
       expect( res.body ).toEqual( { workflowId: 'start-1', runId: 'r-start' } );
       expect( mockClient.startWorkflow ).toHaveBeenCalledWith( 'MyWorkflow', {}, expect.any( Object ) );
+    } );
+
+    it( 'forwards catalog body field as taskQueue to startWorkflow', async () => {
+      await request( `http://localhost:${PORT}` )
+        .post( '/workflow/start' )
+        .send( { workflowName: 'MyWorkflow', input: {}, catalog: 'sepcat' } )
+        .expect( 200 );
+      expect( mockClient.startWorkflow ).toHaveBeenCalledWith( 'MyWorkflow', {}, expect.objectContaining( { taskQueue: 'sepcat' } ) );
+    } );
+
+    it( 'accepts deprecated taskQueue body field, forwards as taskQueue, and warns', async () => {
+      await request( `http://localhost:${PORT}` )
+        .post( '/workflow/start' )
+        .send( { workflowName: 'MyWorkflow', input: {}, taskQueue: 'sepcat' } )
+        .expect( 200 );
+      expect( mockClient.startWorkflow ).toHaveBeenCalledWith( 'MyWorkflow', {}, expect.objectContaining( { taskQueue: 'sepcat' } ) );
+      expect( mockLogger.warn ).toHaveBeenCalledWith(
+        'Deprecated body field',
+        expect.objectContaining( { field: 'taskQueue', successor: 'catalog', route: '/workflow/start' } )
+      );
     } );
 
     it( 'validation error returns 400', async () => {
@@ -403,6 +451,24 @@ describe( 'API endpoints', () => {
       const res = await request( `http://localhost:${PORT}` ).get( '/workflow/runs' ).expect( 200 );
       expect( res.body ).toEqual( { runs: [] } );
       expect( mockClient.listWorkflowRuns ).toHaveBeenCalledWith( expect.any( Object ) );
+    } );
+
+    it( 'forwards catalog query param to listWorkflowRuns as taskQueue', async () => {
+      await request( `http://localhost:${PORT}` ).get( '/workflow/runs?catalog=session-123' ).expect( 200 );
+      expect( mockClient.listWorkflowRuns ).toHaveBeenCalledWith( {
+        workflowType: undefined,
+        taskQueue: 'session-123',
+        limit: 100
+      } );
+    } );
+
+    it( 'forwards both workflowType and catalog (as taskQueue) together', async () => {
+      await request( `http://localhost:${PORT}` ).get( '/workflow/runs?workflowType=simple&catalog=session-456' ).expect( 200 );
+      expect( mockClient.listWorkflowRuns ).toHaveBeenCalledWith( {
+        workflowType: 'simple',
+        taskQueue: 'session-456',
+        limit: 100
+      } );
     } );
 
     it( 'validation error when limit is out of range returns 400', async () => {

--- a/docs/guides/openapi.json
+++ b/docs/guides/openapi.json
@@ -545,9 +545,14 @@
                     "type": "string",
                     "description": "(Optional) The workflowId to use. Must be unique"
                   },
+                  "catalog": {
+                    "type": "string",
+                    "description": "The catalog (Temporal task queue) to route the execution to. Falls back to the default catalog."
+                  },
                   "taskQueue": {
                     "type": "string",
-                    "description": "The name of the task queue to send the workflow to"
+                    "deprecated": true,
+                    "description": "Deprecated alias for `catalog`. If both are sent, `catalog` wins."
                   },
                   "timeout": {
                     "type": "number",
@@ -637,9 +642,14 @@
                     "type": "string",
                     "description": "(Optional) The workflowId to use. Must be unique"
                   },
+                  "catalog": {
+                    "type": "string",
+                    "description": "The catalog (Temporal task queue) to route the execution to. Falls back to the default catalog."
+                  },
                   "taskQueue": {
                     "type": "string",
-                    "description": "The name of the task queue to send the workflow to"
+                    "deprecated": true,
+                    "description": "Deprecated alias for `catalog`. If both are sent, `catalog` wins."
                   }
                 }
               }
@@ -1548,6 +1558,14 @@
               "type": "string"
             },
             "description": "Filter by workflow type/name"
+          },
+          {
+            "in": "query",
+            "name": "catalog",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by catalog ID (scopes runs to a single worker's catalog/session)"
           },
           {
             "in": "query",

--- a/docs/guides/packages/cli.mdx
+++ b/docs/guides/packages/cli.mdx
@@ -210,7 +210,7 @@ output workflow run <workflowName> [scenario]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--input, -i` | — | JSON input or file path (overrides scenario) |
-| `--task-queue, -q` | — | Task queue name |
+| `--catalog, -c` | `OUTPUT_CATALOG_ID` | Catalog name (the deprecated `--task-queue, -q` aliases still work) |
 | `--format, -f` | text | Output format: json, text |
 
 ```bash
@@ -243,7 +243,7 @@ output workflow start <workflowName> [scenario]
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--input, -i` | — | JSON input or file path (overrides scenario) |
-| `--task-queue, -q` | — | Task queue name |
+| `--catalog, -c` | `OUTPUT_CATALOG_ID` | Catalog name (the deprecated `--task-queue, -q` aliases still work) |
 
 ### output workflow status
 

--- a/docs/guides/workflows/running.mdx
+++ b/docs/guides/workflows/running.mdx
@@ -52,7 +52,7 @@ If the workflow fails, the command prints the error and exits with code 1.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--input, -i` | — | JSON string or file path (overrides scenario) |
-| `--task-queue, -q` | — | Task queue name |
+| `--catalog, -c` | `OUTPUT_CATALOG_ID` | Catalog name (the deprecated `--task-queue, -q` aliases still work) |
 | `--format, -f` | text | Output format: `json`, `text` |
 
 ## Starting a Workflow Asynchronously

--- a/sdk/cli/src/api/generated/api.ts
+++ b/sdk/cli/src/api/generated/api.ts
@@ -331,7 +331,12 @@ export type PostWorkflowRunBody = {
   input: unknown;
   /** (Optional) The workflowId to use. Must be unique */
   workflowId?: string;
-  /** The name of the task queue to send the workflow to */
+  /** The catalog (Temporal task queue) to route the execution to. Falls back to the default catalog. */
+  catalog?: string;
+  /**
+     * Deprecated alias for `catalog`. If both are sent, `catalog` wins.
+     * @deprecated
+     */
   taskQueue?: string;
   /** (Optional) The max time to wait for the execution, defaults to 30s */
   timeout?: number;
@@ -370,7 +375,12 @@ export type PostWorkflowStartBody = {
   input: unknown;
   /** (Optional) The workflowId to use. Must be unique */
   workflowId?: string;
-  /** The name of the task queue to send the workflow to */
+  /** The catalog (Temporal task queue) to route the execution to. Falls back to the default catalog. */
+  catalog?: string;
+  /**
+     * Deprecated alias for `catalog`. If both are sent, `catalog` wins.
+     * @deprecated
+     */
   taskQueue?: string;
 };
 
@@ -488,6 +498,10 @@ export type GetWorkflowRunsParams = {
  * Filter by workflow type/name
  */
 workflowType?: string;
+/**
+ * Filter by catalog ID (scopes runs to a single worker's catalog/session)
+ */
+catalog?: string;
 /**
  * Maximum number of runs to return
  * @minimum 1

--- a/sdk/cli/src/commands/workflow/run.spec.ts
+++ b/sdk/cli/src/commands/workflow/run.spec.ts
@@ -32,7 +32,7 @@ describe( 'workflow run command', () => {
       expect( WorkflowRun.args ).toHaveProperty( 'workflowName' );
       expect( WorkflowRun.flags ).toHaveProperty( 'input' );
       expect( WorkflowRun.flags ).toHaveProperty( 'format' );
-      expect( WorkflowRun.flags ).toHaveProperty( 'task-queue' );
+      expect( WorkflowRun.flags ).toHaveProperty( 'catalog' );
     } );
 
     it( 'should have correct flag configuration', async () => {
@@ -62,7 +62,7 @@ describe( 'workflow run command', () => {
       } ) as any;
       ( cmd as any ).parse = vi.fn().mockResolvedValue( {
         args: { workflowName: 'my_workflow', scenario: undefined },
-        flags: { input: undefined, 'task-queue': undefined, format: 'text' }
+        flags: { input: undefined, catalog: undefined, format: 'text' }
       } );
 
       return { cmd, postWorkflowRun: vi.mocked( postWorkflowRun ), resolveInput: vi.mocked( resolveInput ) };
@@ -81,7 +81,7 @@ describe( 'workflow run command', () => {
 
       expect( postWorkflowRun ).toHaveBeenCalledTimes( 1 );
       expect( postWorkflowRun ).toHaveBeenCalledWith(
-        { workflowName: 'my_workflow', input: { key: 'value' }, taskQueue: undefined },
+        { workflowName: 'my_workflow', input: { key: 'value' }, catalog: undefined },
         expect.objectContaining( { config: { timeout: 600000 } } )
       );
       expect( cmd.log ).toHaveBeenCalledWith( 'Executing workflow: my_workflow...' );

--- a/sdk/cli/src/commands/workflow/run.ts
+++ b/sdk/cli/src/commands/workflow/run.ts
@@ -48,7 +48,7 @@ export default class WorkflowRun extends Command {
     '<%= config.bin %> <%= command.id %> simple my_scenario --format json',
     '<%= config.bin %> <%= command.id %> simple --input \'{"values":[1,2,3]}\'',
     '<%= config.bin %> <%= command.id %> simple --input input.json',
-    '<%= config.bin %> <%= command.id %> simple --input \'{"key":"value"}\' --task-queue my-queue'
+    '<%= config.bin %> <%= command.id %> simple --input \'{"key":"value"}\' --catalog my-catalog'
   ];
 
   static override args = {
@@ -68,9 +68,12 @@ export default class WorkflowRun extends Command {
       description: 'Workflow input as JSON string or file path (overrides scenario)',
       required: false
     } ),
-    'task-queue': Flags.string( {
-      char: 'q',
-      description: 'Task queue name for workflow execution (defaults to OUTPUT_CATALOG_ID)',
+    catalog: Flags.string( {
+      char: 'c',
+      aliases: [ 'task-queue' ],
+      charAliases: [ 'q' ],
+      deprecateAliases: true,
+      description: 'Catalog name for workflow execution (defaults to OUTPUT_CATALOG_ID)',
       env: 'OUTPUT_CATALOG_ID'
     } ),
     format: Flags.string( {
@@ -92,7 +95,7 @@ export default class WorkflowRun extends Command {
       body: {
         workflowName: args.workflowName,
         input,
-        taskQueue: flags['task-queue']
+        catalog: flags.catalog
       },
       options: { config: { timeout: 600000 } as const },
       log: msg => this.log( msg )

--- a/sdk/cli/src/commands/workflow/runs/list.ts
+++ b/sdk/cli/src/commands/workflow/runs/list.ts
@@ -67,6 +67,7 @@ export default class WorkflowRunsList extends Command {
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> simple',
     '<%= config.bin %> <%= command.id %> simple --limit 10',
+    '<%= config.bin %> <%= command.id %> --catalog my-catalog',
     '<%= config.bin %> <%= command.id %> --format json',
     '<%= config.bin %> <%= command.id %> --format table'
   ];
@@ -79,6 +80,11 @@ export default class WorkflowRunsList extends Command {
   };
 
   static override flags = {
+    catalog: Flags.string( {
+      char: 'c',
+      description: 'Filter runs by catalog (defaults to OUTPUT_CATALOG_ID)',
+      env: 'OUTPUT_CATALOG_ID'
+    } ),
     limit: Flags.integer( {
       char: 'l',
       description: 'Maximum number of runs to return',
@@ -97,6 +103,7 @@ export default class WorkflowRunsList extends Command {
 
     const { runs, count } = await fetchWorkflowRuns( {
       workflowType: args.workflowName,
+      catalog: flags.catalog,
       limit: flags.limit
     } );
 

--- a/sdk/cli/src/commands/workflow/start.spec.ts
+++ b/sdk/cli/src/commands/workflow/start.spec.ts
@@ -17,7 +17,7 @@ describe( 'workflow start command', () => {
       expect( WorkflowStart.description ).toContain( 'Start a workflow' );
       expect( WorkflowStart.args ).toHaveProperty( 'workflowName' );
       expect( WorkflowStart.flags ).toHaveProperty( 'input' );
-      expect( WorkflowStart.flags ).toHaveProperty( 'task-queue' );
+      expect( WorkflowStart.flags ).toHaveProperty( 'catalog' );
     } );
 
     it( 'should have correct flag configuration', async () => {

--- a/sdk/cli/src/commands/workflow/start.ts
+++ b/sdk/cli/src/commands/workflow/start.ts
@@ -10,7 +10,7 @@ export default class WorkflowStart extends Command {
     '<%= config.bin %> <%= command.id %> simple basic_input',
     '<%= config.bin %> <%= command.id %> simple --input \'{"values":[1,2,3]}\'',
     '<%= config.bin %> <%= command.id %> simple --input input.json',
-    '<%= config.bin %> <%= command.id %> simple --input \'{"key":"value"}\' --task-queue my-queue'
+    '<%= config.bin %> <%= command.id %> simple --input \'{"key":"value"}\' --catalog my-catalog'
   ];
 
   static override args = {
@@ -30,9 +30,12 @@ export default class WorkflowStart extends Command {
       description: 'Workflow input as JSON string or file path (overrides scenario)',
       required: false
     } ),
-    'task-queue': Flags.string( {
-      char: 'q',
-      description: 'Task queue name for workflow execution (defaults to OUTPUT_CATALOG_ID)',
+    catalog: Flags.string( {
+      char: 'c',
+      aliases: [ 'task-queue' ],
+      charAliases: [ 'q' ],
+      deprecateAliases: true,
+      description: 'Catalog name for workflow execution (defaults to OUTPUT_CATALOG_ID)',
       env: 'OUTPUT_CATALOG_ID'
     } )
   };
@@ -47,7 +50,7 @@ export default class WorkflowStart extends Command {
     const response = await postWorkflowStart( {
       workflowName: args.workflowName,
       input,
-      taskQueue: flags['task-queue']
+      catalog: flags.catalog
     } );
 
     if ( !response || !response.data ) {

--- a/sdk/cli/src/services/workflow_runs.ts
+++ b/sdk/cli/src/services/workflow_runs.ts
@@ -12,11 +12,12 @@ export interface WorkflowRunsResult {
 
 export interface FetchWorkflowRunsOptions {
   workflowType?: string;
+  catalog?: string;
   limit?: number;
 }
 
 export async function fetchWorkflowRuns( options: FetchWorkflowRunsOptions = {} ): Promise<WorkflowRunsResult> {
-  const params: { workflowType?: string; limit?: number } = {};
+  const params: { workflowType?: string; catalog?: string; limit?: number } = {};
 
   if ( options.limit ) {
     params.limit = options.limit;
@@ -24,6 +25,10 @@ export async function fetchWorkflowRuns( options: FetchWorkflowRunsOptions = {} 
 
   if ( options.workflowType ) {
     params.workflowType = options.workflowType;
+  }
+
+  if ( options.catalog ) {
+    params.catalog = options.catalog;
   }
 
   const response = await getWorkflowRuns( params );


### PR DESCRIPTION
## Summary

Use `catalog` as the public name for the routing/filtering target across the CLI and HTTP API. Internally the value is still a Temporal task queue — only the user-facing name changes. Addresses issue #9 in [OUT-411](https://linear.app/growthx/issue/OUT-411).

## CLI

- `output workflow runs list` gains `--catalog`/`-c` (with `OUTPUT_CATALOG_ID` env fallback) — scopes listed runs to a single worker's catalog/session.
- `output workflow run` and `output workflow start` rename the routing flag to `--catalog`/`-c`. The previous `--task-queue` and `-q` are kept as deprecated oclif aliases (`deprecateAliases: true` emits a warning when used).

## HTTP API

- `GET /workflow/runs?catalog=...` filters runs by catalog.
- `POST /workflow/run` and `POST /workflow/start` accept a `catalog` body field. The previous `taskQueue` body field is still accepted as a deprecated alias; if both are sent, `catalog` wins. The API logs `Deprecated body field { field: 'taskQueue', successor: 'catalog', route }` when `taskQueue` is used.

## Internal

- `temporal_client.runWorkflow` / `startWorkflow` options renamed `taskQueue` → `catalog`; `listWorkflowRuns` already takes `catalog`.
- The wrapper still calls Temporal's `client.workflow.start({ taskQueue: catalog, ... })` because Temporal's API uses that name.
- `resolveWorkflowName(catalogDef, workflowName, catalog)` clarified to distinguish the catalog *definition* (workflows array) from the catalog *name*.

## Files

| File | Change |
|---|---|
| `api/src/clients/temporal_client.js` | Rename option `taskQueue` → `catalog` on `runWorkflow`/`startWorkflow`/`listWorkflowRuns`. Inner Temporal calls keep `taskQueue`. |
| `api/src/index.js` | Add `resolveCatalogField` helper. Zod schemas for `/workflow/run` and `/workflow/start` accept both `catalog` and `taskQueue`. Swagger updated. |
| `api/src/index.spec.js` | New tests: catalog forwarding, taskQueue→catalog forwarding + deprecation warning, catalog wins when both sent. |
| `api/src/clients/temporal_client.spec.js` | Updated `Workflow alias resolved` log assertion (key is now `catalog`). |
| `sdk/cli/src/commands/workflow/run.ts`, `start.ts`, `runs/list.ts` | New `catalog` flag with `aliases: ['task-queue']`, `charAliases: ['q']`, `deprecateAliases: true`. |
| `sdk/cli/src/commands/workflow/run.spec.ts`, `start.spec.ts` | Flag-existence assertions updated. |
| `sdk/cli/src/services/workflow_runs.ts`, `sdk/cli/src/api/generated/api.ts` | Generated/derived from updated openapi. |
| `api/openapi.json`, `docs/guides/openapi.json` | Regenerated. |
| `docs/guides/workflows/running.mdx`, `docs/guides/packages/cli.mdx` | Flag tables updated. |
| `.changeset/catalog-aware-runs-listing.md` | Patch bump for `output-api` and `@outputai/cli`. |

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run build:packages` — regenerates openapi.json, copies to docs/guides, regens cli api.ts
- [x] `./ops/extra_files_error.sh` — passes
- [x] `npx vitest run --exclude '.claude/worktrees/**' …` — 1605 passed (5 new tests vs main)
- [x] End-to-end against `test_workflows` (worker on catalog `sepcat`, dev stack on shifted ports):
  - `output workflow run simple --catalog sepcat --input '...'` → completed
  - `output workflow run simple --catalog main --input '...'` → 503 `CatalogNotAvailableError`
  - `output workflow run simple -c sepcat ...` → completed
  - `output workflow start simple --catalog sepcat ...` → workflowId
  - `output workflow run simple --task-queue sepcat ...` → completed + oclif warning `Warning: The "--task-queue" flag has been deprecated. Use "--catalog | -c" instead.`
  - `output workflow run simple -q sepcat ...` → completed
  - `output workflow runs list -c sepcat` → only sepcat runs
  - `output workflow runs list -c main` → empty
  - `curl -X POST .../workflow/run -d '{"taskQueue":"sepcat", ...}'` → completed + API log `Deprecated body field { field: 'taskQueue', successor: 'catalog', route: '/workflow/run' }`
  - `curl -X POST .../workflow/run -d '{"catalog":"sepcat", ...}'` → completed (no warning)