### PR TITLE
chore(agents): add workflow reset skill

### DIFF
--- a/coding_assistants/claude/plugins/outputai/.claude-plugin/plugin.json
+++ b/coding_assistants/claude/plugins/outputai/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "outputai",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Workflow development tools",
     "author": {
       "name": "Output.ai",

--- a/coding_assistants/claude/plugins/outputai/agents/workflow_debugger.md
+++ b/coding_assistants/claude/plugins/outputai/agents/workflow_debugger.md
@@ -38,6 +38,7 @@ For detailed command usage, Claude will automatically invoke the relevant skill.
 | `npx output workflow status` | Check execution status |
 | `npx output workflow result` | Get execution result |
 | `npx output workflow stop` | Stop running workflow |
+| `npx output workflow reset` | Rerun workflow from after a completed step |
 | `npx output workflow debug` | Analyze execution trace |
 | `npx output workflow test` | Run offline eval tests against datasets |
 
@@ -68,6 +69,7 @@ Match error symptoms to solutions and verify the fix.
 - **Skills**: `output-error-*` (matched by symptoms)
 - **Skill**: `output-dev-eval-testing` (for offline test evaluation failures)
 - **Skill**: `output-dev-credentials` (for `MissingCredentialError` or `MissingKeyError`)
+- **Skill**: `output-workflow-reset` (for targeted rerun after fixing a downstream step, skipping already-successful earlier steps)
 
 ## Example Interaction
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-debug-workflow/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-debug-workflow/SKILL.md
@@ -181,7 +181,13 @@ npx output workflow run <workflowName> <input>
 npx output workflow start <workflowName> <input>
 npx output workflow status <workflowId>
 npx output workflow result <workflowId>
+
+# Or, if the fix only affects a specific step and earlier steps succeeded,
+# re-run from after the last known-good step (skips re-executing earlier work)
+npx output workflow reset <workflowId> --step <lastGoodStep> --reason "<fix description>"
 ```
+
+For targeted rerun after fixing a downstream step, see the `output-workflow-reset` skill.
 </verification>
 
 </step>

--- a/coding_assistants/claude/plugins/outputai/skills/output-meta-project-context/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-meta-project-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: output-meta-project-context
-description: Comprehensive guide to Output.ai Framework for building durable, LLM-powered workflows orchestrated by Temporal. Covers project structure, workflow patterns, steps, LLM integration, HTTP clients, CLI commands, and complete inventory of available tools (5 agents, 3 commands, 33 skills).
+description: Comprehensive guide to Output.ai Framework for building durable, LLM-powered workflows orchestrated by Temporal. Covers project structure, workflow patterns, steps, LLM integration, HTTP clients, CLI commands, and complete inventory of available tools (5 agents, 3 commands, 34 skills).
 allowed-tools: [Read]
 ---
 
@@ -116,9 +116,9 @@ src/
 | `/output-build-workflow` | Build/implement workflows | After planning, or for modifications |
 | `/output-debug-workflow` | Debug workflow issues | When workflows fail or behave unexpectedly |
 
-### Skills (32)
+### Skills (34)
 
-#### Workflow Operations (5)
+#### Workflow Operations (6)
 | Skill | Purpose |
 |-------|---------|
 | `output-workflow-run` | Synchronous workflow execution (waits for result) |
@@ -126,6 +126,7 @@ src/
 | `output-workflow-list` | List available workflows |
 | `output-workflow-status` | Check async workflow status |
 | `output-workflow-result` | Get async workflow result |
+| `output-workflow-reset` | Rerun a workflow from after a completed step |
 
 #### Monitoring & Debugging (5)
 | Skill | Purpose |
@@ -195,6 +196,10 @@ npx output workflow result <id>              # Get async result
 # Debug
 npx output workflow debug <id>               # Debug failed workflow
 npx output workflow debug <id> --format json # Machine-readable output
+
+# Rerun from a step (replays up to <stepName>, re-executes everything after)
+npx output workflow reset <id> --step <stepName>
+npx output workflow reset <id> --step <stepName> --reason "why"
 
 # Eval Testing
 npx output workflow test <name>              # Run eval tests against datasets

--- a/coding_assistants/claude/plugins/outputai/skills/output-workflow-reset/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-workflow-reset/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: output-workflow-reset
+description: Re-run an Output SDK workflow from after a specific completed step, creating a new run that replays up to that point and re-executes subsequent steps. Use when iterating on a later step's prompt or logic without re-running the entire workflow, or when recovering from a failure that only affects steps after a known-good point.
+allowed-tools: [Bash]
+---
+
+# Rerun Workflow From a Step
+
+## Overview
+
+This skill resets a workflow to re-run from after a specific completed step. The current run is terminated and a new run is created that replays the workflow up to the given step (reusing its recorded output), then re-executes every step after it.
+
+Use this to avoid re-running expensive early steps (like LLM calls or slow HTTP requests) when you only need to iterate on a later step.
+
+## When to Use This Skill
+
+- A workflow failed late, but every step before the failure succeeded — rerun from after the last known-good step instead of starting over
+- You edited a prompt or step function that only affects steps after step N, and want to validate the change against the same upstream inputs
+- You want to branch off an existing run for debugging without re-paying the cost of its earlier LLM/API calls
+- Investigating non-determinism in a later step and want to hold earlier outputs constant
+
+## When NOT to Use This Skill
+
+- The workflow is still running — stop it first with `npx output workflow stop <id>` or `terminate <id>`
+- The target step never completed — reset requires a completed step to replay up to (returns a `409`)
+- You actually want a clean run from scratch — use `npx output workflow run <name>` or `workflow start <name>`
+- Earlier steps had side effects you need to re-execute (e.g. writes to an external system) — the replay skips them
+
+## Instructions
+
+### Basic Syntax
+
+```bash
+npx output workflow reset <workflowId> --step <stepName>
+npx output workflow reset <workflowId> --step <stepName> --reason "<why>"
+```
+
+| Flag | Short | Required | Description |
+|------|-------|----------|-------------|
+| `--step` | `-s` | yes | Name of the completed step to reset after |
+| `--reason` | `-r` | no | Free-text reason, recorded in Temporal history for auditability |
+
+The `workflowId` argument is required. The step name is the step function name as it appears in the trace (e.g. `fetchArticle`, `consolidateCompetitors`).
+
+### Finding the Step Name
+
+Step names come from the workflow's execution trace:
+
+```bash
+npx output workflow debug <workflowId> --format json
+```
+
+Look for step entries with `status: "completed"`. The step name is the one you pass to `--step`.
+
+### What the Command Returns
+
+On success the CLI prints the original `workflowId` and a **new** `runId` — the new run created by the reset. The pre-reset run is terminated.
+
+```
+Workflow reset successfully
+
+Workflow ID: lead_enrichment-a1b2c3d4
+New Run ID: 8f3e2a91-...
+Reset after step: consolidateCompetitors
+Reason: retrying with updated prompt
+```
+
+Use the new `runId` (via the pinned `workflow runs list`) to inspect the new execution. The `workflowId` is unchanged, so `workflow status` / `workflow result` will target the latest run by default.
+
+## Examples
+
+**Scenario**: Rerun after fixing a downstream prompt
+
+```bash
+# The workflow failed at `generateBlogPost`, but `consolidateCompetitors`
+# (the step before it) completed successfully.
+npx output workflow debug lead_enrichment-a1b2c3d4 --format json
+# ... confirms consolidateCompetitors completed
+
+# Edit src/workflows/lead_enrichment/prompts/generate_blog_post@v1.prompt
+# Then rerun from after the last good step — skipping the expensive
+# competitor consolidation LLM call.
+npx output workflow reset lead_enrichment-a1b2c3d4 \
+  --step consolidateCompetitors \
+  --reason "Retry with updated blog-post prompt"
+```
+
+**Scenario**: Iterate on a late step without re-paying upstream costs
+
+```bash
+# Workflow completed, but step output is wrong. Rerun just the last step.
+npx output workflow reset blog_evaluator-xyz789 --step analyze_claims
+
+# Check the new run's result
+npx output workflow result blog_evaluator-xyz789
+```
+
+**Scenario**: Record an audit reason
+
+```bash
+npx output workflow reset wf-12345 \
+  --step fetchCompanyData \
+  --reason "Source API returned stale data; rerunning after cache invalidation"
+```
+
+**Scenario**: Capture the new run ID for follow-up
+
+```bash
+# Grab the new runId from the reset output, then watch it
+npx output workflow reset lead_enrichment-a1b2c3d4 --step lookupCompany
+npx output workflow status lead_enrichment-a1b2c3d4
+npx output workflow result lead_enrichment-a1b2c3d4
+```
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `404` Workflow or step not found | Wrong `workflowId` or `--step` name | Check with `npx output workflow runs list` and `workflow debug <id>` |
+| `409` Step has not completed | Target step is still running or never ran | Wait for the step to complete, or pick an earlier completed step |
+| API returned invalid response | Transport failure | Check services with `docker ps | grep output` and `curl http://localhost:3001/health` |
+
+## Best Practices
+
+1. **Start from `workflow debug`** — confirm which steps completed before picking a reset point
+2. **Reset to the step whose output you want to keep** — reset runs everything *after* `<stepName>`; the step itself is not re-executed
+3. **Record a `--reason`** — it shows up in Temporal history and helps teammates (and future you) understand why the run forked
+4. **Prefer reset over full rerun for expensive workflows** — if early steps make multi-dollar LLM calls, reset saves real money
+5. **Verify side effects first** — if an early step writes to an external system, the replay won't re-write, which is usually what you want but occasionally isn't
+
+## Related Commands
+
+- `npx output workflow debug <id>` — find completed step names to pass to `--step`
+- `npx output workflow runs list` — see the new run created by reset alongside the terminated original
+- `npx output workflow status <id>` — check the new run's status
+- `npx output workflow result <id>` — get the new run's final output
+- `npx output workflow stop <id>` / `workflow terminate <id>` — stop a running workflow before resetting
+- `npx output workflow run <name>` / `workflow start <name>` — fresh run from scratch (no replay)

--- a/docs/guides/packages/cli.mdx
+++ b/docs/guides/packages/cli.mdx
@@ -36,6 +36,7 @@ npx output workflow run lead_enrichment acme
 | `output workflow result` | Get a completed workflow's result |
 | `output workflow stop` | Stop a workflow gracefully |
 | `output workflow terminate` | Force-stop a workflow |
+| `output workflow reset` | Rerun a workflow from after a completed step |
 | `output workflow debug` | Show the execution trace |
 | `output workflow cost` | Calculate execution cost from a trace |
 | `output workflow test` | Run evaluations against a workflow |
@@ -306,6 +307,30 @@ output workflow terminate wf-12345 --reason "Cleaning up old workflows"
 | `--reason, -r` | — | Reason for termination |
 
 Unlike `stop` (which cancels gracefully), `terminate` kills the workflow immediately.
+
+### output workflow reset
+
+Rerun a workflow from after a specific completed step. The current run is terminated and a new run is created that replays up to the given step (reusing its output), then re-executes every step after it. Useful when iterating on a late step without re-paying the cost of earlier LLM or API calls:
+
+```bash
+output workflow reset <workflowId> --step <stepName>
+output workflow reset lead_enrichment-a1b2c3d4 --step consolidateCompetitors --reason "Retry with updated prompt"
+```
+
+<ParamField path="workflowId" type="string" required>
+  The workflow execution ID
+</ParamField>
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--step, -s` | — | **Required.** Name of the completed step to reset after. The step itself is not re-executed; every step after it is. |
+| `--reason, -r` | — | Free-text reason, recorded in Temporal history for auditability |
+
+The command prints the original `workflowId` and a new `runId` for the fresh execution. Use `output workflow status <workflowId>` and `output workflow result <workflowId>` to track it.
+
+<Tip>
+Find valid step names with `output workflow debug <workflowId> --format json` — the step name you pass to `--step` is the one shown on completed step entries.
+</Tip>
 
 ### output workflow debug
 

--- a/docs/guides/workflows/running.mdx
+++ b/docs/guides/workflows/running.mdx
@@ -183,6 +183,22 @@ output workflow stop lead_enrichment-a1b2c3d4
 output workflow terminate lead_enrichment-a1b2c3d4 --reason "Cleaning up old runs"
 ```
 
+## Rerunning From a Step
+
+When a workflow fails late — or you've edited a prompt that only affects a downstream step — you usually don't want to re-run the whole thing. Early steps may have made expensive LLM calls, or slow API requests whose results haven't changed.
+
+`output workflow reset` creates a new run that replays up to a given completed step (reusing its recorded output), then re-executes every step after it:
+
+```bash
+# After editing a prompt used by `generate_blog_post`, rerun just the steps
+# after `consolidate_competitors` — the upstream competitor analysis is reused.
+output workflow reset lead_enrichment-a1b2c3d4 \
+  --step consolidate_competitors \
+  --reason "Retry with updated blog-post prompt"
+```
+
+Find valid step names with `output workflow debug <workflowId> --format json`. The step itself is not re-executed; only the steps after it.
+
 ## Quick Reference
 
 | What you want to do | Command |
@@ -194,6 +210,7 @@ output workflow terminate lead_enrichment-a1b2c3d4 --reason "Cleaning up old run
 | See the execution trace | `output workflow debug <workflowId>` |
 | Stop gracefully | `output workflow stop <workflowId>` |
 | Force stop | `output workflow terminate <workflowId>` |
+| Rerun from after a step | `output workflow reset <workflowId> --step <stepName>` |
 
 For the full CLI reference including all flags and additional commands like `workflow cost` and `workflow test`, see the [CLI package docs](/packages/cli).
 


### PR DESCRIPTION
- New `output-workflow-reset` skill surfaces the existing `npx output workflow reset` CLI command so Claude Code can rerun a workflow from after a completed step instead of starting over (OUT-425).
- Cross-linked from the `output-debug-workflow` skill and the `workflow-debugger` agent — both now recommend reset as the targeted-rerun option after a fix.
- Inventory in `output-meta-project-context` bumped (33 → 34 skills, Workflow Operations 5 → 6) and CLI quick reference updated; outputai plugin bumped to `0.2.1`.
- Public docs now cover the command: new `### output workflow reset` section in `docs/guides/packages/cli.mdx` and a "Rerunning From a Step" subsection plus quick-reference row in `docs/guides/workflows/running.mdx`.