### PR TITLE
feat: Docker port updates

### DIFF
--- a/.changeset/pretty-ends-share.md
+++ b/.changeset/pretty-ends-share.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Enable multiple instance of Output to run locally simultaneously in Docker by enabling dynamic port mapping

--- a/sdk/cli/src/assets/docker/docker-compose-dev.yml
+++ b/sdk/cli/src/assets/docker/docker-compose-dev.yml
@@ -49,7 +49,7 @@ services:
     networks:
       - main
     ports:
-      - '7233:7233'
+      - '${OUTPUT_TEMPORAL_HOST_PORT:-7233}:7233'
     healthcheck:
       test:
         [
@@ -73,7 +73,7 @@ services:
     networks:
       - main
     ports:
-      - '8080:8080'
+      - '${OUTPUT_TEMPORAL_UI_HOST_PORT:-8080}:8080'
 
   api:
     depends_on:
@@ -97,7 +97,7 @@ services:
       - OUTPUT_AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - TEMPORAL_ADDRESS=temporal:7233
     ports:
-      - '3001:3001'
+      - '${OUTPUT_API_HOST_PORT:-3001}:3001'
 
   worker:
     depends_on:

--- a/sdk/cli/src/assets/docker/docker-compose-dev.yml
+++ b/sdk/cli/src/assets/docker/docker-compose-dev.yml
@@ -4,8 +4,6 @@ services:
     image: redis:8-alpine
     networks:
       - main
-    ports:
-      - '6379:6379'
     volumes:
       - redis:/data
     healthcheck:

--- a/sdk/cli/src/assets/docker/docker-compose-dev.yml
+++ b/sdk/cli/src/assets/docker/docker-compose-dev.yml
@@ -46,8 +46,6 @@ services:
     image: temporalio/auto-setup:latest
     networks:
       - main
-    ports:
-      - '${OUTPUT_TEMPORAL_HOST_PORT:-7233}:7233'
     healthcheck:
       test:
         [

--- a/sdk/cli/src/commands/dev/index.ts
+++ b/sdk/cli/src/commands/dev/index.ts
@@ -16,6 +16,7 @@ import type { PullPolicy } from '#services/docker.js';
 import { getErrorMessage } from '#utils/error_utils.js';
 import { ensureClaudePlugin } from '#services/coding_agents.js';
 import { DevApp } from '#views/dev.js';
+import { config } from '#config.js';
 
 export default class Dev extends Command {
   static description = [
@@ -24,7 +25,6 @@ export default class Dev extends Command {
     'To run a second dev stack concurrently, override host ports in .env:',
     '',
     '  OUTPUT_API_HOST_PORT=3002',
-    '  OUTPUT_TEMPORAL_HOST_PORT=7234',
     '  OUTPUT_TEMPORAL_UI_HOST_PORT=8081'
   ].join( '\n' );
 
@@ -75,6 +75,7 @@ export default class Dev extends Command {
     }
 
     this.log( '\n🚀 Starting Output development services...\n' );
+    this.log( `Docker project name: ${config.dockerServiceName}\n` );
 
     if ( flags['compose-file'] ) {
       this.log( `Using custom docker-compose file: ${flags['compose-file']}\n` );

--- a/sdk/cli/src/commands/dev/index.ts
+++ b/sdk/cli/src/commands/dev/index.ts
@@ -18,7 +18,15 @@ import { ensureClaudePlugin } from '#services/coding_agents.js';
 import { DevApp } from '#views/dev.js';
 
 export default class Dev extends Command {
-  static description = 'Start Output development services (auto-restarts worker on file changes)';
+  static description = [
+    'Start Output development services (auto-restarts worker on file changes)',
+    '',
+    'To run a second dev stack concurrently, override host ports in .env:',
+    '',
+    '  OUTPUT_API_HOST_PORT=3002',
+    '  OUTPUT_TEMPORAL_HOST_PORT=7234',
+    '  OUTPUT_TEMPORAL_UI_HOST_PORT=8081'
+  ].join( '\n' );
 
   static examples = [
     '<%= config.bin %> <%= command.id %>',

--- a/sdk/cli/src/commands/dev/index.ts
+++ b/sdk/cli/src/commands/dev/index.ts
@@ -64,6 +64,9 @@ export default class Dev extends Command {
 
     validateDockerEnvironment();
 
+    // Eagerly resolve ports so InvalidPortError surfaces before Ink mounts.
+    void config.ports;
+
     const dockerComposePath = flags['compose-file'] ?
       path.resolve( process.cwd(), flags['compose-file'] ) :
       getDefaultDockerComposePath();

--- a/sdk/cli/src/config.spec.ts
+++ b/sdk/cli/src/config.spec.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { ux } from '@oclif/core';
 import { config } from '#config.js';
 
 describe( 'config', () => {
@@ -79,6 +80,45 @@ describe( 'config', () => {
 
     expect( config.ports ).toEqual( { temporal: 7234, temporalUi: 8081, api: 3002 } );
     expect( config.temporalUiUrl ).toBe( 'http://localhost:8081' );
+  } );
+
+  it( 'treats empty-string OUTPUT_API_HOST_PORT as unset (matches Compose semantics)', () => {
+    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+    delete process.env.OUTPUT_API_URL;
+    process.env.OUTPUT_API_HOST_PORT = '';
+    process.env.OUTPUT_TEMPORAL_HOST_PORT = '';
+    process.env.OUTPUT_TEMPORAL_UI_HOST_PORT = '';
+
+    expect( config.apiUrl ).toBe( 'http://localhost:3001' );
+    expect( config.ports ).toEqual( { temporal: 7233, temporalUi: 8080, api: 3001 } );
+    expect( config.temporalUiUrl ).toBe( 'http://localhost:8080' );
+    expect( warn ).not.toHaveBeenCalled();
+  } );
+
+  it( 'falls back to defaults and warns on non-numeric port values', () => {
+    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+    delete process.env.OUTPUT_API_URL;
+    process.env.OUTPUT_API_HOST_PORT = 'abc';
+
+    expect( config.ports.api ).toBe( 3001 );
+    expect( config.apiUrl ).toBe( 'http://localhost:3001' );
+    expect( warn ).toHaveBeenCalled();
+  } );
+
+  it( 'falls back to defaults and warns on out-of-range port values', () => {
+    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+    process.env.OUTPUT_API_HOST_PORT = '99999';
+
+    expect( config.ports.api ).toBe( 3001 );
+    expect( warn ).toHaveBeenCalled();
+  } );
+
+  it( 'falls back to defaults and warns on trailing-junk port values', () => {
+    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+    process.env.OUTPUT_TEMPORAL_HOST_PORT = '7233abc';
+
+    expect( config.ports.temporal ).toBe( 7233 );
+    expect( warn ).toHaveBeenCalled();
   } );
 
   it( 'reads apiToken from env', () => {

--- a/sdk/cli/src/config.spec.ts
+++ b/sdk/cli/src/config.spec.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { ux } from '@oclif/core';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { config } from '#config.js';
+import { InvalidPortError } from '#utils/validation.js';
 
 describe( 'config', () => {
   const envVars = [
@@ -85,8 +85,7 @@ describe( 'config', () => {
     expect( config.temporalUiUrl ).toBe( 'http://localhost:8081' );
   } );
 
-  it( 'treats empty-string OUTPUT_API_HOST_PORT as unset (matches Compose semantics)', () => {
-    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+  it( 'treats empty-string port env vars as unset (matches Compose semantics)', () => {
     delete process.env.OUTPUT_API_URL;
     process.env.OUTPUT_API_HOST_PORT = '';
     process.env.OUTPUT_TEMPORAL_UI_HOST_PORT = '';
@@ -94,33 +93,28 @@ describe( 'config', () => {
     expect( config.apiUrl ).toBe( 'http://localhost:3001' );
     expect( config.ports ).toEqual( { temporalUi: 8080, api: 3001 } );
     expect( config.temporalUiUrl ).toBe( 'http://localhost:8080' );
-    expect( warn ).not.toHaveBeenCalled();
   } );
 
-  it( 'falls back to defaults and warns on non-numeric port values', () => {
-    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+  it( 'throws InvalidPortError on non-numeric port values', () => {
     delete process.env.OUTPUT_API_URL;
     process.env.OUTPUT_API_HOST_PORT = 'abc';
-
-    expect( config.ports.api ).toBe( 3001 );
-    expect( config.apiUrl ).toBe( 'http://localhost:3001' );
-    expect( warn ).toHaveBeenCalled();
+    expect( () => config.ports ).toThrow( InvalidPortError );
+    expect( () => config.apiUrl ).toThrow( InvalidPortError );
   } );
 
-  it( 'falls back to defaults and warns on out-of-range port values', () => {
-    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+  it( 'throws InvalidPortError on out-of-range port values', () => {
     process.env.OUTPUT_API_HOST_PORT = '99999';
-
-    expect( config.ports.api ).toBe( 3001 );
-    expect( warn ).toHaveBeenCalled();
+    expect( () => config.ports ).toThrow( InvalidPortError );
   } );
 
-  it( 'falls back to defaults and warns on trailing-junk port values', () => {
-    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+  it( 'throws InvalidPortError on trailing-junk port values', () => {
     process.env.OUTPUT_TEMPORAL_UI_HOST_PORT = '8080abc';
+    expect( () => config.ports ).toThrow( InvalidPortError );
+  } );
 
-    expect( config.ports.temporalUi ).toBe( 8080 );
-    expect( warn ).toHaveBeenCalled();
+  it( 'throws InvalidPortError on port 0 (Compose treats 0 as ephemeral - prevents CLI/Docker desync)', () => {
+    process.env.OUTPUT_API_HOST_PORT = '0';
+    expect( () => config.ports ).toThrow( InvalidPortError );
   } );
 
   it( 'reads apiToken from env', () => {

--- a/sdk/cli/src/config.spec.ts
+++ b/sdk/cli/src/config.spec.ts
@@ -4,6 +4,9 @@ import { config } from '#config.js';
 describe( 'config', () => {
   const envVars = [
     'OUTPUT_API_URL',
+    'OUTPUT_API_HOST_PORT',
+    'OUTPUT_TEMPORAL_HOST_PORT',
+    'OUTPUT_TEMPORAL_UI_HOST_PORT',
     'OUTPUT_API_AUTH_TOKEN',
     'DOCKER_SERVICE_NAME',
     'OUTPUT_DEBUG',
@@ -42,14 +45,40 @@ describe( 'config', () => {
 
   it( 'falls back to defaults when env vars are unset', () => {
     delete process.env.OUTPUT_API_URL;
+    delete process.env.OUTPUT_API_HOST_PORT;
+    delete process.env.OUTPUT_TEMPORAL_HOST_PORT;
+    delete process.env.OUTPUT_TEMPORAL_UI_HOST_PORT;
     delete process.env.DOCKER_SERVICE_NAME;
     delete process.env.OUTPUT_DEBUG;
     delete process.env.OUTPUT_CLI_ENV;
 
     expect( config.apiUrl ).toBe( 'http://localhost:3001' );
+    expect( config.ports ).toEqual( { temporal: 7233, temporalUi: 8080, api: 3001 } );
+    expect( config.temporalUiUrl ).toBe( 'http://localhost:8080' );
     expect( config.dockerServiceName ).toBe( 'output-sdk' );
     expect( config.debugMode ).toBe( false );
     expect( config.envFile ).toBe( '.env' );
+  } );
+
+  it( 'derives apiUrl from OUTPUT_API_HOST_PORT when OUTPUT_API_URL is unset', () => {
+    delete process.env.OUTPUT_API_URL;
+    process.env.OUTPUT_API_HOST_PORT = '3002';
+    expect( config.apiUrl ).toBe( 'http://localhost:3002' );
+  } );
+
+  it( 'OUTPUT_API_URL takes precedence over OUTPUT_API_HOST_PORT', () => {
+    process.env.OUTPUT_API_URL = 'https://api.example.com';
+    process.env.OUTPUT_API_HOST_PORT = '3002';
+    expect( config.apiUrl ).toBe( 'https://api.example.com' );
+  } );
+
+  it( 'reads port overrides from env vars', () => {
+    process.env.OUTPUT_TEMPORAL_HOST_PORT = '7234';
+    process.env.OUTPUT_TEMPORAL_UI_HOST_PORT = '8081';
+    process.env.OUTPUT_API_HOST_PORT = '3002';
+
+    expect( config.ports ).toEqual( { temporal: 7234, temporalUi: 8081, api: 3002 } );
+    expect( config.temporalUiUrl ).toBe( 'http://localhost:8081' );
   } );
 
   it( 'reads apiToken from env', () => {

--- a/sdk/cli/src/config.spec.ts
+++ b/sdk/cli/src/config.spec.ts
@@ -6,7 +6,6 @@ describe( 'config', () => {
   const envVars = [
     'OUTPUT_API_URL',
     'OUTPUT_API_HOST_PORT',
-    'OUTPUT_TEMPORAL_HOST_PORT',
     'OUTPUT_TEMPORAL_UI_HOST_PORT',
     'OUTPUT_API_AUTH_TOKEN',
     'DOCKER_SERVICE_NAME',
@@ -47,14 +46,13 @@ describe( 'config', () => {
   it( 'falls back to defaults when env vars are unset', () => {
     delete process.env.OUTPUT_API_URL;
     delete process.env.OUTPUT_API_HOST_PORT;
-    delete process.env.OUTPUT_TEMPORAL_HOST_PORT;
     delete process.env.OUTPUT_TEMPORAL_UI_HOST_PORT;
     delete process.env.DOCKER_SERVICE_NAME;
     delete process.env.OUTPUT_DEBUG;
     delete process.env.OUTPUT_CLI_ENV;
 
     expect( config.apiUrl ).toBe( 'http://localhost:3001' );
-    expect( config.ports ).toEqual( { temporal: 7233, temporalUi: 8080, api: 3001 } );
+    expect( config.ports ).toEqual( { temporalUi: 8080, api: 3001 } );
     expect( config.temporalUiUrl ).toBe( 'http://localhost:8080' );
     expect( config.dockerServiceName ).toBe( 'output-sdk' );
     expect( config.debugMode ).toBe( false );
@@ -73,12 +71,17 @@ describe( 'config', () => {
     expect( config.apiUrl ).toBe( 'https://api.example.com' );
   } );
 
+  it( 'empty-string OUTPUT_API_URL falls through to OUTPUT_API_HOST_PORT (|| not ??)', () => {
+    process.env.OUTPUT_API_URL = '';
+    process.env.OUTPUT_API_HOST_PORT = '3002';
+    expect( config.apiUrl ).toBe( 'http://localhost:3002' );
+  } );
+
   it( 'reads port overrides from env vars', () => {
-    process.env.OUTPUT_TEMPORAL_HOST_PORT = '7234';
     process.env.OUTPUT_TEMPORAL_UI_HOST_PORT = '8081';
     process.env.OUTPUT_API_HOST_PORT = '3002';
 
-    expect( config.ports ).toEqual( { temporal: 7234, temporalUi: 8081, api: 3002 } );
+    expect( config.ports ).toEqual( { temporalUi: 8081, api: 3002 } );
     expect( config.temporalUiUrl ).toBe( 'http://localhost:8081' );
   } );
 
@@ -86,11 +89,10 @@ describe( 'config', () => {
     const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
     delete process.env.OUTPUT_API_URL;
     process.env.OUTPUT_API_HOST_PORT = '';
-    process.env.OUTPUT_TEMPORAL_HOST_PORT = '';
     process.env.OUTPUT_TEMPORAL_UI_HOST_PORT = '';
 
     expect( config.apiUrl ).toBe( 'http://localhost:3001' );
-    expect( config.ports ).toEqual( { temporal: 7233, temporalUi: 8080, api: 3001 } );
+    expect( config.ports ).toEqual( { temporalUi: 8080, api: 3001 } );
     expect( config.temporalUiUrl ).toBe( 'http://localhost:8080' );
     expect( warn ).not.toHaveBeenCalled();
   } );
@@ -115,9 +117,9 @@ describe( 'config', () => {
 
   it( 'falls back to defaults and warns on trailing-junk port values', () => {
     const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
-    process.env.OUTPUT_TEMPORAL_HOST_PORT = '7233abc';
+    process.env.OUTPUT_TEMPORAL_UI_HOST_PORT = '8080abc';
 
-    expect( config.ports.temporal ).toBe( 7233 );
+    expect( config.ports.temporalUi ).toBe( 8080 );
     expect( warn ).toHaveBeenCalled();
   } );
 

--- a/sdk/cli/src/config.ts
+++ b/sdk/cli/src/config.ts
@@ -1,6 +1,16 @@
 export const config = {
   get apiUrl() {
-    return process.env.OUTPUT_API_URL || 'http://localhost:3001';
+    return process.env.OUTPUT_API_URL || `http://localhost:${process.env.OUTPUT_API_HOST_PORT ?? '3001'}`;
+  },
+  get ports() {
+    return {
+      temporal: parseInt( process.env.OUTPUT_TEMPORAL_HOST_PORT ?? '7233', 10 ),
+      temporalUi: parseInt( process.env.OUTPUT_TEMPORAL_UI_HOST_PORT ?? '8080', 10 ),
+      api: parseInt( process.env.OUTPUT_API_HOST_PORT ?? '3001', 10 )
+    };
+  },
+  get temporalUiUrl() {
+    return `http://localhost:${process.env.OUTPUT_TEMPORAL_UI_HOST_PORT ?? '8080'}`;
   },
   get apiToken() {
     return process.env.OUTPUT_API_AUTH_TOKEN;

--- a/sdk/cli/src/config.ts
+++ b/sdk/cli/src/config.ts
@@ -1,7 +1,6 @@
 import { parsePort } from '#utils/validation.js';
 
 const DEFAULT_API_PORT = 3001;
-const DEFAULT_TEMPORAL_PORT = 7233;
 const DEFAULT_TEMPORAL_UI_PORT = 8080;
 
 export const config = {
@@ -10,7 +9,6 @@ export const config = {
   },
   get ports() {
     return {
-      temporal: parsePort( process.env.OUTPUT_TEMPORAL_HOST_PORT, DEFAULT_TEMPORAL_PORT, 'OUTPUT_TEMPORAL_HOST_PORT' ),
       temporalUi: parsePort( process.env.OUTPUT_TEMPORAL_UI_HOST_PORT, DEFAULT_TEMPORAL_UI_PORT, 'OUTPUT_TEMPORAL_UI_HOST_PORT' ),
       api: parsePort( process.env.OUTPUT_API_HOST_PORT, DEFAULT_API_PORT, 'OUTPUT_API_HOST_PORT' )
     };

--- a/sdk/cli/src/config.ts
+++ b/sdk/cli/src/config.ts
@@ -1,16 +1,22 @@
+import { parsePort } from '#utils/validation.js';
+
+const DEFAULT_API_PORT = 3001;
+const DEFAULT_TEMPORAL_PORT = 7233;
+const DEFAULT_TEMPORAL_UI_PORT = 8080;
+
 export const config = {
   get apiUrl() {
-    return process.env.OUTPUT_API_URL || `http://localhost:${process.env.OUTPUT_API_HOST_PORT ?? '3001'}`;
+    return process.env.OUTPUT_API_URL || `http://localhost:${this.ports.api}`;
   },
   get ports() {
     return {
-      temporal: parseInt( process.env.OUTPUT_TEMPORAL_HOST_PORT ?? '7233', 10 ),
-      temporalUi: parseInt( process.env.OUTPUT_TEMPORAL_UI_HOST_PORT ?? '8080', 10 ),
-      api: parseInt( process.env.OUTPUT_API_HOST_PORT ?? '3001', 10 )
+      temporal: parsePort( process.env.OUTPUT_TEMPORAL_HOST_PORT, DEFAULT_TEMPORAL_PORT, 'OUTPUT_TEMPORAL_HOST_PORT' ),
+      temporalUi: parsePort( process.env.OUTPUT_TEMPORAL_UI_HOST_PORT, DEFAULT_TEMPORAL_UI_PORT, 'OUTPUT_TEMPORAL_UI_HOST_PORT' ),
+      api: parsePort( process.env.OUTPUT_API_HOST_PORT, DEFAULT_API_PORT, 'OUTPUT_API_HOST_PORT' )
     };
   },
   get temporalUiUrl() {
-    return `http://localhost:${process.env.OUTPUT_TEMPORAL_UI_HOST_PORT ?? '8080'}`;
+    return `http://localhost:${this.ports.temporalUi}`;
   },
   get apiToken() {
     return process.env.OUTPUT_API_AUTH_TOKEN;

--- a/sdk/cli/src/services/docker.spec.ts
+++ b/sdk/cli/src/services/docker.spec.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { execFileSync } from 'node:child_process';
-import { parseServiceStatus, getServiceStatus, waitForServicesHealthy, isServiceHealthy, isServiceFailed } from './docker.js';
+import { execFileSync, spawn } from 'node:child_process';
+import {
+  parseServiceStatus, getServiceStatus, startDockerCompose, stopDockerCompose,
+  waitForServicesHealthy, isServiceHealthy, isServiceFailed
+} from './docker.js';
 
 vi.mock( 'node:child_process', () => ( {
   execSync: vi.fn(),
@@ -102,7 +105,7 @@ describe( 'docker service', () => {
 
       expect( execFileSync ).toHaveBeenCalledWith(
         'docker',
-        [ 'compose', '-f', '/path/to/docker-compose.yml', 'ps', '--all', '--format', 'json' ],
+        [ 'compose', '-f', '/path/to/docker-compose.yml', '--project-name', 'output-sdk', 'ps', '--all', '--format', 'json' ],
         expect.objectContaining( { encoding: 'utf-8' } )
       );
     } );
@@ -123,6 +126,29 @@ describe( 'docker service', () => {
       } );
 
       await expect( getServiceStatus( '/path/to/docker-compose.yml' ) ).rejects.toThrow();
+    } );
+  } );
+
+  describe( 'startDockerCompose', () => {
+    it( 'should pass --project-name to docker compose up', async () => {
+      await startDockerCompose( '/path/to/docker-compose.yml' );
+      expect( spawn ).toHaveBeenCalledWith(
+        'docker',
+        expect.arrayContaining( [ '--project-name', 'output-sdk', '--project-directory', process.cwd() ] ),
+        expect.anything()
+      );
+    } );
+  } );
+
+  describe( 'stopDockerCompose', () => {
+    it( 'should pass --project-name and --project-directory to docker compose down', async () => {
+      vi.mocked( execFileSync ).mockReturnValue( '' );
+      await stopDockerCompose( '/path/to/docker-compose.yml' );
+      expect( execFileSync ).toHaveBeenCalledWith(
+        'docker',
+        [ 'compose', '-f', '/path/to/docker-compose.yml', '--project-directory', process.cwd(), '--project-name', 'output-sdk', 'down' ],
+        expect.objectContaining( { stdio: 'inherit' } )
+      );
     } );
   } );
 

--- a/sdk/cli/src/services/docker.spec.ts
+++ b/sdk/cli/src/services/docker.spec.ts
@@ -192,6 +192,35 @@ describe( 'docker service', () => {
     } );
   } );
 
+  describe( 'DOCKER_SERVICE_NAME wiring', () => {
+    const saved = process.env.DOCKER_SERVICE_NAME;
+    afterEach( () => {
+      if ( saved === undefined ) {
+        delete process.env.DOCKER_SERVICE_NAME;
+      } else {
+        process.env.DOCKER_SERVICE_NAME = saved;
+      }
+    } );
+
+    it( 'threads DOCKER_SERVICE_NAME through to --project-name (not hardcoded output-sdk)', async () => {
+      process.env.DOCKER_SERVICE_NAME = 'custom-project';
+      vi.mocked( execFileSync ).mockReturnValue( '' );
+
+      await stopDockerCompose( '/path/to/docker-compose.yml' );
+
+      expect( execFileSync ).toHaveBeenCalledWith(
+        'docker',
+        [
+          'compose', '-f', '/path/to/docker-compose.yml',
+          '--project-directory', process.cwd(),
+          '--project-name', 'custom-project',
+          'down'
+        ],
+        expect.objectContaining( { stdio: 'inherit' } )
+      );
+    } );
+  } );
+
   describe( 'stopDockerCompose', () => {
     it( 'should pass --project-name and --project-directory to docker compose down', async () => {
       vi.mocked( execFileSync ).mockReturnValue( '' );

--- a/sdk/cli/src/services/docker.spec.ts
+++ b/sdk/cli/src/services/docker.spec.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { execFileSync, spawn } from 'node:child_process';
 import {
-  parseServiceStatus, getServiceStatus, startDockerCompose, stopDockerCompose,
+  parseServiceStatus, getServiceStatus,
+  startDockerCompose, startDockerComposeDetached, stopDockerCompose,
   waitForServicesHealthy, isServiceHealthy, isServiceFailed
 } from './docker.js';
 
@@ -134,8 +135,59 @@ describe( 'docker service', () => {
       await startDockerCompose( '/path/to/docker-compose.yml' );
       expect( spawn ).toHaveBeenCalledWith(
         'docker',
-        expect.arrayContaining( [ '--project-name', 'output-sdk', '--project-directory', process.cwd() ] ),
-        expect.anything()
+        [
+          'compose', '-f', '/path/to/docker-compose.yml',
+          '--project-directory', process.cwd(),
+          '--project-name', 'output-sdk',
+          'up'
+        ],
+        expect.objectContaining( { stdio: [ 'ignore', 'pipe', 'pipe' ], cwd: process.cwd() } )
+      );
+    } );
+
+    it( 'should append --pull when pullPolicy is provided', async () => {
+      await startDockerCompose( '/path/to/docker-compose.yml', 'always' );
+      expect( spawn ).toHaveBeenCalledWith(
+        'docker',
+        [
+          'compose', '-f', '/path/to/docker-compose.yml',
+          '--project-directory', process.cwd(),
+          '--project-name', 'output-sdk',
+          'up', '--pull', 'always'
+        ],
+        expect.objectContaining( { stdio: [ 'ignore', 'pipe', 'pipe' ], cwd: process.cwd() } )
+      );
+    } );
+  } );
+
+  describe( 'startDockerComposeDetached', () => {
+    it( 'should pass --project-name and -d to docker compose up', () => {
+      vi.mocked( execFileSync ).mockReturnValue( '' );
+      startDockerComposeDetached( '/path/to/docker-compose.yml' );
+      expect( execFileSync ).toHaveBeenCalledWith(
+        'docker',
+        [
+          'compose', '-f', '/path/to/docker-compose.yml',
+          '--project-directory', process.cwd(),
+          '--project-name', 'output-sdk',
+          'up', '-d'
+        ],
+        expect.objectContaining( { stdio: 'inherit', cwd: process.cwd() } )
+      );
+    } );
+
+    it( 'should append --pull when pullPolicy is provided', () => {
+      vi.mocked( execFileSync ).mockReturnValue( '' );
+      startDockerComposeDetached( '/path/to/docker-compose.yml', 'missing' );
+      expect( execFileSync ).toHaveBeenCalledWith(
+        'docker',
+        [
+          'compose', '-f', '/path/to/docker-compose.yml',
+          '--project-directory', process.cwd(),
+          '--project-name', 'output-sdk',
+          'up', '-d', '--pull', 'missing'
+        ],
+        expect.objectContaining( { stdio: 'inherit', cwd: process.cwd() } )
       );
     } );
   } );

--- a/sdk/cli/src/services/docker.ts
+++ b/sdk/cli/src/services/docker.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ux } from '@oclif/core';
 import semver from 'semver';
+import { config } from '#config.js';
 
 const DEFAULT_COMPOSE_PATH = '../assets/docker/docker-compose-dev.yml';
 
@@ -143,7 +144,7 @@ export function parseServiceStatus( jsonOutput: string ): ServiceStatus[] {
 export async function getServiceStatus( dockerComposePath: string ): Promise<ServiceStatus[]> {
   const result = execFileSync(
     'docker',
-    [ 'compose', '-f', dockerComposePath, 'ps', '--all', '--format', 'json' ],
+    [ 'compose', '-f', dockerComposePath, '--project-name', config.dockerServiceName, 'ps', '--all', '--format', 'json' ],
     { encoding: 'utf-8', cwd: process.cwd() }
   );
 
@@ -193,6 +194,7 @@ export async function startDockerCompose(
     'compose',
     '-f', dockerComposePath,
     '--project-directory', process.cwd(),
+    '--project-name', config.dockerServiceName,
     'up'
   ];
 
@@ -218,6 +220,7 @@ export function startDockerComposeDetached(
     'compose',
     '-f', dockerComposePath,
     '--project-directory', process.cwd(),
+    '--project-name', config.dockerServiceName,
     'up', '-d'
   ];
 
@@ -232,7 +235,7 @@ export async function stopDockerCompose( dockerComposePath: string ): Promise<vo
   ux.stdout( '⏹️  Stopping services...\n' );
   execFileSync(
     'docker',
-    [ 'compose', '-f', dockerComposePath, 'down' ],
+    [ 'compose', '-f', dockerComposePath, '--project-directory', process.cwd(), '--project-name', config.dockerServiceName, 'down' ],
     { stdio: 'inherit', cwd: process.cwd() }
   );
 }

--- a/sdk/cli/src/services/messages.ts
+++ b/sdk/cli/src/services/messages.ts
@@ -3,6 +3,7 @@
  */
 
 import { ux } from '@oclif/core';
+import { config } from '#config.js';
 
 /**
  * Creates a colored ASCII art banner for Output.ai
@@ -209,7 +210,7 @@ export const getProjectSuccessMessage = (
     },
     {
       step: 'Monitor workflows',
-      command: 'open http://localhost:8080',
+      command: `open ${config.temporalUiUrl}`,
       note: 'Access Temporal UI for workflow visualization'
     }
   );

--- a/sdk/cli/src/templates/project/.env.example.template
+++ b/sdk/cli/src/templates/project/.env.example.template
@@ -7,3 +7,20 @@ ANTHROPIC_API_KEY=credential:anthropic.api_key
 # Configure if you plan to use OpenAI in your LLM prompts
 OPENAI_API_KEY=credential:openai.api_key
 
+# --- Host port overrides (for running multiple dev stacks) ---
+# These control which ports are exposed on your machine (host side only).
+# Container-internal ports are unchanged.
+# OUTPUT_API_HOST_PORT=3001
+# OUTPUT_TEMPORAL_HOST_PORT=7233
+# OUTPUT_TEMPORAL_UI_HOST_PORT=8080
+
+# --- API connection ---
+# OUTPUT_API_URL takes precedence over OUTPUT_API_HOST_PORT for CLI connectivity.
+# Use OUTPUT_API_URL for remote/staging servers; use OUTPUT_API_HOST_PORT for local port shifts.
+# OUTPUT_API_URL=http://localhost:3001
+
+# --- Project isolation ---
+# Changing DOCKER_SERVICE_NAME on an existing project creates new volumes.
+# Old data (Postgres, Temporal) becomes orphaned under the previous name.
+# Use `docker volume ls` to find and remove orphaned volumes.
+

--- a/sdk/cli/src/templates/project/.env.example.template
+++ b/sdk/cli/src/templates/project/.env.example.template
@@ -18,20 +18,6 @@ OPENAI_API_KEY=credential:openai.api_key
 # Use OUTPUT_API_URL for remote/staging servers; use OUTPUT_API_HOST_PORT for local port shifts.
 # OUTPUT_API_URL=http://localhost:3001
 
-# --- Host-side Temporal CLI access (opt-in) ---
-# By default the Temporal gRPC port (7233) is not exposed on your host - the
-# Temporal UI at localhost:8080 covers most debugging. To run `temporal cli`
-# or `tctl` against the dev cluster from your host, create a
-# docker-compose.override.yml in your project root:
-#
-#   services:
-#     temporal:
-#       ports:
-#         - '7233:7233'
-#
-# Compose auto-merges this file with the bundled dev compose file. Pick any
-# free host port if running multiple stacks.
-
 # --- Project isolation ---
 # Compose prefixes named volumes with the project name, so changing
 # DOCKER_SERVICE_NAME creates fresh `<new-name>_postgres`, `<new-name>_redis`,

--- a/sdk/cli/src/templates/project/.env.example.template
+++ b/sdk/cli/src/templates/project/.env.example.template
@@ -8,19 +8,20 @@ ANTHROPIC_API_KEY=credential:anthropic.api_key
 OPENAI_API_KEY=credential:openai.api_key
 
 # --- Host port overrides (for running multiple dev stacks) ---
-# These control which ports are exposed on your machine (host side only).
-# Container-internal ports are unchanged.
+# Only the host-side port changes; inter-service traffic (e.g. worker -> Temporal
+# at temporal:7233) is unaffected.
 # OUTPUT_API_HOST_PORT=3001
 # OUTPUT_TEMPORAL_HOST_PORT=7233
 # OUTPUT_TEMPORAL_UI_HOST_PORT=8080
 
 # --- API connection ---
-# OUTPUT_API_URL takes precedence over OUTPUT_API_HOST_PORT for CLI connectivity.
+# If OUTPUT_API_URL is set, it overrides OUTPUT_API_HOST_PORT.
 # Use OUTPUT_API_URL for remote/staging servers; use OUTPUT_API_HOST_PORT for local port shifts.
 # OUTPUT_API_URL=http://localhost:3001
 
 # --- Project isolation ---
-# Changing DOCKER_SERVICE_NAME on an existing project creates new volumes.
-# Old data (Postgres, Temporal) becomes orphaned under the previous name.
-# Use `docker volume ls` to find and remove orphaned volumes.
+# Compose prefixes named volumes with the project name, so changing
+# DOCKER_SERVICE_NAME creates fresh `<new-name>_postgres`, `<new-name>_redis`,
+# and `<new-name>_worker_node_modules` volumes while leaving the previous ones
+# behind. Use `docker volume ls` to find and remove orphaned volumes.
 

--- a/sdk/cli/src/templates/project/.env.example.template
+++ b/sdk/cli/src/templates/project/.env.example.template
@@ -20,7 +20,7 @@ OPENAI_API_KEY=credential:openai.api_key
 
 # --- Project isolation ---
 # Compose prefixes named volumes with the project name, so changing
-# DOCKER_SERVICE_NAME creates fresh `<new-name>_postgres`, `<new-name>_redis`,
-# and `<new-name>_worker_node_modules` volumes while leaving the previous ones
-# behind. Use `docker volume ls` to find and remove orphaned volumes.
+# DOCKER_SERVICE_NAME creates fresh volumes and leaves the previous ones behind.
+# Run `docker volume ls --filter name=<old-project-name>` to find orphaned
+# volumes and `docker volume rm` to remove them.
 

--- a/sdk/cli/src/templates/project/.env.example.template
+++ b/sdk/cli/src/templates/project/.env.example.template
@@ -11,13 +11,26 @@ OPENAI_API_KEY=credential:openai.api_key
 # Only the host-side port changes; inter-service traffic (e.g. worker -> Temporal
 # at temporal:7233) is unaffected.
 # OUTPUT_API_HOST_PORT=3001
-# OUTPUT_TEMPORAL_HOST_PORT=7233
 # OUTPUT_TEMPORAL_UI_HOST_PORT=8080
 
 # --- API connection ---
 # If OUTPUT_API_URL is set, it overrides OUTPUT_API_HOST_PORT.
 # Use OUTPUT_API_URL for remote/staging servers; use OUTPUT_API_HOST_PORT for local port shifts.
 # OUTPUT_API_URL=http://localhost:3001
+
+# --- Host-side Temporal CLI access (opt-in) ---
+# By default the Temporal gRPC port (7233) is not exposed on your host - the
+# Temporal UI at localhost:8080 covers most debugging. To run `temporal cli`
+# or `tctl` against the dev cluster from your host, create a
+# docker-compose.override.yml in your project root:
+#
+#   services:
+#     temporal:
+#       ports:
+#         - '7233:7233'
+#
+# Compose auto-merges this file with the bundled dev compose file. Pick any
+# free host port if running multiple stacks.
 
 # --- Project isolation ---
 # Compose prefixes named volumes with the project name, so changing

--- a/sdk/cli/src/utils/validation.spec.ts
+++ b/sdk/cli/src/utils/validation.spec.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-import { ux } from '@oclif/core';
-import { isValidWorkflowName, parsePort } from './validation.js';
+import { describe, expect, it } from 'vitest';
+import { isValidWorkflowName, parsePort, InvalidPortError } from './validation.js';
 
 describe( 'isValidWorkflowName', () => {
   describe( 'valid workflow names', () => {
@@ -162,60 +161,55 @@ describe( 'isValidWorkflowName', () => {
 
 describe( 'parsePort', () => {
   it( 'returns the parsed value for a valid port', () => {
-    expect( parsePort( '3001', 3001 ) ).toBe( 3001 );
-    expect( parsePort( '7234', 7233 ) ).toBe( 7234 );
+    expect( parsePort( '3001', 3001, 'P' ) ).toBe( 3001 );
+    expect( parsePort( '7234', 7233, 'P' ) ).toBe( 7234 );
   } );
 
-  it( 'falls back to default for undefined', () => {
-    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
-    expect( parsePort( undefined, 3001 ) ).toBe( 3001 );
-    expect( warn ).not.toHaveBeenCalled();
+  it( 'falls back to default for undefined silently', () => {
+    expect( parsePort( undefined, 3001, 'P' ) ).toBe( 3001 );
   } );
 
-  it( 'falls back to default for empty string without warning', () => {
-    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
-    expect( parsePort( '', 3001 ) ).toBe( 3001 );
-    expect( warn ).not.toHaveBeenCalled();
+  it( 'falls back to default for empty string silently (matches Compose ${VAR:-default})', () => {
+    expect( parsePort( '', 3001, 'P' ) ).toBe( 3001 );
   } );
 
-  it( 'warns and falls back for non-numeric input', () => {
-    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
-    expect( parsePort( 'abc', 3001 ) ).toBe( 3001 );
-    expect( warn ).toHaveBeenCalled();
+  it( 'throws InvalidPortError for non-numeric input', () => {
+    expect( () => parsePort( 'abc', 3001, 'OUTPUT_API_HOST_PORT' ) ).toThrow( InvalidPortError );
+    expect( () => parsePort( 'abc', 3001, 'OUTPUT_API_HOST_PORT' ) )
+      .toThrow( /OUTPUT_API_HOST_PORT=abc/ );
   } );
 
-  it( 'warns and falls back for trailing junk (parseInt would silently truncate)', () => {
-    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
-    expect( parsePort( '3001abc', 3001 ) ).toBe( 3001 );
-    expect( warn ).toHaveBeenCalled();
+  it( 'throws for trailing junk (parseInt would silently truncate)', () => {
+    expect( () => parsePort( '3001abc', 3001, 'P' ) ).toThrow( InvalidPortError );
   } );
 
-  it( 'warns and falls back for negative input', () => {
-    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
-    expect( parsePort( '-1', 3001 ) ).toBe( 3001 );
-    expect( warn ).toHaveBeenCalled();
+  it( 'throws for negative input', () => {
+    expect( () => parsePort( '-1', 3001, 'P' ) ).toThrow( InvalidPortError );
   } );
 
-  it( 'warns and falls back for port 0', () => {
-    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
-    expect( parsePort( '0', 3001 ) ).toBe( 3001 );
-    expect( warn ).toHaveBeenCalled();
+  it( 'throws for port 0 (CLI rejects but Compose would treat as ephemeral - prevents desync)', () => {
+    expect( () => parsePort( '0', 3001, 'P' ) ).toThrow( InvalidPortError );
   } );
 
-  it( 'warns and falls back for port above 65535', () => {
-    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
-    expect( parsePort( '65536', 3001 ) ).toBe( 3001 );
-    expect( warn ).toHaveBeenCalled();
+  it( 'throws for port above 65535', () => {
+    expect( () => parsePort( '65536', 3001, 'P' ) ).toThrow( InvalidPortError );
+    expect( () => parsePort( '99999', 3001, 'P' ) ).toThrow( InvalidPortError );
   } );
 
   it( 'accepts boundary ports 1 and 65535', () => {
-    expect( parsePort( '1', 3001 ) ).toBe( 1 );
-    expect( parsePort( '65535', 3001 ) ).toBe( 65535 );
+    expect( parsePort( '1', 3001, 'P' ) ).toBe( 1 );
+    expect( parsePort( '65535', 3001, 'P' ) ).toBe( 65535 );
   } );
 
-  it( 'includes env var name in warning when provided', () => {
-    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
-    parsePort( 'abc', 3001, 'OUTPUT_API_HOST_PORT' );
-    expect( warn ).toHaveBeenCalledWith( expect.stringContaining( 'OUTPUT_API_HOST_PORT' ) );
+  it( 'error message includes env var name and remediation hint', () => {
+    try {
+      parsePort( 'abc', 3001, 'OUTPUT_API_HOST_PORT' );
+      expect.fail( 'expected throw' );
+    } catch ( err ) {
+      expect( err ).toBeInstanceOf( InvalidPortError );
+      expect( ( err as Error ).message ).toContain( 'OUTPUT_API_HOST_PORT=abc' );
+      expect( ( err as Error ).message ).toContain( '1-65535' );
+      expect( ( err as Error ).message ).toContain( '.env file' );
+    }
   } );
 } );

--- a/sdk/cli/src/utils/validation.spec.ts
+++ b/sdk/cli/src/utils/validation.spec.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import { isValidWorkflowName } from './validation.js';
+import { describe, expect, it, vi } from 'vitest';
+import { ux } from '@oclif/core';
+import { isValidWorkflowName, parsePort } from './validation.js';
 
 describe( 'isValidWorkflowName', () => {
   describe( 'valid workflow names', () => {
@@ -156,5 +157,65 @@ describe( 'isValidWorkflowName', () => {
       expect( isValidWorkflowName( '_000000000' ) ).toBe( true );
       expect( isValidWorkflowName( 'a_0_1_2_3' ) ).toBe( true );
     } );
+  } );
+} );
+
+describe( 'parsePort', () => {
+  it( 'returns the parsed value for a valid port', () => {
+    expect( parsePort( '3001', 3001 ) ).toBe( 3001 );
+    expect( parsePort( '7234', 7233 ) ).toBe( 7234 );
+  } );
+
+  it( 'falls back to default for undefined', () => {
+    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+    expect( parsePort( undefined, 3001 ) ).toBe( 3001 );
+    expect( warn ).not.toHaveBeenCalled();
+  } );
+
+  it( 'falls back to default for empty string without warning', () => {
+    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+    expect( parsePort( '', 3001 ) ).toBe( 3001 );
+    expect( warn ).not.toHaveBeenCalled();
+  } );
+
+  it( 'warns and falls back for non-numeric input', () => {
+    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+    expect( parsePort( 'abc', 3001 ) ).toBe( 3001 );
+    expect( warn ).toHaveBeenCalled();
+  } );
+
+  it( 'warns and falls back for trailing junk (parseInt would silently truncate)', () => {
+    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+    expect( parsePort( '3001abc', 3001 ) ).toBe( 3001 );
+    expect( warn ).toHaveBeenCalled();
+  } );
+
+  it( 'warns and falls back for negative input', () => {
+    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+    expect( parsePort( '-1', 3001 ) ).toBe( 3001 );
+    expect( warn ).toHaveBeenCalled();
+  } );
+
+  it( 'warns and falls back for port 0', () => {
+    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+    expect( parsePort( '0', 3001 ) ).toBe( 3001 );
+    expect( warn ).toHaveBeenCalled();
+  } );
+
+  it( 'warns and falls back for port above 65535', () => {
+    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+    expect( parsePort( '65536', 3001 ) ).toBe( 3001 );
+    expect( warn ).toHaveBeenCalled();
+  } );
+
+  it( 'accepts boundary ports 1 and 65535', () => {
+    expect( parsePort( '1', 3001 ) ).toBe( 1 );
+    expect( parsePort( '65535', 3001 ) ).toBe( 65535 );
+  } );
+
+  it( 'includes env var name in warning when provided', () => {
+    const warn = vi.spyOn( ux, 'warn' ).mockImplementation( () => undefined as unknown as Error );
+    parsePort( 'abc', 3001, 'OUTPUT_API_HOST_PORT' );
+    expect( warn ).toHaveBeenCalledWith( expect.stringContaining( 'OUTPUT_API_HOST_PORT' ) );
   } );
 } );

--- a/sdk/cli/src/utils/validation.ts
+++ b/sdk/cli/src/utils/validation.ts
@@ -1,3 +1,4 @@
+import { ux } from '@oclif/core';
 import { InvalidNameError, InvalidOutputDirectoryError } from '#types/errors.js';
 
 /**
@@ -25,4 +26,38 @@ export function validateOutputDirectory( outputDir: string ): void {
   if ( !outputDir || outputDir.trim() === '' ) {
     throw new InvalidOutputDirectoryError( outputDir, 'Output directory cannot be empty' );
   }
+}
+
+const MIN_PORT = 1;
+const MAX_PORT = 65535;
+
+/**
+ * Parse a port number from an env var. Empty string and undefined fall back to
+ * the default silently (matching Compose's `${VAR:-default}` semantics).
+ * Invalid values (non-integer, out of range, trailing junk) emit a warning
+ * via ux.warn and fall back to the default so the dev stack still starts.
+ */
+export function parsePort(
+  raw: string | undefined,
+  defaultPort: number,
+  envVarName?: string
+): number {
+  if ( raw === undefined || raw === '' ) {
+    return defaultPort;
+  }
+
+  if ( !/^\d+$/.test( raw ) ) {
+    const label = envVarName ? `${envVarName}=${raw}` : `port "${raw}"`;
+    ux.warn( `Invalid ${label} - falling back to default ${defaultPort}` );
+    return defaultPort;
+  }
+
+  const n = parseInt( raw, 10 );
+  if ( n < MIN_PORT || n > MAX_PORT ) {
+    const label = envVarName ? `${envVarName}=${raw}` : `port ${raw}`;
+    ux.warn( `${label} is out of range (${MIN_PORT}-${MAX_PORT}) - falling back to default ${defaultPort}` );
+    return defaultPort;
+  }
+
+  return n;
 }

--- a/sdk/cli/src/utils/validation.ts
+++ b/sdk/cli/src/utils/validation.ts
@@ -1,4 +1,3 @@
-import { ux } from '@oclif/core';
 import { InvalidNameError, InvalidOutputDirectoryError } from '#types/errors.js';
 
 /**
@@ -31,32 +30,40 @@ export function validateOutputDirectory( outputDir: string ): void {
 const MIN_PORT = 1;
 const MAX_PORT = 65535;
 
+export class InvalidPortError extends Error {
+  constructor( envVarName: string, raw: string, reason: string ) {
+    super(
+      `${envVarName}=${raw} is invalid (${reason}). ` +
+      `Set a port in ${MIN_PORT}-${MAX_PORT} in your .env file, or unset the variable to use the default.`
+    );
+    this.name = 'InvalidPortError';
+  }
+}
+
 /**
  * Parse a port number from an env var. Empty string and undefined fall back to
  * the default silently (matching Compose's `${VAR:-default}` semantics).
- * Invalid values (non-integer, out of range, trailing junk) emit a warning
- * via ux.warn and fall back to the default so the dev stack still starts.
+ * Throws InvalidPortError on anything other than a positive integer literal in
+ * range 1-65535. Throwing (vs warn-and-fallback) prevents CLI/Docker
+ * disagreement: Compose reads the same env var via `${VAR:-default}` and uses
+ * its own parser, so a CLI fallback would silently desync from the bound port.
  */
 export function parsePort(
   raw: string | undefined,
   defaultPort: number,
-  envVarName?: string
+  envVarName: string
 ): number {
   if ( raw === undefined || raw === '' ) {
     return defaultPort;
   }
 
   if ( !/^\d+$/.test( raw ) ) {
-    const label = envVarName ? `${envVarName}=${raw}` : `port "${raw}"`;
-    ux.warn( `Invalid ${label} - falling back to default ${defaultPort}` );
-    return defaultPort;
+    throw new InvalidPortError( envVarName, raw, 'not a positive integer' );
   }
 
   const n = parseInt( raw, 10 );
   if ( n < MIN_PORT || n > MAX_PORT ) {
-    const label = envVarName ? `${envVarName}=${raw}` : `port ${raw}`;
-    ux.warn( `${label} is out of range (${MIN_PORT}-${MAX_PORT}) - falling back to default ${defaultPort}` );
-    return defaultPort;
+    throw new InvalidPortError( envVarName, raw, `out of range ${MIN_PORT}-${MAX_PORT}` );
   }
 
   return n;

--- a/sdk/cli/src/utils/validation.ts
+++ b/sdk/cli/src/utils/validation.ts
@@ -43,10 +43,11 @@ export class InvalidPortError extends Error {
 /**
  * Parse a port number from an env var. Empty string and undefined fall back to
  * the default silently (matching Compose's `${VAR:-default}` semantics).
- * Throws InvalidPortError on anything other than a positive integer literal in
- * range 1-65535. Throwing (vs warn-and-fallback) prevents CLI/Docker
- * disagreement: Compose reads the same env var via `${VAR:-default}` and uses
- * its own parser, so a CLI fallback would silently desync from the bound port.
+ * Throws InvalidPortError on anything else: non-numeric, signed, decimal,
+ * trailing junk (e.g. "3001abc"), or out of range 1-65535. Throwing (vs
+ * warn-and-fallback) prevents CLI/Docker disagreement: Compose reads the same
+ * env var via `${VAR:-default}` and uses its own parser, so a CLI fallback
+ * would silently desync from the bound port.
  */
 export function parsePort(
   raw: string | undefined,

--- a/sdk/cli/src/views/dev.tsx
+++ b/sdk/cli/src/views/dev.tsx
@@ -236,7 +236,6 @@ const DevSuccessMessage: React.FC<{ services: ServiceStatus[] }> = ( { services 
         <Box><Text color="white">{'Temporal:    '}</Text><Text color="yellow">localhost:{config.ports.temporal}</Text></Box>
         <Box><Text color="white">{'Temporal UI: '}</Text><Text color="cyan">{config.temporalUiUrl}</Text></Box>
         <Box><Text color="white">{'API Server:  '}</Text><Text color="yellow">localhost:{config.ports.api}</Text></Box>
-        <Box><Text color="white">{'Redis:       '}</Text><Text color="yellow">localhost:6379</Text></Box>
       </Box>
       <Box marginTop={1} marginBottom={1}><Text dimColor>{divider}</Text></Box>
       <Box marginBottom={1}><Text bold>🚀 RUN A WORKFLOW</Text></Box>

--- a/sdk/cli/src/views/dev.tsx
+++ b/sdk/cli/src/views/dev.tsx
@@ -233,7 +233,6 @@ const DevSuccessMessage: React.FC<{ services: ServiceStatus[] }> = ( { services 
       <Box marginTop={1} marginBottom={1}><Text dimColor>{divider}</Text></Box>
       <Box marginBottom={1}><Text bold>🐳 SERVICES</Text></Box>
       <Box flexDirection="column" marginLeft={2}>
-        <Box><Text color="white">{'Temporal:    '}</Text><Text color="yellow">localhost:{config.ports.temporal}</Text></Box>
         <Box><Text color="white">{'Temporal UI: '}</Text><Text color="cyan">{config.temporalUiUrl}</Text></Box>
         <Box><Text color="white">{'API Server:  '}</Text><Text color="yellow">localhost:{config.ports.api}</Text></Box>
       </Box>

--- a/sdk/cli/src/views/dev.tsx
+++ b/sdk/cli/src/views/dev.tsx
@@ -233,9 +233,9 @@ const DevSuccessMessage: React.FC<{ services: ServiceStatus[] }> = ( { services 
       <Box marginTop={1} marginBottom={1}><Text dimColor>{divider}</Text></Box>
       <Box marginBottom={1}><Text bold>🐳 SERVICES</Text></Box>
       <Box flexDirection="column" marginLeft={2}>
-        <Box><Text color="white">{'Temporal:    '}</Text><Text color="yellow">localhost:7233</Text></Box>
-        <Box><Text color="white">{'Temporal UI: '}</Text><Text color="cyan">http://localhost:8080</Text></Box>
-        <Box><Text color="white">{'API Server:  '}</Text><Text color="yellow">localhost:3001</Text></Box>
+        <Box><Text color="white">{'Temporal:    '}</Text><Text color="yellow">localhost:{config.ports.temporal}</Text></Box>
+        <Box><Text color="white">{'Temporal UI: '}</Text><Text color="cyan">{config.temporalUiUrl}</Text></Box>
+        <Box><Text color="white">{'API Server:  '}</Text><Text color="yellow">localhost:{config.ports.api}</Text></Box>
         <Box><Text color="white">{'Redis:       '}</Text><Text color="yellow">localhost:6379</Text></Box>
       </Box>
       <Box marginTop={1} marginBottom={1}><Text dimColor>{divider}</Text></Box>
@@ -249,7 +249,7 @@ const DevSuccessMessage: React.FC<{ services: ServiceStatus[] }> = ( { services 
       <Box marginTop={1} marginBottom={1}><Text dimColor>{divider}</Text></Box>
       <Box marginBottom={1}><Text bold>⚡ USEFUL COMMANDS</Text></Box>
       <Box flexDirection="column" marginLeft={2}>
-        <Box><Text color="white">{'Open Temporal UI: '}</Text><Text color="cyan">open http://localhost:8080</Text></Box>
+        <Box><Text color="white">{'Open Temporal UI: '}</Text><Text color="cyan">open {config.temporalUiUrl}</Text></Box>
         <Box><Text color="white">{'View logs:        '}</Text><Text color="cyan">{logsCommand}</Text></Box>
         <Box><Text color="white">{'Stop services:    '}</Text><Text color="cyan">Press Ctrl+C</Text></Box>
       </Box>
@@ -286,7 +286,7 @@ const RunningView: React.FC<{
     {workflowSummary && <WorkflowSummarySection summary={workflowSummary} />}
     <Box marginTop={1}>
       <Text color="cyan">{'🌐 Temporal UI: '}</Text>
-      <Text bold>http://localhost:8080</Text>
+      <Text bold>{config.temporalUiUrl}</Text>
     </Box>
     <CommandFooter hints={[
       { key: 'o', label: 'open ui' },
@@ -348,7 +348,7 @@ export const DevApp: React.FC<{
   useMainViewInput(
     activeView === 'main' && phase !== 'waiting',
     {
-      onOpenTemporal: () => openUrl( 'http://localhost:8080' ),
+      onOpenTemporal: () => openUrl( config.temporalUiUrl ),
       onOpenWorkflows: () => setActiveView( 'workflows' )
     }
   );

--- a/sdk/cli/src/views/workflow/list.tsx
+++ b/sdk/cli/src/views/workflow/list.tsx
@@ -7,8 +7,7 @@ import { StatusIcon, statusColor } from '#components/status_icon.js';
 import { elapsedMs, formatDurationCompact } from '#utils/date_formatter.js';
 import { CommandFooter } from '#components/command_footer.js';
 import { openUrl } from '#utils/open_url.js';
-
-const TEMPORAL_UI_BASE = 'http://localhost:8080';
+import { config } from '#config.js';
 const VISIBLE_ROWS = 15;
 
 const STATUS_ORDER: Record<string, number> = {
@@ -181,7 +180,7 @@ export const WorkflowListView: React.FC<{
     } else if ( key.escape || input === 'q' ) {
       onBack();
     } else if ( input === 'o' && selectedWorkflowId ) {
-      openUrl( `${TEMPORAL_UI_BASE}/namespaces/default/workflows/${selectedWorkflowId}` );
+      openUrl( `${config.temporalUiUrl}/namespaces/default/workflows/${selectedWorkflowId}` );
     }
   } );
 


### PR DESCRIPTION
Enable multiple instance of Output to run locally simultaneously in Docker by enabling dynamic port mapping. Users can now specify ports for both the Output API endpoint and Temporal web UI. **NOTE:** this is not done automatically. Output keeps it's default ports, and users can run additional instances of Output but must first specify custom ports for each instance. Users can do this via the `.env` file or directly exporting values in the environment. 

**ALSO NOTE:** I decided to go ahead and **no longer expose the Temporal host URL** - Temporal is now tucked away, just like Redis and Postgres. Users will not have direct access to Temporal. This way, users only need to provide a value for a single thing in their `.env`, a new Output API port. We could revert this and expose the Temporal host, or even conditionally expose it, but there are some hoops to jump through and I thought for now just hide it until someone needs it. 

**Summary of changes:**

- Parameterize Docker host ports for output dev so multiple dev stacks can run concurrently — adds `OUTPUT_API_HOST_PORT` and `OUTPUT_TEMPORAL_UI_HOST_PORT` env vars (defaults: `3001`, `8080`)
- Thread `--project-name` (from `DOCKER_SERVICE_NAME`) through every docker compose invocation (up, up -d, ps, down) so each stack gets its own isolated
container/network/volume namespace
- Remove host-port bindings for Redis (was hardcoded `6379:6379`), Temporal gRPC (was hardcoded `7233`), and Temporal Host (was hardcoded `7233:7233`) — none of these are needed by the CLI; all are reachable container-to-container via Docker's internal network. Eliminates conflicts when running multiple stacks

Generated `.env` files now have commented out information to help power users understand the opt-in escape hatch(s):

```
# .env
# --- Host port overrides (for running multiple dev stacks) ---
# These control which ports are exposed on your machine (host side only).
# Container-internal ports are unchanged.
# OUTPUT_API_HOST_PORT=3001
# OUTPUT_TEMPORAL_UI_HOST_PORT=8080
```