### PR TITLE
Re-export ai.jsonSchema from outputai/llm

### DIFF
--- a/.changeset/twenty-ways-invite.md
+++ b/.changeset/twenty-ways-invite.md
@@ -1,0 +1,5 @@
+---
+"@outputai/llm": patch
+---
+
+re-export ai.jsonSchema for downstream use

--- a/sdk/llm/src/index.d.ts
+++ b/sdk/llm/src/index.d.ts
@@ -123,8 +123,8 @@ export type {
   TextStreamPart
 } from 'ai';
 
-// Re-export the tool helper function, Output, smoothStream, and stop condition helpers
-export { tool, Output, smoothStream, stepCountIs, hasToolCall } from 'ai';
+// Re-export the tool helper function, Output, smoothStream, stop condition helpers, and jsonSchema
+export { tool, Output, smoothStream, stepCountIs, hasToolCall, jsonSchema } from 'ai';
 
 // Web search tool factories
 export { tavilySearch, tavilyExtract, tavilyCrawl, tavilyMap } from '@tavily/ai-sdk';

--- a/sdk/llm/src/index.js
+++ b/sdk/llm/src/index.js
@@ -5,5 +5,5 @@ export { registerProvider, getRegisteredProviders } from './ai_model.js';
 export { tavilySearch, tavilyExtract, tavilyCrawl, tavilyMap } from '@tavily/ai-sdk';
 export { webSearch as exaSearch } from '@exalabs/ai-sdk';
 export { perplexitySearch } from '@perplexity-ai/ai-sdk';
-export { tool, Output, smoothStream, stepCountIs, hasToolCall } from 'ai';
+export { tool, Output, smoothStream, stepCountIs, hasToolCall, jsonSchema } from 'ai';
 export * as ai from 'ai';


### PR DESCRIPTION
## Summary

Other projects are importing `ai.jsonSchema` for things, even though `@outputai/llm` exports `ai`, we don't directly export `jsonSchama`, so this will be helpful so users won't need to add `ai@v6` as an extra dependency when they already have a version we ship with.