### PR TITLE
feat(cli): offer to initialize git in generated project

### DIFF
--- a/.changeset/long-meals-cover.md
+++ b/.changeset/long-meals-cover.md
@@ -2,4 +2,5 @@
 "@outputai/cli": patch
 ---
 
-Offer to initialize a git repository when running `output init`. Adds a `--skip-git` flag to opt out in non-interactive / scripted use.
+- Offer to initialize a git repository when running `output init`. Adds a `--skip-git` flag to opt out in non-interactive / scripted use.
+- Fix `--yes` / `--non-interactive` being rejected as "Nonexistent flag" by oclif's per-command parser when passed to any command.

--- a/.changeset/long-meals-cover.md
+++ b/.changeset/long-meals-cover.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Offer to initialize a git repository when running `output init`. Adds a `--skip-git` flag to opt out in non-interactive / scripted use.

--- a/.changeset/two-horses-cry.md
+++ b/.changeset/two-horses-cry.md
@@ -1,5 +1,0 @@
----
-"@outputai/cli": patch
----
-
-Fix `--yes` / `--non-interactive` flags being rejected as "Nonexistent flag" by oclif's per-command parser. The init hook now strips these global flags from `process.argv` after flipping the non-interactive state, so they reach the hook but not the command-level flag validator.

--- a/.changeset/two-horses-cry.md
+++ b/.changeset/two-horses-cry.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Fix `--yes` / `--non-interactive` flags being rejected as "Nonexistent flag" by oclif's per-command parser. The init hook now strips these global flags from `process.argv` after flipping the non-interactive state, so they reach the hook but not the command-level flag validator.

--- a/sdk/cli/src/commands/init.spec.ts
+++ b/sdk/cli/src/commands/init.spec.ts
@@ -48,7 +48,7 @@ describe( 'init command', () => {
       Object.defineProperty( cmd, 'parse', {
         value: vi.fn().mockResolvedValue( {
           args: { folderName: undefined, ...parsedArgs },
-          flags: { 'skip-env': false, ...flags }
+          flags: { 'skip-env': false, 'skip-git': false, ...flags }
         } ),
         configurable: true
       } );
@@ -66,11 +66,11 @@ describe( 'init command', () => {
       expect( typeof cmd.run ).toBe( 'function' );
     } );
 
-    it( 'should call runInit with skip-env flag and folder name', async () => {
+    it( 'should call runInit with skip-env flag, skip-git flag, and folder name', async () => {
       const cmd = createTestCommand();
       await cmd.run();
 
-      expect( projectScaffold.runInit ).toHaveBeenCalledWith( false, undefined );
+      expect( projectScaffold.runInit ).toHaveBeenCalledWith( false, false, undefined );
     } );
 
     it( 'should handle UserCancelledError', async () => {
@@ -117,14 +117,21 @@ describe( 'init command', () => {
       const cmd = createTestCommand( [], { 'skip-env': true } );
       await cmd.run();
 
-      expect( projectScaffold.runInit ).toHaveBeenCalledWith( true, undefined );
+      expect( projectScaffold.runInit ).toHaveBeenCalledWith( true, false, undefined );
+    } );
+
+    it( 'should pass skip-git flag to runInit when --skip-git is provided', async () => {
+      const cmd = createTestCommand( [], { 'skip-git': true } );
+      await cmd.run();
+
+      expect( projectScaffold.runInit ).toHaveBeenCalledWith( false, true, undefined );
     } );
 
     it( 'should pass folder name to runInit when provided', async () => {
       const cmd = createTestCommand( [], {}, { folderName: 'my-project' } );
       await cmd.run();
 
-      expect( projectScaffold.runInit ).toHaveBeenCalledWith( false, 'my-project' );
+      expect( projectScaffold.runInit ).toHaveBeenCalledWith( false, false, 'my-project' );
     } );
   } );
 } );

--- a/sdk/cli/src/commands/init.ts
+++ b/sdk/cli/src/commands/init.ts
@@ -22,6 +22,10 @@ export default class Init extends Command {
     'skip-env': Flags.boolean( {
       description: 'Skip interactive environment variable configuration',
       default: false
+    } ),
+    'skip-git': Flags.boolean( {
+      description: 'Skip git repository initialization',
+      default: false
     } )
   };
 
@@ -29,7 +33,7 @@ export default class Init extends Command {
     try {
       const { args, flags } = await this.parse( Init );
 
-      await runInit( flags['skip-env'], args.folderName );
+      await runInit( flags['skip-env'], flags['skip-git'], args.folderName );
     } catch ( error: unknown ) {
       if ( error instanceof UserCancelledError ) {
         this.log( error.message );

--- a/sdk/cli/src/hooks/init.spec.ts
+++ b/sdk/cli/src/hooks/init.spec.ts
@@ -1,9 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { checkForUpdate } from '#services/version_check.js';
+import { setNonInteractive } from '#utils/interactive.js';
 
 vi.mock( '#services/version_check.js', () => ( {
   checkForUpdate: vi.fn()
+} ) );
+
+vi.mock( '#utils/interactive.js', () => ( {
+  setNonInteractive: vi.fn()
 } ) );
 
 vi.mock( '@oclif/core', () => ( {
@@ -65,5 +70,51 @@ describe( 'init hook', () => {
     await hook.call( ctx as any, {} as any );
 
     expect( ux.stdout ).not.toHaveBeenCalled();
+  } );
+
+  describe( 'global interactive flags', () => {
+    const originalArgv = process.argv;
+
+    beforeEach( () => {
+      vi.mocked( checkForUpdate ).mockResolvedValue( {
+        updateAvailable: false,
+        currentVersion: '0.8.4',
+        latestVersion: '0.8.4'
+      } );
+    } );
+
+    afterEach( () => {
+      process.argv = originalArgv;
+    } );
+
+    it( 'should strip --yes from process.argv and flip non-interactive', async () => {
+      process.argv = [ 'node', 'run.js', 'init', '--yes', 'my-project' ];
+
+      const ctx = createHookContext();
+      await hook.call( ctx as any, {} as any );
+
+      expect( setNonInteractive ).toHaveBeenCalledWith( true );
+      expect( process.argv ).toEqual( [ 'node', 'run.js', 'init', 'my-project' ] );
+    } );
+
+    it( 'should strip --non-interactive from process.argv and flip non-interactive', async () => {
+      process.argv = [ 'node', 'run.js', 'init', '--non-interactive' ];
+
+      const ctx = createHookContext();
+      await hook.call( ctx as any, {} as any );
+
+      expect( setNonInteractive ).toHaveBeenCalledWith( true );
+      expect( process.argv ).toEqual( [ 'node', 'run.js', 'init' ] );
+    } );
+
+    it( 'should leave process.argv untouched when no global flag is present', async () => {
+      process.argv = [ 'node', 'run.js', 'init', '--skip-env' ];
+
+      const ctx = createHookContext();
+      await hook.call( ctx as any, {} as any );
+
+      expect( setNonInteractive ).not.toHaveBeenCalled();
+      expect( process.argv ).toEqual( [ 'node', 'run.js', 'init', '--skip-env' ] );
+    } );
   } );
 } );

--- a/sdk/cli/src/hooks/init.spec.ts
+++ b/sdk/cli/src/hooks/init.spec.ts
@@ -19,7 +19,7 @@ vi.mock( '@oclif/core', () => ( {
 } ) );
 
 import { ux } from '@oclif/core';
-import hook from './init.js';
+import hook, { hasInteractiveFlag, stripGlobalFlags } from './init.js';
 
 describe( 'init hook', () => {
   beforeEach( () => {
@@ -96,7 +96,6 @@ describe( 'init hook', () => {
       await hook.call( ctx as any, { argv: optsArgv, id: 'init' } as any );
 
       expect( setNonInteractive ).toHaveBeenCalledWith( true );
-      // Same reference — oclif forwards this array to the command parser.
       expect( optsArgv ).toBe( argvRef );
       expect( optsArgv ).toEqual( [ 'my-project' ] );
       expect( process.argv ).toEqual( [ 'node', 'run.js', 'init', 'my-project' ] );
@@ -124,6 +123,44 @@ describe( 'init hook', () => {
       expect( setNonInteractive ).not.toHaveBeenCalled();
       expect( optsArgv ).toEqual( [ '--skip-env' ] );
       expect( process.argv ).toEqual( [ 'node', 'run.js', 'init', '--skip-env' ] );
+    } );
+  } );
+
+  describe( 'hasInteractiveFlag', () => {
+    it( 'returns true when --yes is present', () => {
+      expect( hasInteractiveFlag( [ 'init', '--yes', 'foo' ] ) ).toBe( true );
+    } );
+
+    it( 'returns true when --non-interactive is present', () => {
+      expect( hasInteractiveFlag( [ '--non-interactive' ] ) ).toBe( true );
+    } );
+
+    it( 'returns false for unrelated flags', () => {
+      expect( hasInteractiveFlag( [ 'init', '--skip-env', '--skip-git' ] ) ).toBe( false );
+    } );
+
+    it( 'returns false for an empty argv', () => {
+      expect( hasInteractiveFlag( [] ) ).toBe( false );
+    } );
+  } );
+
+  describe( 'stripGlobalFlags', () => {
+    it( 'mutates argv in place to remove global flags', () => {
+      const argv = [ 'init', '--yes', 'foo', '--non-interactive' ];
+      const ref = argv;
+
+      stripGlobalFlags( argv );
+
+      expect( argv ).toBe( ref );
+      expect( argv ).toEqual( [ 'init', 'foo' ] );
+    } );
+
+    it( 'leaves argv untouched when no global flag is present', () => {
+      const argv = [ 'init', '--skip-env' ];
+
+      stripGlobalFlags( argv );
+
+      expect( argv ).toEqual( [ 'init', '--skip-env' ] );
     } );
   } );
 } );

--- a/sdk/cli/src/hooks/init.spec.ts
+++ b/sdk/cli/src/hooks/init.spec.ts
@@ -38,7 +38,7 @@ describe( 'init hook', () => {
     } );
 
     const ctx = createHookContext();
-    await hook.call( ctx as any, {} as any );
+    await hook.call( ctx as any, { argv: [], id: undefined } as any );
 
     expect( checkForUpdate ).toHaveBeenCalledWith( '0.8.4', '/tmp/test-cache' );
     expect( ux.stdout ).toHaveBeenCalled();
@@ -58,7 +58,7 @@ describe( 'init hook', () => {
     } );
 
     const ctx = createHookContext();
-    await hook.call( ctx as any, {} as any );
+    await hook.call( ctx as any, { argv: [], id: undefined } as any );
 
     expect( ux.stdout ).not.toHaveBeenCalled();
   } );
@@ -67,7 +67,7 @@ describe( 'init hook', () => {
     vi.mocked( checkForUpdate ).mockRejectedValue( new Error( 'network failure' ) );
 
     const ctx = createHookContext();
-    await hook.call( ctx as any, {} as any );
+    await hook.call( ctx as any, { argv: [], id: undefined } as any );
 
     expect( ux.stdout ).not.toHaveBeenCalled();
   } );
@@ -87,33 +87,42 @@ describe( 'init hook', () => {
       process.argv = originalArgv;
     } );
 
-    it( 'should strip --yes from process.argv and flip non-interactive', async () => {
+    it( 'should mutate opts.argv in place to strip --yes', async () => {
       process.argv = [ 'node', 'run.js', 'init', '--yes', 'my-project' ];
+      const optsArgv = [ '--yes', 'my-project' ];
+      const argvRef = optsArgv;
 
       const ctx = createHookContext();
-      await hook.call( ctx as any, {} as any );
+      await hook.call( ctx as any, { argv: optsArgv, id: 'init' } as any );
 
       expect( setNonInteractive ).toHaveBeenCalledWith( true );
+      // Same reference — oclif forwards this array to the command parser.
+      expect( optsArgv ).toBe( argvRef );
+      expect( optsArgv ).toEqual( [ 'my-project' ] );
       expect( process.argv ).toEqual( [ 'node', 'run.js', 'init', 'my-project' ] );
     } );
 
-    it( 'should strip --non-interactive from process.argv and flip non-interactive', async () => {
+    it( 'should mutate opts.argv in place to strip --non-interactive', async () => {
       process.argv = [ 'node', 'run.js', 'init', '--non-interactive' ];
+      const optsArgv = [ '--non-interactive' ];
 
       const ctx = createHookContext();
-      await hook.call( ctx as any, {} as any );
+      await hook.call( ctx as any, { argv: optsArgv, id: 'init' } as any );
 
       expect( setNonInteractive ).toHaveBeenCalledWith( true );
+      expect( optsArgv ).toEqual( [] );
       expect( process.argv ).toEqual( [ 'node', 'run.js', 'init' ] );
     } );
 
-    it( 'should leave process.argv untouched when no global flag is present', async () => {
+    it( 'should leave argv untouched when no global flag is present', async () => {
       process.argv = [ 'node', 'run.js', 'init', '--skip-env' ];
+      const optsArgv = [ '--skip-env' ];
 
       const ctx = createHookContext();
-      await hook.call( ctx as any, {} as any );
+      await hook.call( ctx as any, { argv: optsArgv, id: 'init' } as any );
 
       expect( setNonInteractive ).not.toHaveBeenCalled();
+      expect( optsArgv ).toEqual( [ '--skip-env' ] );
       expect( process.argv ).toEqual( [ 'node', 'run.js', 'init', '--skip-env' ] );
     } );
   } );

--- a/sdk/cli/src/hooks/init.ts
+++ b/sdk/cli/src/hooks/init.ts
@@ -4,14 +4,25 @@ import { setNonInteractive } from '#utils/interactive.js';
 
 const GLOBAL_FLAGS = new Set( [ '--yes', '--non-interactive' ] );
 
-const hook: Hook<'init'> = async function () {
-  const hadGlobalFlag = process.argv.some( arg => GLOBAL_FLAGS.has( arg ) );
+// Strip global flags from an argv array IN PLACE. oclif threads the same
+// array reference from its init hook into the command parser, so a splice
+// here removes the flags before the per-command strict validator sees them.
+// Reassignment (`argv = argv.filter(...)`) would break that shared reference.
+const stripGlobalFlags = ( argv: string[] ): boolean => {
+  const kept = argv.filter( arg => !GLOBAL_FLAGS.has( arg ) );
+  if ( kept.length === argv.length ) {
+    return false;
+  }
+  argv.splice( 0, argv.length, ...kept );
+  return true;
+};
 
-  if ( hadGlobalFlag ) {
+const hook: Hook<'init'> = async function ( opts ) {
+  const strippedFromOpts = stripGlobalFlags( opts.argv );
+  const strippedFromProcess = stripGlobalFlags( process.argv );
+
+  if ( strippedFromOpts || strippedFromProcess ) {
     setNonInteractive( true );
-    // Strip these flags so oclif's per-command strict parser doesn't reject
-    // them (they're handled globally here, not declared on any command).
-    process.argv = process.argv.filter( arg => !GLOBAL_FLAGS.has( arg ) );
   }
 
   try {

--- a/sdk/cli/src/hooks/init.ts
+++ b/sdk/cli/src/hooks/init.ts
@@ -2,26 +2,27 @@ import { Hook, ux } from '@oclif/core';
 import { checkForUpdate } from '#services/version_check.js';
 import { setNonInteractive } from '#utils/interactive.js';
 
-const GLOBAL_FLAGS = new Set( [ '--yes', '--non-interactive' ] );
+export const INTERACTIVE_FLAGS = [ '--yes', '--non-interactive' ];
 
-// Strip global flags from an argv array IN PLACE. oclif threads the same
-// array reference from its init hook into the command parser, so a splice
-// here removes the flags before the per-command strict validator sees them.
-// Reassignment (`argv = argv.filter(...)`) would break that shared reference.
-const stripGlobalFlags = ( argv: string[] ): boolean => {
+export const GLOBAL_FLAGS = new Set<string>( INTERACTIVE_FLAGS );
+
+export const hasInteractiveFlag = ( argv: string[] ): boolean =>
+  argv.some( arg => INTERACTIVE_FLAGS.includes( arg ) );
+
+export const stripGlobalFlags = ( argv: string[] ): void => {
   const kept = argv.filter( arg => !GLOBAL_FLAGS.has( arg ) );
-  if ( kept.length === argv.length ) {
-    return false;
+  if ( kept.length !== argv.length ) {
+    argv.splice( 0, argv.length, ...kept );
   }
-  argv.splice( 0, argv.length, ...kept );
-  return true;
 };
 
 const hook: Hook<'init'> = async function ( opts ) {
-  const strippedFromOpts = stripGlobalFlags( opts.argv );
-  const strippedFromProcess = stripGlobalFlags( process.argv );
+  const interactive = hasInteractiveFlag( opts.argv ) || hasInteractiveFlag( process.argv );
 
-  if ( strippedFromOpts || strippedFromProcess ) {
+  stripGlobalFlags( opts.argv );
+  stripGlobalFlags( process.argv );
+
+  if ( interactive ) {
     setNonInteractive( true );
   }
 

--- a/sdk/cli/src/hooks/init.ts
+++ b/sdk/cli/src/hooks/init.ts
@@ -2,9 +2,16 @@ import { Hook, ux } from '@oclif/core';
 import { checkForUpdate } from '#services/version_check.js';
 import { setNonInteractive } from '#utils/interactive.js';
 
+const GLOBAL_FLAGS = new Set( [ '--yes', '--non-interactive' ] );
+
 const hook: Hook<'init'> = async function () {
-  if ( process.argv.includes( '--yes' ) || process.argv.includes( '--non-interactive' ) ) {
+  const hadGlobalFlag = process.argv.some( arg => GLOBAL_FLAGS.has( arg ) );
+
+  if ( hadGlobalFlag ) {
     setNonInteractive( true );
+    // Strip these flags so oclif's per-command strict parser doesn't reject
+    // them (they're handled globally here, not declared on any command).
+    process.argv = process.argv.filter( arg => !GLOBAL_FLAGS.has( arg ) );
   }
 
   try {

--- a/sdk/cli/src/services/project_scaffold.ts
+++ b/sdk/cli/src/services/project_scaffold.ts
@@ -165,6 +165,25 @@ async function initializeAgents( projectPath: string ): Promise<void> {
   await initializeAgentConfig( { projectRoot: projectPath, force: false } );
 }
 
+async function maybeInitializeGit( projectPath: string ): Promise<boolean> {
+  const shouldInit = await confirm( {
+    message: 'Initialize a git repository?',
+    default: true
+  } );
+
+  if ( !shouldInit ) {
+    return false;
+  }
+
+  return executeCommandWithMessages(
+    async () => {
+      await executeCommand( 'git', [ 'init' ], projectPath );
+    },
+    'Initializing git repository...',
+    'Git repository initialized'
+  );
+}
+
 /**
  * Format error message for init errors
  * Single responsibility: only format error messages, no cleanup logic
@@ -239,10 +258,12 @@ interface RunInitState {
 /**
  * Run the init command workflow
  * @param skipEnv - Whether to skip environment configuration prompts
+ * @param skipGit - Whether to skip git repository initialization
  * @param folderName - Optional folder name to skip folder name prompt
  */
 export async function runInit(
   skipEnv: boolean = false,
+  skipGit: boolean = false,
   folderName?: string
 ): Promise<void> {
   // Track state for SIGINT cleanup using an object to avoid let
@@ -310,6 +331,10 @@ export async function runInit(
       'Installing dependencies...',
       'Dependencies installed'
     );
+
+    if ( !skipGit ) {
+      await maybeInitializeGit( config.projectPath );
+    }
 
     const nextSteps = getProjectSuccessMessage( config.folderName, installSuccess, credentialsConfigured );
     ux.stdout( 'Project created successfully!' );

--- a/sdk/cli/src/services/project_scaffold.ts
+++ b/sdk/cli/src/services/project_scaffold.ts
@@ -258,7 +258,6 @@ interface RunInitState {
 /**
  * Run the init command workflow
  * @param skipEnv - Whether to skip environment configuration prompts
- * @param skipGit - Whether to skip git repository initialization
  * @param folderName - Optional folder name to skip folder name prompt
  */
 export async function runInit(


### PR DESCRIPTION
## Summary

- `output init` now prompts "Initialize a git repository?" (default yes) after `npm install` and runs `git init` in the new project folder when accepted
- Adds `--skip-git` flag, mirroring the existing `--skip-env` pattern for non-interactive / scripted use
- Reuses the existing `executeCommandWithMessages` wrapper so a missing `git` binary or non-zero exit downgrades to a warning instead of failing the whole scaffold
- `.gitignore` is already shipped by the template processor, so the fresh repo immediately ignores `node_modules/`, `.env`, credential `.key` files, etc.

Ref: [OUT-396](https://linear.app/growthx/issue/OUT-396/offer-to-initialize-git-in-generated-project)

## Test plan

- [x] `npm run lint` passes
- [x] `tsc --noEmit` on `@outputai/cli` passes
- [x] Smoke test `--skip-git`: `output init demo --skip-env --skip-git` — no `.git` directory created, no prompt shown
- [x] Smoke test default-accept (non-interactive): `output init demo --skip-env` — `.git` directory created, `git status` clean of ignored paths
- [ ] Manual interactive run: accept the prompt, then decline, confirm both paths behave correctly

## Out of scope

- Auto-cd'ing into the new folder (intentionally deferred — a child process can't change the parent shell's cwd without a shell wrapper, and the ticket's primary ask is the git init offer)