### PR TITLE
feat(cli): Adding .npmrc on new scaffoldded projects

### DIFF
--- a/sdk/cli/bin/copyassets.sh
+++ b/sdk/cli/bin/copyassets.sh
@@ -11,6 +11,12 @@ find ./src -name '.*.template' -type f | while read -r file; do
   cp "$file" "$dest"
 done
 copyfiles './src/assets/**/*' dist -u 1
+# native-copyfiles ** globs skip dotfiles under assets; copy them explicitly
+find ./src/assets -type f -name '.*' | while read -r file; do
+  dest="dist/${file#./src/}"
+  mkdir -p "$(dirname "$dest")"
+  cp "$file" "$dest"
+done
 copyfiles './src/**/*.prompt' dist -u 1
 
 echo "✅ Assets copied to dist/"

--- a/sdk/cli/src/assets/npm/.npmrc
+++ b/sdk/cli/src/assets/npm/.npmrc
@@ -1,0 +1,2 @@
+save-exact=true
+min-release-age=4320 # 72 hours

--- a/sdk/cli/src/services/copy_assets.spec.ts
+++ b/sdk/cli/src/services/copy_assets.spec.ts
@@ -24,4 +24,9 @@ describe( 'copy-assets build output', () => {
     const configFile = path.join( distTemplatesDir, 'config', 'costs.yml.template' );
     expect( fs.existsSync( configFile ), 'Missing config/costs.yml.template in dist' ).toBe( true );
   } );
+
+  it( 'should include scaffold .npmrc asset in dist/assets/npm/', () => {
+    const npmrcPath = path.join( cliRoot, 'dist', 'assets', 'npm', '.npmrc' );
+    expect( fs.existsSync( npmrcPath ), 'Missing assets/npm/.npmrc in dist' ).toBe( true );
+  } );
 } );

--- a/sdk/cli/src/services/project_scaffold.spec.ts
+++ b/sdk/cli/src/services/project_scaffold.spec.ts
@@ -1,5 +1,11 @@
+import path from 'node:path';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getProjectConfig, checkDependencies, createSigintHandler } from './project_scaffold.js';
+import {
+  getProjectConfig,
+  checkDependencies,
+  createSigintHandler,
+  scaffoldProjectFiles
+} from './project_scaffold.js';
 import { UserCancelledError } from '#types/errors.js';
 
 // Mock the framework version utility
@@ -30,7 +36,10 @@ vi.mock( 'node:fs/promises', () => ( {
     copyFile: vi.fn().mockResolvedValue( undefined )
   }
 } ) );
-vi.mock( './template_processor.js' );
+vi.mock( './template_processor.js', () => ( {
+  getTemplateFiles: vi.fn().mockResolvedValue( [] ),
+  processTemplateFile: vi.fn().mockResolvedValue( undefined )
+} ) );
 vi.mock( './coding_agents.js' );
 vi.mock( '#services/docker.js', () => ( {
   isDockerInstalled: vi.fn().mockReturnValue( true )
@@ -125,6 +134,45 @@ describe( 'project_scaffold', () => {
       vi.mocked( confirm ).mockResolvedValue( false );
 
       await expect( checkDependencies() ).rejects.toThrow( UserCancelledError );
+    } );
+  } );
+
+  describe( 'scaffoldProjectFiles', () => {
+    it( 'should copy bundled npmrc to project root as .npmrc', async () => {
+      const fs = await import( 'node:fs/promises' );
+      const projectRoot = path.join( '/tmp', 'output-init-test', 'proj' );
+
+      await scaffoldProjectFiles( projectRoot, 'my-app', 'A test project' );
+
+      expect( vi.mocked( fs.default.copyFile ) ).toHaveBeenCalledWith(
+        expect.stringContaining( path.join( 'assets', 'npm', '.npmrc' ) ),
+        path.join( projectRoot, '.npmrc' )
+      );
+    } );
+
+    it( 'should list .npmrc in created files', async () => {
+      const created = await scaffoldProjectFiles(
+        path.join( '/tmp', 'output-init-test', 'proj2' ),
+        'my-app',
+        'A test project'
+      );
+
+      expect( created ).toContain( '.npmrc' );
+    } );
+
+    it( 'should append .npmrc after template output names', async () => {
+      const { getTemplateFiles } = await import( './template_processor.js' );
+      vi.mocked( getTemplateFiles ).mockResolvedValueOnce( [
+        { name: 'README.md.template', path: '/fake/README.md.template', outputName: 'README.md' }
+      ] );
+
+      const created = await scaffoldProjectFiles(
+        path.join( '/tmp', 'output-init-test', 'proj3' ),
+        'my-app',
+        'A test project'
+      );
+
+      expect( created ).toEqual( [ 'README.md', '.npmrc' ] );
     } );
   } );
 

--- a/sdk/cli/src/services/project_scaffold.ts
+++ b/sdk/cli/src/services/project_scaffold.ts
@@ -121,7 +121,7 @@ export const getProjectConfig = async ( userFolderNameArg?: string ): Promise<Pr
   }
 };
 
-async function scaffoldProjectFiles(
+export async function scaffoldProjectFiles(
   projectPath: string,
   projectName: string,
   description: string
@@ -129,6 +129,7 @@ async function scaffoldProjectFiles(
   const __filename = fileURLToPath( import.meta.url );
   const __dirname = path.dirname( __filename );
   const templatesDir = path.join( __dirname, '..', 'templates', 'project' );
+  const npmrcSourcePath = path.join( __dirname, '..', 'assets', 'npm', '.npmrc' );
 
   // Get framework version for dynamic template injection
   const frameworkVersion = await getFrameworkVersion();
@@ -146,7 +147,9 @@ async function scaffoldProjectFiles(
     templateFiles.map( templateFile => processTemplateFile( templateFile, projectPath, templateVars ) )
   );
 
-  return templateFiles.map( f => f.outputName );
+  await fs.copyFile( npmrcSourcePath, path.join( projectPath, '.npmrc' ) );
+
+  return [ ...templateFiles.map( f => f.outputName ), '.npmrc' ];
 }
 
 const CREDENTIALS_TEMPLATE_CONTENT = 'anthropic:\n  api_key: "<FILL_ME_OUT>"\nopenai:\n  api_key: "<FILL_ME_OUT>"\n';


### PR DESCRIPTION
## Summary

When scaffolding a new project using CLI's `init` command, adds a `.npmrc` file in the root folder, with the following content:
```
save-exact=true
min-release-age=4320 # 72 hours
```

This a opinionated secure config that reflect some good practices:
- `save-exact`: When using `npm install`, don't set _semver_ version operators (`ˆ,~,>=`), stick with fixed versions - this avoids undesired updates on dependencies when installing projects without a lock file or when recreating it;
- `min-release-age`:  To minimize supply chain attacks vulnerability, only install dependencies that are at least 3 days old;

## Test plan

- [x] Unit tests;
- [x] e2e tests;
- [x] Manually scaffolding a project;