### PR TITLE
fix(cli): add outputai prefix back to slash commands

### DIFF
--- a/sdk/cli/src/services/claude_client.spec.ts
+++ b/sdk/cli/src/services/claude_client.spec.ts
@@ -18,7 +18,7 @@ describe( 'invokePlanWorkflow', () => {
     delete process.env.ANTHROPIC_API_KEY;
   } );
 
-  it( 'should invoke /output-plan-workflow slash command with settingSources', async () => {
+  it( 'should invoke /outputai:output-plan-workflow slash command with settingSources', async () => {
     const { query } = await import( '@anthropic-ai/claude-agent-sdk' );
 
     process.env.ANTHROPIC_API_KEY = 'test-key';
@@ -32,7 +32,7 @@ describe( 'invokePlanWorkflow', () => {
     await invokePlanWorkflow( 'Test workflow' );
 
     const calls = vi.mocked( query ).mock.calls;
-    expect( calls[0]?.[0]?.prompt ).toContain( '/output-plan-workflow Test workflow' );
+    expect( calls[0]?.[0]?.prompt ).toContain( '/outputai:output-plan-workflow Test workflow' );
     expect( calls[0]?.[0]?.options?.settingSources ).toEqual( [ 'user', 'project', 'local' ] );
     expect( calls[0]?.[0]?.options?.allowedTools ).toEqual( [ 'Read', 'Grep', 'WebSearch', 'WebFetch', 'TodoWrite' ] );
   } );
@@ -52,7 +52,7 @@ describe( 'invokePlanWorkflow', () => {
     await invokePlanWorkflow( description );
 
     const calls = vi.mocked( query ).mock.calls;
-    expect( calls[0]?.[0]?.prompt ).toContain( `/output-plan-workflow ${description}` );
+    expect( calls[0]?.[0]?.prompt ).toContain( `/outputai:output-plan-workflow ${description}` );
     expect( calls[0]?.[0]?.options?.settingSources ).toEqual( [ 'user', 'project', 'local' ] );
   } );
 

--- a/sdk/cli/src/services/claude_client.ts
+++ b/sdk/cli/src/services/claude_client.ts
@@ -56,10 +56,10 @@ date: <plan-date>
 } as const;
 
 // Slash-command naming convention used by the outputai plugin:
-// `output-<kebab-name>` — skills under coding_assistants/.../skills/, which surface as top-level slash commands without the plugin prefix.
-const PLAN_COMMAND = 'output-plan-workflow';
-const BUILD_COMMAND = 'output-build-workflow';
-const MIGRATE_COMMAND = 'output-migrate';
+// `outputai:<kebab-name>` — skills under coding_assistants/.../skills/, which surface as top-level slash commands without the plugin prefix.
+const PLAN_COMMAND = 'outputai:output-plan-workflow';
+const BUILD_COMMAND = 'outputai:output-build-workflow';
+const MIGRATE_COMMAND = 'outputai:output-migrate';
 
 const GLOBAL_CLAUDE_OPTIONS: Options = {
   settingSources: [ 'user', 'project', 'local' ]


### PR DESCRIPTION
## Problem
We recently removed `outputai:` from the command invocations after they transformed to skills.

Reason being is that in the claude tui, skills were no prefixed with their plugin namespace.

However this is not the case for the skills and command list that comes out of the ClaudeSDK.

Which was causing the plan and build cli commands to emit a warning

## Proof
List of skills
<img width="367" height="272" alt="image" src="https://github.com/user-attachments/assets/1587e714-80e3-48ab-b407-e52b3c3320ec" />

list of commands
<img width="455" height="380" alt="image" src="https://github.com/user-attachments/assets/818c872b-b7d6-4acf-bbac-e51e61bc7a2d" />

warning:
<img width="692" height="250" alt="image" src="https://github.com/user-attachments/assets/c96d6a32-cc0e-4b6c-8bf6-68c6a08a3b51" />


## Solution
Add the namespace back
