### PR TITLE
[WIP][DO NOT REVIEW] feat(cos-216): hook-only usage tracking — os-workflows

### DIFF
--- a/.changeset/flat-chefs-lay.md
+++ b/.changeset/flat-chefs-lay.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Update plugin command invocations to match renamed `output-plan-workflow`, `output-build-workflow`, and `output-debug-workflow` skills.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "outputai",
       "source": "./coding_assistants/claude/plugins/outputai",
       "description": "Output.ai Workflow Assistants",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "author": {
         "name": "Output.ai"
       }

--- a/coding_assistants/claude/plugins/README.md
+++ b/coding_assistants/claude/plugins/README.md
@@ -13,9 +13,9 @@ claude
 Afterwards you should see slash commands in the Claude Code autocomplete.
 
 ```bash
-/outputai:plan_workflow
-/outputai:build_workflow
-/outputai:debug_workflow
+/output-plan-workflow
+/output-build-workflow
+/output-debug-workflow
 # ... and more
 ```
 

--- a/coding_assistants/claude/plugins/outputai/.claude-plugin/plugin.json
+++ b/coding_assistants/claude/plugins/outputai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "outputai",
-    "version": "0.1.5",
+    "version": "0.2.0",
     "description": "Workflow development tools",
     "author": {
       "name": "Output.ai",

--- a/coding_assistants/claude/plugins/outputai/hooks/SESSION_START_CONTEXT.md
+++ b/coding_assistants/claude/plugins/outputai/hooks/SESSION_START_CONTEXT.md
@@ -14,7 +14,7 @@ There will be a skill and/or agent for every task you will need to complete.
 
 ## Workflow Creation Routing
 
-When a user asks to create, build, generate, or scaffold a new workflow, ALWAYS use `/outputai:plan_workflow` with the user's description as arguments. Do not plan or build workflows manually. This command orchestrates specialized subagents for architecture, step design, prompt engineering, and testing strategy.
+When a user asks to create, build, generate, or scaffold a new workflow, ALWAYS use `/output-plan-workflow` with the user's description as arguments. Do not plan or build workflows manually. This command orchestrates specialized subagents for architecture, step design, prompt engineering, and testing strategy.
 
 ---
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-build-workflow/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-build-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: build-workflow
+name: output-build-workflow
 argument-hint: "[workflow-plan-file-path] [workflow-name] [workflow-directory]"
-description: Implement an Output SDK workflow from a plan document. Use when the user asks to build, implement, or code a workflow from an existing plan, or after plan-workflow has produced a plan and the user is ready to build.
+description: Implement an Output SDK workflow from a plan document. Use when the user asks to build, implement, or code a workflow from an existing plan, or after output-plan-workflow has produced a plan and the user is ready to build.
 version: 0.1.3
 model: opus
 ---

--- a/coding_assistants/claude/plugins/outputai/skills/output-debug-workflow/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-debug-workflow/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: debug-workflow
+name: output-debug-workflow
 argument-hint: [problem-description-and-optional-workflow-id]
 description: Debug Output SDK workflow issues. Use when user reports a workflow failing, erroring, hanging, producing wrong results, or asks to debug, troubleshoot, or investigate a workflow execution.
 version: 0.1.3

--- a/coding_assistants/claude/plugins/outputai/skills/output-meta-project-context/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-meta-project-context/SKILL.md
@@ -112,9 +112,9 @@ src/
 
 | Command | Purpose | When to Use |
 |---------|---------|-------------|
-| `/outputai:plan_workflow` | Plan workflow architecture | **ALWAYS FIRST** - creates implementation blueprint |
-| `/outputai:build_workflow` | Build/implement workflows | After planning, or for modifications |
-| `/outputai:debug_workflow` | Debug workflow issues | When workflows fail or behave unexpectedly |
+| `/output-plan-workflow` | Plan workflow architecture | **ALWAYS FIRST** - creates implementation blueprint |
+| `/output-build-workflow` | Build/implement workflows | After planning, or for modifications |
+| `/output-debug-workflow` | Debug workflow issues | When workflows fail or behave unexpectedly |
 
 ### Skills (32)
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-plan-workflow/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-plan-workflow/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: plan-workflow
+name: output-plan-workflow
 argument-hint: [workflow-description-and-additional-instructions]
 description: Use when the user asks to create, build, generate, scaffold, or plan a new workflow. Orchestrates the full planning process including architecture, steps, prompts, evaluators, and testing strategy using specialized subagents.
 version: 0.1.3
@@ -290,7 +290,7 @@ Then instruct the user to:
 
 1. Review the plan
 2. Make any necessary changes
-3. Implement the workflow with the appropriate build command. e.g. `/outputai:build_workflow <plan_file_path> <workflow_name> <workflow_directory>`
+3. Implement the workflow with the appropriate build command. e.g. `/output-build-workflow <plan_file_path> <workflow_name> <workflow_directory>`
 
 </step>
 

--- a/docs/guides/start-here/claude-code.mdx
+++ b/docs/guides/start-here/claude-code.mdx
@@ -36,9 +36,9 @@ In practice, you rarely need to type these directly — Claude Code picks the ri
 
 | Command | What it does | Example |
 |---------|-------------|---------|
-| `/outputai:plan_workflow` | Produces a detailed implementation plan before writing code. Covers workflow structure, step boundaries, prompt design, error handling, and testing strategy. Saves to `.outputai/plans/`. | `A workflow that researches a company and produces a sales brief` |
-| `/outputai:build_workflow` | Takes a plan and generates working code — `workflow.ts`, `steps.ts`, `types.ts`, prompts, evaluators, and test scenarios. Every file follows Output conventions. | `.outputai/plans/2026_03_19_company_research/PLAN.md` |
-| `/outputai:debug_workflow` | Checks infrastructure, pulls execution traces, identifies the failure, and suggests a fix. Systematic — no guessing. | `The company_research workflow is timing out on the scrape step` |
+| `/output-plan-workflow` | Produces a detailed implementation plan before writing code. Covers workflow structure, step boundaries, prompt design, error handling, and testing strategy. Saves to `.outputai/plans/`. | `A workflow that researches a company and produces a sales brief` |
+| `/output-build-workflow` | Takes a plan and generates working code — `workflow.ts`, `steps.ts`, `types.ts`, prompts, evaluators, and test scenarios. Every file follows Output conventions. | `.outputai/plans/2026_03_19_company_research/PLAN.md` |
+| `/output-debug-workflow` | Checks infrastructure, pulls execution traces, identifies the failure, and suggests a fix. Systematic — no guessing. | `The company_research workflow is timing out on the scrape step` |
 
 ### Specialized Agents
 

--- a/sdk/cli/src/commands/workflow/plan.ts
+++ b/sdk/cli/src/commands/workflow/plan.ts
@@ -82,7 +82,7 @@ export default class WorkflowPlan extends Command {
     planName: string,
     projectRoot: string
   ): Promise<void> {
-    this.log( '\nInvoking the /outputai:plan_workflow command...' );
+    this.log( '\nInvoking the /output-plan-workflow command...' );
     this.log( 'This may take a moment...\n' );
 
     const planContent = await invokePlanWorkflow( promptDescription );

--- a/sdk/cli/src/services/claude_client.integration.test.ts
+++ b/sdk/cli/src/services/claude_client.integration.test.ts
@@ -20,7 +20,7 @@ describe( 'invokePlanWorkflow - Integration Tests', () => {
 
     try {
       for await ( const message of query( {
-        prompt: `/outputai:plan_workflow ${description}`,
+        prompt: `/output-plan-workflow ${description}`,
         options: { maxTurns: 1 }
       } ) ) {
         console.log( '\nReceived message:', JSON.stringify( message, null, 2 ) );
@@ -38,7 +38,7 @@ describe( 'invokePlanWorkflow - Integration Tests', () => {
     expect( messages.length ).toBeGreaterThan( 0 );
   }, 60000 ); // 60 second timeout
 
-  it( 'should successfully invoke /outputai:plan_workflow slash command and return content', async () => {
+  it( 'should successfully invoke /output-plan-workflow slash command and return content', async () => {
     const description = 'Simple workflow that takes a number and doubles it';
 
     const result = await invokePlanWorkflow( description );

--- a/sdk/cli/src/services/claude_client.spec.ts
+++ b/sdk/cli/src/services/claude_client.spec.ts
@@ -18,7 +18,7 @@ describe( 'invokePlanWorkflow', () => {
     delete process.env.ANTHROPIC_API_KEY;
   } );
 
-  it( 'should invoke /outputai:plan_workflow slash command with settingSources', async () => {
+  it( 'should invoke /output-plan-workflow slash command with settingSources', async () => {
     const { query } = await import( '@anthropic-ai/claude-agent-sdk' );
 
     process.env.ANTHROPIC_API_KEY = 'test-key';
@@ -32,7 +32,7 @@ describe( 'invokePlanWorkflow', () => {
     await invokePlanWorkflow( 'Test workflow' );
 
     const calls = vi.mocked( query ).mock.calls;
-    expect( calls[0]?.[0]?.prompt ).toContain( '/outputai:plan_workflow Test workflow' );
+    expect( calls[0]?.[0]?.prompt ).toContain( '/output-plan-workflow Test workflow' );
     expect( calls[0]?.[0]?.options?.settingSources ).toEqual( [ 'user', 'project', 'local' ] );
     expect( calls[0]?.[0]?.options?.allowedTools ).toEqual( [ 'Read', 'Grep', 'WebSearch', 'WebFetch', 'TodoWrite' ] );
   } );
@@ -52,7 +52,7 @@ describe( 'invokePlanWorkflow', () => {
     await invokePlanWorkflow( description );
 
     const calls = vi.mocked( query ).mock.calls;
-    expect( calls[0]?.[0]?.prompt ).toContain( `/outputai:plan_workflow ${description}` );
+    expect( calls[0]?.[0]?.prompt ).toContain( `/output-plan-workflow ${description}` );
     expect( calls[0]?.[0]?.options?.settingSources ).toEqual( [ 'user', 'project', 'local' ] );
   } );
 

--- a/sdk/cli/src/services/claude_client.ts
+++ b/sdk/cli/src/services/claude_client.ts
@@ -56,10 +56,9 @@ date: <plan-date>
 } as const;
 
 // Slash-command naming convention used by the outputai plugin:
-// - `outputai:<name>` — plugin commands under coding_assistants/.../commands/
-// - `output-<kebab-name>` — skills under coding_assistants/.../skills/, which surface as top-level slash commands without the plugin prefix.
-const PLAN_COMMAND = 'outputai:plan_workflow';
-const BUILD_COMMAND = 'outputai:build_workflow';
+// `output-<kebab-name>` — skills under coding_assistants/.../skills/, which surface as top-level slash commands without the plugin prefix.
+const PLAN_COMMAND = 'output-plan-workflow';
+const BUILD_COMMAND = 'output-build-workflow';
 const MIGRATE_COMMAND = 'output-migrate';
 
 const GLOBAL_CLAUDE_OPTIONS: Options = {
@@ -285,7 +284,7 @@ export async function replyToClaude(
 }
 
 /**
- * Invoke claude-code with /outputai:plan_workflow slash command
+ * Invoke claude-code with /output-plan-workflow slash command
  * The SDK loads custom commands from .claude/commands/ when settingSources includes 'project'.
  * ensureOutputAISystem() scaffolds the command files to that location.
  * @param description - Workflow description
@@ -298,7 +297,7 @@ export async function invokePlanWorkflow(
 }
 
 /**
- * Invoke claude-code with /outputai:build_workflow slash command
+ * Invoke claude-code with /output-build-workflow slash command
  * The SDK loads custom commands from .claude/commands/ when settingSources includes 'project'.
  * ensureOutputAISystem() scaffolds the command files to that location.
  * @param planFilePath - Absolute path to the plan file

--- a/sdk/cli/src/services/workflow_builder.ts
+++ b/sdk/cli/src/services/workflow_builder.ts
@@ -42,7 +42,7 @@ function isEmpty( modification: string ): boolean {
 }
 
 /**
- * Build a workflow from a plan file using the /outputai:build_workflow slash command
+ * Build a workflow from a plan file using the /output-build-workflow slash command
  * @param planFilePath - Absolute path to the plan file
  * @param workflowDir - Absolute path to the workflow directory
  * @param workflowName - Name of the workflow


### PR DESCRIPTION
## Summary

- Renamed `plan-workflow`, `build-workflow`, and `debug-workflow` skills to use the `output-` prefix, matching the convention of every other skill in the plugin.
- Updated all invocation references (CLI, tests, plugin README, session hook, meta-context skill) from `/outputai:<name>_workflow` to `/output-<name>-workflow`.
- Bumped plugin and marketplace versions to `0.2.0`.

## Test plan
- [ ] `pnpm -w run lint`
- [ ] `pnpm --filter @outputai/cli test claude_client.spec`
- [ ] Manually verify `/output-plan-workflow`, `/output-build-workflow`, `/output-debug-workflow` are available after reinstalling the plugin