### PR TITLE
fix(cli): accept --yes and --non-interactive flags without parser error

### DIFF
--- a/.changeset/two-horses-cry.md
+++ b/.changeset/two-horses-cry.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Fix `--yes` / `--non-interactive` flags being rejected as "Nonexistent flag" by oclif's per-command parser. The init hook now strips these global flags from `process.argv` after flipping the non-interactive state, so they reach the hook but not the command-level flag validator.

--- a/sdk/cli/src/hooks/init.spec.ts
+++ b/sdk/cli/src/hooks/init.spec.ts
@@ -1,9 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { checkForUpdate } from '#services/version_check.js';
+import { setNonInteractive } from '#utils/interactive.js';
 
 vi.mock( '#services/version_check.js', () => ( {
   checkForUpdate: vi.fn()
+} ) );
+
+vi.mock( '#utils/interactive.js', () => ( {
+  setNonInteractive: vi.fn()
 } ) );
 
 vi.mock( '@oclif/core', () => ( {
@@ -65,5 +70,51 @@ describe( 'init hook', () => {
     await hook.call( ctx as any, {} as any );
 
     expect( ux.stdout ).not.toHaveBeenCalled();
+  } );
+
+  describe( 'global interactive flags', () => {
+    const originalArgv = process.argv;
+
+    beforeEach( () => {
+      vi.mocked( checkForUpdate ).mockResolvedValue( {
+        updateAvailable: false,
+        currentVersion: '0.8.4',
+        latestVersion: '0.8.4'
+      } );
+    } );
+
+    afterEach( () => {
+      process.argv = originalArgv;
+    } );
+
+    it( 'should strip --yes from process.argv and flip non-interactive', async () => {
+      process.argv = [ 'node', 'run.js', 'init', '--yes', 'my-project' ];
+
+      const ctx = createHookContext();
+      await hook.call( ctx as any, {} as any );
+
+      expect( setNonInteractive ).toHaveBeenCalledWith( true );
+      expect( process.argv ).toEqual( [ 'node', 'run.js', 'init', 'my-project' ] );
+    } );
+
+    it( 'should strip --non-interactive from process.argv and flip non-interactive', async () => {
+      process.argv = [ 'node', 'run.js', 'init', '--non-interactive' ];
+
+      const ctx = createHookContext();
+      await hook.call( ctx as any, {} as any );
+
+      expect( setNonInteractive ).toHaveBeenCalledWith( true );
+      expect( process.argv ).toEqual( [ 'node', 'run.js', 'init' ] );
+    } );
+
+    it( 'should leave process.argv untouched when no global flag is present', async () => {
+      process.argv = [ 'node', 'run.js', 'init', '--skip-env' ];
+
+      const ctx = createHookContext();
+      await hook.call( ctx as any, {} as any );
+
+      expect( setNonInteractive ).not.toHaveBeenCalled();
+      expect( process.argv ).toEqual( [ 'node', 'run.js', 'init', '--skip-env' ] );
+    } );
   } );
 } );

--- a/sdk/cli/src/hooks/init.ts
+++ b/sdk/cli/src/hooks/init.ts
@@ -2,9 +2,16 @@ import { Hook, ux } from '@oclif/core';
 import { checkForUpdate } from '#services/version_check.js';
 import { setNonInteractive } from '#utils/interactive.js';
 
+const GLOBAL_FLAGS = new Set( [ '--yes', '--non-interactive' ] );
+
 const hook: Hook<'init'> = async function () {
-  if ( process.argv.includes( '--yes' ) || process.argv.includes( '--non-interactive' ) ) {
+  const hadGlobalFlag = process.argv.some( arg => GLOBAL_FLAGS.has( arg ) );
+
+  if ( hadGlobalFlag ) {
     setNonInteractive( true );
+    // Strip these flags so oclif's per-command strict parser doesn't reject
+    // them (they're handled globally here, not declared on any command).
+    process.argv = process.argv.filter( arg => !GLOBAL_FLAGS.has( arg ) );
   }
 
   try {


### PR DESCRIPTION
## Problem

`output init --yes` (and any other command invoked with `--yes` or `--non-interactive`) fails with:

```
 ›   Error: Nonexistent flag: --yes
 ›   See more help with --help
```

The init hook at [sdk/cli/src/hooks/init.ts](sdk/cli/src/hooks/init.ts) inspects `process.argv` for `--yes` / `--non-interactive` and flips the global non-interactive state. But those flags aren't declared on any oclif command, so oclif's per-command strict parser rejects them a moment later.

Introduced in [#137](https://github.com/growthxai/output/pull/137) — the manual smoke test checkbox (`echo '' | npx output init --yes test-project`) was never completed, which is why this slipped through.

## Solution

After the init hook detects either flag, strip it from `process.argv` so oclif's command-level parser never sees it. Small, isolated 2-line change with no API surface impact.

## Test plan

- [x] `npm run lint` passes
- [x] `vitest run src/hooks/init.spec.ts` passes (6 tests, 3 new covering argv stripping + flip-and-no-flag cases)
- [x] Smoke test: `output init --yes --help` and `output --yes init --help` both succeed locally on the linked dev build (previously errored with "Nonexistent flag: --yes")

## Out of scope

- Declaring `--yes` / `--non-interactive` as proper globalFlags (larger refactor). This patch is the minimal fix to unblock the existing documented usage.