### PR TITLE
fix(cli): shadow worker node_modules to stop host corruption

### DIFF
--- a/.changeset/silly-bags-pick.md
+++ b/.changeset/silly-bags-pick.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Shadow the worker container's `/app/node_modules` with a named Docker volume so the worker's in-container `npm install` no longer leaks Linux-native binaries onto the host's `node_modules/`.

--- a/.changeset/silly-bags-pick.md
+++ b/.changeset/silly-bags-pick.md
@@ -2,4 +2,4 @@
 "@outputai/cli": patch
 ---
 
-Shadow the worker container's workflow-dir `node_modules` with a named Docker volume so the worker's in-container install no longer leaks Linux-native artifacts onto the host's `node_modules/`.
+Shadow the worker container's `/app/node_modules` (root pnpm store) with a named Docker volume and run an explicit `output:worker:install` before `output:worker:watch`, so Linux-native packages installed in the container no longer leak into the host's `node_modules/`.

--- a/.changeset/silly-bags-pick.md
+++ b/.changeset/silly-bags-pick.md
@@ -2,4 +2,4 @@
 "@outputai/cli": patch
 ---
 
-Shadow the worker container's `/app/node_modules` with a named Docker volume so the worker's in-container `npm install` no longer leaks Linux-native binaries onto the host's `node_modules/`.
+Shadow the worker container's workflow-dir `node_modules` with a named Docker volume so the worker's in-container install no longer leaks Linux-native artifacts onto the host's `node_modules/`.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,7 +50,7 @@ services:
     working_dir: /app
     volumes:
       - ./:/app
-      - worker_node_modules:/app/test_workflows/node_modules
+      - worker_node_modules:/app/node_modules
 
 volumes:
   worker_node_modules:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -46,7 +46,11 @@ services:
       - OUTPUT_TRACE_LOCAL_ON=true
       - OUTPUT_TRACE_HOST_PATH=${PWD}/test_workflows/logs
       - NODE_OPTIONS=${NODE_OPTIONS:---max-old-space-size=4096}
-    command: sh -c "corepack enable && npm run build:packages && cd ./test_workflows && npm run output:worker:watch"
+    command: sh -c "corepack enable && pnpm install --frozen-lockfile && npm run build:packages && cd ./test_workflows && npm run output:worker:watch"
     working_dir: /app
     volumes:
       - ./:/app
+      - worker_node_modules:/app/node_modules
+
+volumes:
+  worker_node_modules:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -50,7 +50,7 @@ services:
     working_dir: /app
     volumes:
       - ./:/app
-      - worker_node_modules:/app/node_modules
+      - worker_node_modules:/app/test_workflows/node_modules
 
 volumes:
   worker_node_modules:

--- a/sdk/cli/src/assets/docker/docker-compose-dev.yml
+++ b/sdk/cli/src/assets/docker/docker-compose-dev.yml
@@ -126,11 +126,11 @@ services:
       - OUTPUT_TRACE_HTTP_VERBOSE=${OUTPUT_TRACE_HTTP_VERBOSE:-true}
       - TEMPORAL_ADDRESS=temporal:7233
       - NODE_OPTIONS=${NODE_OPTIONS:---max-old-space-size=4096}
-    command: sh -c "corepack enable && npm run output:worker:watch"
+    command: sh -c "corepack enable && npm run output:worker:install && npm run output:worker:watch"
     working_dir: /app/${OUTPUT_WORKFLOWS_DIR:-.}
     volumes:
       - ./:/app
-      - worker_node_modules:/app/${OUTPUT_WORKFLOWS_DIR:-.}/node_modules
+      - worker_node_modules:/app/node_modules
 
 volumes:
   postgres:

--- a/sdk/cli/src/assets/docker/docker-compose-dev.yml
+++ b/sdk/cli/src/assets/docker/docker-compose-dev.yml
@@ -130,7 +130,7 @@ services:
     working_dir: /app/${OUTPUT_WORKFLOWS_DIR:-.}
     volumes:
       - ./:/app
-      - worker_node_modules:/app/${OUTPUT_WORKFLOWS_DIR:-.}/node_modules
+      - worker_node_modules:/app/node_modules
 
 volumes:
   postgres:

--- a/sdk/cli/src/assets/docker/docker-compose-dev.yml
+++ b/sdk/cli/src/assets/docker/docker-compose-dev.yml
@@ -130,7 +130,7 @@ services:
     working_dir: /app/${OUTPUT_WORKFLOWS_DIR:-.}
     volumes:
       - ./:/app
-      - worker_node_modules:/app/node_modules
+      - worker_node_modules:/app/${OUTPUT_WORKFLOWS_DIR:-.}/node_modules
 
 volumes:
   postgres:


### PR DESCRIPTION
## Problem

When `output dev` (`npm run dev` → `npm run dev:up`) spins up the worker container, the bind-mounted `./:/app` exposes the host's `node_modules/` to the container. The worker then runs an install step inside Linux:

- Framework dev (`OUTPUT_WORKFLOWS_DIR=test_workflows`): `output:worker:install` → `pnpm install --frozen-lockfile`
- CLI customer template: `output:worker:install` → `npm install`

For pnpm-workspace projects (the framework, also any customer that uses workspaces), the resulting Linux-native package contents land under `/app/node_modules/.pnpm/` — directly on the host. Concrete failure mode: after one `output dev` + Ctrl+C, the host's `node_modules/.pnpm/@esbuild+linux-arm64@…` is present, and the next `npm run dev` fails on host:

```
You installed esbuild for another platform than the one you're currently using.
the @esbuild/linux-arm64 package is present but this version needs the @esbuild/darwin-arm64 package instead.
```

## Solution

Shadow `/app/node_modules` (the root, where `.pnpm` actually lives) with the `worker_node_modules` named volume in both composes. The container gets its own Linux pnpm store inside the volume; the host's `node_modules/.pnpm/` is untouched.

The named volume persists across container restarts (so the second `output dev` boot is fast) and is purged by `docker compose down -v` / `./run.sh dev:destroy`.

### `docker-compose.dev.yml` (framework)

- Mount `worker_node_modules` at `/app/node_modules`.
- Worker startup already runs `pnpm install --frozen-lockfile` before `npm run build:packages`, so the shadow gets seeded on first boot.

### `sdk/cli/src/assets/docker/docker-compose-dev.yml` (CLI / customer-facing)

- Mount `worker_node_modules` at `/app/node_modules` (was `/app/${OUTPUT_WORKFLOWS_DIR:-.}/node_modules`, which left the root `.pnpm` store on the bind mount).
- Worker command extended to `corepack enable && npm run output:worker:install && npm run output:worker:watch`.

### Why the explicit `output:worker:install` in the CLI compose command

The shadow named volume starts **empty** on first boot (Docker only seeds named volumes from image content at the mount path; `node:24.15.0-slim` has nothing at `/app/node_modules`). `output:worker:watch` immediately launches `npx nodemon`, but `nodemon` is a workspace dep — its symlink at `<workflow_dir>/node_modules/nodemon` points into `../../node_modules/.pnpm/nodemon@…/`, which is now the empty shadow. Without populating the shadow first, the worker dies with `Cannot find module '<workflow_dir>/node_modules/nodemon/bin/nodemon.js'`.

We considered fixing this in the customer's package.json template instead — making `output:worker:watch` install before launching nodemon, and dropping install from nodemon's `--exec` chain. We chose **not** to:

- The compose command is the right layer for this. It's an infra-level guarantee that the shadow is populated before the worker process starts — exactly the kind of bootstrap a Dockerfile's `RUN npm install` provides for production images. We're doing the same thing in dev, just at compose-startup time so the result lands in the named volume.
- Customer-facing scripts stay untouched. No template churn, no need for existing scaffolded projects to run `output fix` to pick up a new script shape, no risk of a downstream user shaping their own watch script in a way that breaks the shadow bootstrap.
- Yes, it means install runs once at compose boot **and** again on each nodemon-triggered file change (since `output:worker` re-runs `output:worker:install`). The boot install is fast against a frozen lockfile, and re-runs after the volume is populated are essentially no-ops, so the cost is negligible.

Ref: [OUT-422](https://linear.app/growthx/issue/OUT-422)

## Verification (run locally)

End-to-end test, **starting from a clean host** (`pnpm install` natively → `node_modules/.pnpm/` contains `@esbuild+darwin-arm64@…` only):

- [x] `docker compose --project-directory . -f sdk/cli/src/assets/docker/docker-compose-dev.yml down -v` — drop any old volumes
- [x] **Cycle 1**: `OUTPUT_API_VERSION=dev OUTPUT_WORKFLOWS_DIR=test_workflows docker compose --project-directory . -f sdk/cli/src/assets/docker/docker-compose-dev.yml up -d` — all containers healthy (worker starts catalog workflow successfully)
- [x] Host snapshot after cycle 1: `node_modules/.pnpm/` still contains only `@esbuild+darwin-arm64`, no `linux-*` artifacts anywhere under `node_modules/`
- [x] `docker compose down` (preserve volumes, simulating the user's Ctrl+C and re-run)
- [x] **Cycle 2**: `npm run build:packages` on host — succeeds (this was the failing step from the report)
- [x] `docker compose up -d` again — all containers healthy
- [x] Host stays darwin-only after cycle 2

## Out of scope

`run.sh` lines 50-54 (the `./run.sh dev` path, not `output dev`) still run `pnpm install --frozen-lockfile` inside a Linux `docker run` with `-v $(pwd):/app`, which writes Linux artifacts into the host's `node_modules/.pnpm/`. Separate corruption source from the worker container itself; follow-up if it still bites.