### PR TITLE
fix: Use lazy getters to defer processing ENV until after reading .env file

### DIFF
--- a/.changeset/soft-teeth-mix.md
+++ b/.changeset/soft-teeth-mix.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Fix issue where values in .env files were silently ignored

--- a/sdk/cli/src/api/http_client.ts
+++ b/sdk/cli/src/api/http_client.ts
@@ -31,26 +31,31 @@ export type ApiRequestOptions = RequestInit & {
   config?: KyOptions;
 };
 
-const api = ky.create( {
-  prefixUrl: config.apiUrl,
-  timeout: config.requestTimeout,
-  retry: {
-    limit: 2,
-    methods: [ 'get', 'put', 'head', 'delete', 'options', 'trace' ],
-    statusCodes: [ 408, 413, 429, 502, 503, 504 ]
-  },
-  throwHttpErrors: false,
-  hooks: {
-    beforeRequest: [
-      request => {
-        // Add auth token if available
-        if ( config.apiToken ) {
-          request.headers.set( 'Authorization', `Basic ${config.apiToken}` );
-        }
+const _state: { api?: ReturnType<typeof ky.create> } = {};
+function getApi() {
+  if ( !_state.api ) {
+    _state.api = ky.create( {
+      prefixUrl: config.apiUrl,
+      timeout: config.requestTimeout,
+      retry: {
+        limit: 2,
+        methods: [ 'get', 'put', 'head', 'delete', 'options', 'trace' ],
+        statusCodes: [ 408, 413, 429, 502, 503, 504 ]
+      },
+      throwHttpErrors: false,
+      hooks: {
+        beforeRequest: [
+          request => {
+            if ( config.apiToken ) {
+              request.headers.set( 'Authorization', `Basic ${config.apiToken}` );
+            }
+          }
+        ]
       }
-    ]
+    } );
   }
-} );
+  return _state.api;
+}
 
 const stripLeadingSlash = ( url: string ): string =>
   url.startsWith( '/' ) ? url.slice( 1 ) : url;
@@ -81,7 +86,7 @@ export const customFetchInstance = async <T>(
   url: string,
   options: ApiRequestOptions
 ): Promise<T> => {
-  const response = await api(
+  const response = await getApi()(
     stripLeadingSlash( url ),
     buildKyOptions( options )
   );

--- a/sdk/cli/src/api/http_client.ts
+++ b/sdk/cli/src/api/http_client.ts
@@ -31,10 +31,10 @@ export type ApiRequestOptions = RequestInit & {
   config?: KyOptions;
 };
 
-const _state: { api?: ReturnType<typeof ky.create> } = {};
+const apiState: { api?: ReturnType<typeof ky.create> } = {};
 function getApi() {
-  if ( !_state.api ) {
-    _state.api = ky.create( {
+  if ( !apiState.api ) {
+    apiState.api = ky.create( {
       prefixUrl: config.apiUrl,
       timeout: config.requestTimeout,
       retry: {
@@ -54,7 +54,7 @@ function getApi() {
       }
     } );
   }
-  return _state.api;
+  return apiState.api;
 }
 
 const stripLeadingSlash = ( url: string ): string =>

--- a/sdk/cli/src/config.spec.ts
+++ b/sdk/cli/src/config.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { config } from '#config.js';
+
+describe( 'config', () => {
+  const envVars = [
+    'OUTPUT_API_URL',
+    'OUTPUT_API_AUTH_TOKEN',
+    'DOCKER_SERVICE_NAME',
+    'OUTPUT_DEBUG',
+    'OUTPUT_CLI_ENV',
+    'OUTPUT_TRACE_REMOTE_S3_BUCKET',
+    'OUTPUT_AWS_REGION',
+    'OUTPUT_AWS_ACCESS_KEY_ID',
+    'OUTPUT_AWS_SECRET_ACCESS_KEY'
+  ] as const;
+
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach( () => {
+    for ( const key of envVars ) {
+      saved[key] = process.env[key];
+    }
+  } );
+
+  afterEach( () => {
+    for ( const key of envVars ) {
+      if ( saved[key] === undefined ) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  } );
+
+  it( 'reads env vars lazily, not at module evaluation time', () => {
+    process.env.OUTPUT_API_URL = 'https://lazy-test.example.com';
+    expect( config.apiUrl ).toBe( 'https://lazy-test.example.com' );
+
+    process.env.OUTPUT_API_URL = 'https://changed.example.com';
+    expect( config.apiUrl ).toBe( 'https://changed.example.com' );
+  } );
+
+  it( 'falls back to defaults when env vars are unset', () => {
+    delete process.env.OUTPUT_API_URL;
+    delete process.env.DOCKER_SERVICE_NAME;
+    delete process.env.OUTPUT_DEBUG;
+    delete process.env.OUTPUT_CLI_ENV;
+
+    expect( config.apiUrl ).toBe( 'http://localhost:3001' );
+    expect( config.dockerServiceName ).toBe( 'output-sdk' );
+    expect( config.debugMode ).toBe( false );
+    expect( config.envFile ).toBe( '.env' );
+  } );
+
+  it( 'reads apiToken from env', () => {
+    process.env.OUTPUT_API_AUTH_TOKEN = 'test-token-123';
+    expect( config.apiToken ).toBe( 'test-token-123' );
+
+    delete process.env.OUTPUT_API_AUTH_TOKEN;
+    expect( config.apiToken ).toBeUndefined();
+  } );
+
+  it( 'reads debugMode as boolean', () => {
+    process.env.OUTPUT_DEBUG = 'true';
+    expect( config.debugMode ).toBe( true );
+
+    process.env.OUTPUT_DEBUG = 'false';
+    expect( config.debugMode ).toBe( false );
+  } );
+
+  it( 'reads s3 config lazily', () => {
+    process.env.OUTPUT_TRACE_REMOTE_S3_BUCKET = 'my-bucket';
+    process.env.OUTPUT_AWS_REGION = 'us-west-2';
+    process.env.OUTPUT_AWS_ACCESS_KEY_ID = 'AKIA123';
+    process.env.OUTPUT_AWS_SECRET_ACCESS_KEY = 'secret123';
+
+    expect( config.s3 ).toEqual( {
+      bucket: 'my-bucket',
+      region: 'us-west-2',
+      accessKeyId: 'AKIA123',
+      secretAccessKey: 'secret123'
+    } );
+  } );
+
+  it( 'has static properties that are not env-derived', () => {
+    expect( config.requestTimeout ).toBe( 30000 );
+    expect( config.agentConfigDir ).toBe( '.outputai' );
+  } );
+} );

--- a/sdk/cli/src/config.ts
+++ b/sdk/cli/src/config.ts
@@ -1,54 +1,27 @@
-/**
- * CLI configuration
- */
 export const config = {
-  /**
-   * Base URL for the Output.ai API server
-   * Can be overridden with OUTPUT_API_URL environment variable
-   */
-  apiUrl: process.env.OUTPUT_API_URL || 'http://localhost:3001',
-
-  /**
-   * API authentication token
-   * Set via OUTPUT_API_AUTH_TOKEN environment variable
-   */
-  apiToken: process.env.OUTPUT_API_AUTH_TOKEN,
-
-  /**
-   * Default timeout for API requests (in milliseconds)
-   */
+  get apiUrl() {
+    return process.env.OUTPUT_API_URL || 'http://localhost:3001';
+  },
+  get apiToken() {
+    return process.env.OUTPUT_API_AUTH_TOKEN;
+  },
   requestTimeout: 30000,
-
-  /**
-   * Docker Compose project name
-   * Can be overridden with DOCKER_SERVICE_NAME environment variable
-   */
-  dockerServiceName: process.env.DOCKER_SERVICE_NAME || 'output-sdk',
-
-  /**
-   * Set the debug mode
-   */
-  debugMode: process.env.OUTPUT_DEBUG === 'true',
-
-  /**
-   * Where the env vars are stored, defaults to `.env`
-   */
-  envFile: process.env.OUTPUT_CLI_ENV || '.env',
-
-  /**
-   * Agent configuration directory name
-   */
+  get dockerServiceName() {
+    return process.env.DOCKER_SERVICE_NAME || 'output-sdk';
+  },
+  get debugMode() {
+    return process.env.OUTPUT_DEBUG === 'true';
+  },
+  get envFile() {
+    return process.env.OUTPUT_CLI_ENV || '.env';
+  },
   agentConfigDir: '.outputai',
-
-  /**
-   * S3 configuration for remote trace storage
-   * Set via OUTPUT_TRACE_REMOTE_S3_BUCKET, OUTPUT_AWS_REGION,
-   * OUTPUT_AWS_ACCESS_KEY_ID, and OUTPUT_AWS_SECRET_ACCESS_KEY environment variables
-   */
-  s3: {
-    bucket: process.env.OUTPUT_TRACE_REMOTE_S3_BUCKET,
-    region: process.env.OUTPUT_AWS_REGION,
-    accessKeyId: process.env.OUTPUT_AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.OUTPUT_AWS_SECRET_ACCESS_KEY
+  get s3() {
+    return {
+      bucket: process.env.OUTPUT_TRACE_REMOTE_S3_BUCKET,
+      region: process.env.OUTPUT_AWS_REGION,
+      accessKeyId: process.env.OUTPUT_AWS_ACCESS_KEY_ID,
+      secretAccessKey: process.env.OUTPUT_AWS_SECRET_ACCESS_KEY
+    };
   }
 };

--- a/sdk/cli/src/utils/env_loader.ts
+++ b/sdk/cli/src/utils/env_loader.ts
@@ -7,13 +7,12 @@ import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import * as dotenv from 'dotenv';
 import debugFactory from 'debug';
-import { config } from '#config.js';
 
 const debug = debugFactory( 'output-cli:env-loader' );
 
 export function loadEnvironment(): void {
   const cwd = process.cwd();
-  const envFile = config.envFile;
+  const envFile = process.env.OUTPUT_CLI_ENV || '.env';
   const envPath = resolve( cwd, envFile );
 
   if ( !existsSync( envPath ) ) {

--- a/sdk/cli/src/utils/error_handler.ts
+++ b/sdk/cli/src/utils/error_handler.ts
@@ -13,13 +13,15 @@ type ErrorOverrides = {
   ECONNREFUSED?: string;
 };
 
-const DEFAULT_MESSAGES = {
-  ECONNREFUSED: `Connection refused to ${config.apiUrl}. Is the API server running?`,
-  401: 'Authentication failed. Check your OUTPUT_API_AUTH_TOKEN.',
-  404: 'Resource not found.',
-  500: 'Server error.',
-  UNKNOWN: 'An unknown error occurred.'
-};
+function getDefaultMessages() {
+  return {
+    ECONNREFUSED: `Connection refused to ${config.apiUrl}. Is the API server running?`,
+    401: 'Authentication failed. Check your OUTPUT_API_AUTH_TOKEN.',
+    404: 'Resource not found.',
+    500: 'Server error.',
+    UNKNOWN: 'An unknown error occurred.'
+  };
+}
 
 interface ApiErrorData {
   error?: string;
@@ -86,7 +88,7 @@ export function handleApiError(
   overrides: ErrorOverrides = {}
 ): never {
   const apiError = error as ApiError & { cause?: Error & { code?: string } };
-  const errorMessages = { ...DEFAULT_MESSAGES, ...overrides };
+  const errorMessages = { ...getDefaultMessages(), ...overrides };
 
   if ( apiError.code === 'ECONNREFUSED' || apiError.cause?.code === 'ECONNREFUSED' ) {
     errorFn( errorMessages.ECONNREFUSED, { exit: 1 } );


### PR DESCRIPTION
## Summary

`config.ts` reads the `process.env` at ES module evaluation time. But `.env` isn't loaded yet at that point, so all env-var-based config set in `.env` files are silently ignored. Overriding default values only works when exported as shell environment variables.

The result is if you set `OUTPUT_API_URL` and `OUTPUT_API_AUTH_TOKEN` in the `.env` file to point to a deployed Output API and try something like `output workflow list`, you'd get an error because it couldn't connect to `localhost:3001` unless it was running locally, in which case you'd get results for the local instance and not the one specified in `OUTPUT_API_URL`
