### PR TITLE
fix(cli,api): show selected run's result in workflow runs pane

### DIFF
--- a/.changeset/out-426-pinned-run-result.md
+++ b/.changeset/out-426-pinned-run-result.md
@@ -1,0 +1,6 @@
+---
+"@outputai/cli": patch
+"output-api": patch
+---
+
+Fix the workflow runs pane in the CLI so the detail view reflects the highlighted run instead of always showing the latest run. `GET /workflow/runs` now includes `runId` per row, and the CLI fetches results via the pinned `GET /workflow/{id}/runs/{rid}/result` endpoint.

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -249,6 +249,10 @@
             "type": "string",
             "description": "Unique identifier for this run"
           },
+          "runId": {
+            "type": "string",
+            "description": "The specific run id for this execution"
+          },
           "workflowType": {
             "type": "string",
             "description": "Name of the workflow definition"

--- a/api/src/clients/temporal_client.js
+++ b/api/src/clients/temporal_client.js
@@ -612,6 +612,7 @@ export default {
        * Workflow run info
        * @typedef {Object} WorkflowRunInfo
        * @property {string} workflowId - The workflow execution id
+       * @property {string} runId - The specific run id for this execution
        * @property {string} workflowType - The workflow type/name
        * @property {string} status - The workflow execution status
        * @property {string} startedAt - The start date of the workflow execution (ISO 8601)
@@ -645,6 +646,7 @@ export default {
 
         const runs = executions.map( execution => ( {
           workflowId: execution.workflowId,
+          runId: execution.runId,
           workflowType: execution.type,
           status: mapWorkflowStatus( execution.status.name ),
           startedAt: execution.startTime.toISOString(),

--- a/api/src/clients/temporal_client.spec.js
+++ b/api/src/clients/temporal_client.spec.js
@@ -16,6 +16,7 @@ const {
   mockQuery,
   mockStart,
   mockGetHandle,
+  mockList,
   mockConnect,
   mockFetchHistory,
   mockCancel,
@@ -32,6 +33,7 @@ const {
   const mockQuery = vi.fn();
   const mockStart = vi.fn();
   const mockGetHandle = vi.fn();
+  const mockList = vi.fn();
   const mockConnect = vi.fn();
   const mockFetchHistory = vi.fn();
   const mockCancel = vi.fn();
@@ -57,6 +59,7 @@ const {
     mockQuery,
     mockStart,
     mockGetHandle,
+    mockList,
     mockConnect,
     mockFetchHistory,
     mockCancel,
@@ -75,7 +78,8 @@ vi.mock( '@temporalio/client', () => ( {
     return {
       workflow: {
         getHandle: mockGetHandle,
-        start: mockStart
+        start: mockStart,
+        list: mockList
       }
     };
   } ),
@@ -118,7 +122,17 @@ const walkCause = e => e?.cause ? walkCause( e.cause ) : ( e?.message ?? null );
 vi.mock( '#utils', () => ( {
   buildWorkflowId: vi.fn( () => 'test-uuid' ),
   extractTraceInfo: vi.fn( e => e?.details?.find?.( d => d.trace )?.trace ),
-  extractErrorMessage: vi.fn( e => walkCause( e ) )
+  extractErrorMessage: vi.fn( e => walkCause( e ) ),
+  takeFromAsyncIterable: async ( iterable, count ) => {
+    const items = [];
+    for await ( const item of iterable ) {
+      if ( items.length >= count ) {
+        break;
+      }
+      items.push( item );
+    }
+    return items;
+  }
 } ) );
 
 describe( 'temporal_client', () => {
@@ -1150,6 +1164,63 @@ describe( 'temporal_client', () => {
         'Temporal getWorkflowExecutionHistory returned no history field',
         expect.objectContaining( { workflowId: 'wf-123', runId: 'run-abc' } )
       );
+    } );
+  } );
+
+  describe( 'listWorkflowRuns', () => {
+    const asAsyncIterable = items => ( {
+      async *[Symbol.asyncIterator]() {
+        for ( const item of items ) {
+          yield item;
+        }
+      }
+    } );
+
+    it( 'includes runId on every run so the CLI can pin result fetches', async () => {
+      const executions = [
+        {
+          workflowId: 'wf-1',
+          runId: 'run-1',
+          type: 'factChecker',
+          status: { name: 'COMPLETED' },
+          startTime: new Date( '2024-04-15T12:00:00Z' ),
+          closeTime: new Date( '2024-04-15T12:05:00Z' )
+        },
+        {
+          workflowId: 'wf-1',
+          runId: 'run-2',
+          type: 'factChecker',
+          status: { name: 'RUNNING' },
+          startTime: new Date( '2024-04-15T12:10:00Z' ),
+          closeTime: null
+        }
+      ];
+      mockList.mockReturnValue( asAsyncIterable( executions ) );
+
+      const temporalClient = ( await import( './temporal_client.js' ) ).default;
+      const client = await temporalClient.init();
+      const result = await client.listWorkflowRuns( { workflowType: 'factChecker', limit: 10 } );
+
+      expect( mockList ).toHaveBeenCalledWith( { query: 'WorkflowType = "factChecker"' } );
+      expect( result.count ).toBe( 2 );
+      expect( result.runs ).toEqual( [
+        {
+          workflowId: 'wf-1',
+          runId: 'run-1',
+          workflowType: 'factChecker',
+          status: 'completed',
+          startedAt: '2024-04-15T12:00:00.000Z',
+          completedAt: '2024-04-15T12:05:00.000Z'
+        },
+        {
+          workflowId: 'wf-1',
+          runId: 'run-2',
+          workflowType: 'factChecker',
+          status: 'running',
+          startedAt: '2024-04-15T12:10:00.000Z',
+          completedAt: null
+        }
+      ] );
     } );
   } );
 } );

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -257,6 +257,9 @@ app.use( ( req, res, next ) => {
  *         workflowId:
  *           type: string
  *           description: Unique identifier for this run
+ *         runId:
+ *           type: string
+ *           description: The specific run id for this execution
  *         workflowType:
  *           type: string
  *           description: Name of the workflow definition

--- a/docs/guides/openapi.json
+++ b/docs/guides/openapi.json
@@ -249,6 +249,10 @@
             "type": "string",
             "description": "Unique identifier for this run"
           },
+          "runId": {
+            "type": "string",
+            "description": "The specific run id for this execution"
+          },
           "workflowType": {
             "type": "string",
             "description": "Name of the workflow definition"

--- a/sdk/cli/src/api/generated/api.ts
+++ b/sdk/cli/src/api/generated/api.ts
@@ -179,6 +179,8 @@ export const WorkflowRunInfoStatus = {
 export interface WorkflowRunInfo {
   /** Unique identifier for this run */
   workflowId?: string;
+  /** The specific run id for this execution */
+  runId?: string;
   /** Name of the workflow definition */
   workflowType?: string;
   /** Current run status */

--- a/sdk/cli/src/views/workflow/list.tsx
+++ b/sdk/cli/src/views/workflow/list.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { Box, Text, useInput } from 'ink';
 import Spinner from 'ink-spinner';
-import { getWorkflowIdResult, type WorkflowResultResponse } from '#api/generated/api.js';
+import { getWorkflowIdRunsRidResult, type WorkflowResultResponse } from '#api/generated/api.js';
 import type { WorkflowRun } from '#services/workflow_runs.js';
 import { StatusIcon, statusColor } from '#components/status_icon.js';
 import { elapsedMs, formatDurationCompact } from '#utils/date_formatter.js';
@@ -129,6 +129,7 @@ export const WorkflowListView: React.FC<{
   const clampedIndex = Math.min( selectedIndex, Math.max( 0, sortedRuns.length - 1 ) );
   const selectedRun = sortedRuns[clampedIndex];
   const selectedWorkflowId = selectedRun?.workflowId;
+  const selectedRunId = selectedRun?.runId;
 
   useEffect( () => {
     if ( clampedIndex !== selectedIndex ) {
@@ -137,12 +138,13 @@ export const WorkflowListView: React.FC<{
   }, [ clampedIndex, selectedIndex ] );
 
   useEffect( () => {
-    if ( !selectedWorkflowId ) {
+    if ( !selectedWorkflowId || !selectedRunId ) {
       setDetail( null );
       return;
     }
 
-    const cached = cacheRef.current.get( selectedWorkflowId );
+    const cacheKey = `${selectedWorkflowId}:${selectedRunId}`;
+    const cached = cacheRef.current.get( cacheKey );
     if ( cached ) {
       setDetail( cached );
       setDetailLoading( false );
@@ -152,13 +154,13 @@ export const WorkflowListView: React.FC<{
     const currentFetchId = ++fetchIdRef.current;
     setDetailLoading( true );
 
-    getWorkflowIdResult( selectedWorkflowId )
+    getWorkflowIdRunsRidResult( selectedWorkflowId, selectedRunId )
       .then( response => {
         if ( fetchIdRef.current !== currentFetchId ) {
           return;
         }
         const data = response.data as WorkflowResultResponse;
-        cacheRef.current.set( selectedWorkflowId, data );
+        cacheRef.current.set( cacheKey, data );
         setDetail( data );
         setDetailLoading( false );
       } )
@@ -169,7 +171,7 @@ export const WorkflowListView: React.FC<{
         setDetail( null );
         setDetailLoading( false );
       } );
-  }, [ selectedWorkflowId ] );
+  }, [ selectedWorkflowId, selectedRunId ] );
 
   useInput( ( input, key ) => {
     if ( key.upArrow ) {


### PR DESCRIPTION
## Problem

In the CLI's workflow runs pane, arrowing to any non-latest run still displayed the **latest** run's result. The detail fetch hit `GET /workflow/:id/result` — an unpinned "latest run" endpoint — so selection had no effect on the output shown.

Root cause was two-layered:

1. `sdk/cli/src/views/workflow/list.tsx` called `getWorkflowIdResult(workflowId)` on every selection change — always latest.
2. `GET /workflow/runs` didn't expose `runId` on each row, so even if the CLI wanted to pin, it had no id to pin with.

## Solution

- **API** — `listWorkflowRuns()` now forwards `runId` from each `WorkflowExecutionInfo`, and the `WorkflowRunInfo` swagger schema gains the field. OpenAPI specs (`api/openapi.json`, `docs/guides/openapi.json`) and the CLI's generated Orval client regenerated.
- **CLI** — `list.tsx` now fetches via `getWorkflowIdRunsRidResult(workflowId, runId)` (the pinned endpoint added in #135) and keys its in-memory cache by `${workflowId}:${runId}`. Fetch is gated on both ids being present.

Ref: [OUT-426](https://linear.app/growthx/issue/OUT-426)

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` — all 1582 tests pass, including new `listWorkflowRuns` coverage in `temporal_client.spec.js`
- [x] `npm run build:packages` passes
- [x] Manual smoke: linked a dev CLI build against a locally-rebuilt `outputai/api:dev` container — hovering older runs in `output workflow list` now shows the selected run's output instead of the latest run's.

## Follow-up (out of scope)

`GET /workflow/:wid/runs/:rid/result` throws `TypeError: Cannot read properties of undefined (reading 'output')` for the internal `$catalog` workflow. Pre-existing (same behavior on the unpinned endpoint) and unrelated to this fix — worth a separate ticket.