### PR TITLE
chore(plugin): update contact email

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "outputai",
   "owner": {
     "name": "Output.ai",
-    "email": "support@output.ai"
+    "email": "oss@growthx.ai"
   },
   "plugins": [
     {

--- a/coding_assistants/claude/plugins/outputai/.claude-plugin/plugin.json
+++ b/coding_assistants/claude/plugins/outputai/.claude-plugin/plugin.json
@@ -4,6 +4,6 @@
     "description": "Workflow development tools",
     "author": {
       "name": "Output.ai",
-      "email": "team@output.ai"
+      "email": "oss@growthx.ai"
     }
   }


### PR DESCRIPTION
## Summary
- Replace `support@output.ai` and `team@output.ai` with `oss@growthx.ai` in the Claude plugin marketplace and plugin manifests so contact info points to the correct GrowthX OSS inbox.

## Test plan
- [ ] Verify `.claude-plugin/marketplace.json` and `coding_assistants/claude/plugins/outputai/.claude-plugin/plugin.json` parse as valid JSON.
- [ ] Reinstall the plugin in Claude Code and confirm it loads without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)