### PR TITLE
feat(core,http): Trace event attributes and http addRequestCost [OUT-428]

### DIFF
--- a/.changeset/strict-hands-pay.md
+++ b/.changeset/strict-hands-pay.md
@@ -1,0 +1,7 @@
+---
+"@outputai/core": patch
+"@outputai/http": patch
+"@outputai/llm": patch
+---
+
+Adding trace event attributes and adding method `addRequestCost` to attach cost related info to an HTTP call made with the http module

--- a/docs/guides/packages/http.mdx
+++ b/docs/guides/packages/http.mdx
@@ -107,6 +107,33 @@ All requests made with `@outputai/http` are automatically traced — no configur
 
 See [Tracing](/operations/tracing) for details on the trace format.
 
+## Attaching Request Cost
+
+When you know the dollar cost of an HTTP request (for example from provider billing headers), you can attach it to the HTTP trace event with `addRequestCost`.
+
+```typescript
+import { httpClient, addRequestCost } from '@outputai/http';
+
+const client = httpClient( { prefixUrl: 'https://api.vendor.com' } );
+
+const response = await client.post( 'search', {
+  json: { query: 'acme' }
+} );
+
+const inputCost = Number( response.headers.get( 'x-cost-input-usd' ) ?? 0 );
+const outputCost = Number( response.headers.get( 'x-cost-output-usd' ) ?? 0 );
+
+addRequestCost( response, {
+  total: inputCost + outputCost,
+  components: [
+    { name: 'input', value: inputCost },
+    { name: 'output', value: outputCost }
+  ]
+} );
+```
+
+`addRequestCost` only works with responses created by `@outputai/http` (or its exported `fetch`). If the response did not come from this package, the function safely no-ops and logs a warning.
+
 ## Error Handling
 
 The client throws `HTTPError` for non-2xx responses and `TimeoutError` for timeouts:

--- a/sdk/core/src/activity_integration/tracing.d.ts
+++ b/sdk/core/src/activity_integration/tracing.d.ts
@@ -1,39 +1,37 @@
 /**
- * Record the start of an event for the current workflow.
+ * Creates a new event.
  *
- * @param args - Event information
- * @param args.id - A unique id for the Event, must be the same across all phases: start, end, error.
+ * @param args
+ * @param args.id - A unique id for the Event.
  * @param args.kind - The kind of Event, like HTTP, DiskWrite, DBOp, etc.
- * @param args.name - The human friendly name of the Event: query, request, create.
- * @param args.details - Arbitrary metadata associated with this phase (e.g., payloads, summaries).
+ * @param args.name - The human-friendly name of the Event: query, request, create.
+ * @param args.details - Arbitrary data to add to this event, it will be used as the "input" field.
  */
 export declare function addEventStart( args: { id: string; kind: string; name: string; details: unknown } ): void;
 
 /**
- * Record the end of an event.
+ * Concludes an event.
  *
- * @param args - Event information
- * @param args.id - Identifier matching the event's start phase.
- * @param args.details - Arbitrary metadata associated with this phase (e.g., results, response body).
+ * @param args
+ * @param args.id - The id of the event to conclude.
+ * @param args.details - Arbitrary data to add to this event, it will be used as the "output" field.
  */
 export declare function addEventEnd( args: { id: string; details: unknown } ): void;
 
 /**
- * Record the error in an event.
+ * Concludes an event with an error.
  *
- * @param args - Event metadata for the error phase.
- * @param args.id - Identifier matching the event's start phase.
- * @param args.details - Arbitrary metadata associated with this phase, possible error info.
+ * @param args
+ * @param args.id - The id of the event to conclude.
+ * @param args.details - Arbitrary data to add to this event, it will be used as the "error" field.
  */
 export declare function addEventError( args: { id: string; details: unknown } ): void;
 
 /**
- * Add an attribute to an event.
+ * Adds an attribute to an event.
  *
- * Use the same id as the start phase to correlate phases.
- *
- * @param args - Arguments for the attribute phase.
- * @param args.eventId - The event id
+ * @param args
+ * @param args.eventId - The id of the event to attach the attribute to.
  * @param args.name - The attribute name
  * @param args.value - The attribute value
  */

--- a/sdk/core/src/activity_integration/tracing.d.ts
+++ b/sdk/core/src/activity_integration/tracing.d.ts
@@ -36,3 +36,10 @@ export declare function addEventError( args: { id: string; details: unknown } ):
  * @param args.value - The attribute value
  */
 export declare function addEventAttribute( args: { eventId: string; name: string, value: unknown } ): void;
+
+/**
+ * Known attributes.
+ */
+export declare const Attribute: {
+  COST: 'cost';
+};

--- a/sdk/core/src/activity_integration/tracing.d.ts
+++ b/sdk/core/src/activity_integration/tracing.d.ts
@@ -32,7 +32,7 @@ export declare function addEventError( args: { id: string; details: unknown } ):
  *
  * Use the same id as the start phase to correlate phases.
  *
- * @param args - Event metadata for the error phase.
+ * @param args - Arguments for the attribute phase.
  * @param args.eventId - The event id
  * @param args.name - The attribute name
  * @param args.value - The attribute value

--- a/sdk/core/src/activity_integration/tracing.d.ts
+++ b/sdk/core/src/activity_integration/tracing.d.ts
@@ -1,5 +1,5 @@
 /**
- * Record the start of an event on the default trace for the current workflow.
+ * Record the start of an event for the current workflow.
  *
  * @param args - Event information
  * @param args.id - A unique id for the Event, must be the same across all phases: start, end, error.
@@ -10,9 +10,7 @@
 export declare function addEventStart( args: { id: string; kind: string; name: string; details: unknown } ): void;
 
 /**
- * Record the end of an event on the default trace for the current workflow.
- *
- * Use the same id as the start phase to correlate phases.
+ * Record the end of an event.
  *
  * @param args - Event information
  * @param args.id - Identifier matching the event's start phase.
@@ -21,12 +19,22 @@ export declare function addEventStart( args: { id: string; kind: string; name: s
 export declare function addEventEnd( args: { id: string; details: unknown } ): void;
 
 /**
- * Record an error for an event on the default trace for the current workflow.
- *
- * Use the same id as the start phase to correlate phases.
+ * Record the error in an event.
  *
  * @param args - Event metadata for the error phase.
  * @param args.id - Identifier matching the event's start phase.
  * @param args.details - Arbitrary metadata associated with this phase, possible error info.
  */
 export declare function addEventError( args: { id: string; details: unknown } ): void;
+
+/**
+ * Add an attribute to an event.
+ *
+ * Use the same id as the start phase to correlate phases.
+ *
+ * @param args - Event metadata for the error phase.
+ * @param args.eventId - The event id
+ * @param args.name - The attribute name
+ * @param args.value - The attribute value
+ */
+export declare function addEventAttribute( args: { eventId: string; name: string, value: unknown } ): void;

--- a/sdk/core/src/activity_integration/tracing.js
+++ b/sdk/core/src/activity_integration/tracing.js
@@ -1,46 +1,46 @@
-import { addEventPhaseWithContext, EventPhase } from '#tracing';
+import { addEventActionWithContext, EventAction } from '#tracing';
 
 /**
- * Adds the start phase of a new event at the default trace for the current workflow.
+ * Creates a new event.
  *
  * @param {object} args
- * @param {string} args.id - A unique id for the Event, must be the same across all phases: start, end, error.
+ * @param {string} args.id - A unique id for the Event.
  * @param {string} args.kind - The kind of Event, like HTTP, DiskWrite, DBOp, etc.
- * @param {string} args.name - The human friendly name of the Event: query, request, create.
- * @param {object} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
+ * @param {string} args.name - The human-friendly name of the Event: query, request, create.
+ * @param {object} args.details - Arbitrary data to add to this event, it will be used as the "input" field.
  * @returns {void}
  */
 export const addEventStart = ( { id, kind, name, details } ) =>
-  addEventPhaseWithContext( EventPhase.START, { kind, name, details, id } );
+  addEventActionWithContext( EventAction.START, { kind, name, details, id } );
 
 /**
- * Adds the end phase for an event using its id.
+ * Concludes an event.
  *
  * @param {object} args
- * @param {string} args.id - A unique id for the Event, must be the same across all phases: start, end, error.
- * @param {object} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
+ * @param {string} args.id - The id of the event to conclude.
+ * @param {object} args.details - Arbitrary data to add to this event, it will be used as the "output" field.
  * @returns {void}
  */
-export const addEventEnd = ( { id, details } ) => addEventPhaseWithContext( EventPhase.END, { id, details } );
+export const addEventEnd = ( { id, details } ) => addEventActionWithContext( EventAction.END, { id, details } );
 
 /**
- * Adds the error phase for an event using its id.
+ * Concludes an event with an error.
  *
  * @param {object} args
- * @param {string} args.id - A unique id for the Event, must be the same across all phases: start, end, error.
- * @param {object} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
+ * @param {string} args.id - The id of the event to conclude.
+ * @param {object} args.details - Arbitrary data to add to this event, it will be used as the "error" field.
  * @returns {void}
  */
-export const addEventError = ( { id, details } ) => addEventPhaseWithContext( EventPhase.ERROR, { id, details } );
+export const addEventError = ( { id, details } ) => addEventActionWithContext( EventAction.ERROR, { id, details } );
 
 /**
- * Adds an attribute to an event using the event id
+ * Adds an attribute to an event.
  *
  * @param {object} args
- * @param {string} args.eventId - The id of the event to attach the attribute
+ * @param {string} args.eventId - The id of the event to attach the attribute to.
  * @param {string} args.name - The attribute name
  * @param {unknown} args.value - The attribute value
  * @returns {void}
  */
 export const addEventAttribute = ( { eventId, name, value } ) =>
-  addEventPhaseWithContext( EventPhase.ADD_ATTR, { id: eventId, details: { name, value } } );
+  addEventActionWithContext( EventAction.ADD_ATTR, { id: eventId, details: { name, value } } );

--- a/sdk/core/src/activity_integration/tracing.js
+++ b/sdk/core/src/activity_integration/tracing.js
@@ -44,3 +44,10 @@ export const addEventError = ( { id, details } ) => addEventActionWithContext( E
  */
 export const addEventAttribute = ( { eventId, name, value } ) =>
   addEventActionWithContext( EventAction.ADD_ATTR, { id: eventId, details: { name, value } } );
+
+/**
+ * Known attributes
+ */
+export const Attribute = {
+  COST: 'cost'
+};

--- a/sdk/core/src/activity_integration/tracing.js
+++ b/sdk/core/src/activity_integration/tracing.js
@@ -1,4 +1,4 @@
-import { addEventPhaseWithContext } from '#tracing';
+import { addEventPhaseWithContext, EventPhase } from '#tracing';
 
 /**
  * Adds the start phase of a new event at the default trace for the current workflow.
@@ -10,28 +10,37 @@ import { addEventPhaseWithContext } from '#tracing';
  * @param {object} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
  * @returns {void}
  */
-export const addEventStart = ( { id, kind, name, details } ) => addEventPhaseWithContext( 'start', { kind, name, details, id } );
+export const addEventStart = ( { id, kind, name, details } ) =>
+  addEventPhaseWithContext( EventPhase.START, { kind, name, details, id } );
 
 /**
- * Adds the end phase at an event at the default trace for the current workflow.
- *
- * It needs to use the same id of the start phase.
+ * Adds the end phase for an event using its id.
  *
  * @param {object} args
  * @param {string} args.id - A unique id for the Event, must be the same across all phases: start, end, error.
  * @param {object} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
  * @returns {void}
  */
-export const addEventEnd = ( { id, details } ) => addEventPhaseWithContext( 'end', { id, details } );
+export const addEventEnd = ( { id, details } ) => addEventPhaseWithContext( EventPhase.END, { id, details } );
 
 /**
- * Adds the error phase at an event as error at the default trace for the current workflow.
- *
- * It needs to use the same id of the start phase.
+ * Adds the error phase for an event using its id.
  *
  * @param {object} args
  * @param {string} args.id - A unique id for the Event, must be the same across all phases: start, end, error.
  * @param {object} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
  * @returns {void}
  */
-export const addEventError = ( { id, details } ) => addEventPhaseWithContext( 'error', { id, details } );
+export const addEventError = ( { id, details } ) => addEventPhaseWithContext( EventPhase.ERROR, { id, details } );
+
+/**
+ * Adds an attribute to an event using the event id
+ *
+ * @param {object} args
+ * @param {string} args.eventId - The id of the event to attach the attribute
+ * @param {string} args.name - The attribute name
+ * @param {unknown} args.value - The attribute value
+ * @returns {void}
+ */
+export const addEventAttribute = ( { eventId, name, value } ) =>
+  addEventPhaseWithContext( EventPhase.ADD_ATTR, { id: eventId, details: { name, value } } );

--- a/sdk/core/src/tracing/internal_interface.js
+++ b/sdk/core/src/tracing/internal_interface.js
@@ -31,7 +31,7 @@ export { EventPhase };
  * @param {string} args.kind - The kind of Event, like HTTP, DiskWrite, DBOp, etc.
  * @param {string} args.name - The human friendly name of the Event: query, request, create.
  * @param {any} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
- * @param {string} args.parentId - The parent Event, used to build a three.
+ * @param {string} args.parentId - The parent Event, used to build a tree.
  * @param {object} args.executionContext - The original execution context from the workflow
  * @returns {void}
  */
@@ -45,7 +45,6 @@ export const addEventStart = options => addEventPhase( EventPhase.START, options
  * @param {object} args
  * @param {string} args.id - A unique id for the Event, must be the same across all phases: start, end, error.
  * @param {any} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
- * @param {string} args.parentId - The parent Event, used to build a three.
  * @param {object} args.executionContext - The original execution context from the workflow
  * @returns {void}
  */
@@ -54,12 +53,11 @@ export const addEventEnd = options => addEventPhase( EventPhase.END, options );
 /**
  * Internal use only
  *
- * Adds the error phase of an event, matching buy its id.
+ * Adds the error phase of an event, matching by its id.
  *
  * @param {object} args
  * @param {string} args.id - A unique id for the Event, must be the same across all phases: start, end, error.
  * @param {any} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
- * @param {string} args.parentId - The parent Event, used to build a three.
  * @param {object} args.executionContext - The original execution context from the workflow
  * @returns {void}
  */
@@ -73,7 +71,6 @@ export const addEventError = options => addEventPhase( EventPhase.ERROR, options
  * @param {object} args
  * @param {string} args.id - A unique id for the Event, must be the same across all phases: start, end, error.
  * @param {any} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
- * @param {string} args.parentId - The parent Event, used to build a three.
  * @param {object} args.executionContext - The original execution context from the workflow
  * @returns {void}
  */

--- a/sdk/core/src/tracing/internal_interface.js
+++ b/sdk/core/src/tracing/internal_interface.js
@@ -1,4 +1,5 @@
 import { addEventPhase, addEventPhaseWithContext, init, getDestinations } from './trace_engine.js';
+import { EventPhase } from './trace_consts.js';
 
 /**
  * Init method, if not called, no processors are attached and trace functions are dummy
@@ -10,12 +11,14 @@ export { init, getDestinations };
  */
 export { addEventPhaseWithContext };
 
+export { EventPhase };
+
 /**
  * Trace nomenclature
  *
  * Trace - The collection of Events;
- * Event - Any entry in the Trace file, must have the two phases START and END or ERROR;
- * Phase - An specific part of an Event, either START or the conclusive END or ERROR;
+ * Event - Any entry in the Trace file, must have the two phases START and END/ERROR, plus any number of ADD_ATTR phases;
+ * Phase - An specific part of an Event, either START, END, ERROR or ADD_ATTR;
  */
 
 /**
@@ -32,40 +35,46 @@ export { addEventPhaseWithContext };
  * @param {object} args.executionContext - The original execution context from the workflow
  * @returns {void}
  */
-export const addEventStart = options => addEventPhase( 'start', options );
+export const addEventStart = options => addEventPhase( EventPhase.START, options );
 
 /**
  * Internal use only
  *
- * Adds the end phase at an event at the default trace for the current workflow.
- *
- * It needs to use the same id of the start phase.
+ * Adds the end phase of an event, matching by its id.
  *
  * @param {object} args
  * @param {string} args.id - A unique id for the Event, must be the same across all phases: start, end, error.
- * @param {string} args.kind - The kind of Event, like HTTP, DiskWrite, DBOp, etc.
- * @param {string} args.name - The human friendly name of the Event: query, request, create.
  * @param {any} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
  * @param {string} args.parentId - The parent Event, used to build a three.
  * @param {object} args.executionContext - The original execution context from the workflow
  * @returns {void}
  */
-export const addEventEnd = options => addEventPhase( 'end', options );
+export const addEventEnd = options => addEventPhase( EventPhase.END, options );
 
 /**
  * Internal use only
  *
- * Adds the error phase at an event as error at the default trace for the current workflow.
- *
- * It needs to use the same id of the start phase.
+ * Adds the error phase of an event, matching buy its id.
  *
  * @param {object} args
  * @param {string} args.id - A unique id for the Event, must be the same across all phases: start, end, error.
- * @param {string} args.kind - The kind of Event, like HTTP, DiskWrite, DBOp, etc.
- * @param {string} args.name - The human friendly name of the Event: query, request, create.
  * @param {any} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
  * @param {string} args.parentId - The parent Event, used to build a three.
  * @param {object} args.executionContext - The original execution context from the workflow
  * @returns {void}
  */
-export const addEventError = options => addEventPhase( 'error', options );
+export const addEventError = options => addEventPhase( EventPhase.ERROR, options );
+
+/**
+ * Internal use only
+ *
+ * Adds an attribute to an event using its id.
+ *
+ * @param {object} args
+ * @param {string} args.id - A unique id for the Event, must be the same across all phases: start, end, error.
+ * @param {any} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
+ * @param {string} args.parentId - The parent Event, used to build a three.
+ * @param {object} args.executionContext - The original execution context from the workflow
+ * @returns {void}
+ */
+export const addEventAttribute = options => addEventPhase( EventPhase.ADD_ATTR, options );

--- a/sdk/core/src/tracing/internal_interface.js
+++ b/sdk/core/src/tracing/internal_interface.js
@@ -1,5 +1,5 @@
-import { addEventPhase, addEventPhaseWithContext, init, getDestinations } from './trace_engine.js';
-import { EventPhase } from './trace_consts.js';
+import { addEventAction, addEventActionWithContext, init, getDestinations } from './trace_engine.js';
+import { EventAction } from './trace_consts.js';
 
 /**
  * Init method, if not called, no processors are attached and trace functions are dummy
@@ -7,61 +7,61 @@ import { EventPhase } from './trace_consts.js';
 export { init, getDestinations };
 
 /**
- * Internal use only - adds event phase with AsyncLocalStorage context resolution
+ * Internal use only - adds an action with AsyncLocalStorage context resolution
  */
-export { addEventPhaseWithContext };
+export { addEventActionWithContext };
 
-export { EventPhase };
+export { EventAction };
 
 /**
  * Trace nomenclature
  *
  * Trace - The collection of Events;
- * Event - Any entry in the Trace file, must have the two phases START and END/ERROR, plus any number of ADD_ATTR phases;
- * Phase - An specific part of an Event, either START, END, ERROR or ADD_ATTR;
+ * Event - Any entry in the Trace file must have both START and END/ERROR actions, plus any number of ADD_ATTR actions;
+ * Action - A specific part of an Event: START, END, ERROR, or ADD_ATTR;
  */
 
 /**
  * Internal use only
  *
- * Adds the start phase of a new event at the default trace for the current workflow.
+ * Creates a new event and appends it to the trace.
  *
  * @param {object} args
- * @param {string} args.id - A unique id for the Event, must be the same across all phases: start, end, error.
+ * @param {string} args.id - A unique id for the Event.
  * @param {string} args.kind - The kind of Event, like HTTP, DiskWrite, DBOp, etc.
- * @param {string} args.name - The human friendly name of the Event: query, request, create.
- * @param {any} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
+ * @param {string} args.name - The human-friendly name of the Event: query, request, create.
+ * @param {any} args.details - Arbitrary data to add to this event, it will be used as the "input" field.
  * @param {string} args.parentId - The parent Event, used to build a tree.
  * @param {object} args.executionContext - The original execution context from the workflow
  * @returns {void}
  */
-export const addEventStart = options => addEventPhase( EventPhase.START, options );
+export const addEventStart = options => addEventAction( EventAction.START, options );
 
 /**
  * Internal use only
  *
- * Adds the end phase of an event, matching by its id.
+ * Concludes an event, matching by its id.
  *
  * @param {object} args
- * @param {string} args.id - A unique id for the Event, must be the same across all phases: start, end, error.
- * @param {any} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
+ * @param {string} args.id - The id of the event to conclude.
+ * @param {any} args.details - Arbitrary data to add to the event; it is used as the "output" field.
  * @param {object} args.executionContext - The original execution context from the workflow
  * @returns {void}
  */
-export const addEventEnd = options => addEventPhase( EventPhase.END, options );
+export const addEventEnd = options => addEventAction( EventAction.END, options );
 
 /**
  * Internal use only
  *
- * Adds the error phase of an event, matching by its id.
+ * Concludes an event with an error, matching by its id.
  *
  * @param {object} args
- * @param {string} args.id - A unique id for the Event, must be the same across all phases: start, end, error.
- * @param {any} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
+ * @param {string} args.id - The id of the event to conclude.
+ * @param {any} args.details - Arbitrary data to add to the event; it is used as the "error" field.
  * @param {object} args.executionContext - The original execution context from the workflow
  * @returns {void}
  */
-export const addEventError = options => addEventPhase( EventPhase.ERROR, options );
+export const addEventError = options => addEventAction( EventAction.ERROR, options );
 
 /**
  * Internal use only
@@ -69,9 +69,9 @@ export const addEventError = options => addEventPhase( EventPhase.ERROR, options
  * Adds an attribute to an event using its id.
  *
  * @param {object} args
- * @param {string} args.id - A unique id for the Event, must be the same across all phases: start, end, error.
- * @param {any} args.details - All details attached to this Event Phase. DB queried records, HTTP response body.
+ * @param {string} args.id - The id of the event to attach the attribute to.
+ * @param {object} args.details - The attribute to add to this event, must be in `{ name: string, value: any }` format.
  * @param {object} args.executionContext - The original execution context from the workflow
  * @returns {void}
  */
-export const addEventAttribute = options => addEventPhase( EventPhase.ADD_ATTR, options );
+export const addEventAttribute = options => addEventAction( EventAction.ADD_ATTR, options );

--- a/sdk/core/src/tracing/processors/local/index.js
+++ b/sdk/core/src/tracing/processors/local/index.js
@@ -23,7 +23,7 @@ const tempTraceFilesDir = join( __dirname, 'temp', 'traces' );
 const createTempFilePath = ( { workflowId, startTime } ) => join( tempTraceFilesDir, `${startTime}_${workflowId}.trace` );
 
 /**
- * Adds an trace entry to the accumulation file
+ * Adds a trace entry to the accumulation file.
  * @param {object} entry - The trace entry
  * @param {string} path - Accumulation file path
  */
@@ -100,12 +100,13 @@ export const init = () => {
 /**
  * Execute this processor:
  *
- * Append each trace entry to a temp file; when the root workflow ends (non-start phase on the
- * workflow id) or any entry is an error phase, build the trace tree and write the JSON file once.
+ * Appends each trace entry to a temp file.
+ *
+ * When the root workflow ends or the entry is an error action, build the trace tree and write the JSON file.
  *
  * @param {object} args
- * @param {object} entry - Trace event phase
- * @param {object} executionContext - Execution info: workflowId, workflowName, startTime
+ * @param {object} args.entry - The trace entry to append.
+ * @param {object} args.executionContext - Execution info: workflowId, workflowName, startTime
  * @returns {void}
  */
 export const exec = ( { entry, executionContext } ) => {
@@ -113,8 +114,8 @@ export const exec = ( { entry, executionContext } ) => {
   const tempFilePath = createTempFilePath( executionContext );
   addEntry( entry, tempFilePath );
 
-  const isRootWorkflowEnd = entry.id === workflowId && entry.phase !== 'start';
-  const isError = entry.phase === 'error';
+  const isRootWorkflowEnd = entry.id === workflowId && entry.action !== 'start';
+  const isError = entry.action === 'error';
 
   if ( !isRootWorkflowEnd && !isError ) {
     return;

--- a/sdk/core/src/tracing/processors/local/index.spec.js
+++ b/sdk/core/src/tracing/processors/local/index.spec.js
@@ -25,10 +25,10 @@ vi.mock( 'node:fs', () => ( {
 const buildTraceTreeMock = vi.fn( entries => ( { count: entries.length } ) );
 vi.mock( '../../tools/build_trace_tree.js', () => ( { default: buildTraceTreeMock } ) );
 
-/** Flush happens when root id matches workflowId and phase is not start, or when phase is error. */
-const rootStart = ( workflowId, ts ) => ( { id: workflowId, phase: 'start', timestamp: ts } );
-const rootEnd = ( workflowId, ts ) => ( { id: workflowId, phase: 'end', timestamp: ts } );
-const childTick = ( id, ts ) => ( { id, phase: 'tick', timestamp: ts } );
+/** Flush happens when the root id matches workflowId and action is not 'start', or when action is 'error'. */
+const rootStart = ( workflowId, ts ) => ( { id: workflowId, action: 'start', timestamp: ts } );
+const rootEnd = ( workflowId, ts ) => ( { id: workflowId, action: 'end', timestamp: ts } );
+const childTick = ( id, ts ) => ( { id, action: 'tick', timestamp: ts } );
 
 describe( 'tracing/processors/local', () => {
   beforeEach( () => {
@@ -86,7 +86,7 @@ describe( 'tracing/processors/local', () => {
     expect( writeFileSyncMock ).not.toHaveBeenCalled();
   } );
 
-  it( 'exec(): flushes on error phase before root end', async () => {
+  it( 'exec(): flushes on error action before root end', async () => {
     const { exec, init } = await import( './index.js' );
     init();
 
@@ -95,7 +95,7 @@ describe( 'tracing/processors/local', () => {
     const ctx = { executionContext: { workflowId, workflowName: 'WF', startTime } };
 
     exec( { ...ctx, entry: rootStart( workflowId, startTime ) } );
-    exec( { ...ctx, entry: { id: 'step-1', phase: 'error', timestamp: startTime + 1 } } );
+    exec( { ...ctx, entry: { id: 'step-1', action: 'error', timestamp: startTime + 1 } } );
 
     expect( buildTraceTreeMock ).toHaveBeenCalledTimes( 1 );
     expect( buildTraceTreeMock.mock.calls[0][0] ).toHaveLength( 2 );

--- a/sdk/core/src/tracing/processors/s3/index.js
+++ b/sdk/core/src/tracing/processors/s3/index.js
@@ -67,11 +67,15 @@ export const init = async () => {
 };
 
 /**
- * Execute this processor: send a complete trace tree file to S3 when the workflow finishes
+ * Execute this processor:
+ *
+ * Appends each trace entry to Redis.
+ *
+ * When the root workflow ends or the entry is an error action, it builds the trace tree and uploads it to S3.
  *
  * @param {object} args
- * @param {object} entry - Trace event phase
- * @param {object} executionContext - Execution info: workflowId, workflowName, startTime
+ * @param {object} args.entry - The trace entry to append
+ * @param {object} args.executionContext - Execution info: workflowId, workflowName, startTime
  */
 export const exec = async ( { entry, executionContext } ) => {
   const { workflowName, workflowId, startTime } = executionContext;
@@ -79,7 +83,7 @@ export const exec = async ( { entry, executionContext } ) => {
 
   await addEntry( entry, cacheKey );
 
-  const isRootWorkflowEnd = entry.id === workflowId && entry.phase !== 'start';
+  const isRootWorkflowEnd = entry.id === workflowId && entry.action !== 'start';
   if ( !isRootWorkflowEnd ) {
     return;
   }

--- a/sdk/core/src/tracing/processors/s3/index.spec.js
+++ b/sdk/core/src/tracing/processors/s3/index.spec.js
@@ -52,9 +52,9 @@ describe( 'tracing/processors/s3', () => {
 
     redisMulti.exec.mockResolvedValue( [] );
 
-    const workflowStart = { id: 'id1', name: 'WF', kind: 'workflow', phase: 'start', details: {}, timestamp: startTime };
-    const activityStart = { id: 'act-1', name: 'DoSomething', kind: 'step', parentId: 'id1', phase: 'start', details: {}, timestamp: startTime + 1 };
-    const workflowEnd = { id: 'id1', phase: 'end', details: { ok: true }, timestamp: startTime + 2 };
+    const workflowStart = { id: 'id1', name: 'WF', kind: 'workflow', action: 'start', details: {}, timestamp: startTime };
+    const activityStart = { id: 'act-1', name: 'DoSomething', kind: 'step', parentId: 'id1', action: 'start', details: {}, timestamp: startTime + 1 };
+    const workflowEnd = { id: 'id1', action: 'end', details: { ok: true }, timestamp: startTime + 2 };
     zRangeMock.mockResolvedValue( [
       JSON.stringify( workflowStart ),
       JSON.stringify( activityStart ),
@@ -97,7 +97,7 @@ describe( 'tracing/processors/s3', () => {
 
     redisMulti.exec.mockResolvedValue( [] );
     const workflowStart = {
-      kind: 'workflow', id: 'id1', name: 'WF', parentId: undefined, phase: 'start', details: {}, timestamp: startTime
+      kind: 'workflow', id: 'id1', name: 'WF', parentId: undefined, action: 'start', details: {}, timestamp: startTime
     };
     zRangeMock.mockResolvedValue( [ JSON.stringify( workflowStart ) ] );
 
@@ -113,8 +113,8 @@ describe( 'tracing/processors/s3', () => {
     const ctx = { executionContext: { workflowId: 'id1', workflowName: 'WF', startTime } };
 
     redisMulti.exec.mockResolvedValue( [] );
-    const workflowStart = { id: 'id1', name: 'WF', kind: 'workflow', phase: 'start', details: {}, timestamp: startTime };
-    const stepEndNoParent = { id: 'step-1', phase: 'end', details: { done: true }, timestamp: startTime + 1 };
+    const workflowStart = { id: 'id1', name: 'WF', kind: 'workflow', action: 'start', details: {}, timestamp: startTime };
+    const stepEndNoParent = { id: 'step-1', action: 'end', details: { done: true }, timestamp: startTime + 1 };
     zRangeMock.mockResolvedValue( [
       JSON.stringify( workflowStart ),
       JSON.stringify( stepEndNoParent )
@@ -136,7 +136,7 @@ describe( 'tracing/processors/s3', () => {
 
     redisMulti.exec.mockResolvedValue( [] );
     const workflowEnd = {
-      kind: 'workflow', id: 'id1', name: 'WF', parentId: undefined, phase: 'end', details: {}, timestamp: startTime
+      kind: 'workflow', id: 'id1', name: 'WF', parentId: undefined, action: 'end', details: {}, timestamp: startTime
     };
     zRangeMock.mockResolvedValue( [ JSON.stringify( workflowEnd ) ] );
     buildTraceTreeMock.mockReturnValueOnce( null );

--- a/sdk/core/src/tracing/tools/build_trace_tree.js
+++ b/sdk/core/src/tracing/tools/build_trace_tree.js
@@ -1,3 +1,4 @@
+import { EventPhase } from '../trace_consts.js';
 /**
  * @typedef {object} NodeEntry
  * @property {string} id
@@ -27,7 +28,8 @@ const createEntry = id => ( {
   input: undefined,
   output: undefined,
   error: undefined,
-  children: []
+  children: [],
+  attributes: {}
 } );
 
 /**
@@ -56,15 +58,17 @@ export default entries => {
     const { kind, id, name, parentId, details, phase, timestamp } = entry;
     const node = ensureNode( id );
 
-    if ( phase === 'start' ) {
+    if ( phase === EventPhase.START ) {
       Object.assign( node, { input: details, startedAt: timestamp, kind, name } );
-    } else if ( phase === 'end' ) {
+    } else if ( phase === EventPhase.ADD_ATTR ) {
+      node.attributes[details.name] = details.value;
+    } else if ( phase === EventPhase.END ) {
       Object.assign( node, { output: details, endedAt: timestamp } );
-    } else if ( phase === 'error' ) {
+    } else if ( phase === EventPhase.ERROR ) {
       Object.assign( node, { error: details, endedAt: timestamp } );
     }
 
-    if ( parentId && phase === 'start' ) {
+    if ( parentId && phase === EventPhase.START ) {
       const parent = ensureNode( parentId );
       parent.children.push( node );
       parent.children.sort( ( a, b ) => a.startedAt - b.startedAt );

--- a/sdk/core/src/tracing/tools/build_trace_tree.js
+++ b/sdk/core/src/tracing/tools/build_trace_tree.js
@@ -1,4 +1,4 @@
-import { EventPhase } from '../trace_consts.js';
+import { EventAction } from '../trace_consts.js';
 /**
  * @typedef {object} NodeEntry
  * @property {string} id
@@ -33,15 +33,16 @@ const createEntry = id => ( {
 } );
 
 /**
- * Build a tree of nodes from a list of entries
+ * Builds a tree of nodes from a list of entries.
  *
  * Each node will have: id, name, kind, children, input, output or error, startedAt, endedAt.
  *
- * Entries with same id will be combined according to their phase (start, end OR error).
- * - The details of the start phase becomes input, timestamp becomes startedAt;
- * - The details of the end phase become output, timestamp becomes endedAt;
- * - The details of the error phase become error, timestamp becomes endedAt;
- * - Only start phase's kind and name are used;
+ * Entries with the same id are combined according to their actions.
+ * - The details of the START action become input, and timestamp becomes startedAt;
+ * - The details of the END action become output, timestamp becomes endedAt;
+ * - The details of the ERROR action become error, timestamp becomes endedAt;
+ * - The details of the ADD_ATTR action are attached to `.attributes`;
+ * - Only the START action's `kind` and `name` fields are used;
  *
  *
  * Children are added according to the parentId of each entry.
@@ -55,20 +56,20 @@ export default entries => {
   const ensureNode = id => nodes.get( id ) ?? nodes.set( id, createEntry( id ) ).get( id );
 
   for ( const entry of entries ) {
-    const { kind, id, name, parentId, details, phase, timestamp } = entry;
+    const { kind, id, name, parentId, details, action, timestamp } = entry;
     const node = ensureNode( id );
 
-    if ( phase === EventPhase.START ) {
+    if ( action === EventAction.START ) {
       Object.assign( node, { input: details, startedAt: timestamp, kind, name } );
-    } else if ( phase === EventPhase.ADD_ATTR ) {
+    } else if ( action === EventAction.ADD_ATTR ) {
       node.attributes[details.name] = details.value;
-    } else if ( phase === EventPhase.END ) {
+    } else if ( action === EventAction.END ) {
       Object.assign( node, { output: details, endedAt: timestamp } );
-    } else if ( phase === EventPhase.ERROR ) {
+    } else if ( action === EventAction.ERROR ) {
       Object.assign( node, { error: details, endedAt: timestamp } );
     }
 
-    if ( parentId && phase === EventPhase.START ) {
+    if ( parentId && action === EventAction.START ) {
       const parent = ensureNode( parentId );
       parent.children.push( node );
       parent.children.sort( ( a, b ) => a.startedAt - b.startedAt );

--- a/sdk/core/src/tracing/tools/build_trace_tree.spec.js
+++ b/sdk/core/src/tracing/tools/build_trace_tree.spec.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { EventPhase } from '../trace_consts.js';
 import buildTraceTree from './build_trace_tree.js';
 
 describe( 'build_trace_tree', () => {
@@ -8,7 +9,7 @@ describe( 'build_trace_tree', () => {
 
   it( 'sets root output with a fixed message when workflow has no end/error phase yet', () => {
     const entries = [
-      { kind: 'workflow', id: 'wf', parentId: undefined, phase: 'start', name: 'wf', details: {}, timestamp: 1000 }
+      { kind: 'workflow', id: 'wf', parentId: undefined, phase: EventPhase.START, name: 'wf', details: {}, timestamp: 1000 }
     ];
     const result = buildTraceTree( entries );
     expect( result ).not.toBeNull();
@@ -19,17 +20,52 @@ this can indicate it timed out or was interrupted.>>' );
 
   it( 'returns null when there is no root (all entries have parentId)', () => {
     const entries = [
-      { id: 'a', parentId: 'x', phase: 'start', name: 'a', timestamp: 1 },
-      { id: 'b', parentId: 'a', phase: 'start', name: 'b', timestamp: 2 }
+      { id: 'a', parentId: 'x', phase: EventPhase.START, name: 'a', timestamp: 1 },
+      { id: 'b', parentId: 'a', phase: EventPhase.START, name: 'b', timestamp: 2 }
     ];
     expect( buildTraceTree( entries ) ).toBeNull();
   } );
 
+  it( 'add_attr phase merges details.name and details.value into node.attributes', () => {
+    const entries = [
+      { kind: 'workflow', id: 'wf', parentId: undefined, phase: EventPhase.START, name: 'wf', details: {}, timestamp: 100 },
+      { kind: 'step', id: 's', parentId: 'wf', phase: EventPhase.START, name: 'step', details: {}, timestamp: 200 },
+      { id: 's', phase: EventPhase.ADD_ATTR, details: { name: 'latency_ms', value: 42 }, timestamp: 250 },
+      { id: 's', phase: EventPhase.ADD_ATTR, details: { name: 'retries', value: 1 }, timestamp: 260 },
+      { id: 'wf', phase: EventPhase.END, details: {}, timestamp: 300 }
+    ];
+    const result = buildTraceTree( entries );
+    expect( result ).not.toBeNull();
+    expect( result.children[0].attributes ).toEqual( { latency_ms: 42, retries: 1 } );
+  } );
+
+  it( 'add_attr phase overwrites prior value for the same attribute name', () => {
+    const entries = [
+      { kind: 'workflow', id: 'wf', parentId: undefined, phase: EventPhase.START, name: 'wf', details: {}, timestamp: 1 },
+      { id: 'wf', phase: EventPhase.ADD_ATTR, details: { name: 'x', value: 1 }, timestamp: 2 },
+      { id: 'wf', phase: EventPhase.ADD_ATTR, details: { name: 'x', value: 2 }, timestamp: 3 },
+      { id: 'wf', phase: EventPhase.END, details: {}, timestamp: 4 }
+    ];
+    const result = buildTraceTree( entries );
+    expect( result.attributes ).toEqual( { x: 2 } );
+  } );
+
+  it( 'add_attr does not attach nodes as children (only start does)', () => {
+    const entries = [
+      { kind: 'workflow', id: 'wf', parentId: undefined, phase: EventPhase.START, name: 'wf', details: {}, timestamp: 1 },
+      { id: 'orphan', parentId: 'wf', phase: EventPhase.ADD_ATTR, details: { name: 'k', value: 'v' }, timestamp: 2 },
+      { id: 'wf', phase: EventPhase.END, details: {}, timestamp: 3 }
+    ];
+    const result = buildTraceTree( entries );
+    expect( result.children ).toHaveLength( 0 );
+    expect( result.attributes ).toEqual( {} );
+  } );
+
   it( 'error phase sets error and endedAt on node', () => {
     const entries = [
-      { kind: 'wf', id: 'r', parentId: undefined, phase: 'start', name: 'root', details: {}, timestamp: 100 },
-      { kind: 'step', id: 's', parentId: 'r', phase: 'start', name: 'step', details: {}, timestamp: 200 },
-      { id: 's', phase: 'error', details: { message: 'failed' }, timestamp: 300 }
+      { kind: 'wf', id: 'r', parentId: undefined, phase: EventPhase.START, name: 'root', details: {}, timestamp: 100 },
+      { kind: 'step', id: 's', parentId: 'r', phase: EventPhase.START, name: 'step', details: {}, timestamp: 200 },
+      { id: 's', phase: EventPhase.ERROR, details: { message: 'failed' }, timestamp: 300 }
     ];
     const result = buildTraceTree( entries );
     expect( result ).not.toBeNull();
@@ -41,27 +77,28 @@ this can indicate it timed out or was interrupted.>>' );
   it( 'builds a tree from workflow/step/IO entries with grouping and sorting', () => {
     const entries = [
       // workflow start
-      { kind: 'workflow', phase: 'start', name: 'wf', id: 'wf', parentId: undefined, details: { a: 1 }, timestamp: 1000 },
+      { kind: 'workflow', phase: EventPhase.START, name: 'wf', id: 'wf', parentId: undefined, details: { a: 1 }, timestamp: 1000 },
       // evaluator start/stop
-      { kind: 'evaluator', phase: 'start', name: 'eval', id: 'eval', parentId: 'wf', details: { z: 0 }, timestamp: 1500 },
-      { id: 'eval', phase: 'end', details: { z: 1 }, timestamp: 1600 },
+      { kind: 'evaluator', phase: EventPhase.START, name: 'eval', id: 'eval', parentId: 'wf', details: { z: 0 }, timestamp: 1500 },
+      { id: 'eval', phase: EventPhase.END, details: { z: 1 }, timestamp: 1600 },
       // step1 start
-      { kind: 'step', phase: 'start', name: 'step-1', id: 's1', parentId: 'wf', details: { x: 1 }, timestamp: 2000 },
+      { kind: 'step', phase: EventPhase.START, name: 'step-1', id: 's1', parentId: 'wf', details: { x: 1 }, timestamp: 2000 },
+      { id: 's1', phase: EventPhase.ADD_ATTR, details: { name: 'step_tag', value: 'alpha' }, timestamp: 2050 },
       // IO under step1
-      { kind: 'IO', phase: 'start', name: 'test-1', id: 'io1', parentId: 's1', details: { y: 2 }, timestamp: 2300 },
+      { kind: 'IO', phase: EventPhase.START, name: 'test-1', id: 'io1', parentId: 's1', details: { y: 2 }, timestamp: 2300 },
       // step2 start
-      { kind: 'step', phase: 'start', name: 'step-2', id: 's2', parentId: 'wf', details: { x: 2 }, timestamp: 2400 },
+      { kind: 'step', phase: EventPhase.START, name: 'step-2', id: 's2', parentId: 'wf', details: { x: 2 }, timestamp: 2400 },
       // IO under step2
-      { kind: 'IO', phase: 'start', name: 'test-2', id: 'io2', parentId: 's2', details: { y: 3 }, timestamp: 2500 },
-      { id: 'io2', phase: 'end', details: { y: 4 }, timestamp: 2600 },
+      { kind: 'IO', phase: EventPhase.START, name: 'test-2', id: 'io2', parentId: 's2', details: { y: 3 }, timestamp: 2500 },
+      { id: 'io2', phase: EventPhase.END, details: { y: 4 }, timestamp: 2600 },
       // IO under step1 ends
-      { id: 'io1', phase: 'end', details: { y: 5 }, timestamp: 2700 },
+      { id: 'io1', phase: EventPhase.END, details: { y: 5 }, timestamp: 2700 },
       // step1 end
-      { id: 's1', phase: 'end', details: { done: true }, timestamp: 2800 },
+      { id: 's1', phase: EventPhase.END, details: { done: true }, timestamp: 2800 },
       // step2 end
-      { id: 's2', phase: 'end', details: { done: true }, timestamp: 2900 },
+      { id: 's2', phase: EventPhase.END, details: { done: true }, timestamp: 2900 },
       // workflow end
-      { id: 'wf', phase: 'end', details: { ok: true }, timestamp: 3000 }
+      { id: 'wf', phase: EventPhase.END, details: { ok: true }, timestamp: 3000 }
     ];
 
     const result = buildTraceTree( entries );
@@ -74,6 +111,7 @@ this can indicate it timed out or was interrupted.>>' );
       endedAt: 3000,
       input: { a: 1 },
       output: { ok: true },
+      attributes: {},
       children: [
         {
           id: 'eval',
@@ -83,6 +121,7 @@ this can indicate it timed out or was interrupted.>>' );
           endedAt: 1600,
           input: { z: 0 },
           output: { z: 1 },
+          attributes: {},
           children: []
         },
         {
@@ -93,6 +132,7 @@ this can indicate it timed out or was interrupted.>>' );
           endedAt: 2800,
           input: { x: 1 },
           output: { done: true },
+          attributes: { step_tag: 'alpha' },
           children: [
             {
               id: 'io1',
@@ -102,6 +142,7 @@ this can indicate it timed out or was interrupted.>>' );
               endedAt: 2700,
               input: { y: 2 },
               output: { y: 5 },
+              attributes: {},
               children: []
             }
           ]
@@ -114,6 +155,7 @@ this can indicate it timed out or was interrupted.>>' );
           endedAt: 2900,
           input: { x: 2 },
           output: { done: true },
+          attributes: {},
           children: [
             {
               id: 'io2',
@@ -123,6 +165,7 @@ this can indicate it timed out or was interrupted.>>' );
               endedAt: 2600,
               input: { y: 3 },
               output: { y: 4 },
+              attributes: {},
               children: []
             }
           ]

--- a/sdk/core/src/tracing/tools/build_trace_tree.spec.js
+++ b/sdk/core/src/tracing/tools/build_trace_tree.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { EventPhase } from '../trace_consts.js';
+import { EventAction } from '../trace_consts.js';
 import buildTraceTree from './build_trace_tree.js';
 
 describe( 'build_trace_tree', () => {
@@ -7,9 +7,9 @@ describe( 'build_trace_tree', () => {
     expect( buildTraceTree( [] ) ).toBeNull();
   } );
 
-  it( 'sets root output with a fixed message when workflow has no end/error phase yet', () => {
+  it( 'sets root output with a fixed message when workflow has no end/error action yet', () => {
     const entries = [
-      { kind: 'workflow', id: 'wf', parentId: undefined, phase: EventPhase.START, name: 'wf', details: {}, timestamp: 1000 }
+      { kind: 'workflow', id: 'wf', parentId: undefined, action: EventAction.START, name: 'wf', details: {}, timestamp: 1000 }
     ];
     const result = buildTraceTree( entries );
     expect( result ).not.toBeNull();
@@ -20,31 +20,31 @@ this can indicate it timed out or was interrupted.>>' );
 
   it( 'returns null when there is no root (all entries have parentId)', () => {
     const entries = [
-      { id: 'a', parentId: 'x', phase: EventPhase.START, name: 'a', timestamp: 1 },
-      { id: 'b', parentId: 'a', phase: EventPhase.START, name: 'b', timestamp: 2 }
+      { id: 'a', parentId: 'x', action: EventAction.START, name: 'a', timestamp: 1 },
+      { id: 'b', parentId: 'a', action: EventAction.START, name: 'b', timestamp: 2 }
     ];
     expect( buildTraceTree( entries ) ).toBeNull();
   } );
 
-  it( 'add_attr phase merges details.name and details.value into node.attributes', () => {
+  it( 'add_attr action merges details.name and details.value into node.attributes', () => {
     const entries = [
-      { kind: 'workflow', id: 'wf', parentId: undefined, phase: EventPhase.START, name: 'wf', details: {}, timestamp: 100 },
-      { kind: 'step', id: 's', parentId: 'wf', phase: EventPhase.START, name: 'step', details: {}, timestamp: 200 },
-      { id: 's', phase: EventPhase.ADD_ATTR, details: { name: 'latency_ms', value: 42 }, timestamp: 250 },
-      { id: 's', phase: EventPhase.ADD_ATTR, details: { name: 'retries', value: 1 }, timestamp: 260 },
-      { id: 'wf', phase: EventPhase.END, details: {}, timestamp: 300 }
+      { kind: 'workflow', id: 'wf', parentId: undefined, action: EventAction.START, name: 'wf', details: {}, timestamp: 100 },
+      { kind: 'step', id: 's', parentId: 'wf', action: EventAction.START, name: 'step', details: {}, timestamp: 200 },
+      { id: 's', action: EventAction.ADD_ATTR, details: { name: 'latency_ms', value: 42 }, timestamp: 250 },
+      { id: 's', action: EventAction.ADD_ATTR, details: { name: 'retries', value: 1 }, timestamp: 260 },
+      { id: 'wf', action: EventAction.END, details: {}, timestamp: 300 }
     ];
     const result = buildTraceTree( entries );
     expect( result ).not.toBeNull();
     expect( result.children[0].attributes ).toEqual( { latency_ms: 42, retries: 1 } );
   } );
 
-  it( 'add_attr phase overwrites prior value for the same attribute name', () => {
+  it( 'add_attr action overwrites prior value for the same attribute name', () => {
     const entries = [
-      { kind: 'workflow', id: 'wf', parentId: undefined, phase: EventPhase.START, name: 'wf', details: {}, timestamp: 1 },
-      { id: 'wf', phase: EventPhase.ADD_ATTR, details: { name: 'x', value: 1 }, timestamp: 2 },
-      { id: 'wf', phase: EventPhase.ADD_ATTR, details: { name: 'x', value: 2 }, timestamp: 3 },
-      { id: 'wf', phase: EventPhase.END, details: {}, timestamp: 4 }
+      { kind: 'workflow', id: 'wf', parentId: undefined, action: EventAction.START, name: 'wf', details: {}, timestamp: 1 },
+      { id: 'wf', action: EventAction.ADD_ATTR, details: { name: 'x', value: 1 }, timestamp: 2 },
+      { id: 'wf', action: EventAction.ADD_ATTR, details: { name: 'x', value: 2 }, timestamp: 3 },
+      { id: 'wf', action: EventAction.END, details: {}, timestamp: 4 }
     ];
     const result = buildTraceTree( entries );
     expect( result.attributes ).toEqual( { x: 2 } );
@@ -52,20 +52,20 @@ this can indicate it timed out or was interrupted.>>' );
 
   it( 'add_attr does not attach nodes as children (only start does)', () => {
     const entries = [
-      { kind: 'workflow', id: 'wf', parentId: undefined, phase: EventPhase.START, name: 'wf', details: {}, timestamp: 1 },
-      { id: 'orphan', parentId: 'wf', phase: EventPhase.ADD_ATTR, details: { name: 'k', value: 'v' }, timestamp: 2 },
-      { id: 'wf', phase: EventPhase.END, details: {}, timestamp: 3 }
+      { kind: 'workflow', id: 'wf', parentId: undefined, action: EventAction.START, name: 'wf', details: {}, timestamp: 1 },
+      { id: 'orphan', parentId: 'wf', action: EventAction.ADD_ATTR, details: { name: 'k', value: 'v' }, timestamp: 2 },
+      { id: 'wf', action: EventAction.END, details: {}, timestamp: 3 }
     ];
     const result = buildTraceTree( entries );
     expect( result.children ).toHaveLength( 0 );
     expect( result.attributes ).toEqual( {} );
   } );
 
-  it( 'error phase sets error and endedAt on node', () => {
+  it( 'error action sets error and endedAt on node', () => {
     const entries = [
-      { kind: 'wf', id: 'r', parentId: undefined, phase: EventPhase.START, name: 'root', details: {}, timestamp: 100 },
-      { kind: 'step', id: 's', parentId: 'r', phase: EventPhase.START, name: 'step', details: {}, timestamp: 200 },
-      { id: 's', phase: EventPhase.ERROR, details: { message: 'failed' }, timestamp: 300 }
+      { kind: 'wf', id: 'r', parentId: undefined, action: EventAction.START, name: 'root', details: {}, timestamp: 100 },
+      { kind: 'step', id: 's', parentId: 'r', action: EventAction.START, name: 'step', details: {}, timestamp: 200 },
+      { id: 's', action: EventAction.ERROR, details: { message: 'failed' }, timestamp: 300 }
     ];
     const result = buildTraceTree( entries );
     expect( result ).not.toBeNull();
@@ -77,28 +77,28 @@ this can indicate it timed out or was interrupted.>>' );
   it( 'builds a tree from workflow/step/IO entries with grouping and sorting', () => {
     const entries = [
       // workflow start
-      { kind: 'workflow', phase: EventPhase.START, name: 'wf', id: 'wf', parentId: undefined, details: { a: 1 }, timestamp: 1000 },
+      { kind: 'workflow', action: EventAction.START, name: 'wf', id: 'wf', parentId: undefined, details: { a: 1 }, timestamp: 1000 },
       // evaluator start/stop
-      { kind: 'evaluator', phase: EventPhase.START, name: 'eval', id: 'eval', parentId: 'wf', details: { z: 0 }, timestamp: 1500 },
-      { id: 'eval', phase: EventPhase.END, details: { z: 1 }, timestamp: 1600 },
+      { kind: 'evaluator', action: EventAction.START, name: 'eval', id: 'eval', parentId: 'wf', details: { z: 0 }, timestamp: 1500 },
+      { id: 'eval', action: EventAction.END, details: { z: 1 }, timestamp: 1600 },
       // step1 start
-      { kind: 'step', phase: EventPhase.START, name: 'step-1', id: 's1', parentId: 'wf', details: { x: 1 }, timestamp: 2000 },
-      { id: 's1', phase: EventPhase.ADD_ATTR, details: { name: 'step_tag', value: 'alpha' }, timestamp: 2050 },
+      { kind: 'step', action: EventAction.START, name: 'step-1', id: 's1', parentId: 'wf', details: { x: 1 }, timestamp: 2000 },
+      { id: 's1', action: EventAction.ADD_ATTR, details: { name: 'step_tag', value: 'alpha' }, timestamp: 2050 },
       // IO under step1
-      { kind: 'IO', phase: EventPhase.START, name: 'test-1', id: 'io1', parentId: 's1', details: { y: 2 }, timestamp: 2300 },
+      { kind: 'IO', action: EventAction.START, name: 'test-1', id: 'io1', parentId: 's1', details: { y: 2 }, timestamp: 2300 },
       // step2 start
-      { kind: 'step', phase: EventPhase.START, name: 'step-2', id: 's2', parentId: 'wf', details: { x: 2 }, timestamp: 2400 },
+      { kind: 'step', action: EventAction.START, name: 'step-2', id: 's2', parentId: 'wf', details: { x: 2 }, timestamp: 2400 },
       // IO under step2
-      { kind: 'IO', phase: EventPhase.START, name: 'test-2', id: 'io2', parentId: 's2', details: { y: 3 }, timestamp: 2500 },
-      { id: 'io2', phase: EventPhase.END, details: { y: 4 }, timestamp: 2600 },
+      { kind: 'IO', action: EventAction.START, name: 'test-2', id: 'io2', parentId: 's2', details: { y: 3 }, timestamp: 2500 },
+      { id: 'io2', action: EventAction.END, details: { y: 4 }, timestamp: 2600 },
       // IO under step1 ends
-      { id: 'io1', phase: EventPhase.END, details: { y: 5 }, timestamp: 2700 },
+      { id: 'io1', action: EventAction.END, details: { y: 5 }, timestamp: 2700 },
       // step1 end
-      { id: 's1', phase: EventPhase.END, details: { done: true }, timestamp: 2800 },
+      { id: 's1', action: EventAction.END, details: { done: true }, timestamp: 2800 },
       // step2 end
-      { id: 's2', phase: EventPhase.END, details: { done: true }, timestamp: 2900 },
+      { id: 's2', action: EventAction.END, details: { done: true }, timestamp: 2900 },
       // workflow end
-      { id: 'wf', phase: EventPhase.END, details: { ok: true }, timestamp: 3000 }
+      { id: 'wf', action: EventAction.END, details: { ok: true }, timestamp: 3000 }
     ];
 
     const result = buildTraceTree( entries );

--- a/sdk/core/src/tracing/trace_consts.js
+++ b/sdk/core/src/tracing/trace_consts.js
@@ -1,0 +1,9 @@
+/**
+ * Each possible phase a of a trace event
+ */
+export const EventPhase = {
+  START: 'start',
+  END: 'end',
+  ERROR: 'error',
+  ADD_ATTR: 'add_attr'
+};

--- a/sdk/core/src/tracing/trace_consts.js
+++ b/sdk/core/src/tracing/trace_consts.js
@@ -1,5 +1,5 @@
 /**
- * Each possible phase a of a trace event
+ * Each possible phase of a trace event
  */
 export const EventPhase = {
   START: 'start',

--- a/sdk/core/src/tracing/trace_consts.js
+++ b/sdk/core/src/tracing/trace_consts.js
@@ -1,7 +1,7 @@
 /**
- * Each possible phase of a trace event
+ * Each possible action of a trace event
  */
-export const EventPhase = {
+export const EventAction = {
   START: 'start',
   END: 'end',
   ERROR: 'error',

--- a/sdk/core/src/tracing/trace_engine.js
+++ b/sdk/core/src/tracing/trace_engine.js
@@ -64,34 +64,34 @@ export const init = async () => {
 const serializeDetails = details => details instanceof Error ? serializeError( details ) : details;
 
 /**
- * Creates a new trace event phase and sends it to be written
+ * Emits an event action to the event bus.
  *
- * @param {string} phase - The phase
+ * @param {string} action - The action
  * @param {object} fields - All the trace fields
  * @returns {void}
  */
-export const addEventPhase = ( phase, { kind, name, id, parentId, details, executionContext } ) => {
+export const addEventAction = ( action, { kind, name, id, parentId, details, executionContext } ) => {
   // Ignores internal steps in the actual trace files, ignore trace if the flag is true
   if ( kind !== ComponentType.INTERNAL_STEP && !executionContext.disableTrace ) {
     traceBus.emit( 'entry', {
       executionContext,
-      entry: { kind, phase, name, id, parentId, timestamp: Date.now(), details: serializeDetails( details ) }
+      entry: { kind, action, name, id, parentId, timestamp: Date.now(), details: serializeDetails( details ) }
     } );
   }
 };
 
 /**
- * Adds an Event Phase, complementing the options with parentId and executionContext from the async storage.
+ * Attaches contextual information to an event action before calling the method to emit it to the bus.
  *
- * This function will have no effect if called from outside an Temporal Workflow/Activity environment,
- * so it is safe to be used on unit tests or any dependencies that might be used elsewhere
+ * This function has no effect if called outside a Temporal Workflow/Activity environment,
+ * so it is safe to use in unit tests or dependencies that might be used elsewhere.
  *
  * @param {object} options - The common trace configurations
  */
-export function addEventPhaseWithContext( phase, options ) {
+export function addEventActionWithContext( action, options ) {
   const storeContent = Storage.load();
-  if ( storeContent ) { // If there is no storageContext this was not called from an Temporal Environment
+  if ( storeContent ) { // If there is no storageContext this was not called from a Temporal environment
     const { parentId, executionContext } = storeContent;
-    addEventPhase( phase, { ...options, parentId, executionContext } );
+    addEventAction( action, { ...options, parentId, executionContext } );
   }
 };

--- a/sdk/core/src/tracing/trace_engine.spec.js
+++ b/sdk/core/src/tracing/trace_engine.spec.js
@@ -39,7 +39,7 @@ describe( 'tracing/trace_engine', () => {
   it( 'init() starts only enabled processors and attaches listeners', async () => {
     process.env.OUTPUT_TRACE_LOCAL_ON = '1';
     process.env.OUTPUT_TRACE_REMOTE_ON = '0';
-    const { init, addEventPhase } = await loadTraceEngine();
+    const { init, addEventAction } = await loadTraceEngine();
 
     await init();
 
@@ -47,96 +47,96 @@ describe( 'tracing/trace_engine', () => {
     expect( s3InitMock ).not.toHaveBeenCalled();
 
     const executionContext = { disableTrace: false };
-    addEventPhase( 'start', {
+    addEventAction( 'start', {
       kind: 'step', name: 'N', id: '1', parentId: 'p', details: { ok: true }, executionContext
     } );
     expect( localExecMock ).toHaveBeenCalledTimes( 1 );
     const payload = localExecMock.mock.calls[0][0];
     expect( payload.entry.name ).toBe( 'N' );
     expect( payload.entry.kind ).toBe( 'step' );
-    expect( payload.entry.phase ).toBe( 'start' );
+    expect( payload.entry.action ).toBe( 'start' );
     expect( payload.entry.details ).toEqual( { ok: true } );
     expect( payload.executionContext ).toBe( executionContext );
   } );
 
-  it( 'addEventPhase() emits an entry consumed by processors', async () => {
+  it( 'addEventAction() emits an entry consumed by processors', async () => {
     process.env.OUTPUT_TRACE_LOCAL_ON = 'on';
-    const { init, addEventPhase } = await loadTraceEngine();
+    const { init, addEventAction } = await loadTraceEngine();
     await init();
 
-    addEventPhase( 'end', {
+    addEventAction( 'end', {
       kind: 'workflow', name: 'W', id: '2', parentId: 'p2', details: 'done',
       executionContext: { disableTrace: false }
     } );
     expect( localExecMock ).toHaveBeenCalledTimes( 1 );
     const payload = localExecMock.mock.calls[0][0];
     expect( payload.entry.name ).toBe( 'W' );
-    expect( payload.entry.phase ).toBe( 'end' );
+    expect( payload.entry.action ).toBe( 'end' );
     expect( payload.entry.details ).toBe( 'done' );
   } );
 
-  it( 'addEventPhase() does not emit when executionContext.disableTrace is true', async () => {
+  it( 'addEventAction() does not emit when executionContext.disableTrace is true', async () => {
     process.env.OUTPUT_TRACE_LOCAL_ON = '1';
-    const { init, addEventPhase } = await loadTraceEngine();
+    const { init, addEventAction } = await loadTraceEngine();
     await init();
 
-    addEventPhase( 'start', {
+    addEventAction( 'start', {
       kind: 'step', name: 'X', id: '1', parentId: 'p', details: {},
       executionContext: { disableTrace: true }
     } );
     expect( localExecMock ).not.toHaveBeenCalled();
   } );
 
-  it( 'addEventPhase() does not emit when kind is INTERNAL_STEP', async () => {
+  it( 'addEventAction() does not emit when kind is INTERNAL_STEP', async () => {
     process.env.OUTPUT_TRACE_LOCAL_ON = '1';
-    const { init, addEventPhase } = await loadTraceEngine();
+    const { init, addEventAction } = await loadTraceEngine();
     await init();
 
-    addEventPhase( 'start', {
+    addEventAction( 'start', {
       kind: 'internal_step', name: 'Internal', id: '1', parentId: 'p', details: {},
       executionContext: { disableTrace: false }
     } );
     expect( localExecMock ).not.toHaveBeenCalled();
   } );
 
-  it( 'addEventPhaseWithContext() uses storage when available', async () => {
+  it( 'addEventActionWithContext() uses storage when available', async () => {
     process.env.OUTPUT_TRACE_LOCAL_ON = 'true';
     storageLoadMock.mockReturnValue( {
       parentId: 'ctx-p',
       executionContext: { runId: 'r1', disableTrace: false }
     } );
-    const { init, addEventPhaseWithContext } = await loadTraceEngine();
+    const { init, addEventActionWithContext } = await loadTraceEngine();
     await init();
 
-    addEventPhaseWithContext( 'tick', { kind: 'step', name: 'S', id: '3', details: 1 } );
+    addEventActionWithContext( 'tick', { kind: 'step', name: 'S', id: '3', details: 1 } );
     expect( localExecMock ).toHaveBeenCalledTimes( 1 );
     const payload = localExecMock.mock.calls[0][0];
     expect( payload.executionContext ).toEqual( { runId: 'r1', disableTrace: false } );
     expect( payload.entry.parentId ).toBe( 'ctx-p' );
     expect( payload.entry.name ).toBe( 'S' );
-    expect( payload.entry.phase ).toBe( 'tick' );
+    expect( payload.entry.action ).toBe( 'tick' );
   } );
 
-  it( 'addEventPhaseWithContext() does not emit when storage executionContext.disableTrace is true', async () => {
+  it( 'addEventActionWithContext() does not emit when storage executionContext.disableTrace is true', async () => {
     process.env.OUTPUT_TRACE_LOCAL_ON = '1';
     storageLoadMock.mockReturnValue( {
       parentId: 'ctx-p',
       executionContext: { runId: 'r1', disableTrace: true }
     } );
-    const { init, addEventPhaseWithContext } = await loadTraceEngine();
+    const { init, addEventActionWithContext } = await loadTraceEngine();
     await init();
 
-    addEventPhaseWithContext( 'tick', { kind: 'step', name: 'S', id: '3', details: 1 } );
+    addEventActionWithContext( 'tick', { kind: 'step', name: 'S', id: '3', details: 1 } );
     expect( localExecMock ).not.toHaveBeenCalled();
   } );
 
-  it( 'addEventPhaseWithContext() is a no-op when storage is absent', async () => {
+  it( 'addEventActionWithContext() is a no-op when storage is absent', async () => {
     process.env.OUTPUT_TRACE_LOCAL_ON = '1';
     storageLoadMock.mockReturnValue( undefined );
-    const { init, addEventPhaseWithContext } = await loadTraceEngine();
+    const { init, addEventActionWithContext } = await loadTraceEngine();
     await init();
 
-    addEventPhaseWithContext( 'noop', { kind: 'step', name: 'X', id: '4', details: null } );
+    addEventActionWithContext( 'noop', { kind: 'step', name: 'X', id: '4', details: null } );
     expect( localExecMock ).not.toHaveBeenCalled();
   } );
 

--- a/sdk/http/src/config.ts
+++ b/sdk/http/src/config.ts
@@ -6,7 +6,5 @@ export const config = {
    * Whether to log verbose HTTP information (headers and bodies)
    * Controlled by OUTPUT_TRACE_HTTP_VERBOSE environment variable
    */
-  logVerbose: [ '1', 'true' ].includes( process.env.OUTPUT_TRACE_HTTP_VERBOSE as string ),
-
-  requestIdSymbol: Symbol( 'request_id' )
+  logVerbose: [ '1', 'true' ].includes( process.env.OUTPUT_TRACE_HTTP_VERBOSE as string )
 };

--- a/sdk/http/src/config.ts
+++ b/sdk/http/src/config.ts
@@ -6,5 +6,7 @@ export const config = {
    * Whether to log verbose HTTP information (headers and bodies)
    * Controlled by OUTPUT_TRACE_HTTP_VERBOSE environment variable
    */
-  logVerbose: [ '1', 'true' ].includes( process.env.OUTPUT_TRACE_HTTP_VERBOSE as string )
+  logVerbose: [ '1', 'true' ].includes( process.env.OUTPUT_TRACE_HTTP_VERBOSE as string ),
+
+  requestIdSymbol: Symbol( 'request_id' )
 };

--- a/sdk/http/src/consts.ts
+++ b/sdk/http/src/consts.ts
@@ -1,0 +1,4 @@
+/**
+ * Symbol used to store request id in the response object.
+ */
+export const requestIdSymbol = Symbol( 'request_id' );

--- a/sdk/http/src/cost.spec.ts
+++ b/sdk/http/src/cost.spec.ts
@@ -22,11 +22,11 @@ describe( 'addRequestCost', () => {
     vi.restoreAllMocks();
   } );
 
-  it( 'shortcircuits when the response has no http request id', async () => {
+  it( 'shortcircuits when the response has no http request id', () => {
     const response = new Response();
     const cost = { total: 1 };
 
-    await addRequestCost( response, cost );
+    addRequestCost( response, cost );
 
     expect( console.warn ).toHaveBeenCalledWith(
       'addRequestCost(): The "response" argument did not originate from @outputai/http, no costs were added.'
@@ -34,16 +34,50 @@ describe( 'addRequestCost', () => {
     expect( tracing.addEventAttribute ).not.toHaveBeenCalled();
   } );
 
-  it( 'records cost on the trace event when the response carries the request id', async () => {
+  it( 'records cost on the trace event when the response carries the request id', () => {
     const response = new Response();
     Reflect.set( response, config.requestIdSymbol, 'evt-cost-1' );
     const cost = { total: 2.5 };
 
-    await addRequestCost( response, cost );
+    addRequestCost( response, cost );
 
     expect( console.warn ).not.toHaveBeenCalled();
     expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
       eventId: 'evt-cost-1',
+      name: 'cost',
+      value: cost
+    } );
+  } );
+
+  it( 'forwards multiple components to tracing', () => {
+    const response = new Response();
+    Reflect.set( response, config.requestIdSymbol, 'evt-cost-2' );
+    const cost = {
+      total: 10,
+      components: [
+        { name: 'input', value: 3 },
+        { name: 'output', value: 7 }
+      ]
+    };
+
+    addRequestCost( response, cost );
+
+    expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
+      eventId: 'evt-cost-2',
+      name: 'cost',
+      value: cost
+    } );
+  } );
+
+  it( 'forwards an empty components array to tracing', () => {
+    const response = new Response();
+    Reflect.set( response, config.requestIdSymbol, 'evt-cost-3' );
+    const cost = { total: 1, components: [] };
+
+    addRequestCost( response, cost );
+
+    expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
+      eventId: 'evt-cost-3',
       name: 'cost',
       value: cost
     } );

--- a/sdk/http/src/cost.spec.ts
+++ b/sdk/http/src/cost.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { config } from './config.js';
+
+vi.mock( '@outputai/core/sdk_activity_integration', () => ( {
+  Tracing: {
+    addEventAttribute: vi.fn()
+  }
+} ) );
+
+import { Tracing } from '@outputai/core/sdk_activity_integration';
+import { addRequestCost } from './cost.js';
+
+const tracing = vi.mocked( Tracing, true );
+
+describe( 'addRequestCost', () => {
+  beforeEach( () => {
+    tracing.addEventAttribute.mockClear();
+    vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
+  } );
+
+  afterEach( () => {
+    vi.restoreAllMocks();
+  } );
+
+  it( 'shortcircuits when the response has no http request id', async () => {
+    const response = new Response();
+    const cost = { total: 1 };
+
+    await addRequestCost( response, cost );
+
+    expect( console.warn ).toHaveBeenCalledWith(
+      'addRequestCost(): The "response" argument did not originate from @outputai/http, no costs were added.'
+    );
+    expect( tracing.addEventAttribute ).not.toHaveBeenCalled();
+  } );
+
+  it( 'records cost on the trace event when the response carries the request id', async () => {
+    const response = new Response();
+    Reflect.set( response, config.requestIdSymbol, 'evt-cost-1' );
+    const cost = { total: 2.5 };
+
+    await addRequestCost( response, cost );
+
+    expect( console.warn ).not.toHaveBeenCalled();
+    expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
+      eventId: 'evt-cost-1',
+      name: 'cost',
+      value: cost
+    } );
+  } );
+} );

--- a/sdk/http/src/cost.spec.ts
+++ b/sdk/http/src/cost.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { config } from './config.js';
+import { requestIdSymbol } from './consts.js';
 
 vi.mock( '@outputai/core/sdk_activity_integration', () => ( {
   Tracing: {
@@ -36,7 +36,7 @@ describe( 'addRequestCost', () => {
 
   it( 'records cost on the trace event when the response carries the request id', () => {
     const response = new Response();
-    Reflect.set( response, config.requestIdSymbol, 'evt-cost-1' );
+    Reflect.set( response, requestIdSymbol, 'evt-cost-1' );
     const cost = { total: 2.5 };
 
     addRequestCost( response, cost );
@@ -51,7 +51,7 @@ describe( 'addRequestCost', () => {
 
   it( 'forwards multiple components to tracing', () => {
     const response = new Response();
-    Reflect.set( response, config.requestIdSymbol, 'evt-cost-2' );
+    Reflect.set( response, requestIdSymbol, 'evt-cost-2' );
     const cost = {
       total: 10,
       components: [
@@ -71,7 +71,7 @@ describe( 'addRequestCost', () => {
 
   it( 'forwards an empty components array to tracing', () => {
     const response = new Response();
-    Reflect.set( response, config.requestIdSymbol, 'evt-cost-3' );
+    Reflect.set( response, requestIdSymbol, 'evt-cost-3' );
     const cost = { total: 1, components: [] };
 
     addRequestCost( response, cost );

--- a/sdk/http/src/cost.spec.ts
+++ b/sdk/http/src/cost.spec.ts
@@ -3,7 +3,10 @@ import { requestIdSymbol } from './consts.js';
 
 vi.mock( '@outputai/core/sdk_activity_integration', () => ( {
   Tracing: {
-    addEventAttribute: vi.fn()
+    addEventAttribute: vi.fn(),
+    Attribute: {
+      COST: 'cost'
+    }
   }
 } ) );
 
@@ -44,7 +47,7 @@ describe( 'addRequestCost', () => {
     expect( console.warn ).not.toHaveBeenCalled();
     expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
       eventId: 'evt-cost-1',
-      name: 'cost',
+      name: Tracing.Attribute.COST,
       value: cost
     } );
   } );
@@ -64,7 +67,7 @@ describe( 'addRequestCost', () => {
 
     expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
       eventId: 'evt-cost-2',
-      name: 'cost',
+      name: Tracing.Attribute.COST,
       value: cost
     } );
   } );
@@ -78,7 +81,7 @@ describe( 'addRequestCost', () => {
 
     expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
       eventId: 'evt-cost-3',
-      name: 'cost',
+      name: Tracing.Attribute.COST,
       value: cost
     } );
   } );

--- a/sdk/http/src/cost.ts
+++ b/sdk/http/src/cost.ts
@@ -14,5 +14,9 @@ export type RequestCost = {
 
 export const addRequestCost = async ( response: KyResponse | Response, cost: RequestCost ) : Promise<void> => {
   const eventId = Reflect.get( response, config.requestIdSymbol ) as string;
+  if ( !eventId ) {
+    console.warn( 'addRequestCost(): The "response" argument did not originate from @outputai/http, no costs were added.' );
+    return;
+  }
   Tracing.addEventAttribute( { eventId, name: 'cost', value: cost } );
 };

--- a/sdk/http/src/cost.ts
+++ b/sdk/http/src/cost.ts
@@ -4,15 +4,20 @@ import { Tracing } from '@outputai/core/sdk_activity_integration';
 
 export type RequestCost = {
   total: number,
-  components?: [
-    {
-      name: string,
-      value: number
-    }
-  ]
+  components?: Array<{
+    name: string,
+    value: number
+  }>
 };
 
-export const addRequestCost = async ( response: KyResponse | Response, cost: RequestCost ) : Promise<void> => {
+/**
+ * Attach cost information to the trace of an HTTP Request using the response
+ *
+ * @param response - The response of the HTTP Request to attach the information
+ * @param cost - The cost information
+ * @returns
+ */
+export const addRequestCost = ( response: KyResponse | Response, cost: RequestCost ) : void => {
   const eventId = Reflect.get( response, config.requestIdSymbol ) as string;
   if ( !eventId ) {
     console.warn( 'addRequestCost(): The "response" argument did not originate from @outputai/http, no costs were added.' );

--- a/sdk/http/src/cost.ts
+++ b/sdk/http/src/cost.ts
@@ -23,5 +23,5 @@ export const addRequestCost = ( response: KyResponse | Response, cost: RequestCo
     console.warn( 'addRequestCost(): The "response" argument did not originate from @outputai/http, no costs were added.' );
     return;
   }
-  Tracing.addEventAttribute( { eventId, name: 'cost', value: cost } );
+  Tracing.addEventAttribute( { eventId, name: Tracing.Attribute.COST, value: cost } );
 };

--- a/sdk/http/src/cost.ts
+++ b/sdk/http/src/cost.ts
@@ -1,6 +1,6 @@
 import { KyResponse } from 'ky';
-import { config } from './config.js';
 import { Tracing } from '@outputai/core/sdk_activity_integration';
+import { requestIdSymbol } from './consts.js';
 
 export type RequestCost = {
   total: number,
@@ -18,7 +18,7 @@ export type RequestCost = {
  * @returns
  */
 export const addRequestCost = ( response: KyResponse | Response, cost: RequestCost ) : void => {
-  const eventId = Reflect.get( response, config.requestIdSymbol ) as string;
+  const eventId = Reflect.get( response, requestIdSymbol ) as string;
   if ( !eventId ) {
     console.warn( 'addRequestCost(): The "response" argument did not originate from @outputai/http, no costs were added.' );
     return;

--- a/sdk/http/src/cost.ts
+++ b/sdk/http/src/cost.ts
@@ -1,0 +1,18 @@
+import { KyResponse } from 'ky';
+import { config } from './config.js';
+import { Tracing } from '@outputai/core/sdk_activity_integration';
+
+export type RequestCost = {
+  total: number,
+  components?: [
+    {
+      name: string,
+      value: number
+    }
+  ]
+};
+
+export const addRequestCost = async ( response: KyResponse | Response, cost: RequestCost ) : Promise<void> => {
+  const eventId = Reflect.get( response, config.requestIdSymbol ) as string;
+  Tracing.addEventAttribute( { eventId, name: 'cost', value: cost } );
+};

--- a/sdk/http/src/fetch/index.spec.ts
+++ b/sdk/http/src/fetch/index.spec.ts
@@ -12,6 +12,9 @@ const loggerMock = vi.hoisted( () => ( {
   logError: vi.fn( ( _args: { requestId: string; response: UndiciResponse } ): void => {} ),
   logFailure: vi.fn( ( _args: { requestId: string; error: Error } ): void => {} )
 } ) );
+const utilsMock = vi.hoisted( () => ( {
+  addRequestIdToResponse: vi.fn()
+} ) );
 
 vi.mock( 'node:crypto', () => ( {
   randomUUID: () => randomUUIDMock()
@@ -22,6 +25,9 @@ vi.mock( './logger.js', () => ( {
   logResponse: loggerMock.logResponse,
   logError: loggerMock.logError,
   logFailure: loggerMock.logFailure
+} ) );
+vi.mock( './utils.js', () => ( {
+  addRequestIdToResponse: utilsMock.addRequestIdToResponse
 } ) );
 
 import { fetch } from './index.js';
@@ -46,6 +52,7 @@ describe( 'fetch/index', () => {
     loggerMock.logResponse.mockClear();
     loggerMock.logError.mockClear();
     loggerMock.logFailure.mockClear();
+    utilsMock.addRequestIdToResponse.mockClear();
     randomUUIDMock.mockClear();
     randomUUIDMock.mockImplementation( () => FIXED_REQUEST_ID );
   } );
@@ -80,6 +87,8 @@ describe( 'fetch/index', () => {
       expect( loggerMock.logResponse ).toHaveBeenCalledTimes( 1 );
       expect( loggerMock.logResponse.mock.calls[0][0].requestId ).toBe( FIXED_REQUEST_ID );
       expect( loggerMock.logResponse.mock.calls[0][0].response ).toBe( response );
+      expect( utilsMock.addRequestIdToResponse ).toHaveBeenCalledTimes( 1 );
+      expect( utilsMock.addRequestIdToResponse ).toHaveBeenCalledWith( response, FIXED_REQUEST_ID );
 
       expect( loggerMock.logError ).not.toHaveBeenCalled();
       expect( loggerMock.logFailure ).not.toHaveBeenCalled();
@@ -101,6 +110,8 @@ describe( 'fetch/index', () => {
       expect( loggerMock.logError ).toHaveBeenCalledTimes( 1 );
       expect( loggerMock.logError.mock.calls[0][0].requestId ).toBe( FIXED_REQUEST_ID );
       expect( loggerMock.logError.mock.calls[0][0].response ).toBe( response );
+      expect( utilsMock.addRequestIdToResponse ).toHaveBeenCalledTimes( 1 );
+      expect( utilsMock.addRequestIdToResponse ).toHaveBeenCalledWith( response, FIXED_REQUEST_ID );
     } );
 
     it( 'treats status 399 as success (logs response end, not HTTP error)', async () => {
@@ -184,6 +195,7 @@ describe( 'fetch/index', () => {
       expect( loggerMock.logRequest ).toHaveBeenCalledTimes( 1 );
       expect( loggerMock.logResponse ).not.toHaveBeenCalled();
       expect( loggerMock.logFailure ).toHaveBeenCalledTimes( 1 );
+      expect( utilsMock.addRequestIdToResponse ).not.toHaveBeenCalled();
     } );
 
     it( 'passes method and body through to undici for POST JSON', async () => {

--- a/sdk/http/src/fetch/index.ts
+++ b/sdk/http/src/fetch/index.ts
@@ -2,6 +2,7 @@ import * as undici from 'undici';
 import { randomUUID } from 'node:crypto';
 import { logRequest, logResponse, logError, logFailure } from './logger.js';
 import type { RequestInfo, RequestInit } from 'undici';
+import { config } from '../config.js';
 
 /*
  * Unifies undici and nodes realms
@@ -46,6 +47,9 @@ export const fetch = async ( input: RequestInfo | Request, init?: RequestInit ) 
 
   try {
     const response = await undici.fetch( request );
+
+    Object.defineProperty( response, config.requestIdSymbol, { value: requestId, enumerable: false, configurable: false, writable: false } );
+
     if ( response.status > 399 ) {
       await logError( { requestId, response } );
       return response;

--- a/sdk/http/src/fetch/index.ts
+++ b/sdk/http/src/fetch/index.ts
@@ -2,7 +2,7 @@ import * as undici from 'undici';
 import { randomUUID } from 'node:crypto';
 import { logRequest, logResponse, logError, logFailure } from './logger.js';
 import type { RequestInfo, RequestInit } from 'undici';
-import { config } from '../config.js';
+import { addRequestIdToResponse } from './utils.js';
 
 /*
  * Unifies undici and nodes realms
@@ -48,7 +48,8 @@ export const fetch = async ( input: RequestInfo | Request, init?: RequestInit ) 
   try {
     const response = await undici.fetch( request );
 
-    Object.defineProperty( response, config.requestIdSymbol, { value: requestId, enumerable: false, configurable: false, writable: false } );
+    // This enriches the response of the request id, so it is identifiable later.
+    addRequestIdToResponse( response, requestId );
 
     if ( response.status > 399 ) {
       await logError( { requestId, response } );

--- a/sdk/http/src/fetch/logger.spec.ts
+++ b/sdk/http/src/fetch/logger.spec.ts
@@ -5,7 +5,8 @@ vi.mock( '@outputai/core/sdk_activity_integration', () => ( {
   Tracing: {
     addEventStart: vi.fn(),
     addEventEnd: vi.fn(),
-    addEventError: vi.fn()
+    addEventError: vi.fn(),
+    addEventAttribute: vi.fn()
   }
 } ) );
 
@@ -28,10 +29,19 @@ beforeEach( () => {
   tracing.addEventStart.mockClear();
   tracing.addEventEnd.mockClear();
   tracing.addEventError.mockClear();
+  tracing.addEventAttribute.mockClear();
 } );
 
 describe( 'fetch/logger', () => {
   describe( 'logRequest', () => {
+    const expectRequestIdAttribute = ( requestId: string ) => {
+      expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
+        eventId: requestId,
+        name: 'requestId',
+        value: requestId
+      } );
+    };
+
     it( 'records minimal details when verbose is off', async () => {
       const { logRequest } = await logLogger( false );
       const request = new Request( 'https://api.example.com/r', { method: 'GET' } );
@@ -47,6 +57,7 @@ describe( 'fetch/logger', () => {
           url: 'https://api.example.com/r'
         }
       } );
+      expectRequestIdAttribute( 'req-1' );
     } );
 
     it( 'defaults method to GET', async () => {
@@ -56,6 +67,7 @@ describe( 'fetch/logger', () => {
       await logRequest( { requestId: 'r2', request } );
 
       expect( ( tracing.addEventStart.mock.calls[0][0].details as { method: string } ).method ).toBe( 'GET' );
+      expectRequestIdAttribute( 'r2' );
     } );
 
     it( 'includes redacted headers and parsed body when verbose is on', async () => {
@@ -83,6 +95,7 @@ describe( 'fetch/logger', () => {
           body: { x: 1 }
         }
       } );
+      expectRequestIdAttribute( 'req-v' );
     } );
   } );
 

--- a/sdk/http/src/fetch/logger.ts
+++ b/sdk/http/src/fetch/logger.ts
@@ -10,7 +10,7 @@ import { parseBody, redactHeaders, serializeError } from './utils.js';
  * @param options.requestId - id of the request
  * @param options.request - The HTTP Request object
  */
-export const logRequest = async ( { requestId, request } : { requestId: string, request: Request } ) : Promise<void> =>
+export const logRequest = async ( { requestId, request } : { requestId: string, request: Request } ) : Promise<void> => {
   Tracing.addEventStart( {
     id: requestId, kind: 'http', name: 'request', details: {
       method: request.method,
@@ -18,6 +18,8 @@ export const logRequest = async ( { requestId, request } : { requestId: string, 
       ...( config.logVerbose && { headers: redactHeaders( request.headers ), body: await parseBody( request ) } )
     }
   } );
+  Tracing.addEventAttribute( { eventId: requestId, name: 'requestId', value: requestId } );
+};
 
 /**
  * Sends the trace error event for an http response with error status

--- a/sdk/http/src/fetch/utils.spec.ts
+++ b/sdk/http/src/fetch/utils.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { Response, Request, Headers } from 'undici';
-import { parseBody, redactHeaders, serializeError } from './utils.js';
+import { requestIdSymbol } from '../consts.js';
+import { addRequestIdToResponse, parseBody, redactHeaders, serializeError } from './utils.js';
 
 const createMultiLevelError = ( levels : number, depth : number = 1 ) : Error =>
   depth === levels ?
@@ -288,6 +289,31 @@ describe( 'fetch/utils', () => {
         body: raw
       } );
       await expect( parseBody( request ) ).resolves.toBe( raw );
+    } );
+  } );
+
+  describe( 'addRequestIdToResponse', () => {
+    it( 'stores request id under requestIdSymbol and returns the same response', () => {
+      const response = new Response( 'ok' );
+
+      const enriched = addRequestIdToResponse( response, 'req-123' );
+
+      expect( enriched ).toBe( response );
+      expect( ( response as unknown as Record<symbol, unknown> )[requestIdSymbol] ).toBe( 'req-123' );
+    } );
+
+    it( 'defines request id as non-enumerable, non-writable and non-configurable', () => {
+      const response = new Response( 'ok' );
+      addRequestIdToResponse( response, 'req-456' );
+
+      const descriptor = Object.getOwnPropertyDescriptor( response, requestIdSymbol );
+      expect( descriptor ).toBeDefined();
+      expect( descriptor ).toMatchObject( {
+        enumerable: false,
+        configurable: false,
+        writable: false,
+        value: 'req-456'
+      } );
     } );
   } );
 } );

--- a/sdk/http/src/fetch/utils.ts
+++ b/sdk/http/src/fetch/utils.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, Headers } from 'undici';
+import { requestIdSymbol } from '../consts.js';
 
 /**
  * Header names that look sensitive by substring rules but are not secret material.
@@ -97,3 +98,14 @@ export const parseBody = async ( r : Request | Response ) : Promise<string | obj
     return textContent;
   }
 };
+
+/**
+ * Adds a non-enumerable, non-configurable and non-writable property to a response.
+ *
+ * This property is identified by a unique symbol and contains the id of the request.
+ *
+ * @param response
+ * @param requestId
+ */
+export const addRequestIdToResponse = ( response: Response, requestId: string ) =>
+  Object.defineProperty( response, requestIdSymbol, { value: requestId, enumerable: false, configurable: false, writable: false } );

--- a/sdk/http/src/index.ts
+++ b/sdk/http/src/index.ts
@@ -31,3 +31,5 @@ export function httpClient( options: Options = {} ) {
 export { HTTPError, TimeoutError } from 'ky';
 export type { Options as HttpClientOptions } from 'ky';
 export * from './fetch/index.js';
+
+export { addRequestCost } from './cost.js';

--- a/sdk/llm/src/ai_sdk.spec.js
+++ b/sdk/llm/src/ai_sdk.spec.js
@@ -3,7 +3,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 const tracingSpies = {
   addEventStart: vi.fn(),
   addEventEnd: vi.fn(),
-  addEventError: vi.fn()
+  addEventError: vi.fn(),
+  addEventAttribute: vi.fn()
 };
 const emitEventSpy = vi.fn();
 vi.mock( '@outputai/core/sdk_activity_integration', () => ( {
@@ -111,19 +112,28 @@ describe( 'ai_sdk', () => {
   it( 'generateText: validates, traces, calls AI and returns text', async () => {
     const { generateText } = await importSut();
     const result = await generateText( { prompt: 'test_prompt@v1' } );
+    const defaultUsage = { inputTokens: 10, outputTokens: 5, totalTokens: 15 };
 
     expect( validators.validateGenerateTextArgs ).toHaveBeenCalledWith( { prompt: 'test_prompt@v1' } );
     expect( loadPromptImpl ).toHaveBeenCalledWith( 'test_prompt@v1', undefined, undefined );
     expect( tracingSpies.addEventStart ).toHaveBeenCalledTimes( 1 );
+    expect( tracingSpies.addEventAttribute ).toHaveBeenCalledTimes( 1 );
+    expect( tracingSpies.addEventAttribute ).toHaveBeenCalledWith(
+      expect.objectContaining( { name: 'cost', value: cost } )
+    );
     expect( tracingSpies.addEventEnd ).toHaveBeenCalledTimes( 1 );
     expect( tracingSpies.addEventEnd ).toHaveBeenCalledWith(
-      expect.objectContaining( { details: expect.objectContaining( { cost } ) } )
+      expect.objectContaining( {
+        details: expect.objectContaining( {
+          result: 'TEXT',
+          usage: defaultUsage
+        } )
+      } )
     );
     expect( calculateLLMCallCostImpl ).toHaveBeenCalledWith( {
-      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+      usage: defaultUsage,
       modelId: basePrompt.config.model
     } );
-    const defaultUsage = { inputTokens: 10, outputTokens: 5, totalTokens: 15 };
     expect( emitEventSpy ).toHaveBeenCalledTimes( 1 );
     expect( emitEventSpy ).toHaveBeenCalledWith( 'llm:call_cost', {
       modelId: basePrompt.config.model,
@@ -390,12 +400,14 @@ describe( 'ai_sdk', () => {
       cost,
       usage
     } );
+    expect( tracingSpies.addEventAttribute ).toHaveBeenCalledWith(
+      expect.objectContaining( { name: 'cost', value: cost } )
+    );
     expect( tracingSpies.addEventEnd ).toHaveBeenCalledWith(
       expect.objectContaining( {
         details: {
           result: 'STREAMED_TEXT',
           usage,
-          cost,
           providerMetadata: finishEvent.providerMetadata
         }
       } )
@@ -606,8 +618,14 @@ describe( 'ai_sdk', () => {
     expect( result.sources ).toEqual( nativeSources );
   } );
 
-  it( 'generateText: includes costs from cost module in trace details', async () => {
-    const customCost = { total: 0.02, components: { input: { value: 0.01 }, output: { value: 0.01 } } };
+  it( 'generateText: records cost from cost module as a trace attribute', async () => {
+    const customCost = {
+      total: 0.02,
+      components: [
+        { name: 'input_tokens', value: 0.01 },
+        { name: 'output_tokens', value: 0.01 }
+      ]
+    };
     calculateLLMCallCostImpl.mockResolvedValueOnce( customCost );
 
     const { generateText } = await importSut();
@@ -617,8 +635,8 @@ describe( 'ai_sdk', () => {
       usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
       modelId: basePrompt.config.model
     } );
-    expect( tracingSpies.addEventEnd ).toHaveBeenCalledWith(
-      expect.objectContaining( { details: expect.objectContaining( { cost: customCost } ) } )
+    expect( tracingSpies.addEventAttribute ).toHaveBeenCalledWith(
+      expect.objectContaining( { name: 'cost', value: customCost } )
     );
   } );
 

--- a/sdk/llm/src/ai_sdk.spec.js
+++ b/sdk/llm/src/ai_sdk.spec.js
@@ -4,7 +4,10 @@ const tracingSpies = {
   addEventStart: vi.fn(),
   addEventEnd: vi.fn(),
   addEventError: vi.fn(),
-  addEventAttribute: vi.fn()
+  addEventAttribute: vi.fn(),
+  Attribute: {
+    COST: 'cost'
+  }
 };
 const emitEventSpy = vi.fn();
 vi.mock( '@outputai/core/sdk_activity_integration', () => ( {
@@ -119,7 +122,7 @@ describe( 'ai_sdk', () => {
     expect( tracingSpies.addEventStart ).toHaveBeenCalledTimes( 1 );
     expect( tracingSpies.addEventAttribute ).toHaveBeenCalledTimes( 1 );
     expect( tracingSpies.addEventAttribute ).toHaveBeenCalledWith(
-      expect.objectContaining( { name: 'cost', value: cost } )
+      expect.objectContaining( { name: tracingSpies.Attribute.COST, value: cost } )
     );
     expect( tracingSpies.addEventEnd ).toHaveBeenCalledTimes( 1 );
     expect( tracingSpies.addEventEnd ).toHaveBeenCalledWith(
@@ -401,7 +404,7 @@ describe( 'ai_sdk', () => {
       usage
     } );
     expect( tracingSpies.addEventAttribute ).toHaveBeenCalledWith(
-      expect.objectContaining( { name: 'cost', value: cost } )
+      expect.objectContaining( { name: tracingSpies.Attribute.COST, value: cost } )
     );
     expect( tracingSpies.addEventEnd ).toHaveBeenCalledWith(
       expect.objectContaining( {
@@ -636,7 +639,7 @@ describe( 'ai_sdk', () => {
       modelId: basePrompt.config.model
     } );
     expect( tracingSpies.addEventAttribute ).toHaveBeenCalledWith(
-      expect.objectContaining( { name: 'cost', value: customCost } )
+      expect.objectContaining( { name: tracingSpies.Attribute.COST, value: customCost } )
     );
   } );
 

--- a/sdk/llm/src/cost/index.js
+++ b/sdk/llm/src/cost/index.js
@@ -5,37 +5,6 @@ const M = 1_000_000;
 const calcCost = ( tokens, ppm ) => Decimal( tokens ?? 0 ).div( M ).mul( ppm ).toNumber();
 
 /**
- * Calculates the input cost based on the input value
- */
-const calculateInput = ( { tokens, cost } ) =>
-  !Number.isFinite( cost.input ) ? { value: null, message: 'Missing input cost' } : { value: calcCost( tokens, cost.input ) };
-
-/**
- * Calculates the input cost based on the cache_read
- */
-const calculateCachedInput = ( { tokens, cost } ) =>
-  !Number.isFinite( cost.cache_read ) ? { value: null, message: 'Missing cache input cost' } : { value: calcCost( tokens, cost.cache_read ) };
-
-/**
- * Calculates the output cost based on the output value
- */
-const calculateOutput = ( { tokens, cost } ) =>
-  !Number.isFinite( cost.output ) ? { value: null, message: 'Missing output' } : { value: calcCost( tokens, cost.output ) };
-
-/**
- * Calculates the reasoning cost based on the reasoning token's
- * If there isn't reasoning costs, this means this providers doesn't differentiate reasoning vs output,
- * so don't calculate it as the price is included in output
- */
-const calculateReasoning = ( { tokens, cost } ) =>
-  Number.isFinite( cost.reasoning ) ? { value: calcCost( tokens, cost.reasoning ) } : undefined;
-
-/**
- * Calculates the total cost based on the components
- */
-const calculateTotal = components => Object.values( components ).reduce( ( v, e ) => v.plus( e?.value ? e.value : 0 ), Decimal( 0 ) ).toNumber();
-
-/**
  * Calculates the cost of an llm call based on the model and usage.
  * @param {object} args
  * @param {string} args.modelId - Name of the mode, provider prefix is optional
@@ -58,14 +27,14 @@ export const calculateLLMCallCost = async ( { modelId, usage } ) => {
 
     const nonCachedTokens = inputTokens - ( cachedInputTokens ?? 0 );
 
-    const components = {
-      input: calculateInput( { tokens: nonCachedTokens, cost } ),
-      cachedInput: calculateCachedInput( { tokens: cachedInputTokens, cost } ),
-      output: calculateOutput( { tokens: outputTokens, cost } ),
-      reasoning: calculateReasoning( { tokens: reasoningTokens ?? 0, cost } )
-    };
-
-    return { total: calculateTotal( components ), components };
+    const components = [
+      Number.isFinite( cost.input ) ? { name: 'input_tokens', value: calcCost( nonCachedTokens, cost.input ) } : false,
+      Number.isFinite( cost.cache_read ) ? { name: 'input_cached_tokens', value: calcCost( cachedInputTokens, cost.cache_read ) } : false,
+      Number.isFinite( cost.output ) ? { name: 'output_tokens', value: calcCost( outputTokens, cost.output ) } : false,
+      /* When there aren't reasoning costs, the providers doesn't differentiate reasoning vs output, so the price is included in the output */
+      Number.isFinite( cost.reasoning ) ? { name: 'reasoning_tokens', value: calcCost( reasoningTokens, cost.reasoning ) } : false
+    ].filter( v => !!v );
+    return { total: components.reduce( ( v, e ) => v.plus( e.value ), Decimal( 0 ) ).toNumber(), components };
   } catch ( error ) {
     console.error( 'Error calculating LLM call costs', error );
     return { total: null, message: `Error calculating LLM call costs: ${error.constructor.name} - ${error.message}` };

--- a/sdk/llm/src/cost/index.spec.js
+++ b/sdk/llm/src/cost/index.spec.js
@@ -47,10 +47,11 @@ describe( 'calculateLLMCallCost', () => {
     } );
 
     expect( result.total ).toBe( 7 );
-    expect( result.components.input ).toEqual( { value: 2 } );
-    expect( result.components.cachedInput ).toEqual( { value: 0 } );
-    expect( result.components.output ).toEqual( { value: 5 } );
-    expect( result.components.reasoning ).toBeUndefined();
+    expect( result.components ).toEqual( [
+      { name: 'input_tokens', value: 2 },
+      { name: 'input_cached_tokens', value: 0 },
+      { name: 'output_tokens', value: 5 }
+    ] );
   } );
 
   it( 'splits input into non-cached and cached at respective rates', async () => {
@@ -62,13 +63,15 @@ describe( 'calculateLLMCallCost', () => {
       usage: { inputTokens: 1_000_000, cachedInputTokens: 500_000, outputTokens: 100_000 }
     } );
 
-    expect( result.components.input ).toEqual( { value: 2 } );
-    expect( result.components.cachedInput ).toEqual( { value: 0.5 } );
-    expect( result.components.output ).toEqual( { value: 1 } );
+    expect( result.components ).toEqual( [
+      { name: 'input_tokens', value: 2 },
+      { name: 'input_cached_tokens', value: 0.5 },
+      { name: 'output_tokens', value: 1 }
+    ] );
     expect( result.total ).toBeCloseTo( 3.5 );
   } );
 
-  it( 'sets cachedInput to null when model has no cache_read', async () => {
+  it( 'omits cached component when model has no cache_read (non-cached rate applies to full input minus cached)', async () => {
     mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'no-cache', { input: 2, output: 10 } ] ] ) );
 
     const result = await calculateLLMCallCost( {
@@ -76,12 +79,14 @@ describe( 'calculateLLMCallCost', () => {
       usage: { inputTokens: 1_000_000, cachedInputTokens: 200_000, outputTokens: 0 }
     } );
 
-    expect( result.components.input ).toEqual( { value: 1.6 } );
-    expect( result.components.cachedInput ).toEqual( { value: null, message: 'Missing cache input cost' } );
+    expect( result.components ).toEqual( [
+      { name: 'input_tokens', value: 1.6 },
+      { name: 'output_tokens', value: 0 }
+    ] );
     expect( result.total ).toBe( 1.6 );
   } );
 
-  it( 'sets input to null and message when pricing has no input', async () => {
+  it( 'omits input component when pricing has no input rate', async () => {
     mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'out-only', { output: 10 } ] ] ) );
 
     const result = await calculateLLMCallCost( {
@@ -90,11 +95,12 @@ describe( 'calculateLLMCallCost', () => {
     } );
 
     expect( result.total ).toBe( 0.0005 );
-    expect( result.components.input ).toEqual( { value: null, message: 'Missing input cost' } );
-    expect( result.components.output ).toEqual( { value: 0.0005 } );
+    expect( result.components ).toEqual( [
+      { name: 'output_tokens', value: 0.0005 }
+    ] );
   } );
 
-  it( 'sets output to null and message when pricing has no output', async () => {
+  it( 'omits output component when pricing has no output rate', async () => {
     mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'in-only', { input: 1 } ] ] ) );
 
     const result = await calculateLLMCallCost( {
@@ -103,8 +109,9 @@ describe( 'calculateLLMCallCost', () => {
     } );
 
     expect( result.total ).toBe( 0.0001 );
-    expect( result.components.input ).toEqual( { value: 0.0001 } );
-    expect( result.components.output ).toEqual( { value: null, message: 'Missing output' } );
+    expect( result.components ).toEqual( [
+      { name: 'input_tokens', value: 0.0001 }
+    ] );
   } );
 
   it( 'uses reasoning cost when present', async () => {
@@ -119,7 +126,11 @@ describe( 'calculateLLMCallCost', () => {
     } );
 
     expect( result.total ).toBeCloseTo( 0.0033 );
-    expect( result.components.reasoning ).toEqual( { value: 0.003 } );
+    expect( result.components ).toEqual( [
+      { name: 'input_tokens', value: 0.0001 },
+      { name: 'output_tokens', value: 0.0002 },
+      { name: 'reasoning_tokens', value: 0.003 }
+    ] );
   } );
 
   it( 'omits reasoning component when reasoning cost missing (included in output)', async () => {
@@ -131,10 +142,13 @@ describe( 'calculateLLMCallCost', () => {
     } );
 
     expect( result.total ).toBeCloseTo( 0.0003 );
-    expect( result.components.reasoning ).toBeUndefined();
+    expect( result.components ).toEqual( [
+      { name: 'input_tokens', value: 0.0001 },
+      { name: 'output_tokens', value: 0.0002 }
+    ] );
   } );
 
-  it( 'Calculate reasoning component when reasoningTokens is zero', async () => {
+  it( 'includes reasoning component with zero when reasoningTokens is zero', async () => {
     mockFetchModelsPricing.mockResolvedValue( new Map( [ [
       'full',
       { input: 2, output: 8, reasoning: 60 }
@@ -145,7 +159,11 @@ describe( 'calculateLLMCallCost', () => {
       usage: { inputTokens: 100, outputTokens: 50, reasoningTokens: 0 }
     } );
 
-    expect( result.components.reasoning ).toEqual( { value: 0 } );
+    expect( result.components ).toEqual( [
+      { name: 'input_tokens', value: 0.0002 },
+      { name: 'output_tokens', value: 0.0004 },
+      { name: 'reasoning_tokens', value: 0 }
+    ] );
     expect( result.total ).toBeCloseTo( 0.0006 );
   } );
 
@@ -158,5 +176,9 @@ describe( 'calculateLLMCallCost', () => {
     } );
 
     expect( result.total ).toBe( 0 );
+    expect( result.components ).toEqual( [
+      { name: 'input_tokens', value: 0 },
+      { name: 'output_tokens', value: 0 }
+    ] );
   } );
 } );

--- a/sdk/llm/src/trace_utils.js
+++ b/sdk/llm/src/trace_utils.js
@@ -15,7 +15,7 @@ export const endTraceWithSuccess = async ( traceId, modelId, response, extraDeta
   const { text: result, totalUsage: usage, providerMetadata } = response;
   const cost = await calculateLLMCallCost( { usage, modelId } );
   emitEvent( 'llm:call_cost', { modelId, cost, usage } );
-  Tracing.addEventAttribute( { eventId: traceId, name: 'cost', value: cost } );
+  Tracing.addEventAttribute( { eventId: traceId, name: Tracing.Attribute.COST, value: cost } );
   Tracing.addEventEnd( { id: traceId, details: { result, usage, providerMetadata, ...extraDetails } } );
 };
 

--- a/sdk/llm/src/trace_utils.js
+++ b/sdk/llm/src/trace_utils.js
@@ -15,7 +15,8 @@ export const endTraceWithSuccess = async ( traceId, modelId, response, extraDeta
   const { text: result, totalUsage: usage, providerMetadata } = response;
   const cost = await calculateLLMCallCost( { usage, modelId } );
   emitEvent( 'llm:call_cost', { modelId, cost, usage } );
-  Tracing.addEventEnd( { id: traceId, details: { result, usage, cost, providerMetadata, ...extraDetails } } );
+  Tracing.addEventAttribute( { eventId: traceId, name: 'cost', value: cost } );
+  Tracing.addEventEnd( { id: traceId, details: { result, usage, providerMetadata, ...extraDetails } } );
 };
 
 export const traceStreamCallbacks = ( traceId, modelId, { onFinish: userOnFinish, onError: userOnError } = {} ) => ( {

--- a/test_workflows/src/workflows/http/api_client.ts
+++ b/test_workflows/src/workflows/http/api_client.ts
@@ -1,4 +1,4 @@
-import { httpClient, HttpClientOptions } from '@outputai/http';
+import { httpClient, HttpClientOptions, addRequestCost } from '@outputai/http';
 import type { HttpBinResponse, ClientInput, ContractInput } from './types.js';
 
 const httpBinClient = httpClient( {
@@ -57,6 +57,9 @@ export async function exportClients(): Promise<HttpBinResponse> {
  */
 export async function getContracts(): Promise<HttpBinResponse> {
   const response = await contractsClient.get( '' );
+  await addRequestCost( response, {
+    total: 120
+  } );
   return response.json() as Promise<HttpBinResponse>;
 }
 
@@ -66,5 +69,6 @@ export async function getContracts(): Promise<HttpBinResponse> {
  */
 export async function createContract( data: ContractInput ): Promise<HttpBinResponse> {
   const response = await contractsClient.post( '', { json: data } );
+
   return response.json() as Promise<HttpBinResponse>;
 }


### PR DESCRIPTION
## Summary

### Add event attributes
Adding a new tracing feature `Tracing.addEventAttribute()` to add "attributes" to trace events. This is a new object field for each trace event in the trace file, that accepts any kind of values:

```js
[
  {
    "id": "generateText-1777069221681",
    "kind": "llm",
    "name": "generateText",
    "startedAt": 1777069221681,
    "endedAt": 1777069225372,
    "input": {
      ...
    },
    "output": {
      ...
    },
    "children": [],
    "attributes": {
      "flavor": "vanilla" // <-- ATTRIBUTE
    }
  }
],
```

### Add HTTP request cost
Adding a new method to the `@outputai/http` module `addRequestCost()`, that allows user to add a cost attribute to an HTTP trace event using the response (both fetch's `Response` or ky's `KyResponse`):

```js
import { fetch } from '@outputai/http';

const response = await fetch( https://foo );
addRequestCost( response, {
  total: 32,
  components: [
    { name: 'api', value: 24 },
    { name: 'caching', value: 12 } 
  ]
} );
```

The cost format must respect:
```ts
export type RequestCost = {
  total: number,
  components?: [
    {
      name: string,
      value: number
    }
  ]
```

## Refactoring LLM cost

Refactoring `@outputai/llm` to attach LLM costs using `Tracing.addEventAttribute()`, with the same format used by the HTTP module.

## Test plan

- [x] Unit tests
- [x] e2e tests
- [x] Manual tests  
