### PR TITLE
fix(cli,credentials): clean error messages for credentials.key failures [OUT-431]

### DIFF
--- a/.changeset/fix-credentials-handling.md
+++ b/.changeset/fix-credentials-handling.md
@@ -1,0 +1,5 @@
+---
+"@outputai/credentials": patch
+"@outputai/cli": patch
+---
+Improve encrypted credentials loading: add clearer errors when keys are missing or invalid and ensure the CLI exits gracefully instead of printing stack traces.

--- a/sdk/cli/bin/run.js
+++ b/sdk/cli/bin/run.js
@@ -3,11 +3,11 @@
 import { execute } from '@oclif/core';
 import { loadEnvironment } from '../dist/utils/env_loader.js';
 import { bootstrapProxy } from '../dist/utils/proxy.js';
-import { resolveCredentialRefs } from '@outputai/credentials';
+import { loadCredentialRefs } from '../dist/utils/credentials_loader.js';
 
 // Load environment variables from .env files before executing CLI
 loadEnvironment();
 bootstrapProxy();
-resolveCredentialRefs();
+loadCredentialRefs();
 
 await execute( { dir: import.meta.url } );

--- a/sdk/cli/src/utils/credentials_loader.spec.ts
+++ b/sdk/cli/src/utils/credentials_loader.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as credentials from '@outputai/credentials';
+import { loadCredentialRefs } from './credentials_loader.js';
+
+vi.mock( '@outputai/credentials', async () => {
+  const actual = await vi.importActual<typeof import( '@outputai/credentials' )>( '@outputai/credentials' );
+  return {
+    ...actual,
+    resolveCredentialRefs: vi.fn()
+  };
+} );
+
+describe( 'loadCredentialRefs', () => {
+  beforeEach( () => {
+    vi.clearAllMocks();
+  } );
+
+  afterEach( () => {
+    vi.restoreAllMocks();
+  } );
+
+  it( 'should call resolveCredentialRefs without errors when no credentials are misconfigured', () => {
+    vi.mocked( credentials.resolveCredentialRefs ).mockReturnValue( [] );
+
+    expect( () => loadCredentialRefs() ).not.toThrow();
+    expect( credentials.resolveCredentialRefs ).toHaveBeenCalledTimes( 1 );
+  } );
+
+  it( 'should print a clean error message and exit on MissingKeyError without dumping a stack trace', () => {
+    vi.mocked( credentials.resolveCredentialRefs ).mockImplementation( () => {
+      throw new credentials.MissingKeyError();
+    } );
+
+    const consoleErrorSpy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+    const exitSpy = vi.spyOn( process, 'exit' ).mockImplementation( ( () => undefined ) as never );
+
+    loadCredentialRefs();
+
+    expect( consoleErrorSpy ).toHaveBeenCalledTimes( 1 );
+    const printedMessage = consoleErrorSpy.mock.calls[0]?.[0] as string;
+    expect( printedMessage ).toContain( 'No credentials key found' );
+    expect( printedMessage ).toContain( 'OUTPUT_CREDENTIALS_KEY' );
+    expect( printedMessage ).toContain( 'config/credentials.key' );
+    expect( printedMessage ).not.toContain( '    at ' );
+
+    expect( exitSpy ).toHaveBeenCalledWith( 1 );
+  } );
+
+  it( 'should include the environment-specific hints in the printed message when an environment is set', () => {
+    vi.mocked( credentials.resolveCredentialRefs ).mockImplementation( () => {
+      throw new credentials.MissingKeyError( 'production' );
+    } );
+
+    const consoleErrorSpy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+    const exitSpy = vi.spyOn( process, 'exit' ).mockImplementation( ( () => undefined ) as never );
+
+    loadCredentialRefs();
+
+    const printedMessage = consoleErrorSpy.mock.calls[0]?.[0] as string;
+    expect( printedMessage ).toContain( 'OUTPUT_CREDENTIALS_KEY_PRODUCTION' );
+    expect( printedMessage ).toContain( 'config/credentials/production.key' );
+    expect( exitSpy ).toHaveBeenCalledWith( 1 );
+  } );
+
+  it( 'should rethrow unexpected errors so they are not silently swallowed', () => {
+    vi.mocked( credentials.resolveCredentialRefs ).mockImplementation( () => {
+      throw new Error( 'something else broke' );
+    } );
+
+    expect( () => loadCredentialRefs() ).toThrow( 'something else broke' );
+  } );
+} );

--- a/sdk/cli/src/utils/credentials_loader.spec.ts
+++ b/sdk/cli/src/utils/credentials_loader.spec.ts
@@ -81,6 +81,28 @@ describe( 'loadCredentialRefs', () => {
     expect( exitSpy ).toHaveBeenCalledWith( 1 );
   } );
 
+  it( 'should print a clean error message and exit on MalformedCredentialsKeyError', () => {
+    vi.mocked( credentials.resolveCredentialRefs ).mockImplementation( () => {
+      throw new credentials.MalformedCredentialsKeyError(
+        'config/credentials.yml.enc',
+        'hex string expected, got unpadded hex of length 55'
+      );
+    } );
+
+    const consoleErrorSpy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+    const exitSpy = vi.spyOn( process, 'exit' ).mockImplementation( ( () => undefined ) as never );
+
+    loadCredentialRefs();
+
+    const printedMessage = consoleErrorSpy.mock.calls[0]?.[0] as string;
+    expect( printedMessage ).toContain( 'is malformed' );
+    expect( printedMessage ).toContain( 'must be exactly 64 hex characters' );
+    expect( printedMessage ).toContain( 'unpadded hex of length 55' );
+    expect( printedMessage ).not.toContain( '    at ' );
+
+    expect( exitSpy ).toHaveBeenCalledWith( 1 );
+  } );
+
   it( 'should rethrow unexpected errors so they are not silently swallowed', () => {
     vi.mocked( credentials.resolveCredentialRefs ).mockImplementation( () => {
       throw new Error( 'something else broke' );

--- a/sdk/cli/src/utils/credentials_loader.spec.ts
+++ b/sdk/cli/src/utils/credentials_loader.spec.ts
@@ -62,6 +62,25 @@ describe( 'loadCredentialRefs', () => {
     expect( exitSpy ).toHaveBeenCalledWith( 1 );
   } );
 
+  it( 'should print a clean error message and exit on InvalidCredentialsKeyError', () => {
+    vi.mocked( credentials.resolveCredentialRefs ).mockImplementation( () => {
+      throw new credentials.InvalidCredentialsKeyError( 'config/credentials.yml.enc' );
+    } );
+
+    const consoleErrorSpy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+    const exitSpy = vi.spyOn( process, 'exit' ).mockImplementation( ( () => undefined ) as never );
+
+    loadCredentialRefs();
+
+    expect( consoleErrorSpy ).toHaveBeenCalledTimes( 1 );
+    const printedMessage = consoleErrorSpy.mock.calls[0]?.[0] as string;
+    expect( printedMessage ).toContain( 'Failed to decrypt config/credentials.yml.enc' );
+    expect( printedMessage ).toContain( 'does not match' );
+    expect( printedMessage ).not.toContain( '    at ' );
+
+    expect( exitSpy ).toHaveBeenCalledWith( 1 );
+  } );
+
   it( 'should rethrow unexpected errors so they are not silently swallowed', () => {
     vi.mocked( credentials.resolveCredentialRefs ).mockImplementation( () => {
       throw new Error( 'something else broke' );

--- a/sdk/cli/src/utils/credentials_loader.ts
+++ b/sdk/cli/src/utils/credentials_loader.ts
@@ -1,10 +1,20 @@
-import { InvalidCredentialsKeyError, MissingKeyError, resolveCredentialRefs } from '@outputai/credentials';
+import {
+  InvalidCredentialsKeyError,
+  MalformedCredentialsKeyError,
+  MissingKeyError,
+  resolveCredentialRefs
+} from '@outputai/credentials';
+
+const isCredentialsConfigError = ( error: unknown ): error is Error =>
+  error instanceof MissingKeyError ||
+  error instanceof InvalidCredentialsKeyError ||
+  error instanceof MalformedCredentialsKeyError;
 
 export const loadCredentialRefs = (): void => {
   try {
     resolveCredentialRefs();
   } catch ( error: unknown ) {
-    if ( error instanceof MissingKeyError || error instanceof InvalidCredentialsKeyError ) {
+    if ( isCredentialsConfigError( error ) ) {
       console.error( `Error: ${error.message}` );
       process.exit( 1 );
     } else {

--- a/sdk/cli/src/utils/credentials_loader.ts
+++ b/sdk/cli/src/utils/credentials_loader.ts
@@ -1,10 +1,10 @@
-import { MissingKeyError, resolveCredentialRefs } from '@outputai/credentials';
+import { InvalidCredentialsKeyError, MissingKeyError, resolveCredentialRefs } from '@outputai/credentials';
 
 export const loadCredentialRefs = (): void => {
   try {
     resolveCredentialRefs();
   } catch ( error: unknown ) {
-    if ( error instanceof MissingKeyError ) {
+    if ( error instanceof MissingKeyError || error instanceof InvalidCredentialsKeyError ) {
       console.error( `Error: ${error.message}` );
       process.exit( 1 );
     } else {

--- a/sdk/cli/src/utils/credentials_loader.ts
+++ b/sdk/cli/src/utils/credentials_loader.ts
@@ -1,0 +1,14 @@
+import { MissingKeyError, resolveCredentialRefs } from '@outputai/credentials';
+
+export const loadCredentialRefs = (): void => {
+  try {
+    resolveCredentialRefs();
+  } catch ( error: unknown ) {
+    if ( error instanceof MissingKeyError ) {
+      console.error( `Error: ${error.message}` );
+      process.exit( 1 );
+    } else {
+      throw error;
+    }
+  }
+};

--- a/sdk/credentials/src/encrypted_yaml_provider.spec.ts
+++ b/sdk/credentials/src/encrypted_yaml_provider.spec.ts
@@ -99,6 +99,23 @@ describe( 'encrypted YAML provider', () => {
       expect( () => provider.loadGlobal( { environment: undefined } ) )
         .toThrow( 'No credentials key found' );
     } );
+
+    it( 'should throw InvalidCredentialsKeyError when the key does not match the encrypted file', async () => {
+      process.env.OUTPUT_CREDENTIALS_KEY = generateKey();
+
+      vi.doMock( 'node:fs', () => ( {
+        readFileSync: () => ciphertext,
+        existsSync: ( path: string ) => path.endsWith( 'credentials.yml.enc' )
+      } ) );
+
+      const provider = await loadProvider();
+      const { InvalidCredentialsKeyError } = await import( './errors.js' );
+
+      expect( () => provider.loadGlobal( { environment: undefined } ) )
+        .toThrow( InvalidCredentialsKeyError );
+      expect( () => provider.loadGlobal( { environment: undefined } ) )
+        .toThrow( /Failed to decrypt .*credentials\.yml\.enc/ );
+    } );
   } );
 
   describe( 'loadForWorkflow', () => {

--- a/sdk/credentials/src/encrypted_yaml_provider.spec.ts
+++ b/sdk/credentials/src/encrypted_yaml_provider.spec.ts
@@ -117,7 +117,7 @@ describe( 'encrypted YAML provider', () => {
         .toThrow( /Failed to decrypt .*credentials\.yml\.enc/ );
     } );
 
-    it( 'should throw InvalidCredentialsKeyError when the key has the wrong length', async () => {
+    it( 'should throw MalformedCredentialsKeyError when the key has the wrong length', async () => {
       process.env.OUTPUT_CREDENTIALS_KEY = key.slice( 0, 55 );
 
       vi.doMock( 'node:fs', () => ( {
@@ -126,13 +126,15 @@ describe( 'encrypted YAML provider', () => {
       } ) );
 
       const provider = await loadProvider();
-      const { InvalidCredentialsKeyError } = await import( './errors.js' );
+      const { MalformedCredentialsKeyError } = await import( './errors.js' );
 
       expect( () => provider.loadGlobal( { environment: undefined } ) )
-        .toThrow( InvalidCredentialsKeyError );
+        .toThrow( MalformedCredentialsKeyError );
+      expect( () => provider.loadGlobal( { environment: undefined } ) )
+        .toThrow( /must be exactly 64 hex characters/ );
     } );
 
-    it( 'should throw InvalidCredentialsKeyError when the key contains non-hex characters', async () => {
+    it( 'should throw MalformedCredentialsKeyError when the key contains non-hex characters', async () => {
       process.env.OUTPUT_CREDENTIALS_KEY = `${key.slice( 0, 10 )} ${key.slice( 11 )}`;
 
       vi.doMock( 'node:fs', () => ( {
@@ -141,10 +143,41 @@ describe( 'encrypted YAML provider', () => {
       } ) );
 
       const provider = await loadProvider();
-      const { InvalidCredentialsKeyError } = await import( './errors.js' );
+      const { MalformedCredentialsKeyError } = await import( './errors.js' );
 
       expect( () => provider.loadGlobal( { environment: undefined } ) )
-        .toThrow( InvalidCredentialsKeyError );
+        .toThrow( MalformedCredentialsKeyError );
+      expect( () => provider.loadGlobal( { environment: undefined } ) )
+        .toThrow( /typos, whitespace, or truncation/ );
+    } );
+
+    it( 'should throw InvalidCredentialsKeyError with the underlying message for unknown decrypt failures', async () => {
+      process.env.OUTPUT_CREDENTIALS_KEY = key;
+
+      vi.doMock( 'node:fs', () => ( {
+        readFileSync: () => ciphertext,
+        existsSync: ( path: string ) => path.endsWith( 'credentials.yml.enc' )
+      } ) );
+
+      vi.doMock( './encryption.js', () => ( {
+        decrypt: () => {
+          throw new Error( 'unexpected internal failure' );
+        }
+      } ) );
+
+      try {
+        const provider = await loadProvider();
+        const { InvalidCredentialsKeyError } = await import( './errors.js' );
+
+        expect( () => provider.loadGlobal( { environment: undefined } ) )
+          .toThrow( InvalidCredentialsKeyError );
+        expect( () => provider.loadGlobal( { environment: undefined } ) )
+          .toThrow( /unexpected internal failure/ );
+        expect( () => provider.loadGlobal( { environment: undefined } ) )
+          .toThrow( /may not match.*or the credentials file may be corrupted/ );
+      } finally {
+        vi.doUnmock( './encryption.js' );
+      }
     } );
   } );
 

--- a/sdk/credentials/src/encrypted_yaml_provider.spec.ts
+++ b/sdk/credentials/src/encrypted_yaml_provider.spec.ts
@@ -116,6 +116,36 @@ describe( 'encrypted YAML provider', () => {
       expect( () => provider.loadGlobal( { environment: undefined } ) )
         .toThrow( /Failed to decrypt .*credentials\.yml\.enc/ );
     } );
+
+    it( 'should throw InvalidCredentialsKeyError when the key has the wrong length', async () => {
+      process.env.OUTPUT_CREDENTIALS_KEY = key.slice( 0, 55 );
+
+      vi.doMock( 'node:fs', () => ( {
+        readFileSync: () => ciphertext,
+        existsSync: ( path: string ) => path.endsWith( 'credentials.yml.enc' )
+      } ) );
+
+      const provider = await loadProvider();
+      const { InvalidCredentialsKeyError } = await import( './errors.js' );
+
+      expect( () => provider.loadGlobal( { environment: undefined } ) )
+        .toThrow( InvalidCredentialsKeyError );
+    } );
+
+    it( 'should throw InvalidCredentialsKeyError when the key contains non-hex characters', async () => {
+      process.env.OUTPUT_CREDENTIALS_KEY = `${key.slice( 0, 10 )} ${key.slice( 11 )}`;
+
+      vi.doMock( 'node:fs', () => ( {
+        readFileSync: () => ciphertext,
+        existsSync: ( path: string ) => path.endsWith( 'credentials.yml.enc' )
+      } ) );
+
+      const provider = await loadProvider();
+      const { InvalidCredentialsKeyError } = await import( './errors.js' );
+
+      expect( () => provider.loadGlobal( { environment: undefined } ) )
+        .toThrow( InvalidCredentialsKeyError );
+    } );
   } );
 
   describe( 'loadForWorkflow', () => {

--- a/sdk/credentials/src/encrypted_yaml_provider.ts
+++ b/sdk/credentials/src/encrypted_yaml_provider.ts
@@ -1,7 +1,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { load as parseYaml } from 'js-yaml';
 import { decrypt } from './encryption.js';
-import { InvalidCredentialsKeyError, MissingKeyError } from './errors.js';
+import { InvalidCredentialsKeyError, MalformedCredentialsKeyError, MissingKeyError } from './errors.js';
 import {
   resolveKeyEnvVar,
   resolveCredentialsPath,
@@ -52,8 +52,17 @@ const resolveWorkflowKey = ( workflowName: string, workflowDir: string ): string
 const safeDecrypt = ( ciphertext: string, key: string, credPath: string ): string => {
   try {
     return decrypt( ciphertext, key );
-  } catch {
-    throw new InvalidCredentialsKeyError( credPath );
+  } catch ( error ) {
+    if ( error instanceof RangeError ) {
+      throw new MalformedCredentialsKeyError( credPath, error.message );
+    }
+    if ( error instanceof Error && error.message.includes( 'aes/gcm' ) ) {
+      throw new InvalidCredentialsKeyError( credPath );
+    }
+    throw new InvalidCredentialsKeyError(
+      credPath,
+      error instanceof Error ? error.message : String( error )
+    );
   }
 };
 

--- a/sdk/credentials/src/encrypted_yaml_provider.ts
+++ b/sdk/credentials/src/encrypted_yaml_provider.ts
@@ -1,7 +1,7 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { load as parseYaml } from 'js-yaml';
 import { decrypt } from './encryption.js';
-import { MissingKeyError } from './errors.js';
+import { InvalidCredentialsKeyError, MissingKeyError } from './errors.js';
 import {
   resolveKeyEnvVar,
   resolveCredentialsPath,
@@ -49,8 +49,16 @@ const resolveWorkflowKey = ( workflowName: string, workflowDir: string ): string
   return resolveKey( undefined );
 };
 
-const decryptYaml = ( credPath: string, key: string ): Record<string, unknown> =>
-  ( parseYaml( decrypt( readFileSync( credPath, 'utf8' ).trim(), key ) ) as Record<string, unknown> ) || {};
+const decryptYaml = ( credPath: string, key: string ): Record<string, unknown> => {
+  try {
+    return ( parseYaml( decrypt( readFileSync( credPath, 'utf8' ).trim(), key ) ) as Record<string, unknown> ) || {};
+  } catch ( error: unknown ) {
+    if ( error instanceof Error && error.message.includes( 'aes/gcm' ) ) {
+      throw new InvalidCredentialsKeyError( credPath );
+    }
+    throw error;
+  }
+};
 
 export const encryptedYamlProvider: CredentialsProvider = {
   loadGlobal: ( { environment } ) => {

--- a/sdk/credentials/src/encrypted_yaml_provider.ts
+++ b/sdk/credentials/src/encrypted_yaml_provider.ts
@@ -49,15 +49,18 @@ const resolveWorkflowKey = ( workflowName: string, workflowDir: string ): string
   return resolveKey( undefined );
 };
 
-const decryptYaml = ( credPath: string, key: string ): Record<string, unknown> => {
+const safeDecrypt = ( ciphertext: string, key: string, credPath: string ): string => {
   try {
-    return ( parseYaml( decrypt( readFileSync( credPath, 'utf8' ).trim(), key ) ) as Record<string, unknown> ) || {};
-  } catch ( error: unknown ) {
-    if ( error instanceof Error && error.message.includes( 'aes/gcm' ) ) {
-      throw new InvalidCredentialsKeyError( credPath );
-    }
-    throw error;
+    return decrypt( ciphertext, key );
+  } catch {
+    throw new InvalidCredentialsKeyError( credPath );
   }
+};
+
+const decryptYaml = ( credPath: string, key: string ): Record<string, unknown> => {
+  const ciphertext = readFileSync( credPath, 'utf8' ).trim();
+  const plaintext = safeDecrypt( ciphertext, key, credPath );
+  return ( parseYaml( plaintext ) as Record<string, unknown> ) || {};
 };
 
 export const encryptedYamlProvider: CredentialsProvider = {

--- a/sdk/credentials/src/errors.ts
+++ b/sdk/credentials/src/errors.ts
@@ -17,3 +17,13 @@ export class MissingCredentialError extends Error {
     this.name = 'MissingCredentialError';
   }
 }
+
+export class InvalidCredentialsKeyError extends Error {
+  constructor( credentialsPath: string ) {
+    super(
+      `Failed to decrypt ${credentialsPath}. The credentials key does not match the one used to encrypt this file. ` +
+      'Check OUTPUT_CREDENTIALS_KEY env var or config/credentials.key.'
+    );
+    this.name = 'InvalidCredentialsKeyError';
+  }
+}

--- a/sdk/credentials/src/errors.ts
+++ b/sdk/credentials/src/errors.ts
@@ -7,11 +7,13 @@ export class MissingKeyError extends Error {
       `config/credentials/${environment}.key` :
       'config/credentials.key';
     super( `No credentials key found. Set ${envVar} env var or create ${keyFile}.` );
+    this.name = 'MissingKeyError';
   }
 }
 
 export class MissingCredentialError extends Error {
   constructor( path: string ) {
     super( `Required credential not found: "${path}".` );
+    this.name = 'MissingCredentialError';
   }
 }

--- a/sdk/credentials/src/errors.ts
+++ b/sdk/credentials/src/errors.ts
@@ -19,11 +19,25 @@ export class MissingCredentialError extends Error {
 }
 
 export class InvalidCredentialsKeyError extends Error {
-  constructor( credentialsPath: string ) {
-    super(
+  constructor( credentialsPath: string, underlyingError?: string ) {
+    const message = underlyingError ?
+      `Failed to decrypt ${credentialsPath}: ${underlyingError}. ` +
+      'The credentials key may not match the one used to encrypt this file, or the credentials file may be corrupted. ' +
+      'Check OUTPUT_CREDENTIALS_KEY env var or config/credentials.key.' :
       `Failed to decrypt ${credentialsPath}. The credentials key does not match the one used to encrypt this file. ` +
-      'Check OUTPUT_CREDENTIALS_KEY env var or config/credentials.key.'
-    );
+      'Check OUTPUT_CREDENTIALS_KEY env var or config/credentials.key.';
+    super( message );
     this.name = 'InvalidCredentialsKeyError';
+  }
+}
+
+export class MalformedCredentialsKeyError extends Error {
+  constructor( credentialsPath: string, detail: string ) {
+    super(
+      `Credentials key for ${credentialsPath} is malformed (${detail}). ` +
+      'The key must be exactly 64 hex characters. ' +
+      'Check OUTPUT_CREDENTIALS_KEY env var or config/credentials.key for typos, whitespace, or truncation.'
+    );
+    this.name = 'MalformedCredentialsKeyError';
   }
 }

--- a/sdk/credentials/src/index.ts
+++ b/sdk/credentials/src/index.ts
@@ -4,7 +4,7 @@ export { credentials, resolveCredentialRefs } from './credentials.js';
 export { setProvider, getProvider } from './provider_registry.js';
 export { encryptedYamlProvider } from './encrypted_yaml_provider.js';
 export { encrypt, decrypt, generateKey } from './encryption.js';
-export { MissingCredentialError, MissingKeyError } from './errors.js';
+export { InvalidCredentialsKeyError, MissingCredentialError, MissingKeyError } from './errors.js';
 export {
   getNestedValue,
   resolveCredentialsPath,

--- a/sdk/credentials/src/index.ts
+++ b/sdk/credentials/src/index.ts
@@ -4,7 +4,7 @@ export { credentials, resolveCredentialRefs } from './credentials.js';
 export { setProvider, getProvider } from './provider_registry.js';
 export { encryptedYamlProvider } from './encrypted_yaml_provider.js';
 export { encrypt, decrypt, generateKey } from './encryption.js';
-export { InvalidCredentialsKeyError, MissingCredentialError, MissingKeyError } from './errors.js';
+export { InvalidCredentialsKeyError, MalformedCredentialsKeyError, MissingCredentialError, MissingKeyError } from './errors.js';
 export {
   getNestedValue,
   resolveCredentialsPath,


### PR DESCRIPTION
## Summary

Running any `output` CLI command with `credential:` env refs used to dump a raw stack trace when credentials couldn't be loaded. This PR turns both failure modes from [OUT-431](https://linear.app/growthx/issue/OUT-431) into a single clean error line + exit 1:

1. **Missing `credentials.key`** → caught at the bin layer; prints the existing `MissingKeyError` message without a stack trace.
2. **Wrong `credentials.key`** → AES-GCM auth tag failure inside `@noble/ciphers` is now wrapped into a new `InvalidCredentialsKeyError` that names the credentials file, then handled at the bin layer the same way.

Unrelated errors still propagate.

### Before (wrong key)
```
file:///.../@noble/ciphers/aes.js:820
    throw new Error('aes/gcm: invalid ghash tag');
Error: aes/gcm: invalid ghash tag
    at Object.decrypt (...)
    [...8 more frames...]
```

### After (wrong key)
```
Error: Failed to decrypt /path/to/config/credentials.yml.enc. The credentials key does not match the one used to encrypt this file. Check OUTPUT_CREDENTIALS_KEY env var or config/credentials.key.
```

### Before (missing key)
```
file:///.../encrypted_yaml_provider.js:19
    throw new MissingKeyError(environment);
MissingKeyError: No credentials key found. Set OUTPUT_CREDENTIALS_KEY env var or create config/credentials.key.
    at resolveKey (...)
    [...8 more frames...]
```

### After (missing key)
```
Error: No credentials key found. Set OUTPUT_CREDENTIALS_KEY env var or create config/credentials.key.
```

## Changes

- `sdk/credentials/src/errors.ts` — adds `InvalidCredentialsKeyError`; sets `error.name` on credential error classes
- `sdk/credentials/src/encrypted_yaml_provider.ts` — wraps `decryptYaml` to translate the cipher's GCM tag error into `InvalidCredentialsKeyError`
- `sdk/credentials/src/index.ts` — exports `InvalidCredentialsKeyError`
- `sdk/cli/src/utils/credentials_loader.ts` *(new)* — catches `MissingKeyError`/`InvalidCredentialsKeyError` from `resolveCredentialRefs()`, prints the message, exits 1; rethrows everything else
- `sdk/cli/bin/run.js` — uses the new wrapper

## Test plan

- [x] New unit tests in `credentials_loader.spec.ts` (5 tests) cover happy path, both error types, env-specific message variants, and rethrow-on-unexpected-error
- [x] New test in `encrypted_yaml_provider.spec.ts` verifies a wrong key throws `InvalidCredentialsKeyError` with the credentials path
- [x] Existing credentials package tests still pass
- [x] Lint passes
- [x] Manual: run `npx output --version` in a project with `credential:` env refs and (a) no `credentials.key`, (b) wrong `credentials.key` — confirm clean message + exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)