### PR TITLE
feat(core): Adding support to use workflows installed via npm [OUT-404]

### DIFF
--- a/.changeset/young-breads-drive.md
+++ b/.changeset/young-breads-drive.md
@@ -1,0 +1,5 @@
+---
+"@outputai/core": patch
+---
+
+Add support for discovering and running workflows from installed npm packages.

--- a/.changeset/young-breads-drive.md
+++ b/.changeset/young-breads-drive.md
@@ -1,5 +1,7 @@
 ---
-"@outputai/core": patch
+"@outputai/core": minor
 ---
 
 Add support for discovering and running workflows from installed npm packages.
+
+Rename the Output.ai settings property in `package.json` from `output` to `@outputai/config`.

--- a/docs/guides/costs/cost-events.mdx
+++ b/docs/guides/costs/cost-events.mdx
@@ -16,7 +16,7 @@ Cost events use the same [hooks system](/operations/error-hooks) as error hooks:
 
 1. Create a hook file and import `on` from `@outputai/core/hooks`.
 2. Register a handler for `cost:llm:request`, `cost:http:request`, or both.
-3. Add the file path to `@outputai/config.hookFiles` in `package.json`.
+3. Add the file path to `outputai.hookFiles` in `package.json`.
 
 See [Error Hooks — Setup](/operations/error-hooks#setup) for the hook file registration pattern.
 

--- a/docs/guides/costs/cost-events.mdx
+++ b/docs/guides/costs/cost-events.mdx
@@ -16,7 +16,7 @@ Cost events use the same [hooks system](/operations/error-hooks) as error hooks:
 
 1. Create a hook file and import `on` from `@outputai/core/hooks`.
 2. Register a handler for `cost:llm:request`, `cost:http:request`, or both.
-3. Add the file path to `output.hookFiles` in `package.json`.
+3. Add the file path to `@outputai/config.hookFiles` in `package.json`.
 
 See [Error Hooks — Setup](/operations/error-hooks#setup) for the hook file registration pattern.
 

--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -99,6 +99,7 @@
               "operations/credentials",
               "operations/error-handling",
               "operations/error-hooks",
+              "operations/external-workflow-packages",
               "operations/testing",
               "operations/tracing"
             ]

--- a/docs/guides/migrations/index.mdx
+++ b/docs/guides/migrations/index.mdx
@@ -24,4 +24,7 @@ It reads the `@outputai/*` version in your `package.json`, finds the matching gu
   <Card title="v0.2.0 → v0.3.0" href="/migrations/v0.2.0-to-v0.3.0">
     LLM cost payload format and cost event name.
   </Card>
+  <Card title="v0.3.0 → v0.4.0" href="/migrations/v0.3.0-to-v0.4.0">
+    Package.json Output.ai config section rename.
+  </Card>
 </CardGroup>

--- a/docs/guides/migrations/v0.3.0-to-v0.4.0.mdx
+++ b/docs/guides/migrations/v0.3.0-to-v0.4.0.mdx
@@ -1,0 +1,40 @@
+---
+title: "v0.3.0 → v0.4.0"
+description: "Upgrading Output.ai projects from v0.3.0 to v0.4.0: New package.json config section."
+---
+
+The dedicated `package.json` section for Output.ai settings changed from `output` to `@outputai/config`.
+
+Only the top level has changed.
+
+## Migration steps
+
+### Rename field
+
+Replace `output` with `@outputai/config`.
+
+#### Before
+_package.json_
+```json
+{
+  ...
+  "output": {
+    "hookFiles": [
+      "./src/hooks.js"
+    ]
+  }
+}
+```
+
+#### After
+_package.json_
+```json
+{
+  ...
+  "@outputai/config": {
+    "hookFiles": [
+      "./src/hooks.js"
+    ]
+  }
+}
+```

--- a/docs/guides/migrations/v0.3.0-to-v0.4.0.mdx
+++ b/docs/guides/migrations/v0.3.0-to-v0.4.0.mdx
@@ -3,7 +3,7 @@ title: "v0.3.0 → v0.4.0"
 description: "Upgrading Output.ai projects from v0.3.0 to v0.4.0: New package.json config section."
 ---
 
-The dedicated `package.json` section for Output.ai settings changed from `output` to `@outputai/config`.
+The dedicated `package.json` section for Output.ai settings changed from `output` to `outputai`.
 
 Only the top level has changed.
 
@@ -11,7 +11,7 @@ Only the top level has changed.
 
 ### Rename field
 
-Replace `output` with `@outputai/config`.
+Replace `output` with `outputai`.
 
 #### Before
 _package.json_
@@ -31,7 +31,7 @@ _package.json_
 ```json
 {
   ...
-  "@outputai/config": {
+  "outputai": {
     "hookFiles": [
       "./src/hooks.js"
     ]

--- a/docs/guides/operations/credentials.mdx
+++ b/docs/guides/operations/credentials.mdx
@@ -75,11 +75,11 @@ OPENAI_API_KEY=credential:openai.api_key
 
 When the worker starts, it scans `process.env` for any values starting with `credential:` and replaces them with the decrypted values from `config/credentials.yml.enc`. By the time your first workflow runs, `ANTHROPIC_API_KEY` contains the real key — no code changes needed.
 
-This resolution is triggered by the `@outputai/config.hookFiles` entry in your `package.json`:
+This resolution is triggered by the `outputai.hookFiles` entry in your `package.json`:
 
 ```json package.json
 {
-  "@outputai/config": {
+  "outputai": {
     "hookFiles": ["node_modules/@outputai/credentials/dist/hooks.js"]
   }
 }

--- a/docs/guides/operations/credentials.mdx
+++ b/docs/guides/operations/credentials.mdx
@@ -75,11 +75,11 @@ OPENAI_API_KEY=credential:openai.api_key
 
 When the worker starts, it scans `process.env` for any values starting with `credential:` and replaces them with the decrypted values from `config/credentials.yml.enc`. By the time your first workflow runs, `ANTHROPIC_API_KEY` contains the real key — no code changes needed.
 
-This resolution is triggered by the `output.hookFiles` entry in your `package.json`:
+This resolution is triggered by the `@outputai/config.hookFiles` entry in your `package.json`:
 
 ```json package.json
 {
-  "output": {
+  "@outputai/config": {
     "hookFiles": ["node_modules/@outputai/credentials/dist/hooks.js"]
   }
 }

--- a/docs/guides/operations/error-hooks.mdx
+++ b/docs/guides/operations/error-hooks.mdx
@@ -22,12 +22,12 @@ onError(async (payload) => {
 
 ### 2. Register the file in package.json
 
-List your hook file(s) under `@outputai/config.hookFiles`. Paths are relative to the package root. The worker loads these files at startup.
+List your hook file(s) under `outputai.hookFiles`. Paths are relative to the package root. The worker loads these files at startup.
 
 ```json
 {
   "name": "my-workflows",
-  "@outputai/config": {
+  "outputai": {
     "hookFiles": ["./src/error_hooks.js"]
   }
 }

--- a/docs/guides/operations/error-hooks.mdx
+++ b/docs/guides/operations/error-hooks.mdx
@@ -22,12 +22,12 @@ onError(async (payload) => {
 
 ### 2. Register the file in package.json
 
-List your hook file(s) under `output.hookFiles`. Paths are relative to the package root. The worker loads these files at startup.
+List your hook file(s) under `@outputai/config.hookFiles`. Paths are relative to the package root. The worker loads these files at startup.
 
 ```json
 {
   "name": "my-workflows",
-  "output": {
+  "@outputai/config": {
     "hookFiles": ["./src/error_hooks.js"]
   }
 }

--- a/docs/guides/operations/external-workflow-packages.mdx
+++ b/docs/guides/operations/external-workflow-packages.mdx
@@ -193,7 +193,29 @@ pnpm add @acme/sales-workflows
 
 Use your package manager of choice. The important part is that the package is installed in the workflow project's `node_modules`.
 
-## Step 6: Call the external workflow
+## Step 6: Call the workflow directly through the API
+
+When the worker starts, it discovers exposed workflow packages, registers their workflows, and loads package-level shared activities. You can call an external workflow by its `name` without writing a local wrapper workflow.
+
+For example, the package above registers `acmePostCallFollowup`:
+
+```bash
+curl -X POST http://localhost:3001/workflow/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "workflowName": "acmePostCallFollowup",
+    "input": {
+      "transcript": "Customer asked for pricing and implementation timeline.",
+      "accountName": "Acme Corp"
+    }
+  }'
+```
+
+This is useful for shared internal automations and workflow catalogs where consumers should not need to write local workflow code just to run a packaged workflow.
+
+## Step 7: Call from another workflow
+
+You can also import an external workflow and call it from local workflow code. Use this when the packaged workflow is one part of a larger local orchestration.
 
 Import the workflow from the npm package and call it inside your local workflow:
 
@@ -228,7 +250,7 @@ export default workflow({
 });
 ```
 
-When the worker starts, it discovers exposed workflow packages, registers their workflows, and loads package-level shared activities. Calls to imported workflows run as child workflows.
+Calls to imported workflows run as child workflows.
 
 ## Caveats
 

--- a/docs/guides/operations/external-workflow-packages.mdx
+++ b/docs/guides/operations/external-workflow-packages.mdx
@@ -17,7 +17,7 @@ An external workflow package should:
 
 - Follow the standard Output file conventions: `workflow.js`, `steps.js`, `evaluators.js`, `shared/steps/*.js`, `shared/evaluators/*.js`, and so on.
 - Export the workflows from the package entry point. This can be a barrel export or named workflow exports.
-- Set `output.workflows.expose` to `true` in `package.json`.
+- Set `@outputai/config.workflows.expose` to `true` in `package.json`.
 - Publish JavaScript files. If the package is authored in TypeScript, build `.js` files and matching `.d.ts` files before publishing.
 - Declare `@outputai/core` as a peer dependency. If your declaration files import `zod`, declare `zod` too.
 
@@ -132,7 +132,7 @@ import { postCallFollowup } from '@acme/sales-workflows';
 
 ## Step 3: Mark the package as exposing workflows
 
-Add `output.workflows.expose` to `package.json`:
+Add `@outputai/config.workflows.expose` to `package.json`:
 
 ```json package.json
 {
@@ -150,7 +150,7 @@ Add `output.workflows.expose` to `package.json`:
     "@outputai/llm": ">=0.2.0",
     "zod": "^4.3.0"
   },
-  "output": {
+  "@outputai/config": {
     "workflows": {
       "expose": true
     }
@@ -254,7 +254,7 @@ The worker only scans packages with:
 
 ```json
 {
-  "output": {
+  "@outputai/config": {
     "workflows": {
       "expose": true
     }

--- a/docs/guides/operations/external-workflow-packages.mdx
+++ b/docs/guides/operations/external-workflow-packages.mdx
@@ -1,0 +1,277 @@
+---
+title: "External Workflow Packages"
+description: "Publish workflows as npm packages and call them from local Output workflows"
+---
+
+External workflow packages let you share reusable workflows across projects. Publish a normal npm package that exposes Output workflows, install it in another Output project, and call those workflows from your local workflow code.
+
+This is useful for workflow catalogs, shared internal automations, or reusable domain-specific workflows that multiple teams call as child workflows.
+
+## What you'll build
+
+In this guide, we'll create an npm package with a post-call follow-up workflow, mark it as discoverable by Output, publish it, then install and call it from another project.
+
+## Package requirements
+
+An external workflow package should:
+
+- Follow the standard Output file conventions: `workflow.js`, `steps.js`, `evaluators.js`, `shared/steps/*.js`, `shared/evaluators/*.js`, and so on.
+- Export the workflows from the package entry point. This can be a barrel export or named workflow exports.
+- Set `output.workflows.expose` to `true` in `package.json`.
+- Publish JavaScript files. If the package is authored in TypeScript, build `.js` files and matching `.d.ts` files before publishing.
+- Declare `@outputai/core` as a peer dependency. If your declaration files import `zod`, declare `zod` too.
+
+## Step 1: Create the workflow package
+
+Create a package with the same shape as a regular Output project:
+
+```text
+sales-workflows/
+├── package.json
+└── src/
+    ├── index.ts
+    ├── shared/
+    │   └── steps/
+    │       └── normalize_transcript.ts
+    └── workflows/
+        └── post_call_followup/
+            ├── prompts/
+            │   └── draft_followup_email@v1.prompt
+            ├── steps.ts
+            └── workflow.ts
+```
+
+The workflow can call local child workflows, local steps, or package-level shared steps:
+
+```typescript src/workflows/post_call_followup/workflow.ts
+import { workflow, z } from '@outputai/core';
+import { normalizeTranscript } from '../../shared/steps/normalize_transcript.js';
+import { draftFollowUpEmail } from './steps.js';
+
+export default workflow({
+  name: 'acmePostCallFollowup',
+  description: 'Draft a follow-up email from a sales call transcript',
+  inputSchema: z.object({
+    transcript: z.string(),
+    accountName: z.string().optional()
+  }),
+  outputSchema: z.object({
+    subject: z.string(),
+    body: z.string(),
+    actionItems: z.array(z.string())
+  }),
+  fn: async (input) => {
+    const transcript = await normalizeTranscript(input.transcript);
+    return draftFollowUpEmail({
+      transcript,
+      accountName: input.accountName
+    });
+  }
+});
+```
+
+Workflow-specific steps stay next to the workflow:
+
+```typescript src/workflows/post_call_followup/steps.ts
+import { step, z } from '@outputai/core';
+import { generateText, Output } from '@outputai/llm';
+
+const followUpSchema = z.object({
+  subject: z.string(),
+  body: z.string(),
+  actionItems: z.array(z.string())
+});
+
+export const draftFollowUpEmail = step({
+  name: 'acmeDraftFollowUpEmail',
+  description: 'Draft a concise follow-up email and action item list',
+  inputSchema: z.object({
+    transcript: z.string(),
+    accountName: z.string().optional()
+  }),
+  outputSchema: followUpSchema,
+  fn: async ({ transcript, accountName }) => {
+    const { output } = await generateText({
+      prompt: 'draft_followup_email@v1',
+      variables: { transcript, accountName },
+      output: Output.object({ schema: followUpSchema })
+    });
+
+    return output;
+  }
+});
+```
+
+Shared activities live under `shared/steps` or `shared/evaluators` when more than one workflow in the package can use them:
+
+```typescript src/shared/steps/normalize_transcript.ts
+import { step, z } from '@outputai/core';
+
+export const normalizeTranscript = step({
+  name: 'acmeNormalizeTranscript',
+  description: 'Normalize whitespace in a call transcript',
+  inputSchema: z.string(),
+  outputSchema: z.string(),
+  fn: async (transcript) => transcript.replace(/\s+/g, ' ').trim()
+});
+```
+
+## Step 2: Export the workflow
+
+Export workflows from the package entry point:
+
+```typescript src/index.ts
+export { default as postCallFollowup } from './workflows/post_call_followup/workflow.js';
+```
+
+Consumers import from this package entry point:
+
+```javascript
+import { postCallFollowup } from '@acme/sales-workflows';
+```
+
+## Step 3: Mark the package as exposing workflows
+
+Add `output.workflows.expose` to `package.json`:
+
+```json package.json
+{
+  "name": "@acme/sales-workflows",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsc"
+  },
+  "peerDependencies": {
+    "@outputai/core": ">=0.2.0",
+    "@outputai/llm": ">=0.2.0",
+    "zod": "^4.3.0"
+  },
+  "output": {
+    "workflows": {
+      "expose": true
+    }
+  }
+}
+```
+
+This flag tells the Output worker that the package is intended to expose workflows for external discovery. Without it, the worker skips the package during automatic discovery.
+
+## Step 4: Build and publish
+
+If the package is written directly in JavaScript, make sure the published files are included in npm.
+
+If the package is written in TypeScript, compile it before publishing:
+
+```bash
+pnpm build
+pnpm publish
+```
+
+Your published package should contain runnable `.js` files. `.d.ts` files are strongly recommended so consumer projects get correct types.
+
+## Step 5: Install the package
+
+In the project that will call the external workflow:
+
+```bash
+pnpm add @acme/sales-workflows
+```
+
+Use your package manager of choice. The important part is that the package is installed in the workflow project's `node_modules`.
+
+## Step 6: Call the external workflow
+
+Import the workflow from the npm package and call it inside your local workflow:
+
+```typescript src/workflows/customer_call_review/workflow.ts
+import { workflow, z } from '@outputai/core';
+import { postCallFollowup } from '@acme/sales-workflows';
+
+export default workflow({
+  name: 'customerCallReview',
+  description: 'Review a customer call and prepare the next follow-up',
+  inputSchema: z.object({
+    transcript: z.string(),
+    accountName: z.string()
+  }),
+  outputSchema: z.object({
+    followUpSubject: z.string(),
+    followUpBody: z.string(),
+    nextSteps: z.array(z.string())
+  }),
+  fn: async (input) => {
+    const followUp = await postCallFollowup({
+      transcript: input.transcript,
+      accountName: input.accountName
+    });
+
+    return {
+      followUpSubject: followUp.subject,
+      followUpBody: followUp.body,
+      nextSteps: followUp.actionItems
+    };
+  }
+});
+```
+
+When the worker starts, it discovers exposed workflow packages, registers their workflows, and loads package-level shared activities. Calls to imported workflows run as child workflows.
+
+## Caveats
+
+### Workflow names must be unique
+
+External workflow names share the same catalog as local workflow names. If two workflows use the same `name`, they collide.
+
+Choose stable, package-specific workflow names when publishing reusable workflows:
+
+```javascript
+workflow({
+  name: 'acmePostCallFollowup',
+  // ...
+});
+```
+
+### Shared activity names can collide
+
+Package-level shared steps and evaluators are registered in the same shared namespace as local shared activities. If two shared activities use the same `name`, the later registration can overwrite the earlier one.
+
+Use descriptive shared activity names for published packages:
+
+```javascript
+step({
+  name: 'acmeNormalizeTranscript',
+  // ...
+});
+```
+
+### Only exposed packages are auto-discovered
+
+The worker only scans packages with:
+
+```json
+{
+  "output": {
+    "workflows": {
+      "expose": true
+    }
+  }
+}
+```
+
+If a workflow import rewrites successfully but the package is not exposed, the workflow may fail at runtime with a "workflow does not exist" error because it was not discovered by the worker.
+
+### Keep workflow package code workflow-safe
+
+Workflow code runs in Temporal's workflow runtime. Avoid importing Node-only APIs or non-deterministic code from workflow files. If a package needs a workflow-safe entry point, it can provide an `output-workflow-bundle` export condition so the worker bundle resolves the safe version.
+
+## Next steps
+
+After installing an external workflow package:
+
+- Start the worker and verify the external workflows appear in the catalog.
+- Trigger a local workflow that calls the external workflow.
+- Check traces to confirm the external workflow runs as a child workflow.

--- a/docs/guides/operations/external-workflow-packages.mdx
+++ b/docs/guides/operations/external-workflow-packages.mdx
@@ -16,7 +16,7 @@ In this guide, we'll create an npm package with a post-call follow-up workflow, 
 An external workflow package should:
 
 - Follow the standard Output file conventions: `workflow.js`, `steps.js`, `evaluators.js`, `shared/steps/*.js`, `shared/evaluators/*.js`, and so on.
-- Export the workflows from the package entry point. This can be a barrel export or named workflow exports.
+- Export workflows from the package entry point using static ESM re-exports.
 - Set `@outputai/config.workflows.expose` to `true` in `package.json`.
 - Publish JavaScript files. If the package is authored in TypeScript, build `.js` files and matching `.d.ts` files before publishing.
 - Declare `@outputai/core` as a peer dependency. If your declaration files import `zod`, declare `zod` too.
@@ -118,7 +118,7 @@ export const normalizeTranscript = step({
 
 ## Step 2: Export the workflow
 
-Export workflows from the package entry point:
+Export workflows from the package entry point with static ESM re-exports:
 
 ```typescript src/index.ts
 export { default as postCallFollowup } from './workflows/post_call_followup/workflow.js';
@@ -127,6 +127,16 @@ export { default as postCallFollowup } from './workflows/post_call_followup/work
 Consumers import from this package entry point:
 
 ```javascript
+import { postCallFollowup } from '@acme/sales-workflows';
+```
+
+Avoid namespace imports when calling workflows from a package:
+
+```javascript
+// Not supported
+import * as salesWorkflows from '@acme/sales-workflows';
+
+// Supported
 import { postCallFollowup } from '@acme/sales-workflows';
 ```
 
@@ -263,6 +273,25 @@ The worker only scans packages with:
 ```
 
 If a workflow import rewrites successfully but the package is not exposed, the workflow may fail at runtime with a "workflow does not exist" error because it was not discovered by the worker.
+
+### Use static ESM re-exports
+
+The worker resolves external workflow imports by statically following package entry point exports until it reaches `workflow.js` files. Use explicit ESM re-exports with relative paths:
+
+```javascript
+export { default as postCallFollowup } from './workflows/post_call_followup/workflow.js';
+export * from './workflows/renewal_reminder/workflow.js';
+```
+
+Dynamic exports, CommonJS re-exports, computed paths, and runtime export assembly are not supported for workflow discovery:
+
+```javascript
+// Not supported
+module.exports = { postCallFollowup };
+exports.postCallFollowup = require('./workflows/post_call_followup/workflow.js');
+```
+
+Namespace imports from workflow packages are also not supported. Import each workflow directly by name so the worker can map the local binding to the workflow runtime name.
 
 ### Keep workflow package code workflow-safe
 

--- a/docs/guides/operations/external-workflow-packages.mdx
+++ b/docs/guides/operations/external-workflow-packages.mdx
@@ -17,7 +17,7 @@ An external workflow package should:
 
 - Follow the standard Output file conventions: `workflow.js`, `steps.js`, `evaluators.js`, `shared/steps/*.js`, `shared/evaluators/*.js`, and so on.
 - Export workflows from the package entry point using static ESM re-exports.
-- Set `@outputai/config.workflows.expose` to `true` in `package.json`.
+- Set `outputai.workflows.expose` to `true` in `package.json`.
 - Publish JavaScript files. If the package is authored in TypeScript, build `.js` files and matching `.d.ts` files before publishing.
 - Declare `@outputai/core` as a peer dependency. If your declaration files import `zod`, declare `zod` too.
 
@@ -142,7 +142,7 @@ import { postCallFollowup } from '@acme/sales-workflows';
 
 ## Step 3: Mark the package as exposing workflows
 
-Add `@outputai/config.workflows.expose` to `package.json`:
+Add `outputai.workflows.expose` to `package.json`:
 
 ```json package.json
 {
@@ -160,7 +160,7 @@ Add `@outputai/config.workflows.expose` to `package.json`:
     "@outputai/llm": ">=0.2.0",
     "zod": "^4.3.0"
   },
-  "@outputai/config": {
+  "outputai": {
     "workflows": {
       "expose": true
     }
@@ -286,7 +286,7 @@ The worker only scans packages with:
 
 ```json
 {
-  "@outputai/config": {
+  "outputai": {
     "workflows": {
       "expose": true
     }

--- a/docs/guides/packages/core.mdx
+++ b/docs/guides/packages/core.mdx
@@ -92,7 +92,7 @@ When you call a step from a workflow, Output executes it as a durable activity w
 
 ## Hooks
 
-Register handlers in hook files that the worker loads at startup (list paths under `@outputai/config.hookFiles` in `package.json`). Import from `@outputai/core/hooks`. The framework wraps each handler in a try/catch: failures are logged and do not stop the worker or workflow runs.
+Register handlers in hook files that the worker loads at startup (list paths under `outputai.hookFiles` in `package.json`). Import from `@outputai/core/hooks`. The framework wraps each handler in a try/catch: failures are logged and do not stop the worker or workflow runs.
 
 | Function | When it runs | Payload |
 |----------|--------------|---------|

--- a/docs/guides/packages/core.mdx
+++ b/docs/guides/packages/core.mdx
@@ -92,7 +92,7 @@ When you call a step from a workflow, Output executes it as a durable activity w
 
 ## Hooks
 
-Register handlers in hook files that the worker loads at startup (list paths under `output.hookFiles` in `package.json`). Import from `@outputai/core/hooks`. The framework wraps each handler in a try/catch: failures are logged and do not stop the worker or workflow runs.
+Register handlers in hook files that the worker loads at startup (list paths under `@outputai/config.hookFiles` in `package.json`). Import from `@outputai/core/hooks`. The framework wraps each handler in a try/catch: failures are logged and do not stop the worker or workflow runs.
 
 | Function | When it runs | Payload |
 |----------|--------------|---------|

--- a/docs/guides/packages/credentials.mdx
+++ b/docs/guides/packages/credentials.mdx
@@ -279,11 +279,11 @@ When the worker starts, these references are resolved before any workflow code r
 ### How Resolution Works
 
 1. Worker loads `.env` — `ANTHROPIC_API_KEY` is set to `"credential:anthropic.api_key"`
-2. Worker reads `output.hookFiles` from `package.json` and imports each listed file at startup. Including `node_modules/@outputai/credentials/dist/hooks.js` registers the credential resolution hook:
+2. Worker reads `@outputai/config.hookFiles` from `package.json` and imports each listed file at startup. Including `node_modules/@outputai/credentials/dist/hooks.js` registers the credential resolution hook:
 
 ```json package.json
 {
-  "output": {
+  "@outputai/config": {
     "hookFiles": ["node_modules/@outputai/credentials/dist/hooks.js"]
   }
 }

--- a/docs/guides/packages/credentials.mdx
+++ b/docs/guides/packages/credentials.mdx
@@ -279,11 +279,11 @@ When the worker starts, these references are resolved before any workflow code r
 ### How Resolution Works
 
 1. Worker loads `.env` — `ANTHROPIC_API_KEY` is set to `"credential:anthropic.api_key"`
-2. Worker reads `@outputai/config.hookFiles` from `package.json` and imports each listed file at startup. Including `node_modules/@outputai/credentials/dist/hooks.js` registers the credential resolution hook:
+2. Worker reads `outputai.hookFiles` from `package.json` and imports each listed file at startup. Including `node_modules/@outputai/credentials/dist/hooks.js` registers the credential resolution hook:
 
 ```json package.json
 {
-  "@outputai/config": {
+  "outputai": {
     "hookFiles": ["node_modules/@outputai/credentials/dist/hooks.js"]
   }
 }

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -604,7 +604,7 @@ Options set in the prompt file (temperature, maxTokens) can be overridden at cal
 
 ## LLM call cost event
 
-Each `generateText` and `streamText` call emits a `cost:llm:request` event after the LLM responds. You can observe it with the same [hooks mechanism](/packages/core#error-hooks) as error hooks: register a handler with `on('cost:llm:request', handler)` from `@outputai/core/hooks` in a hook file listed under `output.hookFiles`. The payload includes token usage, computed cost, workflow/activity context, and model id. For payload details, setup, and cost structure, see [Cost Events](/costs/cost-events).
+Each `generateText` and `streamText` call emits a `cost:llm:request` event after the LLM responds. You can observe it with the same [hooks mechanism](/packages/core#error-hooks) as error hooks: register a handler with `on('cost:llm:request', handler)` from `@outputai/core/hooks` in a hook file listed under `@outputai/config.hookFiles`. The payload includes token usage, computed cost, workflow/activity context, and model id. For payload details, setup, and cost structure, see [Cost Events](/costs/cost-events).
 
 ## loadPrompt
 

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -604,7 +604,7 @@ Options set in the prompt file (temperature, maxTokens) can be overridden at cal
 
 ## LLM call cost event
 
-Each `generateText` and `streamText` call emits a `cost:llm:request` event after the LLM responds. You can observe it with the same [hooks mechanism](/packages/core#error-hooks) as error hooks: register a handler with `on('cost:llm:request', handler)` from `@outputai/core/hooks` in a hook file listed under `@outputai/config.hookFiles`. The payload includes token usage, computed cost, workflow/activity context, and model id. For payload details, setup, and cost structure, see [Cost Events](/costs/cost-events).
+Each `generateText` and `streamText` call emits a `cost:llm:request` event after the LLM responds. You can observe it with the same [hooks mechanism](/packages/core#error-hooks) as error hooks: register a handler with `on('cost:llm:request', handler)` from `@outputai/core/hooks` in a hook file listed under `outputai.hookFiles`. The payload includes token usage, computed cost, workflow/activity context, and model id. For payload details, setup, and cost structure, see [Cost Events](/costs/cost-events).
 
 ## loadPrompt
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,6 +436,9 @@ importers:
 
   test_workflows:
     dependencies:
+      '@growthxlabs/workflows_catalog':
+        specifier: 0.0.3
+        version: 0.0.3(@outputai/core@sdk+core)
       '@outputai/core':
         specifier: workspace:^
         version: link:../sdk/core
@@ -1078,6 +1081,11 @@ packages:
 
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
+
+  '@growthxlabs/workflows_catalog@0.0.3':
+    resolution: {integrity: sha512-/p/cAku0nIZJ/tWdx0d/nYSdVjdofZTvRUq63hV0CD4zXlSCul64+1rFYQKvNxmF7CvdsQq36Rf9xd8FaDZiwg==}
+    peerDependencies:
+      '@outputai/core': '>=0.2.0'
 
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
@@ -8563,6 +8571,10 @@ snapshots:
       '@shikijs/themes': 3.23.0
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
+
+  '@growthxlabs/workflows_catalog@0.0.3(@outputai/core@sdk+core)':
+    dependencies:
+      '@outputai/core': link:sdk/core
 
   '@grpc/grpc-js@1.14.3':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,7 +225,7 @@ importers:
         version: 4.1.0
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@5.5.0)
+        version: 4.4.3(supports-color@8.1.1)
       dotenv:
         specifier: 17.4.2
         version: 17.4.2
@@ -437,8 +437,8 @@ importers:
   test_workflows:
     dependencies:
       '@growthxlabs/workflows_catalog':
-        specifier: 0.0.3
-        version: 0.0.3(@outputai/core@sdk+core)
+        specifier: 0.0.12
+        version: 0.0.12(@outputai/core@sdk+core)(zod@4.3.6)
       '@outputai/core':
         specifier: workspace:^
         version: link:../sdk/core
@@ -1082,10 +1082,11 @@ packages:
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
-  '@growthxlabs/workflows_catalog@0.0.3':
-    resolution: {integrity: sha512-/p/cAku0nIZJ/tWdx0d/nYSdVjdofZTvRUq63hV0CD4zXlSCul64+1rFYQKvNxmF7CvdsQq36Rf9xd8FaDZiwg==}
+  '@growthxlabs/workflows_catalog@0.0.12':
+    resolution: {integrity: sha512-h42rGIBcyV2pDAvvq0Ip9DANIcyyDOgkvYR6Kxb7rLKpuKUlfNbZX9H6NR6t40R19eYA3735lt+nHFtw9Pl9zA==}
     peerDependencies:
       '@outputai/core': '>=0.2.0'
+      zod: ^4.3.0
 
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
@@ -8572,9 +8573,10 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@growthxlabs/workflows_catalog@0.0.3(@outputai/core@sdk+core)':
+  '@growthxlabs/workflows_catalog@0.0.12(@outputai/core@sdk+core)(zod@4.3.6)':
     dependencies:
       '@outputai/core': link:sdk/core
+      zod: 4.3.6
 
   '@grpc/grpc-js@1.14.3':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,5 @@ catalog:
   zod: 4.3.6
 
 minimumReleaseAge: 4320
+minimumReleaseAgeExclude:
+  - "@growthxlabs/workflows_catalog"

--- a/sdk/cli/src/templates/project/package.json.template
+++ b/sdk/cli/src/templates/project/package.json.template
@@ -23,7 +23,7 @@
   "engines": {
     "node": ">=24.3.0"
   },
-  "@outputai/config": {
+  "outputai": {
     "hookFiles": ["node_modules/@outputai/credentials/dist/hooks.js"]
   }
 }

--- a/sdk/cli/src/templates/project/package.json.template
+++ b/sdk/cli/src/templates/project/package.json.template
@@ -23,7 +23,7 @@
   "engines": {
     "node": ">=24.3.0"
   },
-  "output": {
+  "@outputai/config": {
     "hookFiles": ["node_modules/@outputai/credentials/dist/hooks.js"]
   }
 }

--- a/sdk/core/src/worker/bundler_options.js
+++ b/sdk/core/src/worker/bundler_options.js
@@ -1,21 +1,39 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { isExternalWorkflowPackagePath } from './webpack_loaders/tools.js';
+import {
+  findPackageRoot,
+  isPathDescendentFromNodeModules,
+  packageExposesWorkflows
+} from './loader_tools.js';
 
 const __dirname = dirname( fileURLToPath( import.meta.url ) );
 const workerDir = __dirname; // sdk/core/src/worker
 const interfaceDir = join( __dirname, '..', 'interface' );
+const packagesWithWorkflowsMap = new Map();
 
-/** Skip loaders for most of node_modules; allow known external workflow packages (see tools.js list). */
-const excludeUnlessExternalWorkflowPackages = resource => {
+/**
+ * Skip loaders for most of `node_modules`, except packages that expose workflows.
+ */
+const excludeUnlessPackageExposeWorkflows = resource => {
+  // internal parts: exclude
   if ( resource.startsWith( workerDir ) || resource.startsWith( interfaceDir ) ) {
     return true;
   }
-  const inNodeModules = /[/\\]node_modules[/\\]/.test( resource );
-  if ( !inNodeModules ) {
+  // not node_modules/: include
+  if ( !isPathDescendentFromNodeModules( resource ) ) {
     return false;
   }
-  return !isExternalWorkflowPackagePath( resource );
+
+  const rootPath = findPackageRoot( resource );
+  if ( !rootPath ) {
+    return true;
+  }
+
+  if ( !packagesWithWorkflowsMap.has( rootPath ) ) {
+    packagesWithWorkflowsMap.set( rootPath, packageExposesWorkflows( join( rootPath, 'package.json' ) ) );
+  }
+
+  return !packagesWithWorkflowsMap.get( rootPath );
 };
 
 export const webpackConfigHook = config => {
@@ -36,7 +54,7 @@ export const webpackConfigHook = config => {
   // Validation loader (runs first)
   config.module.rules.push( {
     test: /\.js$/,
-    exclude: excludeUnlessExternalWorkflowPackages,
+    exclude: excludeUnlessPackageExposeWorkflows,
     enforce: 'pre',
     use: {
       loader: join( __dirname, './webpack_loaders/workflow_validator/index.mjs' )
@@ -45,7 +63,7 @@ export const webpackConfigHook = config => {
   // Use AST-based loader for rewriting steps/workflows
   config.module.rules.push( {
     test: /\.js$/,
-    exclude: excludeUnlessExternalWorkflowPackages,
+    exclude: excludeUnlessPackageExposeWorkflows,
     use: {
       loader: join( __dirname, './webpack_loaders/workflow_rewriter/index.mjs' )
     }

--- a/sdk/core/src/worker/bundler_options.js
+++ b/sdk/core/src/worker/bundler_options.js
@@ -1,9 +1,22 @@
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isExternalWorkflowPackagePath } from './webpack_loaders/tools.js';
 
 const __dirname = dirname( fileURLToPath( import.meta.url ) );
 const workerDir = __dirname; // sdk/core/src/worker
 const interfaceDir = join( __dirname, '..', 'interface' );
+
+/** Skip loaders for most of node_modules; allow known external workflow packages (see tools.js list). */
+const excludeUnlessExternalWorkflowPackages = resource => {
+  if ( resource.startsWith( workerDir ) || resource.startsWith( interfaceDir ) ) {
+    return true;
+  }
+  const inNodeModules = /[/\\]node_modules[/\\]/.test( resource );
+  if ( !inNodeModules ) {
+    return false;
+  }
+  return !isExternalWorkflowPackagePath( resource );
+};
 
 export const webpackConfigHook = config => {
   // Prefer the "output-workflow-bundle" export condition when resolving packages.
@@ -23,8 +36,7 @@ export const webpackConfigHook = config => {
   // Validation loader (runs first)
   config.module.rules.push( {
     test: /\.js$/,
-    // Exclude node_modules and internal core worker files
-    exclude: resource => /node_modules/.test( resource ) || resource.startsWith( workerDir ) || resource.startsWith( interfaceDir ),
+    exclude: excludeUnlessExternalWorkflowPackages,
     enforce: 'pre',
     use: {
       loader: join( __dirname, './webpack_loaders/workflow_validator/index.mjs' )
@@ -33,8 +45,7 @@ export const webpackConfigHook = config => {
   // Use AST-based loader for rewriting steps/workflows
   config.module.rules.push( {
     test: /\.js$/,
-    // Exclude node_modules and internal core worker files
-    exclude: resource => /node_modules/.test( resource ) || resource.startsWith( workerDir ) || resource.startsWith( interfaceDir ),
+    exclude: excludeUnlessExternalWorkflowPackages,
     use: {
       loader: join( __dirname, './webpack_loaders/workflow_rewriter/index.mjs' )
     }

--- a/sdk/core/src/worker/bundler_options.spec.js
+++ b/sdk/core/src/worker/bundler_options.spec.js
@@ -1,0 +1,62 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { webpackConfigHook } from './bundler_options.js';
+
+const __dirname = dirname( fileURLToPath( import.meta.url ) );
+const TEMP_BASE = join( process.cwd(), 'sdk/core/temp_test_bundler_options' );
+
+afterEach( () => {
+  rmSync( TEMP_BASE, { recursive: true, force: true } );
+} );
+
+const buildExcludes = () => {
+  const config = webpackConfigHook( {} );
+  return config.module.rules.map( rule => rule.exclude );
+};
+
+const writePackageResource = ( packagePath, pkgJson ) => {
+  const resource = join( packagePath, 'lib', 'index.js' );
+  mkdirSync( dirname( resource ), { recursive: true } );
+  writeFileSync( join( packagePath, 'package.json' ), JSON.stringify( pkgJson ) );
+  writeFileSync( resource, 'export const x = 1;\n' );
+  return resource;
+};
+
+describe( 'webpackConfigHook loader excludes', () => {
+  it( 'keeps loaders enabled for project files outside node_modules', () => {
+    for ( const exclude of buildExcludes() ) {
+      expect( exclude( join( TEMP_BASE, 'src', 'workflow.js' ) ) ).toBe( false );
+    }
+  } );
+
+  it( 'excludes worker and interface internals', () => {
+    for ( const exclude of buildExcludes() ) {
+      expect( exclude( join( __dirname, 'loader.js' ) ) ).toBe( true );
+      expect( exclude( join( __dirname, '..', 'interface', 'index.js' ) ) ).toBe( true );
+    }
+  } );
+
+  it( 'keeps loaders enabled for packages that expose workflows', () => {
+    const resource = writePackageResource(
+      join( TEMP_BASE, 'node_modules', '@acme', 'catalog' ),
+      { name: '@acme/catalog', output: { workflows: { expose: true } } }
+    );
+
+    for ( const exclude of buildExcludes() ) {
+      expect( exclude( resource ) ).toBe( false );
+    }
+  } );
+
+  it( 'excludes packages that do not expose workflows', () => {
+    const resource = writePackageResource(
+      join( TEMP_BASE, 'node_modules', 'plain_lib' ),
+      { name: 'plain_lib', dependencies: { '@outputai/core': '1.0.0' } }
+    );
+
+    for ( const exclude of buildExcludes() ) {
+      expect( exclude( resource ) ).toBe( true );
+    }
+  } );
+} );

--- a/sdk/core/src/worker/bundler_options.spec.js
+++ b/sdk/core/src/worker/bundler_options.spec.js
@@ -41,7 +41,7 @@ describe( 'webpackConfigHook loader excludes', () => {
   it( 'keeps loaders enabled for packages that expose workflows', () => {
     const resource = writePackageResource(
       join( TEMP_BASE, 'node_modules', '@acme', 'catalog' ),
-      { name: '@acme/catalog', output: { workflows: { expose: true } } }
+      { name: '@acme/catalog', '@outputai/config': { workflows: { expose: true } } }
     );
 
     for ( const exclude of buildExcludes() ) {

--- a/sdk/core/src/worker/bundler_options.spec.js
+++ b/sdk/core/src/worker/bundler_options.spec.js
@@ -41,7 +41,7 @@ describe( 'webpackConfigHook loader excludes', () => {
   it( 'keeps loaders enabled for packages that expose workflows', () => {
     const resource = writePackageResource(
       join( TEMP_BASE, 'node_modules', '@acme', 'catalog' ),
-      { name: '@acme/catalog', '@outputai/config': { workflows: { expose: true } } }
+      { name: '@acme/catalog', outputai: { workflows: { expose: true } } }
     );
 
     for ( const exclude of buildExcludes() ) {

--- a/sdk/core/src/worker/loader.js
+++ b/sdk/core/src/worker/loader.js
@@ -158,7 +158,7 @@ Workflow names and aliases must be unique.` );
 };
 
 /**
- * Loads the hook files from package.json's "@outputai/config" section.
+ * Loads the hook files from package.json's "outputai" section.
  *
  * @param {string} rootDir
  * @returns {void}
@@ -170,8 +170,8 @@ export async function loadHooks( rootDir ) {
     const content = pkg.default;
     const hooks = [];
     // @DEPRECATED: "output" is the legacy namespace for configs, can be removed after couple version (this is being added in 0.3.x)
-    hooks.push( ...( content.output?.hookFiles ?? [] ) );
-    hooks.push( ...( content['@outputai/config']?.hookFiles ?? [] ) );
+    hooks.push( ...( content['output']?.hookFiles ?? [] ) );
+    hooks.push( ...( content['outputai']?.hookFiles ?? [] ) );
     for ( const path of hooks ) {
       const hookFile = join( rootDir, path );
       await import( hookFile );

--- a/sdk/core/src/worker/loader.js
+++ b/sdk/core/src/worker/loader.js
@@ -20,6 +20,7 @@ import {
   ACTIVITY_GET_TRACE_DESTINATIONS
 } from '#consts';
 import { createChildLogger } from '#logger';
+import { ValidationError } from '#errors';
 
 const log = createChildLogger( 'Scanner' );
 
@@ -77,27 +78,28 @@ export async function loadActivities( rootDir, workflows ) {
       log.info( 'Component loaded', { type: metadata.type, name: metadata.name, path, workflow: workflowName, ...( external && { external } ) } );
       // Activities loaded from a workflow path will use the workflow name as a namespace, which is unique across the platform, avoiding collision
       const activityKey = generateActivityKey( { namespace: workflowName, activityName: metadata.name } );
+      if ( activities[activityKey] ) {
+        throw new ValidationError( `Activity "${metadata.name}" in workflow "${workflowName}" conflicts with another \
+activity in the same workflow. Activity names must be unique within a workflow.` );
+      }
       activities[activityKey] = fn;
       // propagate the custom options set on the step()/evaluator() constructor
       activityOptionsMap[activityKey] = metadata.options?.activityOptions ?? undefined;
     }
   }
 
-  // Load shared activities/evaluators
-  const sharedMatchers = [ staticMatchers.sharedStepsDir, staticMatchers.sharedEvaluatorsDir ];
-  for await ( const { fn, metadata, path } of importComponents( matchFiles( rootDir, sharedMatchers ) ) ) {
-    log.info( 'Shared component loaded', { type: metadata.type, name: metadata.name, path } );
-    // The namespace for shared activities is fixed
-    const activityKey = generateActivityKey( { namespace: SHARED_STEP_PREFIX, activityName: metadata.name } );
-    activities[activityKey] = fn;
-    activityOptionsMap[activityKey] = metadata.options?.activityOptions ?? undefined;
-  }
-
-  // Load shared activities/evaluators from external npm modules
-  for await ( const { fn, metadata, path } of importComponents( findSharedActivitiesFromWorkflows( workflows.filter( w => w.external ) ) ) ) {
-    log.info( 'Shared component loaded', { type: metadata.type, name: metadata.name, path, external: true } );
+  // Load shared activities/evaluators from local and external npm modules
+  const localSharedActivities = matchFiles( rootDir, [ staticMatchers.sharedStepsDir, staticMatchers.sharedEvaluatorsDir ] );
+  const externalSharedActivities = findSharedActivitiesFromWorkflows( workflows.filter( w => w.external ) );
+  for await ( const { fn, metadata, path } of importComponents( [ ...localSharedActivities, ...externalSharedActivities ] ) ) {
+    const external = externalSharedActivities.some( a => a.path === path );
+    log.info( 'Shared component loaded', { type: metadata.type, name: metadata.name, path, ...( external && { external } ) } );
     // Reuses the same global namespace for shared activities
     const activityKey = generateActivityKey( { namespace: SHARED_STEP_PREFIX, activityName: metadata.name } );
+    if ( activities[activityKey] ) {
+      throw new ValidationError( `Shared activity "${metadata.name}" conflicts with another shared activity. \
+Shared activity names must be unique.` );
+    }
     activities[activityKey] = fn;
     activityOptionsMap[activityKey] = metadata.options?.activityOptions ?? undefined;
   }
@@ -120,17 +122,37 @@ export async function loadActivities( rootDir, workflows ) {
  * @returns {object[]}
  */
 export async function loadWorkflows( rootDir ) {
+  const workflowNames = new Set();
   const workflows = [];
-  for await ( const { metadata, path } of importComponents( matchFiles( rootDir, [ staticMatchers.workflowFile ] ) ) ) {
+  const localWorkflows = matchFiles( rootDir, [ staticMatchers.workflowFile ] );
+  const externalWorkflows = findWorkflowsInNodeModules( rootDir );
+  for await ( const { metadata, path } of importComponents( [ ...localWorkflows, ...externalWorkflows ] ) ) {
+    const external = externalWorkflows.some( a => a.path === path );
     if ( staticMatchers.workflowPathHasShared( path ) ) {
-      throw new Error( 'Workflow directory can\'t be named "shared"' );
+      throw new ValidationError( 'Workflow directory can\'t be named "shared"' );
     }
-    log.info( 'Workflow loaded', { name: metadata.name, path } );
-    workflows.push( { ...metadata, path } );
-  }
-  for await ( const { metadata, path } of importComponents( findWorkflowsInNodeModules( rootDir ) ) ) {
-    log.info( 'Workflow loaded', { name: metadata.name, path, external: true } );
-    workflows.push( { ...metadata, path, external: true } );
+    const { name, aliases } = metadata;
+    if ( workflowNames.has( name ) ) {
+      throw new ValidationError( `Workflow name "${name}" conflicts with another workflow or alias. \
+Workflow names and aliases must be unique.` );
+    }
+    if ( WORKFLOW_CATALOG === name ) {
+      throw new ValidationError( `Workflow name "${name}" is reserved for the internal catalog workflow.` );
+    }
+    workflowNames.add( name );
+    for ( const alias of aliases ?? [] ) {
+      if ( workflowNames.has( alias ) ) {
+        throw new ValidationError( `Workflow "${name}" alias "${alias}" conflicts with another workflow or alias. \
+Workflow names and aliases must be unique.` );
+      }
+      if ( WORKFLOW_CATALOG === alias ) {
+        throw new ValidationError( `Workflow "${name}" alias "${alias}" is reserved for the internal catalog workflow.` );
+      }
+      workflowNames.add( alias );
+    }
+
+    log.info( 'Workflow loaded', { name, path, aliases, ...( external && { external } ) } );
+    workflows.push( { ...metadata, path, external } );
   }
   return workflows;
 };
@@ -159,48 +181,12 @@ export async function loadHooks( rootDir ) {
 };
 
 /**
- * Validates that all workflow names and aliases are unique across the project.
- *
- * @param {object[]} workflows
- * @throws {Error} If any alias conflicts with a workflow name or another alias
- */
-function validateWorkflowNames( workflows ) {
-  const allNames = new Map();
-
-  // Register primary names (case-insensitive to prevent confusing collisions)
-  for ( const { name } of workflows ) {
-    allNames.set( name.toLowerCase(), `workflow "${name}"` );
-  }
-
-  // Check the reserved catalog name
-  allNames.set( WORKFLOW_CATALOG.toLowerCase(), 'system workflow "$catalog"' );
-
-  // Check aliases against all names
-  for ( const { name, aliases = [] } of workflows ) {
-    const lowerCaseName = name.toLowerCase();
-    for ( const alias of aliases ) {
-      const lowerAliasName = alias.toLowerCase();
-      if ( lowerAliasName === lowerCaseName ) {
-        throw new Error( `Workflow "${name}" has an alias identical to its own name` );
-      }
-      const conflict = allNames.get( lowerAliasName );
-      if ( conflict ) {
-        throw new Error( `Alias "${alias}" on workflow "${name}" conflicts with ${conflict}` );
-      }
-      allNames.set( lowerAliasName, `alias "${alias}" on workflow "${name}"` );
-    }
-  }
-}
-
-/**
  * Creates a temporary index file importing all workflows for Temporal.
  *
  * @param {object[]} workflows
  * @returns
  */
 export function createWorkflowsEntryPoint( workflows ) {
-  validateWorkflowNames( workflows );
-
   const path = join( __dirname, 'temp', WORKFLOWS_INDEX_FILENAME );
 
   // default system catalog workflow

--- a/sdk/core/src/worker/loader.js
+++ b/sdk/core/src/worker/loader.js
@@ -136,7 +136,7 @@ export async function loadWorkflows( rootDir ) {
 };
 
 /**
- * Loads the hook files from package.json's output config section.
+ * Loads the hook files from package.json's "@outputai/config" section.
  *
  * @param {string} rootDir
  * @returns {void}
@@ -145,7 +145,12 @@ export async function loadHooks( rootDir ) {
   const packageFile = join( rootDir, 'package.json' );
   if ( existsSync( packageFile ) ) {
     const pkg = await import( packageFile, { with: { type: 'json' } } );
-    for ( const path of pkg.default.output?.hookFiles ?? [] ) {
+    const content = pkg.default;
+    const hooks = [];
+    // @DEPRECATED: "output" is the legacy namespace for configs, can be removed after couple version (this is being added in 0.3.x)
+    hooks.push( ...( content.output?.hookFiles ?? [] ) );
+    hooks.push( ...( content['@outputai/config']?.hookFiles ?? [] ) );
+    for ( const path of hooks ) {
       const hookFile = join( rootDir, path );
       await import( hookFile );
       log.info( 'Hook file loaded', { path } );

--- a/sdk/core/src/worker/loader.js
+++ b/sdk/core/src/worker/loader.js
@@ -3,7 +3,14 @@ import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { EOL } from 'node:os';
 import { fileURLToPath } from 'url';
 import { getTraceDestinations, sendHttpRequest } from '#internal_activities';
-import { importComponents, staticMatchers, activityMatchersBuilder } from './loader_tools.js';
+import {
+  activityMatchersBuilder,
+  findSharedActivitiesFromWorkflows,
+  findWorkflowsInNodeModules,
+  importComponents,
+  matchFiles,
+  staticMatchers
+} from './loader_tools.js';
 import {
   ACTIVITY_SEND_HTTP_REQUEST,
   ACTIVITY_OPTIONS_FILENAME,
@@ -66,7 +73,7 @@ export async function loadActivities( rootDir, workflows ) {
   // Load workflow based activities
   for ( const { path: workflowPath, name: workflowName, external } of workflows ) {
     const dir = dirname( workflowPath );
-    for await ( const { fn, metadata, path } of importComponents( dir, Object.values( activityMatchersBuilder( dir ) ) ) ) {
+    for await ( const { fn, metadata, path } of importComponents( matchFiles( dir, Object.values( activityMatchersBuilder( dir ) ) ) ) ) {
       log.info( 'Component loaded', { type: metadata.type, name: metadata.name, path, workflow: workflowName, ...( external && { external } ) } );
       // Activities loaded from a workflow path will use the workflow name as a namespace, which is unique across the platform, avoiding collision
       const activityKey = generateActivityKey( { namespace: workflowName, activityName: metadata.name } );
@@ -77,9 +84,19 @@ export async function loadActivities( rootDir, workflows ) {
   }
 
   // Load shared activities/evaluators
-  for await ( const { fn, metadata, path } of importComponents( rootDir, [ staticMatchers.sharedStepsDir, staticMatchers.sharedEvaluatorsDir ] ) ) {
+  const sharedMatchers = [ staticMatchers.sharedStepsDir, staticMatchers.sharedEvaluatorsDir ];
+  for await ( const { fn, metadata, path } of importComponents( matchFiles( rootDir, sharedMatchers ) ) ) {
     log.info( 'Shared component loaded', { type: metadata.type, name: metadata.name, path } );
     // The namespace for shared activities is fixed
+    const activityKey = generateActivityKey( { namespace: SHARED_STEP_PREFIX, activityName: metadata.name } );
+    activities[activityKey] = fn;
+    activityOptionsMap[activityKey] = metadata.options?.activityOptions ?? undefined;
+  }
+
+  // Load shared activities/evaluators from external npm modules
+  for await ( const { fn, metadata, path } of importComponents( findSharedActivitiesFromWorkflows( workflows.filter( w => w.external ) ) ) ) {
+    log.info( 'Shared component loaded', { type: metadata.type, name: metadata.name, path, external: true } );
+    // Reuses the same global namespace for shared activities
     const activityKey = generateActivityKey( { namespace: SHARED_STEP_PREFIX, activityName: metadata.name } );
     activities[activityKey] = fn;
     activityOptionsMap[activityKey] = metadata.options?.activityOptions ?? undefined;
@@ -104,15 +121,14 @@ export async function loadActivities( rootDir, workflows ) {
  */
 export async function loadWorkflows( rootDir ) {
   const workflows = [];
-  for await ( const { metadata, path } of importComponents( rootDir, [ staticMatchers.workflowFile ] ) ) {
+  for await ( const { metadata, path } of importComponents( matchFiles( rootDir, [ staticMatchers.workflowFile ] ) ) ) {
     if ( staticMatchers.workflowPathHasShared( path ) ) {
       throw new Error( 'Workflow directory can\'t be named "shared"' );
     }
     log.info( 'Workflow loaded', { name: metadata.name, path } );
     workflows.push( { ...metadata, path } );
   }
-  const externalWorkflowsDir = join( rootDir, 'node_modules', '@growthxlabs' );
-  for await ( const { metadata, path } of importComponents( externalWorkflowsDir, [ staticMatchers.workflowFile ] ) ) {
+  for await ( const { metadata, path } of importComponents( findWorkflowsInNodeModules( rootDir ) ) ) {
     log.info( 'Workflow loaded', { name: metadata.name, path, external: true } );
     workflows.push( { ...metadata, path, external: true } );
   }

--- a/sdk/core/src/worker/loader.js
+++ b/sdk/core/src/worker/loader.js
@@ -64,10 +64,10 @@ export async function loadActivities( rootDir, workflows ) {
   const activityOptionsMap = {};
 
   // Load workflow based activities
-  for ( const { path: workflowPath, name: workflowName } of workflows ) {
+  for ( const { path: workflowPath, name: workflowName, external } of workflows ) {
     const dir = dirname( workflowPath );
     for await ( const { fn, metadata, path } of importComponents( dir, Object.values( activityMatchersBuilder( dir ) ) ) ) {
-      log.info( 'Component loaded', { type: metadata.type, name: metadata.name, path, workflow: workflowName } );
+      log.info( 'Component loaded', { type: metadata.type, name: metadata.name, path, workflow: workflowName, ...( external && { external } ) } );
       // Activities loaded from a workflow path will use the workflow name as a namespace, which is unique across the platform, avoiding collision
       const activityKey = generateActivityKey( { namespace: workflowName, activityName: metadata.name } );
       activities[activityKey] = fn;
@@ -110,6 +110,11 @@ export async function loadWorkflows( rootDir ) {
     }
     log.info( 'Workflow loaded', { name: metadata.name, path } );
     workflows.push( { ...metadata, path } );
+  }
+  const externalWorkflowsDir = join( rootDir, 'node_modules', '@growthxlabs' );
+  for await ( const { metadata, path } of importComponents( externalWorkflowsDir, [ staticMatchers.workflowFile ] ) ) {
+    log.info( 'Workflow loaded', { name: metadata.name, path, external: true } );
+    workflows.push( { ...metadata, path, external: true } );
   }
   return workflows;
 };

--- a/sdk/core/src/worker/loader.spec.js
+++ b/sdk/core/src/worker/loader.spec.js
@@ -104,6 +104,32 @@ describe( 'worker/loader', () => {
     expect( written['A#EmptyOptions'] ).toBeUndefined();
   } );
 
+  it( 'loadActivities throws when two activities in the same workflow share a name', async () => {
+    const { loadActivities } = await import( './loader.js' );
+    importComponentsMock.mockImplementationOnce( async function *() {
+      yield { fn: () => {}, metadata: { name: 'DuplicateActivity' }, path: '/a/steps.js' };
+      yield { fn: () => {}, metadata: { name: 'DuplicateActivity' }, path: '/a/evaluators.js' };
+    } );
+
+    await expect( loadActivities( '/root', [ { name: 'A', path: '/a/workflow.js' } ] ) ).rejects.toThrow(
+      'Activity "DuplicateActivity" in workflow "A" conflicts with another activity in the same workflow. \
+Activity names must be unique within a workflow.'
+    );
+  } );
+
+  it( 'loadActivities throws when two shared activities share a name', async () => {
+    const { loadActivities } = await import( './loader.js' );
+    importComponentsMock.mockImplementationOnce( async function *() {} );
+    importComponentsMock.mockImplementationOnce( async function *() {
+      yield { fn: () => {}, metadata: { name: 'DuplicateShared' }, path: '/root/shared/steps/a.js' };
+      yield { fn: () => {}, metadata: { name: 'DuplicateShared' }, path: '/root/shared/evaluators/a.js' };
+    } );
+
+    await expect( loadActivities( '/root', [ { name: 'A', path: '/a/workflow.js' } ] ) ).rejects.toThrow(
+      'Shared activity "DuplicateShared" conflicts with another shared activity. Shared activity names must be unique.'
+    );
+  } );
+
   describe( 'loadWorkflows', () => {
     it( 'returns local workflows from importComponents with metadata spread onto each entry', async () => {
       const { loadWorkflows } = await import( './loader.js' );
@@ -115,7 +141,7 @@ describe( 'worker/loader', () => {
       } );
 
       const workflows = await loadWorkflows( '/root' );
-      expect( workflows ).toEqual( [ { name: 'Flow1', description: 'd', path: '/b/workflow.js' } ] );
+      expect( workflows ).toEqual( [ { name: 'Flow1', description: 'd', path: '/b/workflow.js', external: false } ] );
       expect( importComponentsMock ).toHaveBeenNthCalledWith( 1, localFiles );
       expect( findWorkflowsInNodeModulesMock ).toHaveBeenCalledOnce();
       expect( findWorkflowsInNodeModulesMock ).toHaveBeenCalledWith( '/root' );
@@ -132,9 +158,8 @@ describe( 'worker/loader', () => {
 
       expect( matchFilesMock ).toHaveBeenCalledOnce();
       expect( matchFilesMock ).toHaveBeenCalledWith( '/my/app', [ staticMatchers.workflowFile ] );
-      expect( importComponentsMock ).toHaveBeenCalledTimes( 2 );
-      expect( importComponentsMock ).toHaveBeenNthCalledWith( 1, localFiles );
-      expect( importComponentsMock ).toHaveBeenNthCalledWith( 2, externalFiles );
+      expect( importComponentsMock ).toHaveBeenCalledTimes( 1 );
+      expect( importComponentsMock ).toHaveBeenNthCalledWith( 1, [ ...localFiles, ...externalFiles ] );
       expect( findWorkflowsInNodeModulesMock ).toHaveBeenCalledOnce();
       expect( findWorkflowsInNodeModulesMock ).toHaveBeenCalledWith( '/my/app' );
     } );
@@ -144,8 +169,6 @@ describe( 'worker/loader', () => {
 
       importComponentsMock.mockImplementationOnce( async function *() {
         yield { metadata: { name: 'LocalFlow', description: 'local' }, path: '/my/app/workflows/wf/workflow.js' };
-      } );
-      importComponentsMock.mockImplementationOnce( async function *() {
         yield {
           metadata: { name: '__sum_numbers', description: 'from catalog' },
           path: '/my/app/node_modules/catalog_pkg/src/w/workflow.js'
@@ -155,7 +178,7 @@ describe( 'worker/loader', () => {
 
       const workflows = await loadWorkflows( '/my/app' );
       expect( workflows ).toEqual( [
-        { name: 'LocalFlow', description: 'local', path: '/my/app/workflows/wf/workflow.js' },
+        { name: 'LocalFlow', description: 'local', path: '/my/app/workflows/wf/workflow.js', external: false },
         {
           name: '__sum_numbers',
           description: 'from catalog',
@@ -168,7 +191,6 @@ describe( 'worker/loader', () => {
     it( 'returns only external workflows when the project root has none', async () => {
       const { loadWorkflows } = await import( './loader.js' );
 
-      importComponentsMock.mockImplementationOnce( async function *() {} );
       importComponentsMock.mockImplementationOnce( async function *() {
         yield { metadata: { name: 'PkgFlow', description: 'pkg' }, path: '/proj/node_modules/a/w/workflow.js' };
       } );
@@ -192,7 +214,101 @@ describe( 'worker/loader', () => {
       } );
 
       await expect( loadWorkflows( '/root' ) ).rejects.toThrow( 'Workflow directory can\'t be named "shared"' );
-      expect( findWorkflowsInNodeModulesMock ).not.toHaveBeenCalled();
+      expect( findWorkflowsInNodeModulesMock ).toHaveBeenCalledOnce();
+    } );
+
+    it( 'throws when a workflow name conflicts with an earlier workflow name', async () => {
+      const { loadWorkflows } = await import( './loader.js' );
+      importComponentsMock.mockImplementationOnce( async function *() {
+        yield { metadata: { name: 'duplicate' }, path: '/root/a/workflow.js' };
+        yield { metadata: { name: 'duplicate' }, path: '/root/b/workflow.js' };
+      } );
+
+      await expect( loadWorkflows( '/root' ) ).rejects.toThrow(
+        'Workflow name "duplicate" conflicts with another workflow or alias. Workflow names and aliases must be unique.'
+      );
+    } );
+
+    it( 'throws when a workflow name conflicts with an earlier alias', async () => {
+      const { loadWorkflows } = await import( './loader.js' );
+      importComponentsMock.mockImplementationOnce( async function *() {
+        yield { metadata: { name: 'alpha', aliases: [ 'legacy' ] }, path: '/root/a/workflow.js' };
+        yield { metadata: { name: 'legacy' }, path: '/root/b/workflow.js' };
+      } );
+
+      await expect( loadWorkflows( '/root' ) ).rejects.toThrow(
+        'Workflow name "legacy" conflicts with another workflow or alias. Workflow names and aliases must be unique.'
+      );
+    } );
+
+    it( 'throws when an alias conflicts with an earlier workflow name', async () => {
+      const { loadWorkflows } = await import( './loader.js' );
+      importComponentsMock.mockImplementationOnce( async function *() {
+        yield { metadata: { name: 'alpha' }, path: '/root/a/workflow.js' };
+        yield { metadata: { name: 'beta', aliases: [ 'alpha' ] }, path: '/root/b/workflow.js' };
+      } );
+
+      await expect( loadWorkflows( '/root' ) ).rejects.toThrow(
+        'Workflow "beta" alias "alpha" conflicts with another workflow or alias. Workflow names and aliases must be unique.'
+      );
+    } );
+
+    it( 'throws when an alias conflicts with an earlier alias', async () => {
+      const { loadWorkflows } = await import( './loader.js' );
+      importComponentsMock.mockImplementationOnce( async function *() {
+        yield { metadata: { name: 'alpha', aliases: [ 'shared_alias' ] }, path: '/root/a/workflow.js' };
+        yield { metadata: { name: 'beta', aliases: [ 'shared_alias' ] }, path: '/root/b/workflow.js' };
+      } );
+
+      await expect( loadWorkflows( '/root' ) ).rejects.toThrow(
+        'Workflow "beta" alias "shared_alias" conflicts with another workflow or alias. Workflow names and aliases must be unique.'
+      );
+    } );
+
+    it( 'throws when an alias is identical to its workflow name', async () => {
+      const { loadWorkflows } = await import( './loader.js' );
+      importComponentsMock.mockImplementationOnce( async function *() {
+        yield { metadata: { name: 'alpha', aliases: [ 'alpha' ] }, path: '/root/a/workflow.js' };
+      } );
+
+      await expect( loadWorkflows( '/root' ) ).rejects.toThrow(
+        'Workflow "alpha" alias "alpha" conflicts with another workflow or alias. Workflow names and aliases must be unique.'
+      );
+    } );
+
+    it( 'allows workflow names and aliases that only differ by case', async () => {
+      const { loadWorkflows } = await import( './loader.js' );
+      importComponentsMock.mockImplementationOnce( async function *() {
+        yield { metadata: { name: 'Alpha', aliases: [ 'Legacy' ] }, path: '/root/a/workflow.js' };
+        yield { metadata: { name: 'alpha', aliases: [ 'legacy' ] }, path: '/root/b/workflow.js' };
+      } );
+
+      await expect( loadWorkflows( '/root' ) ).resolves.toEqual( [
+        { name: 'Alpha', aliases: [ 'Legacy' ], path: '/root/a/workflow.js', external: false },
+        { name: 'alpha', aliases: [ 'legacy' ], path: '/root/b/workflow.js', external: false }
+      ] );
+    } );
+
+    it( 'throws when a workflow name is reserved for the internal catalog', async () => {
+      const { loadWorkflows } = await import( './loader.js' );
+      importComponentsMock.mockImplementationOnce( async function *() {
+        yield { metadata: { name: 'catalog' }, path: '/root/catalog/workflow.js' };
+      } );
+
+      await expect( loadWorkflows( '/root' ) ).rejects.toThrow(
+        'Workflow name "catalog" is reserved for the internal catalog workflow.'
+      );
+    } );
+
+    it( 'throws when a workflow alias is reserved for the internal catalog', async () => {
+      const { loadWorkflows } = await import( './loader.js' );
+      importComponentsMock.mockImplementationOnce( async function *() {
+        yield { metadata: { name: 'alpha', aliases: [ 'catalog' ] }, path: '/root/a/workflow.js' };
+      } );
+
+      await expect( loadWorkflows( '/root' ) ).rejects.toThrow(
+        'Workflow "alpha" alias "catalog" is reserved for the internal catalog workflow.'
+      );
     } );
   } );
 
@@ -222,53 +338,6 @@ describe( 'worker/loader', () => {
     expect( contents ).toContain( 'export { default as W_legacy } from \'/abs/wf.js\';' );
   } );
 
-  it( 'createWorkflowsEntryPoint throws on alias conflicting with primary name', async () => {
-    const { createWorkflowsEntryPoint } = await import( './loader.js' );
-
-    const workflows = [
-      { name: 'alpha', path: '/a.js', aliases: [] },
-      { name: 'beta', path: '/b.js', aliases: [ 'alpha' ] }
-    ];
-    expect( () => createWorkflowsEntryPoint( workflows ) ).toThrow( /Alias "alpha" on workflow "beta" conflicts with workflow "alpha"/ );
-  } );
-
-  it( 'createWorkflowsEntryPoint throws on alias conflicting with another alias', async () => {
-    const { createWorkflowsEntryPoint } = await import( './loader.js' );
-
-    const workflows = [
-      { name: 'alpha', path: '/a.js', aliases: [ 'shared_alias' ] },
-      { name: 'beta', path: '/b.js', aliases: [ 'shared_alias' ] }
-    ];
-    expect( () => createWorkflowsEntryPoint( workflows ) ).toThrow( /Alias "shared_alias" on workflow "beta" conflicts with/ );
-  } );
-
-  it( 'createWorkflowsEntryPoint throws on alias identical to own name', async () => {
-    const { createWorkflowsEntryPoint } = await import( './loader.js' );
-
-    const workflows = [ { name: 'alpha', path: '/a.js', aliases: [ 'alpha' ] } ];
-    expect( () => createWorkflowsEntryPoint( workflows ) ).toThrow( /Workflow "alpha" has an alias identical to its own name/ );
-  } );
-
-  it( 'createWorkflowsEntryPoint catches case-insensitive alias collision with primary name', async () => {
-    const { createWorkflowsEntryPoint } = await import( './loader.js' );
-
-    const workflows = [
-      { name: 'Alpha', path: '/a.js', aliases: [] },
-      { name: 'beta', path: '/b.js', aliases: [ 'alpha' ] }
-    ];
-    expect( () => createWorkflowsEntryPoint( workflows ) ).toThrow( /Alias "alpha" on workflow "beta" conflicts with workflow "Alpha"/ );
-  } );
-
-  it( 'createWorkflowsEntryPoint catches case-insensitive alias-to-alias collision', async () => {
-    const { createWorkflowsEntryPoint } = await import( './loader.js' );
-
-    const workflows = [
-      { name: 'alpha', path: '/a.js', aliases: [ 'Legacy' ] },
-      { name: 'beta', path: '/b.js', aliases: [ 'legacy' ] }
-    ];
-    expect( () => createWorkflowsEntryPoint( workflows ) ).toThrow( /Alias "legacy" on workflow "beta" conflicts with/ );
-  } );
-
   it( 'loadActivities uses folder-based matchers for steps/evaluators and shared', async () => {
     const { loadActivities } = await import( './loader.js' );
     const workflowFiles = [ { path: '/a/steps/foo.js' } ];
@@ -295,10 +364,9 @@ describe( 'worker/loader', () => {
     expect( secondMatchers.some( fn => fn( '/root/shared/steps/baz.js' ) ) ).toBe( true );
     expect( secondMatchers.some( fn => fn( '/root/shared/evaluators/qux.js' ) ) ).toBe( true );
 
-    expect( importComponentsMock ).toHaveBeenCalledTimes( 3 );
+    expect( importComponentsMock ).toHaveBeenCalledTimes( 2 );
     expect( importComponentsMock ).toHaveBeenNthCalledWith( 1, workflowFiles );
     expect( importComponentsMock ).toHaveBeenNthCalledWith( 2, sharedFiles );
-    expect( importComponentsMock ).toHaveBeenNthCalledWith( 3, [] );
   } );
 
   it( 'loads shared activities from external workflow packages', async () => {
@@ -307,7 +375,6 @@ describe( 'worker/loader', () => {
     const localWorkflow = { name: 'Local', path: '/root/workflows/local/workflow.js' };
     const externalWorkflow = { name: 'External', path: '/root/node_modules/pkg/workflows/a/workflow.js', external: true };
     findSharedActivitiesFromWorkflowsMock.mockReturnValue( externalSharedFiles );
-    importComponentsMock.mockImplementationOnce( async function *() {} );
     importComponentsMock.mockImplementationOnce( async function *() {} );
     importComponentsMock.mockImplementationOnce( async function *() {} );
     importComponentsMock.mockImplementationOnce( async function *() {
@@ -321,7 +388,7 @@ describe( 'worker/loader', () => {
     const activities = await loadActivities( '/root', [ localWorkflow, externalWorkflow ] );
 
     expect( findSharedActivitiesFromWorkflowsMock ).toHaveBeenCalledWith( [ externalWorkflow ] );
-    expect( importComponentsMock ).toHaveBeenNthCalledWith( 4, externalSharedFiles );
+    expect( importComponentsMock ).toHaveBeenNthCalledWith( 3, externalSharedFiles );
     expect( activities['$shared#ExternalShared'] ).toBeTypeOf( 'function' );
     const written = JSON.parse(
       fsMocks.writeFileSync.mock.calls[0][1].replace( /^export default\s*/, '' ).replace( /;\s*$/, '' )

--- a/sdk/core/src/worker/loader.spec.js
+++ b/sdk/core/src/worker/loader.spec.js
@@ -388,14 +388,14 @@ describe( 'worker/loader', () => {
       expect( fsMocks.existsSync ).toHaveBeenCalledWith( join( '/root', 'package.json' ) );
     } );
 
-    it( 'imports hook files listed in package.json output.hookFiles', async () => {
+    it( 'imports hook files listed in package.json @outputai/config.hookFiles', async () => {
       vi.doUnmock( 'node:fs' );
       vi.resetModules();
       const fs = await import( 'node:fs' );
       const tmpDir = fs.mkdtempSync( join( tmpdir(), 'loader-spec-' ) );
       try {
         fs.writeFileSync( join( tmpDir, 'package.json' ), JSON.stringify( {
-          output: { hookFiles: [ 'hook.js' ] }
+          '@outputai/config': { hookFiles: [ 'hook.js' ] }
         } ) );
         fs.writeFileSync( join( tmpDir, 'hook.js' ), 'globalThis.__loadHooksTestLoaded = true;' );
 
@@ -404,6 +404,26 @@ describe( 'worker/loader', () => {
         expect( globalThis.__loadHooksTestLoaded ).toBe( true );
       } finally {
         delete globalThis.__loadHooksTestLoaded;
+        fs.rmSync( tmpDir, { recursive: true, force: true } );
+      }
+    } );
+
+    it( 'imports hook files from legacy package.json output.hookFiles', async () => {
+      vi.doUnmock( 'node:fs' );
+      vi.resetModules();
+      const fs = await import( 'node:fs' );
+      const tmpDir = fs.mkdtempSync( join( tmpdir(), 'loader-spec-' ) );
+      try {
+        fs.writeFileSync( join( tmpDir, 'package.json' ), JSON.stringify( {
+          output: { hookFiles: [ 'legacy_hook.js' ] }
+        } ) );
+        fs.writeFileSync( join( tmpDir, 'legacy_hook.js' ), 'globalThis.__loadHooksLegacyTestLoaded = true;' );
+
+        const { loadHooks } = await import( './loader.js' );
+        await loadHooks( tmpDir );
+        expect( globalThis.__loadHooksLegacyTestLoaded ).toBe( true );
+      } finally {
+        delete globalThis.__loadHooksLegacyTestLoaded;
         fs.rmSync( tmpDir, { recursive: true, force: true } );
       }
     } );

--- a/sdk/core/src/worker/loader.spec.js
+++ b/sdk/core/src/worker/loader.spec.js
@@ -455,14 +455,14 @@ Activity names must be unique within a workflow.'
       expect( fsMocks.existsSync ).toHaveBeenCalledWith( join( '/root', 'package.json' ) );
     } );
 
-    it( 'imports hook files listed in package.json @outputai/config.hookFiles', async () => {
+    it( 'imports hook files listed in package.json outputai.hookFiles', async () => {
       vi.doUnmock( 'node:fs' );
       vi.resetModules();
       const fs = await import( 'node:fs' );
       const tmpDir = fs.mkdtempSync( join( tmpdir(), 'loader-spec-' ) );
       try {
         fs.writeFileSync( join( tmpDir, 'package.json' ), JSON.stringify( {
-          '@outputai/config': { hookFiles: [ 'hook.js' ] }
+          outputai: { hookFiles: [ 'hook.js' ] }
         } ) );
         fs.writeFileSync( join( tmpDir, 'hook.js' ), 'globalThis.__loadHooksTestLoaded = true;' );
 

--- a/sdk/core/src/worker/loader.spec.js
+++ b/sdk/core/src/worker/loader.spec.js
@@ -38,6 +38,8 @@ vi.mock( 'node:fs', () => ( {
 describe( 'worker/loader', () => {
   beforeEach( () => {
     vi.clearAllMocks();
+    importComponentsMock.mockReset();
+    importComponentsMock.mockImplementation( async function *() {} );
   } );
 
   it( 'loadActivities returns map including system activity and writes options file', async () => {
@@ -89,12 +91,59 @@ describe( 'worker/loader', () => {
   it( 'loadWorkflows returns array of workflows with metadata', async () => {
     const { loadWorkflows } = await import( './loader.js' );
 
-    importComponentsMock.mockImplementationOnce( async function *() {
-      yield { metadata: { name: 'Flow1', description: 'd' }, path: '/b/workflow.js' };
-    } );
+    importComponentsMock
+      .mockImplementationOnce( async function *() {
+        yield { metadata: { name: 'Flow1', description: 'd' }, path: '/b/workflow.js' };
+      } )
+      .mockImplementationOnce( async function *() {} );
 
     const workflows = await loadWorkflows( '/root' );
     expect( workflows ).toEqual( [ { name: 'Flow1', description: 'd', path: '/b/workflow.js' } ] );
+  } );
+
+  it( 'loadWorkflows scans project root then node_modules/@growthxlabs with the workflow file matcher', async () => {
+    const { loadWorkflows } = await import( './loader.js' );
+
+    importComponentsMock
+      .mockImplementationOnce( async function *() {} )
+      .mockImplementationOnce( async function *() {} );
+
+    await loadWorkflows( '/my/app' );
+
+    expect( importComponentsMock ).toHaveBeenCalledTimes( 2 );
+    expect( importComponentsMock.mock.calls[0][0] ).toBe( '/my/app' );
+    expect( importComponentsMock.mock.calls[1][0] ).toBe( join( '/my/app', 'node_modules', '@growthxlabs' ) );
+    const [ , matchersA ] = importComponentsMock.mock.calls[0];
+    const [ , matchersB ] = importComponentsMock.mock.calls[1];
+    expect( matchersA.length ).toBe( 1 );
+    expect( matchersB.length ).toBe( 1 );
+    expect( matchersB[0] ).toBe( matchersA[0] );
+  } );
+
+  it( 'loadWorkflows merges local workflows and installed @growthxlabs workflows with external flag', async () => {
+    const { loadWorkflows } = await import( './loader.js' );
+
+    importComponentsMock
+      .mockImplementationOnce( async function *() {
+        yield { metadata: { name: 'LocalFlow', description: 'local' }, path: '/my/app/workflows/wf/workflow.js' };
+      } )
+      .mockImplementationOnce( async function *() {
+        yield {
+          metadata: { name: '__sum_numbers', description: 'from catalog' },
+          path: '/my/app/node_modules/@growthxlabs/workflows_catalog/src/w/workflow.js'
+        };
+      } );
+
+    const workflows = await loadWorkflows( '/my/app' );
+    expect( workflows ).toEqual( [
+      { name: 'LocalFlow', description: 'local', path: '/my/app/workflows/wf/workflow.js' },
+      {
+        name: '__sum_numbers',
+        description: 'from catalog',
+        path: '/my/app/node_modules/@growthxlabs/workflows_catalog/src/w/workflow.js',
+        external: true
+      }
+    ] );
   } );
 
   it( 'createWorkflowsEntryPoint writes index and returns its path', async () => {

--- a/sdk/core/src/worker/loader.spec.js
+++ b/sdk/core/src/worker/loader.spec.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { staticMatchers } from './loader_tools.js';
 
 vi.mock( '#consts', () => ( {
   ACTIVITY_SEND_HTTP_REQUEST: '__internal#sendHttpRequest',
@@ -18,10 +19,22 @@ vi.mock( '#internal_activities', () => ( {
   getTraceDestinations: getTraceDestinationsMock
 } ) );
 
-const importComponentsMock = vi.fn();
+const { importComponentsMock, findSharedActivitiesFromWorkflowsMock, findWorkflowsInNodeModulesMock, matchFilesMock } = vi.hoisted( () => ( {
+  importComponentsMock: vi.fn(),
+  findSharedActivitiesFromWorkflowsMock: vi.fn(),
+  findWorkflowsInNodeModulesMock: vi.fn(),
+  matchFilesMock: vi.fn()
+} ) );
+
 vi.mock( './loader_tools.js', async importOriginal => {
   const actual = await importOriginal();
-  return { ...actual, importComponents: importComponentsMock };
+  return {
+    ...actual,
+    importComponents: importComponentsMock,
+    findSharedActivitiesFromWorkflows: findSharedActivitiesFromWorkflowsMock,
+    findWorkflowsInNodeModules: findWorkflowsInNodeModulesMock,
+    matchFiles: matchFilesMock
+  };
 } );
 
 const fsMocks = vi.hoisted( () => ( {
@@ -40,12 +53,17 @@ describe( 'worker/loader', () => {
     vi.clearAllMocks();
     importComponentsMock.mockReset();
     importComponentsMock.mockImplementation( async function *() {} );
+    findSharedActivitiesFromWorkflowsMock.mockReset();
+    findSharedActivitiesFromWorkflowsMock.mockReturnValue( [] );
+    findWorkflowsInNodeModulesMock.mockReset();
+    findWorkflowsInNodeModulesMock.mockReturnValue( [] );
+    matchFilesMock.mockReset();
+    matchFilesMock.mockReturnValue( [] );
   } );
 
   it( 'loadActivities returns map including system activity and writes options file', async () => {
     const { loadActivities } = await import( './loader.js' );
 
-    // First call: workflow directory scan (options.activityOptions propagated to activity options file)
     importComponentsMock.mockImplementationOnce( async function *() {
       yield {
         fn: () => {},
@@ -53,7 +71,6 @@ describe( 'worker/loader', () => {
         path: '/a/steps.js'
       };
     } );
-    // Second call: shared activities scan (no results)
     importComponentsMock.mockImplementationOnce( async function *() {} );
 
     const workflows = [ { name: 'A', path: '/a/workflow.js' } ];
@@ -61,7 +78,6 @@ describe( 'worker/loader', () => {
     expect( activities['A#Act1'] ).toBeTypeOf( 'function' );
     expect( activities['__internal#sendHttpRequest'] ).toBe( sendHttpRequestMock );
 
-    // options file written with the collected activityOptions map
     expect( fsMocks.writeFileSync ).toHaveBeenCalledTimes( 1 );
     const [ writtenPath, contents ] = fsMocks.writeFileSync.mock.calls[0];
     expect( writtenPath ).toMatch( /temp\/__activity_options\.js$/ );
@@ -88,62 +104,96 @@ describe( 'worker/loader', () => {
     expect( written['A#EmptyOptions'] ).toBeUndefined();
   } );
 
-  it( 'loadWorkflows returns array of workflows with metadata', async () => {
-    const { loadWorkflows } = await import( './loader.js' );
+  describe( 'loadWorkflows', () => {
+    it( 'returns local workflows from importComponents with metadata spread onto each entry', async () => {
+      const { loadWorkflows } = await import( './loader.js' );
+      const localFiles = [ { path: '/b/workflow.js', url: 'file:///b/workflow.js' } ];
+      matchFilesMock.mockReturnValueOnce( localFiles );
 
-    importComponentsMock
-      .mockImplementationOnce( async function *() {
+      importComponentsMock.mockImplementationOnce( async function *() {
         yield { metadata: { name: 'Flow1', description: 'd' }, path: '/b/workflow.js' };
-      } )
-      .mockImplementationOnce( async function *() {} );
-
-    const workflows = await loadWorkflows( '/root' );
-    expect( workflows ).toEqual( [ { name: 'Flow1', description: 'd', path: '/b/workflow.js' } ] );
-  } );
-
-  it( 'loadWorkflows scans project root then node_modules/@growthxlabs with the workflow file matcher', async () => {
-    const { loadWorkflows } = await import( './loader.js' );
-
-    importComponentsMock
-      .mockImplementationOnce( async function *() {} )
-      .mockImplementationOnce( async function *() {} );
-
-    await loadWorkflows( '/my/app' );
-
-    expect( importComponentsMock ).toHaveBeenCalledTimes( 2 );
-    expect( importComponentsMock.mock.calls[0][0] ).toBe( '/my/app' );
-    expect( importComponentsMock.mock.calls[1][0] ).toBe( join( '/my/app', 'node_modules', '@growthxlabs' ) );
-    const [ , matchersA ] = importComponentsMock.mock.calls[0];
-    const [ , matchersB ] = importComponentsMock.mock.calls[1];
-    expect( matchersA.length ).toBe( 1 );
-    expect( matchersB.length ).toBe( 1 );
-    expect( matchersB[0] ).toBe( matchersA[0] );
-  } );
-
-  it( 'loadWorkflows merges local workflows and installed @growthxlabs workflows with external flag', async () => {
-    const { loadWorkflows } = await import( './loader.js' );
-
-    importComponentsMock
-      .mockImplementationOnce( async function *() {
-        yield { metadata: { name: 'LocalFlow', description: 'local' }, path: '/my/app/workflows/wf/workflow.js' };
-      } )
-      .mockImplementationOnce( async function *() {
-        yield {
-          metadata: { name: '__sum_numbers', description: 'from catalog' },
-          path: '/my/app/node_modules/@growthxlabs/workflows_catalog/src/w/workflow.js'
-        };
       } );
 
-    const workflows = await loadWorkflows( '/my/app' );
-    expect( workflows ).toEqual( [
-      { name: 'LocalFlow', description: 'local', path: '/my/app/workflows/wf/workflow.js' },
-      {
-        name: '__sum_numbers',
-        description: 'from catalog',
-        path: '/my/app/node_modules/@growthxlabs/workflows_catalog/src/w/workflow.js',
-        external: true
-      }
-    ] );
+      const workflows = await loadWorkflows( '/root' );
+      expect( workflows ).toEqual( [ { name: 'Flow1', description: 'd', path: '/b/workflow.js' } ] );
+      expect( importComponentsMock ).toHaveBeenNthCalledWith( 1, localFiles );
+      expect( findWorkflowsInNodeModulesMock ).toHaveBeenCalledOnce();
+      expect( findWorkflowsInNodeModulesMock ).toHaveBeenCalledWith( '/root' );
+    } );
+
+    it( 'calls matchFiles with rootDir and workflowFile matcher', async () => {
+      const { loadWorkflows } = await import( './loader.js' );
+      const localFiles = [ { path: '/my/app/workflow.js', url: 'file:///my/app/workflow.js' } ];
+      const externalFiles = [ { path: '/my/app/node_modules/pkg/workflow.js', url: 'file:///my/app/node_modules/pkg/workflow.js' } ];
+      matchFilesMock.mockReturnValueOnce( localFiles );
+      findWorkflowsInNodeModulesMock.mockReturnValue( externalFiles );
+
+      await loadWorkflows( '/my/app' );
+
+      expect( matchFilesMock ).toHaveBeenCalledOnce();
+      expect( matchFilesMock ).toHaveBeenCalledWith( '/my/app', [ staticMatchers.workflowFile ] );
+      expect( importComponentsMock ).toHaveBeenCalledTimes( 2 );
+      expect( importComponentsMock ).toHaveBeenNthCalledWith( 1, localFiles );
+      expect( importComponentsMock ).toHaveBeenNthCalledWith( 2, externalFiles );
+      expect( findWorkflowsInNodeModulesMock ).toHaveBeenCalledOnce();
+      expect( findWorkflowsInNodeModulesMock ).toHaveBeenCalledWith( '/my/app' );
+    } );
+
+    it( 'appends node_modules workflows after local ones and sets external: true', async () => {
+      const { loadWorkflows } = await import( './loader.js' );
+
+      importComponentsMock.mockImplementationOnce( async function *() {
+        yield { metadata: { name: 'LocalFlow', description: 'local' }, path: '/my/app/workflows/wf/workflow.js' };
+      } );
+      importComponentsMock.mockImplementationOnce( async function *() {
+        yield {
+          metadata: { name: '__sum_numbers', description: 'from catalog' },
+          path: '/my/app/node_modules/catalog_pkg/src/w/workflow.js'
+        };
+      } );
+      findWorkflowsInNodeModulesMock.mockReturnValue( [ { path: '/my/app/node_modules/catalog_pkg/src/w/workflow.js' } ] );
+
+      const workflows = await loadWorkflows( '/my/app' );
+      expect( workflows ).toEqual( [
+        { name: 'LocalFlow', description: 'local', path: '/my/app/workflows/wf/workflow.js' },
+        {
+          name: '__sum_numbers',
+          description: 'from catalog',
+          path: '/my/app/node_modules/catalog_pkg/src/w/workflow.js',
+          external: true
+        }
+      ] );
+    } );
+
+    it( 'returns only external workflows when the project root has none', async () => {
+      const { loadWorkflows } = await import( './loader.js' );
+
+      importComponentsMock.mockImplementationOnce( async function *() {} );
+      importComponentsMock.mockImplementationOnce( async function *() {
+        yield { metadata: { name: 'PkgFlow', description: 'pkg' }, path: '/proj/node_modules/a/w/workflow.js' };
+      } );
+      findWorkflowsInNodeModulesMock.mockReturnValue( [ { path: '/proj/node_modules/a/w/workflow.js' } ] );
+
+      const workflows = await loadWorkflows( '/proj' );
+      expect( workflows ).toEqual( [
+        {
+          name: 'PkgFlow',
+          description: 'pkg',
+          path: '/proj/node_modules/a/w/workflow.js',
+          external: true
+        }
+      ] );
+    } );
+
+    it( 'throws when a local workflow path is under a shared directory', async () => {
+      const { loadWorkflows } = await import( './loader.js' );
+      importComponentsMock.mockImplementationOnce( async function *() {
+        yield { metadata: { name: 'Invalid' }, path: '/root/shared/workflow.js' };
+      } );
+
+      await expect( loadWorkflows( '/root' ) ).rejects.toThrow( 'Workflow directory can\'t be named "shared"' );
+      expect( findWorkflowsInNodeModulesMock ).not.toHaveBeenCalled();
+    } );
   } );
 
   it( 'createWorkflowsEntryPoint writes index and returns its path', async () => {
@@ -221,40 +271,69 @@ describe( 'worker/loader', () => {
 
   it( 'loadActivities uses folder-based matchers for steps/evaluators and shared', async () => {
     const { loadActivities } = await import( './loader.js' );
-    // First call (workflow dir): no results
+    const workflowFiles = [ { path: '/a/steps/foo.js' } ];
+    const sharedFiles = [ { path: '/root/shared/steps/baz.js' } ];
+    matchFilesMock.mockReturnValueOnce( workflowFiles );
+    matchFilesMock.mockReturnValueOnce( sharedFiles );
     importComponentsMock.mockImplementationOnce( async function *() {} );
-    // Second call (shared): no results
     importComponentsMock.mockImplementationOnce( async function *() {} );
 
     const workflows = [ { name: 'A', path: '/a/workflow.js' } ];
     await loadActivities( '/root', workflows );
 
-    // First invocation should target the workflow directory with folder/file matchers
-    expect( importComponentsMock ).toHaveBeenCalledTimes( 2 );
-    const [ firstDir, firstMatchers ] = importComponentsMock.mock.calls[0];
+    expect( matchFilesMock ).toHaveBeenCalledTimes( 2 );
+    const [ firstDir, firstMatchers ] = matchFilesMock.mock.calls[0];
     expect( firstDir ).toBe( '/a' );
     expect( Array.isArray( firstMatchers ) ).toBe( true );
-    // Should match folder-based steps and evaluators files
     expect( firstMatchers.some( fn => fn( '/a/steps/foo.js' ) ) ).toBe( true );
     expect( firstMatchers.some( fn => fn( '/a/evaluators/bar.js' ) ) ).toBe( true );
-    // And also direct file names
     expect( firstMatchers.some( fn => fn( '/a/steps.js' ) ) ).toBe( true );
     expect( firstMatchers.some( fn => fn( '/a/evaluators.js' ) ) ).toBe( true );
 
-    // Second invocation should target root with shared matchers
-    const [ secondDir, secondMatchers ] = importComponentsMock.mock.calls[1];
+    const [ secondDir, secondMatchers ] = matchFilesMock.mock.calls[1];
     expect( secondDir ).toBe( '/root' );
     expect( secondMatchers.some( fn => fn( '/root/shared/steps/baz.js' ) ) ).toBe( true );
     expect( secondMatchers.some( fn => fn( '/root/shared/evaluators/qux.js' ) ) ).toBe( true );
+
+    expect( importComponentsMock ).toHaveBeenCalledTimes( 3 );
+    expect( importComponentsMock ).toHaveBeenNthCalledWith( 1, workflowFiles );
+    expect( importComponentsMock ).toHaveBeenNthCalledWith( 2, sharedFiles );
+    expect( importComponentsMock ).toHaveBeenNthCalledWith( 3, [] );
+  } );
+
+  it( 'loads shared activities from external workflow packages', async () => {
+    const { loadActivities } = await import( './loader.js' );
+    const externalSharedFiles = [ { path: '/root/node_modules/pkg/shared/steps/prepare.js' } ];
+    const localWorkflow = { name: 'Local', path: '/root/workflows/local/workflow.js' };
+    const externalWorkflow = { name: 'External', path: '/root/node_modules/pkg/workflows/a/workflow.js', external: true };
+    findSharedActivitiesFromWorkflowsMock.mockReturnValue( externalSharedFiles );
+    importComponentsMock.mockImplementationOnce( async function *() {} );
+    importComponentsMock.mockImplementationOnce( async function *() {} );
+    importComponentsMock.mockImplementationOnce( async function *() {} );
+    importComponentsMock.mockImplementationOnce( async function *() {
+      yield {
+        fn: () => {},
+        metadata: { name: 'ExternalShared', options: { activityOptions: { retry: { maximumAttempts: 2 } } } },
+        path: '/root/node_modules/pkg/shared/steps/prepare.js'
+      };
+    } );
+
+    const activities = await loadActivities( '/root', [ localWorkflow, externalWorkflow ] );
+
+    expect( findSharedActivitiesFromWorkflowsMock ).toHaveBeenCalledWith( [ externalWorkflow ] );
+    expect( importComponentsMock ).toHaveBeenNthCalledWith( 4, externalSharedFiles );
+    expect( activities['$shared#ExternalShared'] ).toBeTypeOf( 'function' );
+    const written = JSON.parse(
+      fsMocks.writeFileSync.mock.calls[0][1].replace( /^export default\s*/, '' ).replace( /;\s*$/, '' )
+    );
+    expect( written['$shared#ExternalShared'] ).toEqual( { retry: { maximumAttempts: 2 } } );
   } );
 
   it( 'loadActivities includes nested workflow steps and shared evaluators', async () => {
     const { loadActivities } = await import( './loader.js' );
-    // Workflow dir scan returns a nested step
     importComponentsMock.mockImplementationOnce( async function *() {
       yield { fn: () => {}, metadata: { name: 'ActNested' }, path: '/a/steps/foo.js' };
     } );
-    // Shared scan returns a shared evaluator
     importComponentsMock.mockImplementationOnce( async function *() {
       yield { fn: () => {}, metadata: { name: 'SharedEval' }, path: '/root/shared/evaluators/bar.js' };
     } );
@@ -265,24 +344,14 @@ describe( 'worker/loader', () => {
     expect( activities['$shared#SharedEval'] ).toBeTypeOf( 'function' );
   } );
 
-  it( 'loadWorkflows throws when workflow is under shared directory', async () => {
-    const { loadWorkflows } = await import( './loader.js' );
-    importComponentsMock.mockImplementationOnce( async function *() {
-      yield { metadata: { name: 'Invalid' }, path: '/root/shared/workflow.js' };
-    } );
-    await expect( loadWorkflows( '/root' ) ).rejects.toThrow( 'Workflow directory can\'t be named \"shared\"' );
-  } );
-
   it( 'collects workflow nested steps and evaluators across multiple subfolders', async () => {
     const { loadActivities } = await import( './loader.js' );
-    // Workflow dir scan returns nested steps and evaluators
     importComponentsMock.mockImplementationOnce( async function *() {
       yield { fn: () => {}, metadata: { name: 'StepPrimary' }, path: '/a/steps/primary/foo.js' };
       yield { fn: () => {}, metadata: { name: 'StepSecondary' }, path: '/a/steps/secondary/bar.js' };
       yield { fn: () => {}, metadata: { name: 'EvalPrimary' }, path: '/a/evaluators/primary/baz.js' };
       yield { fn: () => {}, metadata: { name: 'EvalSecondary' }, path: '/a/evaluators/secondary/qux.js' };
     } );
-    // Shared scan returns nothing for this test
     importComponentsMock.mockImplementationOnce( async function *() {} );
 
     const workflows = [ { name: 'A', path: '/a/workflow.js' } ];
@@ -295,9 +364,7 @@ describe( 'worker/loader', () => {
 
   it( 'collects shared nested steps and evaluators across multiple subfolders', async () => {
     const { loadActivities } = await import( './loader.js' );
-    // Workflow dir scan returns nothing for this test
     importComponentsMock.mockImplementationOnce( async function *() {} );
-    // Shared scan returns nested steps and evaluators
     importComponentsMock.mockImplementationOnce( async function *() {
       yield { fn: () => {}, metadata: { name: 'SharedStepPrimary' }, path: '/root/shared/steps/primary/a.js' };
       yield { fn: () => {}, metadata: { name: 'SharedStepSecondary' }, path: '/root/shared/steps/secondary/b.js' };

--- a/sdk/core/src/worker/loader_tools.js
+++ b/sdk/core/src/worker/loader_tools.js
@@ -1,77 +1,21 @@
-import { resolve, sep } from 'path';
+import { dirname, resolve, sep } from 'path';
 import { pathToFileURL } from 'url';
 import { METADATA_ACCESS_SYMBOL } from '#consts';
-import { lstatSync, readdirSync, realpathSync } from 'fs';
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync } from 'fs';
 
 /**
- * @typedef {object} CollectedFile
- * @property {string} path - The file path
- * @property {string} url - The resolved url of the file, ready to be imported
+ * Returns the real path for symlink
+ *
+ * If the link is broken, returns null
+ *
+ * @param {string} link - The symlink to resolve
+ * @returns {string|null} The real path or null if it is unresolvable
  */
-/**
- * @typedef {object} Component
- * @property {Function} fn - The loaded component function
- * @property {object} metadata - Associated metadata with the component
- * @property {string} path - Associated metadata with the component
- */
-
-/**
- * Recursive traverse directories collection files with paths that match one of the given matches.
- *
- * Follows symlinks to directories
- *
- * @param {string} path - The path to scan
- * @param {function[]} matchers - Boolean functions to match files to add to collection
- * @returns {CollectedFile[]} An array containing the collected files
- */
-const findByNameRecursively = ( parentPath, matchers, ignoreDirNames = [ 'vendor', 'node_modules' ] ) => {
-  const collection = [];
-  for ( const entry of readdirSync( parentPath, { withFileTypes: true } ) ) {
-    if ( ignoreDirNames.includes( entry.name ) ) {
-      continue;
-    }
-
-    const path = resolve( parentPath, entry.name );
-    if ( entry.isSymbolicLink() ) {
-      const symLinkTarget = realpathSync( path );
-      if ( lstatSync( symLinkTarget ).isDirectory() ) {
-        collection.push( ...findByNameRecursively( symLinkTarget, matchers ) );
-      }
-    } else if ( entry.isDirectory() ) {
-      collection.push( ...findByNameRecursively( path, matchers ) );
-    } else if ( matchers.some( m => m( path ) ) ) {
-      collection.push( { path, url: pathToFileURL( path ).href } );
-    }
-  }
-
-  return collection;
-};
-
-/**
- * Scan a path for files testing each path against a matching function.
- *
- * For each file found, dynamic import it and for each exports on that file, yields it.
- *
- * @remarks
- * - Only yields exports that have the METADATA_ACCESS_SYMBOL, as they are output components (steps, evaluators, etc).
- *
- * @generator
- * @async
- * @function importComponents
- * @param {string} target - Place to look for files
- * @param {function[]} matchers - Boolean functions to match files
- * @yields {Component}
- */
-export async function *importComponents( target, matchers ) {
-  for ( const { url, path } of findByNameRecursively( target, matchers ) ) {
-    const imported = await import( url );
-    for ( const fn of Object.values( imported ) ) {
-      const metadata = fn[METADATA_ACCESS_SYMBOL];
-      if ( !metadata ) {
-        continue;
-      }
-      yield { fn, metadata, path };
-    }
+export const resolveSymlink = link => {
+  try {
+    return realpathSync( link );
+  } catch {
+    return null;
   }
 };
 
@@ -136,4 +80,225 @@ export const staticMatchers = {
    * @returns {boolean}
    */
   sharedEvaluatorsDir: v => v.includes( `${sep}shared${sep}evaluators${sep}` ) && v.endsWith( '.js' )
+};
+
+/**
+ * @typedef {object} File
+ * @property {string} path - The file path
+ * @property {string} url - The resolved url of the file, ready to be imported
+ */
+/**
+ * @typedef {object} Component
+ * @property {Function} fn - The loaded component function
+ * @property {object} metadata - Associated metadata with the component
+ * @property {string} path - Associated metadata with the component
+ */
+
+/**
+ * Recursive traverse directories collection files with paths that match one of the given matches.
+ *
+ * Follows symlinks to directories
+ *
+ * @param {string} parentPath - The path to scan
+ * @param {function[]} matchers - Boolean functions to match files to add to collection
+ * @returns {File[]} An array containing the collected files
+ */
+export const matchFiles = ( parentPath, matchers, ignoreDirNames = [ 'vendor', 'node_modules' ] ) => {
+  const collection = [];
+  for ( const entry of readdirSync( parentPath, { withFileTypes: true } ) ) {
+    if ( ignoreDirNames.includes( entry.name ) ) {
+      continue;
+    }
+    const path = resolve( parentPath, entry.name );
+    const realPath = entry.isSymbolicLink() ? resolveSymlink( path ) : path;
+    if ( !realPath ) {
+      continue;
+    }
+    const stat = lstatSync( realPath );
+    if ( stat.isDirectory() ) {
+      collection.push( ...matchFiles( realPath, matchers ) );
+    } else if ( stat.isFile() && matchers.some( m => m( realPath ) ) ) {
+      collection.push( { path, url: pathToFileURL( realPath ).href } );
+    }
+  }
+  return collection;
+};
+
+/**
+ * Returns true if given package.json indicates that its workflows are exposed for external usage.
+ *
+ * @param {string} pkgJsonPath
+ * @returns {boolean}
+ */
+export const packageExposesWorkflows = pkgJsonPath => {
+  if ( !existsSync( pkgJsonPath ) ) {
+    return false;
+  }
+  const pkgJsonRawContent = readFileSync( pkgJsonPath );
+  try {
+    const { output: outputConfig } = JSON.parse( pkgJsonRawContent );
+    return outputConfig?.workflows?.expose === true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Normalize path separators for cross-platform path matching.
+ *
+ * @param {string} path
+ * @returns {string}
+ */
+const normalizeSlashes = path => path.replace( /\\/g, '/' );
+
+/**
+ * Returns true if the given path is inside a node_modules tree.
+ *
+ * @param {string} path
+ * @returns {boolean}
+ */
+export const isPathDescendentFromNodeModules = path =>
+  /(^|\/)node_modules(\/|$)/.test( normalizeSlashes( path ) );
+
+/**
+ * Returns true if the given path is an installed package root inside node_modules.
+ *
+ * Matches both unscoped packages and scoped packages.
+ *
+ * @param {string} path
+ * @returns {boolean}
+ */
+export const isPackageRoot = path =>
+  /\/node_modules\/(?:@[^/]+\/[^/]+|[^/@][^/]*)$/.test( normalizeSlashes( path ) );
+
+/**
+ * Walk upward from a file path to find the closest installed package root under node_modules.
+ *
+ * @param {string} path
+ * @returns {string|null}
+ */
+export const findPackageRoot = path => {
+  if ( isPackageRoot( path ) && existsSync( resolve( path, 'package.json' ) ) ) {
+    return path;
+  }
+  const parent = dirname( path );
+  return parent !== path ? findPackageRoot( parent ) : null;
+};
+
+/**
+ * Resolves the closest node_modules directory
+ *
+ * @param {string} targetPath - A reference path to start the search, can be a dir or a file path
+ * @returns {string|null} The closest node_modules/ or null
+ */
+export const resolveNodeModulesPath = targetPath => {
+  if ( !existsSync( targetPath ) ) {
+    return null;
+  }
+  const path = lstatSync( targetPath ).isDirectory() ? targetPath : dirname( targetPath );
+  const nodeModulesPath = resolve( path, 'node_modules' );
+  if ( existsSync( nodeModulesPath ) ) {
+    const stat = lstatSync( nodeModulesPath );
+    if ( stat.isDirectory() ) {
+      return nodeModulesPath;
+    }
+    if ( stat.isSymbolicLink() ) {
+      const symlinkTarget = resolveSymlink( nodeModulesPath );
+      if ( symlinkTarget && lstatSync( symlinkTarget ).isDirectory() ) {
+        return symlinkTarget;
+      }
+    }
+  }
+
+  const parentPath = resolve( path, '..' );
+  return parentPath !== path ? resolveNodeModulesPath( parentPath ) : null;
+};
+
+/**
+ * Scans a node_modules/ path and look for all projects that contain workflows.
+ *
+ * A project contains workflows when packageExposesWorkflows() resolves to true.
+ *
+ * For each of these projects, load workflows using matchFiles().
+ *
+ * @param {string} nodeModulesPath
+ * @returns {File[]} An array containing the collected files
+ *
+ */
+export const findWorkflowsInPackages = nodeModulesPath => {
+  const collection = [];
+  for ( const entry of readdirSync( nodeModulesPath, { withFileTypes: true } ) ) {
+    const path = resolve( nodeModulesPath, entry.name );
+    const realPath = entry.isSymbolicLink() ? resolveSymlink( path ) : path;
+
+    if ( realPath && lstatSync( realPath ).isDirectory() ) {
+      if ( entry.name.startsWith( '@' ) ) { // scoped package root
+        collection.push( ...findWorkflowsInPackages( realPath ) );
+      } else if ( packageExposesWorkflows( resolve( realPath, 'package.json' ) ) ) { // is a package folder
+        collection.push( ...matchFiles( realPath, [ staticMatchers.workflowFile ] ) );
+      }
+    }
+  }
+  return collection;
+};
+
+/**
+ * Recursive traverse the closest node_modules/ directory loading workflows.
+ *
+ * Deduplicates by file url.
+ *
+ * @param {string} parentPath - The starting path
+ * @returns {File[]} An array containing the collected files
+ */
+export const findWorkflowsInNodeModules = parentPath => {
+  const nodeModulesPath = resolveNodeModulesPath( parentPath );
+  if ( !nodeModulesPath ) {
+    return [];
+  }
+  const collection = findWorkflowsInPackages( nodeModulesPath );
+
+  // deduplicate collection by .url in case symlinked packages end up resolving the same dependencies more than once
+  return collection.reduce( ( map, value ) => map.set( value.url, value ), new Map() ).values().toArray();
+};
+
+/**
+ * Based on workflow urls, traverse those projects looking for shared activities (steps, evaluators).
+ *
+ * @param {Component[]} workflows
+ * @returns {File[]}
+ */
+export const findSharedActivitiesFromWorkflows = workflows => {
+  const paths = workflows.map( wf => findPackageRoot( wf.path ) );
+  const uniquePaths = new Set( paths.filter( p => !!p ) ).values().toArray();
+  const files = [];
+  for ( const path of uniquePaths ) {
+    files.push( ...matchFiles( path, [ staticMatchers.sharedStepsDir, staticMatchers.sharedEvaluatorsDir ] ) );
+  }
+  return files;
+};
+
+/**
+ * Receives an array of Files and import each one.
+ *
+ * For each exported function from that file that has metadata, yields the path, metadata and the function itself.
+ *
+ * metadata is accessible thru METADATA_ACCESS_SYMBOL.
+ *
+ * @generator
+ * @async
+ * @function importComponents
+ * @param {File} Files - Collected files to load
+ * @yields {Component}
+ */
+export async function *importComponents( files ) {
+  for ( const { url, path } of files ) {
+    const imported = await import( url );
+    for ( const fn of Object.values( imported ) ) {
+      const metadata = fn[METADATA_ACCESS_SYMBOL];
+      if ( !metadata ) {
+        continue;
+      }
+      yield { fn, metadata, path };
+    }
+  }
 };

--- a/sdk/core/src/worker/loader_tools.js
+++ b/sdk/core/src/worker/loader_tools.js
@@ -137,7 +137,7 @@ export const packageExposesWorkflows = pkgJsonPath => {
   const pkgJsonRawContent = readFileSync( pkgJsonPath );
   try {
     const packageContent = JSON.parse( pkgJsonRawContent );
-    return packageContent['@outputai/config']?.workflows?.expose === true;
+    return packageContent['outputai']?.workflows?.expose === true;
   } catch {
     return false;
   }

--- a/sdk/core/src/worker/loader_tools.js
+++ b/sdk/core/src/worker/loader_tools.js
@@ -136,8 +136,8 @@ export const packageExposesWorkflows = pkgJsonPath => {
   }
   const pkgJsonRawContent = readFileSync( pkgJsonPath );
   try {
-    const { output: outputConfig } = JSON.parse( pkgJsonRawContent );
-    return outputConfig?.workflows?.expose === true;
+    const packageContent = JSON.parse( pkgJsonRawContent );
+    return packageContent['@outputai/config']?.workflows?.expose === true;
   } catch {
     return false;
   }

--- a/sdk/core/src/worker/loader_tools.js
+++ b/sdk/core/src/worker/loader_tools.js
@@ -1,7 +1,7 @@
 import { resolve, sep } from 'path';
 import { pathToFileURL } from 'url';
 import { METADATA_ACCESS_SYMBOL } from '#consts';
-import { readdirSync } from 'fs';
+import { lstatSync, readdirSync, realpathSync } from 'fs';
 
 /**
  * @typedef {object} CollectedFile
@@ -18,6 +18,8 @@ import { readdirSync } from 'fs';
 /**
  * Recursive traverse directories collection files with paths that match one of the given matches.
  *
+ * Follows symlinks to directories
+ *
  * @param {string} path - The path to scan
  * @param {function[]} matchers - Boolean functions to match files to add to collection
  * @returns {CollectedFile[]} An array containing the collected files
@@ -30,7 +32,12 @@ const findByNameRecursively = ( parentPath, matchers, ignoreDirNames = [ 'vendor
     }
 
     const path = resolve( parentPath, entry.name );
-    if ( entry.isDirectory() ) {
+    if ( entry.isSymbolicLink() ) {
+      const symLinkTarget = realpathSync( path );
+      if ( lstatSync( symLinkTarget ).isDirectory() ) {
+        collection.push( ...findByNameRecursively( symLinkTarget, matchers ) );
+      }
+    } else if ( entry.isDirectory() ) {
       collection.push( ...findByNameRecursively( path, matchers ) );
     } else if ( matchers.some( m => m( path ) ) ) {
       collection.push( { path, url: pathToFileURL( path ).href } );

--- a/sdk/core/src/worker/loader_tools.spec.js
+++ b/sdk/core/src/worker/loader_tools.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
 import { join, sep } from 'node:path';
 import { importComponents, staticMatchers } from './loader_tools.js';
 
@@ -112,6 +112,56 @@ describe( '.importComponents', () => {
     }
     expect( collected.length ).toBe( 1 );
     expect( collected[0].path ).toBe( okFile );
+
+    rmSync( root, { recursive: true, force: true } );
+  } );
+
+  it( 'follows symlinks to directories and collects matching files inside the target', async () => {
+    const base = join( process.cwd(), 'sdk/core/temp_test_modules', `symlink-dir-${Date.now()}` );
+    const targetDir = join( base, 'target' );
+    const scanRoot = join( base, 'root' );
+    mkdirSync( targetDir, { recursive: true } );
+    mkdirSync( scanRoot, { recursive: true } );
+    const moduleFile = join( targetDir, 'meta.module.js' );
+    writeFileSync( moduleFile, [
+      'import { METADATA_ACCESS_SYMBOL } from "#consts";',
+      'export const ViaLink = () => {};',
+      'ViaLink[METADATA_ACCESS_SYMBOL] = { kind: "step", name: "via_link" };'
+    ].join( '\n' ) );
+
+    symlinkSync( join( '..', 'target' ), join( scanRoot, 'pkg' ), 'dir' );
+
+    const collected = [];
+    for await ( const m of importComponents( scanRoot, [ v => v.endsWith( 'meta.module.js' ) ] ) ) {
+      collected.push( m );
+    }
+
+    expect( collected.length ).toBe( 1 );
+    expect( collected[0].path ).toBe( moduleFile );
+    expect( collected[0].metadata.name ).toBe( 'via_link' );
+
+    rmSync( base, { recursive: true, force: true } );
+  } );
+
+  it( 'does not traverse a symlink whose target is a file (only directory targets are recursed)', async () => {
+    const root = join( process.cwd(), 'sdk/core/temp_test_modules', `symlink-file-${Date.now()}` );
+    mkdirSync( root, { recursive: true } );
+    const realFile = join( root, 'real.module.js' );
+    writeFileSync( realFile, [
+      'import { METADATA_ACCESS_SYMBOL } from "#consts";',
+      'export const R = () => {};',
+      'R[METADATA_ACCESS_SYMBOL] = { kind: "step", name: "r" };'
+    ].join( '\n' ) );
+    const linkPath = join( root, 'alias.module.js' );
+    symlinkSync( 'real.module.js', linkPath, 'file' );
+
+    const collected = [];
+    for await ( const m of importComponents( root, [ v => v.endsWith( '.module.js' ) ] ) ) {
+      collected.push( m );
+    }
+
+    expect( collected.length ).toBe( 1 );
+    expect( collected[0].path ).toBe( realFile );
 
     rmSync( root, { recursive: true, force: true } );
   } );

--- a/sdk/core/src/worker/loader_tools.spec.js
+++ b/sdk/core/src/worker/loader_tools.spec.js
@@ -230,7 +230,7 @@ describe( 'findWorkflowsInPackages', () => {
     mkdirSync( join( pkg, 'lib' ), { recursive: true } );
     writeFileSync( join( pkg, 'package.json' ), JSON.stringify( {
       name: 'wf_pkg',
-      '@outputai/config': { workflows: { expose: true } }
+      outputai: { workflows: { expose: true } }
     } ) );
     const wf = join( pkg, 'lib', 'workflow.js' );
     writeFileSync( wf, 'export default {};\n' );
@@ -249,7 +249,7 @@ describe( 'findWorkflowsInPackages', () => {
     const wf = join( realPkg, 'w', 'workflow.js' );
     writeFileSync( join( realPkg, 'package.json' ), JSON.stringify( {
       name: 'real_pkg',
-      '@outputai/config': { workflows: { expose: true } }
+      outputai: { workflows: { expose: true } }
     } ) );
     writeFileSync( wf, 'export default {};\n' );
     symlinkSync( 'real_pkg', linkPkg, 'dir' );
@@ -410,19 +410,19 @@ describe( 'importComponents', () => {
 } );
 
 describe( 'packageExposesWorkflows', () => {
-  it( 'returns true when @outputai/config.workflows.expose is true', () => {
+  it( 'returns true when outputai.workflows.expose is true', () => {
     const dir = join( TEMP_BASE, `wf-proj-expose-${Date.now()}` );
     mkdirSync( dir, { recursive: true } );
     const pkg = join( dir, 'package.json' );
-    writeFileSync( pkg, JSON.stringify( { '@outputai/config': { workflows: { expose: true } } } ) );
+    writeFileSync( pkg, JSON.stringify( { outputai: { workflows: { expose: true } } } ) );
     expect( packageExposesWorkflows( pkg ) ).toBe( true );
   } );
 
-  it( 'returns false when @outputai/config.workflows.expose is false', () => {
+  it( 'returns false when outputai.workflows.expose is false', () => {
     const dir = join( TEMP_BASE, `wf-proj-no-expose-${Date.now()}` );
     mkdirSync( dir, { recursive: true } );
     const pkg = join( dir, 'package.json' );
-    writeFileSync( pkg, JSON.stringify( { '@outputai/config': { workflows: { expose: false } } } ) );
+    writeFileSync( pkg, JSON.stringify( { outputai: { workflows: { expose: false } } } ) );
     expect( packageExposesWorkflows( pkg ) ).toBe( false );
   } );
 
@@ -463,7 +463,7 @@ describe( 'findWorkflowsInNodeModules', () => {
     mkdirSync( join( pkg, 'w' ), { recursive: true } );
     writeFileSync( join( pkg, 'package.json' ), JSON.stringify( {
       name: 'pkg_a',
-      '@outputai/config': { workflows: { expose: true } }
+      outputai: { workflows: { expose: true } }
     } ) );
     const wf = join( pkg, 'w', 'workflow.js' );
     writeFileSync( wf, 'export default {};\n' );
@@ -480,7 +480,7 @@ describe( 'findWorkflowsInNodeModules', () => {
     mkdirSync( join( pkg, 'workflows', 'a' ), { recursive: true } );
     writeFileSync( join( pkg, 'package.json' ), JSON.stringify( {
       name: 'catalog_pkg',
-      '@outputai/config': { workflows: { expose: true } }
+      outputai: { workflows: { expose: true } }
     } ) );
     writeFileSync( join( pkg, 'workflows', 'a', 'workflow.js' ), 'export default {};\n' );
 
@@ -497,7 +497,7 @@ describe( 'findWorkflowsInNodeModules', () => {
     mkdirSync( join( pkg, 'lib' ), { recursive: true } );
     writeFileSync( join( pkg, 'package.json' ), JSON.stringify( {
       name: '@acme/wf_pkg',
-      '@outputai/config': { workflows: { expose: true } }
+      outputai: { workflows: { expose: true } }
     } ) );
     writeFileSync( join( pkg, 'lib', 'workflow.js' ), 'export default {};\n' );
 
@@ -526,7 +526,7 @@ describe( 'findWorkflowsInNodeModules', () => {
     const wf = join( realPkg, 'w', 'workflow.js' );
     writeFileSync( join( realPkg, 'package.json' ), JSON.stringify( {
       name: 'real_pkg',
-      '@outputai/config': { workflows: { expose: true } }
+      outputai: { workflows: { expose: true } }
     } ) );
     writeFileSync( wf, 'export default {};\n' );
     symlinkSync( 'real_pkg', linkPkg, 'dir' );

--- a/sdk/core/src/worker/loader_tools.spec.js
+++ b/sdk/core/src/worker/loader_tools.spec.js
@@ -230,7 +230,7 @@ describe( 'findWorkflowsInPackages', () => {
     mkdirSync( join( pkg, 'lib' ), { recursive: true } );
     writeFileSync( join( pkg, 'package.json' ), JSON.stringify( {
       name: 'wf_pkg',
-      output: { workflows: { expose: true } }
+      '@outputai/config': { workflows: { expose: true } }
     } ) );
     const wf = join( pkg, 'lib', 'workflow.js' );
     writeFileSync( wf, 'export default {};\n' );
@@ -249,7 +249,7 @@ describe( 'findWorkflowsInPackages', () => {
     const wf = join( realPkg, 'w', 'workflow.js' );
     writeFileSync( join( realPkg, 'package.json' ), JSON.stringify( {
       name: 'real_pkg',
-      output: { workflows: { expose: true } }
+      '@outputai/config': { workflows: { expose: true } }
     } ) );
     writeFileSync( wf, 'export default {};\n' );
     symlinkSync( 'real_pkg', linkPkg, 'dir' );
@@ -410,19 +410,27 @@ describe( 'importComponents', () => {
 } );
 
 describe( 'packageExposesWorkflows', () => {
-  it( 'returns true when output.workflows.expose is true', () => {
+  it( 'returns true when @outputai/config.workflows.expose is true', () => {
     const dir = join( TEMP_BASE, `wf-proj-expose-${Date.now()}` );
     mkdirSync( dir, { recursive: true } );
     const pkg = join( dir, 'package.json' );
-    writeFileSync( pkg, JSON.stringify( { output: { workflows: { expose: true } } } ) );
+    writeFileSync( pkg, JSON.stringify( { '@outputai/config': { workflows: { expose: true } } } ) );
     expect( packageExposesWorkflows( pkg ) ).toBe( true );
   } );
 
-  it( 'returns false when output.workflows.expose is false', () => {
+  it( 'returns false when @outputai/config.workflows.expose is false', () => {
     const dir = join( TEMP_BASE, `wf-proj-no-expose-${Date.now()}` );
     mkdirSync( dir, { recursive: true } );
     const pkg = join( dir, 'package.json' );
-    writeFileSync( pkg, JSON.stringify( { output: { workflows: { expose: false } } } ) );
+    writeFileSync( pkg, JSON.stringify( { '@outputai/config': { workflows: { expose: false } } } ) );
+    expect( packageExposesWorkflows( pkg ) ).toBe( false );
+  } );
+
+  it( 'returns false for the legacy output.workflows.expose field', () => {
+    const dir = join( TEMP_BASE, `wf-proj-legacy-expose-${Date.now()}` );
+    mkdirSync( dir, { recursive: true } );
+    const pkg = join( dir, 'package.json' );
+    writeFileSync( pkg, JSON.stringify( { output: { workflows: { expose: true } } } ) );
     expect( packageExposesWorkflows( pkg ) ).toBe( false );
   } );
 
@@ -455,7 +463,7 @@ describe( 'findWorkflowsInNodeModules', () => {
     mkdirSync( join( pkg, 'w' ), { recursive: true } );
     writeFileSync( join( pkg, 'package.json' ), JSON.stringify( {
       name: 'pkg_a',
-      output: { workflows: { expose: true } }
+      '@outputai/config': { workflows: { expose: true } }
     } ) );
     const wf = join( pkg, 'w', 'workflow.js' );
     writeFileSync( wf, 'export default {};\n' );
@@ -472,7 +480,7 @@ describe( 'findWorkflowsInNodeModules', () => {
     mkdirSync( join( pkg, 'workflows', 'a' ), { recursive: true } );
     writeFileSync( join( pkg, 'package.json' ), JSON.stringify( {
       name: 'catalog_pkg',
-      output: { workflows: { expose: true } }
+      '@outputai/config': { workflows: { expose: true } }
     } ) );
     writeFileSync( join( pkg, 'workflows', 'a', 'workflow.js' ), 'export default {};\n' );
 
@@ -489,7 +497,7 @@ describe( 'findWorkflowsInNodeModules', () => {
     mkdirSync( join( pkg, 'lib' ), { recursive: true } );
     writeFileSync( join( pkg, 'package.json' ), JSON.stringify( {
       name: '@acme/wf_pkg',
-      output: { workflows: { expose: true } }
+      '@outputai/config': { workflows: { expose: true } }
     } ) );
     writeFileSync( join( pkg, 'lib', 'workflow.js' ), 'export default {};\n' );
 
@@ -518,7 +526,7 @@ describe( 'findWorkflowsInNodeModules', () => {
     const wf = join( realPkg, 'w', 'workflow.js' );
     writeFileSync( join( realPkg, 'package.json' ), JSON.stringify( {
       name: 'real_pkg',
-      output: { workflows: { expose: true } }
+      '@outputai/config': { workflows: { expose: true } }
     } ) );
     writeFileSync( wf, 'export default {};\n' );
     symlinkSync( 'real_pkg', linkPkg, 'dir' );

--- a/sdk/core/src/worker/loader_tools.spec.js
+++ b/sdk/core/src/worker/loader_tools.spec.js
@@ -1,15 +1,268 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync, symlinkSync } from 'node:fs';
-import { join, sep } from 'node:path';
-import { importComponents, staticMatchers } from './loader_tools.js';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join, sep } from 'node:path';
+import { tmpdir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+import {
+  activityMatchersBuilder,
+  matchFiles,
+  findWorkflowsInNodeModules,
+  findWorkflowsInPackages,
+  findSharedActivitiesFromWorkflows,
+  importComponents,
+  findPackageRoot,
+  isPackageRoot,
+  isPathDescendentFromNodeModules,
+  resolveNodeModulesPath,
+  resolveSymlink,
+  staticMatchers,
+  packageExposesWorkflows
+} from './loader_tools.js';
 
-describe( '.importComponents', () => {
-  const TEMP_BASE = join( process.cwd(), 'sdk/core/temp_test_modules' );
-  afterEach( () => {
-    rmSync( TEMP_BASE, { recursive: true, force: true } );
+const TEMP_BASE = join( process.cwd(), 'sdk/core/temp_test_modules' );
+
+afterEach( () => {
+  rmSync( TEMP_BASE, { recursive: true, force: true } );
+} );
+
+const fileEntry = path => ( { path, url: pathToFileURL( path ).href } );
+
+describe( 'resolveSymlink', () => {
+  it( 'returns the canonical path for a directory', () => {
+    const dir = join( TEMP_BASE, `rs-dir-${Date.now()}` );
+    mkdirSync( dir, { recursive: true } );
+    expect( resolveSymlink( dir ) ).toBe( dir );
   } );
+
+  it( 'returns the canonical path for a regular file', () => {
+    const dir = join( TEMP_BASE, `rs-file-${Date.now()}` );
+    mkdirSync( dir, { recursive: true } );
+    const file = join( dir, 'a.txt' );
+    writeFileSync( file, 'x' );
+    expect( resolveSymlink( file ) ).toBe( file );
+  } );
+
+  it( 'returns null for a broken symlink', () => {
+    const dir = join( TEMP_BASE, `rs-broken-${Date.now()}` );
+    mkdirSync( dir, { recursive: true } );
+    const link = join( dir, 'broken' );
+    symlinkSync( 'missing-target', link, 'file' );
+    expect( resolveSymlink( link ) ).toBe( null );
+  } );
+} );
+
+describe( 'resolveNodeModulesPath', () => {
+  it( 'returns node_modules when passed that directory', () => {
+    const root = join( TEMP_BASE, `rnm-direct-${Date.now()}` );
+    const nm = join( root, 'node_modules' );
+    mkdirSync( nm, { recursive: true } );
+    expect( resolveNodeModulesPath( nm ) ).toBe( nm );
+  } );
+
+  it( 'finds node_modules from a project root directory', () => {
+    const root = join( TEMP_BASE, `rnm-root-${Date.now()}` );
+    const nm = join( root, 'node_modules' );
+    mkdirSync( nm, { recursive: true } );
+    expect( resolveNodeModulesPath( root ) ).toBe( nm );
+  } );
+
+  it( 'walks upward from a nested path until node_modules is found', () => {
+    const root = join( TEMP_BASE, `rnm-walk-${Date.now()}` );
+    const nm = join( root, 'node_modules' );
+    const nested = join( root, 'src', 'deep' );
+    mkdirSync( nested, { recursive: true } );
+    mkdirSync( nm, { recursive: true } );
+    expect( resolveNodeModulesPath( nested ) ).toBe( nm );
+  } );
+
+  it( 'uses dirname when targetPath is a file', () => {
+    const root = join( TEMP_BASE, `rnm-file-${Date.now()}` );
+    const nm = join( root, 'node_modules' );
+    const file = join( root, 'index.js' );
+    mkdirSync( nm, { recursive: true } );
+    writeFileSync( file, '' );
+    expect( resolveNodeModulesPath( file ) ).toBe( nm );
+  } );
+
+  it( 'returns null when targetPath does not exist', () => {
+    expect( resolveNodeModulesPath( join( TEMP_BASE, 'nope', 'missing' ) ) ).toBe( null );
+  } );
+
+  it( 'returns null when no ancestor has node_modules', () => {
+    const isolated = mkdtempSync( join( tmpdir(), 'loader-tools-rnm-' ) );
+    try {
+      const orphan = join( isolated, 'nested', 'sub' );
+      mkdirSync( orphan, { recursive: true } );
+      expect( resolveNodeModulesPath( orphan ) ).toBe( null );
+    } finally {
+      rmSync( isolated, { recursive: true, force: true } );
+    }
+  } );
+
+  it( 'returns the canonical directory when node_modules is a symlink', () => {
+    const root = join( TEMP_BASE, `rnm-symlink-${Date.now()}` );
+    const realNm = join( root, 'real_node_modules' );
+    const nmLink = join( root, 'node_modules' );
+    mkdirSync( realNm, { recursive: true } );
+    symlinkSync( 'real_node_modules', nmLink, 'dir' );
+    expect( resolveNodeModulesPath( root ) ).toBe( realNm );
+  } );
+
+  it( 'walks up when node_modules is a broken symlink', () => {
+    const grandparent = join( TEMP_BASE, `rnm-walkup-${Date.now()}` );
+    const root = join( grandparent, 'proj' );
+    const nmBroken = join( root, 'node_modules' );
+    const nmUp = join( grandparent, 'node_modules' );
+    mkdirSync( nmUp, { recursive: true } );
+    mkdirSync( root, { recursive: true } );
+    symlinkSync( 'does-not-exist', nmBroken, 'dir' );
+    expect( resolveNodeModulesPath( root ) ).toBe( nmUp );
+  } );
+} );
+
+describe( 'node_modules package resource helpers', () => {
+  it( 'detects paths inside node_modules', () => {
+    expect( isPathDescendentFromNodeModules( `${sep}app${sep}node_modules${sep}pkg${sep}index.js` ) ).toBe( true );
+    expect( isPathDescendentFromNodeModules( 'C:\\app\\node_modules\\pkg\\index.js' ) ).toBe( true );
+    expect( isPathDescendentFromNodeModules( `${sep}app${sep}src${sep}index.js` ) ).toBe( false );
+  } );
+
+  it( 'detects installed package roots', () => {
+    expect( isPackageRoot( `${sep}app${sep}node_modules${sep}pkg` ) ).toBe( true );
+    expect( isPackageRoot( `${sep}app${sep}node_modules${sep}@scope${sep}pkg` ) ).toBe( true );
+    expect( isPackageRoot( `${sep}app${sep}node_modules${sep}@scope` ) ).toBe( false );
+    expect( isPackageRoot( `${sep}app${sep}node_modules${sep}pkg${sep}lib` ) ).toBe( false );
+  } );
+
+  it( 'finds the closest installed package root for a file', () => {
+    const root = join( TEMP_BASE, `pkgroot-${Date.now()}` );
+    const pkgRoot = join( root, 'node_modules', '@acme', 'wf_pkg' );
+    const deepFile = join( pkgRoot, 'lib', 'nested', 'workflow.js' );
+    mkdirSync( join( pkgRoot, 'lib', 'nested' ), { recursive: true } );
+    writeFileSync( join( pkgRoot, 'package.json' ), JSON.stringify( {
+      name: '@acme/wf_pkg',
+      dependencies: { '@outputai/core': '1.0.0' }
+    } ) );
+    writeFileSync( deepFile, 'export default {};\n' );
+
+    expect( findPackageRoot( deepFile ) ).toBe( pkgRoot );
+  } );
+
+  it( 'returns null when no installed package root is found', () => {
+    const root = join( TEMP_BASE, `pkgroot-missing-${Date.now()}` );
+    const deepFile = join( root, 'node_modules', 'plain_lib', 'index.js' );
+    mkdirSync( dirname( deepFile ), { recursive: true } );
+    writeFileSync( deepFile, 'export const x = 1;\n' );
+
+    expect( findPackageRoot( deepFile ) ).toBe( null );
+  } );
+} );
+
+describe( 'activityMatchersBuilder', () => {
+  const base = `${sep}app${sep}proj`;
+
+  it( 'stepsFile matches only steps.js at base', () => {
+    const m = activityMatchersBuilder( base );
+    expect( m.stepsFile( `${base}${sep}steps.js` ) ).toBe( true );
+    expect( m.stepsFile( `${base}${sep}nested${sep}steps.js` ) ).toBe( false );
+  } );
+
+  it( 'evaluatorsFile matches only evaluators.js at base', () => {
+    const m = activityMatchersBuilder( base );
+    expect( m.evaluatorsFile( `${base}${sep}evaluators.js` ) ).toBe( true );
+    expect( m.evaluatorsFile( `${base}${sep}sub${sep}evaluators.js` ) ).toBe( false );
+  } );
+
+  it( 'stepsDir matches js under steps/', () => {
+    const m = activityMatchersBuilder( base );
+    expect( m.stepsDir( `${base}${sep}steps${sep}a.js` ) ).toBe( true );
+    expect( m.stepsDir( `${base}${sep}steps${sep}sub${sep}b.js` ) ).toBe( true );
+    expect( m.stepsDir( `${base}${sep}other${sep}a.js` ) ).toBe( false );
+  } );
+
+  it( 'evaluatorsDir matches js under evaluators/', () => {
+    const m = activityMatchersBuilder( base );
+    expect( m.evaluatorsDir( `${base}${sep}evaluators${sep}x.js` ) ).toBe( true );
+    expect( m.evaluatorsDir( `${base}${sep}evaluators${sep}y${sep}z.js` ) ).toBe( true );
+    expect( m.evaluatorsDir( `${base}${sep}steps${sep}x.js` ) ).toBe( false );
+  } );
+} );
+
+describe( 'matchFiles', () => {
+  it( 'collects files matching matchers', () => {
+    const root = join( TEMP_BASE, `fbnr-files-${Date.now()}` );
+    mkdirSync( root, { recursive: true } );
+    writeFileSync( join( root, 'a.txt' ), '' );
+    writeFileSync( join( root, 'b.txt' ), '' );
+    const found = matchFiles( root, [ p => p.endsWith( 'a.txt' ) ] );
+    expect( found ).toHaveLength( 1 );
+    expect( found[0].path ).toBe( join( root, 'a.txt' ) );
+  } );
+
+  it( 'skips broken symlinks without throwing', () => {
+    const root = join( TEMP_BASE, `fbnr-broken-${Date.now()}` );
+    mkdirSync( root, { recursive: true } );
+    symlinkSync( 'nowhere', join( root, 'bad' ), 'file' );
+    writeFileSync( join( root, 'ok.txt' ), '' );
+    const found = matchFiles( root, [ p => p.endsWith( '.txt' ) ] );
+    expect( found.map( f => f.path ) ).toEqual( [ join( root, 'ok.txt' ) ] );
+  } );
+
+  it( 'follows symlinks to directories', () => {
+    const base = join( TEMP_BASE, `fbnr-symlink-dir-${Date.now()}` );
+    const targetDir = join( base, 'target' );
+    const scanRoot = join( base, 'root' );
+    mkdirSync( targetDir, { recursive: true } );
+    mkdirSync( scanRoot, { recursive: true } );
+    writeFileSync( join( targetDir, 'x.txt' ), '' );
+    symlinkSync( join( '..', 'target' ), join( scanRoot, 'link' ), 'dir' );
+    const found = matchFiles( scanRoot, [ p => p.endsWith( 'x.txt' ) ] );
+    expect( found ).toHaveLength( 1 );
+    expect( found[0].path ).toBe( join( targetDir, 'x.txt' ) );
+  } );
+} );
+
+describe( 'findWorkflowsInPackages', () => {
+  it( 'collects workflow.js from exposed workflow packages under node_modules', () => {
+    const root = join( TEMP_BASE, `fwp-${Date.now()}` );
+    const nm = join( root, 'node_modules' );
+    const pkg = join( nm, 'wf_pkg' );
+    mkdirSync( join( pkg, 'lib' ), { recursive: true } );
+    writeFileSync( join( pkg, 'package.json' ), JSON.stringify( {
+      name: 'wf_pkg',
+      output: { workflows: { expose: true } }
+    } ) );
+    const wf = join( pkg, 'lib', 'workflow.js' );
+    writeFileSync( wf, 'export default {};\n' );
+
+    const found = findWorkflowsInPackages( nm );
+    expect( found ).toHaveLength( 1 );
+    expect( found[0].path ).toBe( wf );
+  } );
+
+  it( 'lists the same workflow twice when package scan sees a canonical package and symlink alias', () => {
+    const root = join( TEMP_BASE, `fwp-symlink-${Date.now()}` );
+    const nm = join( root, 'node_modules' );
+    const realPkg = join( nm, 'real_pkg' );
+    const linkPkg = join( nm, 'link_pkg' );
+    mkdirSync( join( realPkg, 'w' ), { recursive: true } );
+    const wf = join( realPkg, 'w', 'workflow.js' );
+    writeFileSync( join( realPkg, 'package.json' ), JSON.stringify( {
+      name: 'real_pkg',
+      output: { workflows: { expose: true } }
+    } ) );
+    writeFileSync( wf, 'export default {};\n' );
+    symlinkSync( 'real_pkg', linkPkg, 'dir' );
+
+    const found = findWorkflowsInPackages( nm );
+    expect( found ).toHaveLength( 2 );
+    expect( new Set( found.map( f => realpathSync( f.path ) ) ).size ).toBe( 1 );
+  } );
+} );
+
+describe( 'importComponents', () => {
   it( 'imports modules and yields metadata from exports tagged with METADATA_ACCESS_SYMBOL', async () => {
-    const root = join( process.cwd(), 'sdk/core/temp_test_modules', `meta-${Date.now()}` );
+    const root = join( TEMP_BASE, `meta-${Date.now()}` );
     mkdirSync( root, { recursive: true } );
     const file = join( root, 'meta.module.js' );
     writeFileSync( file, [
@@ -21,7 +274,7 @@ describe( '.importComponents', () => {
     ].join( '\n' ) );
 
     const collected = [];
-    for await ( const m of importComponents( root, [ v => v.endsWith( 'meta.module.js' ) ] ) ) {
+    for await ( const m of importComponents( [ fileEntry( file ) ] ) ) {
       collected.push( m );
     }
 
@@ -32,12 +285,10 @@ describe( '.importComponents', () => {
       expect( m.path ).toBe( file );
       expect( typeof m.fn ).toBe( 'function' );
     }
-
-    rmSync( root, { recursive: true, force: true } );
   } );
 
   it( 'ignores exports without metadata symbol', async () => {
-    const root = join( process.cwd(), 'sdk/core/temp_test_modules', `meta-${Date.now()}-nometa` );
+    const root = join( TEMP_BASE, `meta-${Date.now()}-nometa` );
     mkdirSync( root, { recursive: true } );
     const file = join( root, 'meta.module.js' );
     writeFileSync( file, [
@@ -46,16 +297,15 @@ describe( '.importComponents', () => {
     ].join( '\n' ) );
 
     const collected = [];
-    for await ( const m of importComponents( root, [ v => v.endsWith( 'meta.module.js' ) ] ) ) {
+    for await ( const m of importComponents( [ fileEntry( file ) ] ) ) {
       collected.push( m );
     }
 
     expect( collected.length ).toBe( 0 );
-    rmSync( root, { recursive: true, force: true } );
   } );
 
   it( 'skips files inside ignored directories (node_modules, vendor)', async () => {
-    const root = join( process.cwd(), 'sdk/core/temp_test_modules', `meta-${Date.now()}-ignoredirs` );
+    const root = join( TEMP_BASE, `meta-${Date.now()}-ignoredirs` );
     const okDir = join( root, 'ok' );
     const nmDir = join( root, 'node_modules' );
     const vendorDir = join( root, 'vendor' );
@@ -77,18 +327,16 @@ describe( '.importComponents', () => {
     writeFileSync( vendorFile, fileContents );
 
     const collected = [];
-    for await ( const m of importComponents( root, [ v => v.endsWith( 'meta.module.js' ) ] ) ) {
+    for await ( const m of importComponents( matchFiles( root, [ v => v.endsWith( 'meta.module.js' ) ] ) ) ) {
       collected.push( m );
     }
 
     expect( collected.length ).toBe( 1 );
     expect( collected[0].path ).toBe( okFile );
-
-    rmSync( root, { recursive: true, force: true } );
   } );
 
   it( 'supports partial matching by folder name', async () => {
-    const root = join( process.cwd(), 'sdk/core/temp_test_modules', `meta-${Date.now()}-foldermatch` );
+    const root = join( TEMP_BASE, `meta-${Date.now()}-foldermatch` );
     const okDir = join( root, 'features', 'ok' );
     const otherDir = join( root, 'features', 'other' );
     mkdirSync( okDir, { recursive: true } );
@@ -104,20 +352,17 @@ describe( '.importComponents', () => {
     writeFileSync( okFile, src );
     writeFileSync( otherFile, src );
 
-    // Match any JS under a folder named "ok"
     const matcher = v => v.includes( `${join( 'features', 'ok' )}${sep}` );
     const collected = [];
-    for await ( const m of importComponents( root, [ matcher ] ) ) {
+    for await ( const m of importComponents( matchFiles( root, [ matcher ] ) ) ) {
       collected.push( m );
     }
     expect( collected.length ).toBe( 1 );
     expect( collected[0].path ).toBe( okFile );
-
-    rmSync( root, { recursive: true, force: true } );
   } );
 
   it( 'follows symlinks to directories and collects matching files inside the target', async () => {
-    const base = join( process.cwd(), 'sdk/core/temp_test_modules', `symlink-dir-${Date.now()}` );
+    const base = join( TEMP_BASE, `symlink-dir-${Date.now()}` );
     const targetDir = join( base, 'target' );
     const scanRoot = join( base, 'root' );
     mkdirSync( targetDir, { recursive: true } );
@@ -132,19 +377,17 @@ describe( '.importComponents', () => {
     symlinkSync( join( '..', 'target' ), join( scanRoot, 'pkg' ), 'dir' );
 
     const collected = [];
-    for await ( const m of importComponents( scanRoot, [ v => v.endsWith( 'meta.module.js' ) ] ) ) {
+    for await ( const m of importComponents( matchFiles( scanRoot, [ v => v.endsWith( 'meta.module.js' ) ] ) ) ) {
       collected.push( m );
     }
 
     expect( collected.length ).toBe( 1 );
     expect( collected[0].path ).toBe( moduleFile );
     expect( collected[0].metadata.name ).toBe( 'via_link' );
-
-    rmSync( base, { recursive: true, force: true } );
   } );
 
-  it( 'does not traverse a symlink whose target is a file (only directory targets are recursed)', async () => {
-    const root = join( process.cwd(), 'sdk/core/temp_test_modules', `symlink-file-${Date.now()}` );
+  it( 'collects a symlinked file when the matcher matches the realpath target (canonical url)', async () => {
+    const root = join( TEMP_BASE, `symlink-file-${Date.now()}` );
     mkdirSync( root, { recursive: true } );
     const realFile = join( root, 'real.module.js' );
     writeFileSync( realFile, [
@@ -156,19 +399,189 @@ describe( '.importComponents', () => {
     symlinkSync( 'real.module.js', linkPath, 'file' );
 
     const collected = [];
-    for await ( const m of importComponents( root, [ v => v.endsWith( '.module.js' ) ] ) ) {
+    for await ( const m of importComponents( matchFiles( root, [ v => v.endsWith( '.module.js' ) ] ) ) ) {
       collected.push( m );
     }
 
-    expect( collected.length ).toBe( 1 );
-    expect( collected[0].path ).toBe( realFile );
-
-    rmSync( root, { recursive: true, force: true } );
+    expect( collected.length ).toBe( 2 );
+    expect( collected.every( m => m.metadata.name === 'r' ) ).toBe( true );
+    expect( collected[0].fn ).toBe( collected[1].fn );
   } );
 } );
 
-describe( '.staticMatchers', () => {
-  describe( '.sharedStepsDir', () => {
+describe( 'packageExposesWorkflows', () => {
+  it( 'returns true when output.workflows.expose is true', () => {
+    const dir = join( TEMP_BASE, `wf-proj-expose-${Date.now()}` );
+    mkdirSync( dir, { recursive: true } );
+    const pkg = join( dir, 'package.json' );
+    writeFileSync( pkg, JSON.stringify( { output: { workflows: { expose: true } } } ) );
+    expect( packageExposesWorkflows( pkg ) ).toBe( true );
+  } );
+
+  it( 'returns false when output.workflows.expose is false', () => {
+    const dir = join( TEMP_BASE, `wf-proj-no-expose-${Date.now()}` );
+    mkdirSync( dir, { recursive: true } );
+    const pkg = join( dir, 'package.json' );
+    writeFileSync( pkg, JSON.stringify( { output: { workflows: { expose: false } } } ) );
+    expect( packageExposesWorkflows( pkg ) ).toBe( false );
+  } );
+
+  it( 'returns false when only OutputAI dependencies are present', () => {
+    const dir = join( TEMP_BASE, `wf-proj-dep-only-${Date.now()}` );
+    mkdirSync( dir, { recursive: true } );
+    const pkg = join( dir, 'package.json' );
+    writeFileSync( pkg, JSON.stringify( { dependencies: { '@outputai/core': '1.0.0' } } ) );
+    expect( packageExposesWorkflows( pkg ) ).toBe( false );
+  } );
+
+  it( 'returns false when package.json is missing', () => {
+    expect( packageExposesWorkflows( join( TEMP_BASE, 'missing-package-json', 'package.json' ) ) ).toBe( false );
+  } );
+
+  it( 'returns false when package.json is not valid JSON', () => {
+    const dir = join( TEMP_BASE, `wf-proj-badjson-${Date.now()}` );
+    mkdirSync( dir, { recursive: true } );
+    const pkg = join( dir, 'package.json' );
+    writeFileSync( pkg, '{ not json' );
+    expect( packageExposesWorkflows( pkg ) ).toBe( false );
+  } );
+} );
+
+describe( 'findWorkflowsInNodeModules', () => {
+  it( 'resolves node_modules from project root and finds workflows', () => {
+    const root = join( TEMP_BASE, `nm-from-root-${Date.now()}` );
+    const nm = join( root, 'node_modules' );
+    const pkg = join( nm, 'pkg_a' );
+    mkdirSync( join( pkg, 'w' ), { recursive: true } );
+    writeFileSync( join( pkg, 'package.json' ), JSON.stringify( {
+      name: 'pkg_a',
+      output: { workflows: { expose: true } }
+    } ) );
+    const wf = join( pkg, 'w', 'workflow.js' );
+    writeFileSync( wf, 'export default {};\n' );
+
+    const found = findWorkflowsInNodeModules( root );
+    expect( found.length ).toBe( 1 );
+    expect( found[0].path ).toBe( wf );
+  } );
+
+  it( 'finds workflow.js under an unscoped package with exposed workflows', () => {
+    const root = join( TEMP_BASE, `nm-unscoped-${Date.now()}` );
+    const nm = join( root, 'node_modules' );
+    const pkg = join( nm, 'catalog_pkg' );
+    mkdirSync( join( pkg, 'workflows', 'a' ), { recursive: true } );
+    writeFileSync( join( pkg, 'package.json' ), JSON.stringify( {
+      name: 'catalog_pkg',
+      output: { workflows: { expose: true } }
+    } ) );
+    writeFileSync( join( pkg, 'workflows', 'a', 'workflow.js' ), 'export default {};\n' );
+
+    const found = findWorkflowsInNodeModules( nm );
+    expect( found.length ).toBe( 1 );
+    expect( found[0].path ).toBe( join( pkg, 'workflows', 'a', 'workflow.js' ) );
+    expect( found[0].url ).toBe( pathToFileURL( join( pkg, 'workflows', 'a', 'workflow.js' ) ).href );
+  } );
+
+  it( 'finds workflow.js under a scoped package', () => {
+    const root = join( TEMP_BASE, `nm-scoped-${Date.now()}` );
+    const nm = join( root, 'node_modules' );
+    const pkg = join( nm, '@acme', 'wf_pkg' );
+    mkdirSync( join( pkg, 'lib' ), { recursive: true } );
+    writeFileSync( join( pkg, 'package.json' ), JSON.stringify( {
+      name: '@acme/wf_pkg',
+      output: { workflows: { expose: true } }
+    } ) );
+    writeFileSync( join( pkg, 'lib', 'workflow.js' ), 'export default {};\n' );
+
+    const found = findWorkflowsInNodeModules( nm );
+    expect( found.length ).toBe( 1 );
+    expect( found[0].path ).toBe( join( pkg, 'lib', 'workflow.js' ) );
+  } );
+
+  it( 'skips packages that do not expose workflows', () => {
+    const root = join( TEMP_BASE, `nm-skip-${Date.now()}` );
+    const nm = join( root, 'node_modules' );
+    const pkg = join( nm, 'plain_lib' );
+    mkdirSync( pkg, { recursive: true } );
+    writeFileSync( join( pkg, 'package.json' ), JSON.stringify( { name: 'plain_lib' } ) );
+    writeFileSync( join( pkg, 'workflow.js' ), 'export default {};\n' );
+
+    expect( findWorkflowsInNodeModules( nm ) ).toEqual( [] );
+  } );
+
+  it( 'deduplicates the same workflow when reachable via symlink alias and canonical package', () => {
+    const root = join( TEMP_BASE, `nm-dedupe-${Date.now()}` );
+    const nm = join( root, 'node_modules' );
+    const realPkg = join( nm, 'real_pkg' );
+    const linkPkg = join( nm, 'link_pkg' );
+    mkdirSync( join( realPkg, 'w' ), { recursive: true } );
+    const wf = join( realPkg, 'w', 'workflow.js' );
+    writeFileSync( join( realPkg, 'package.json' ), JSON.stringify( {
+      name: 'real_pkg',
+      output: { workflows: { expose: true } }
+    } ) );
+    writeFileSync( wf, 'export default {};\n' );
+    symlinkSync( 'real_pkg', linkPkg, 'dir' );
+
+    const found = findWorkflowsInNodeModules( nm );
+    expect( found ).toHaveLength( 1 );
+    expect( realpathSync( found[0].path ) ).toBe( wf );
+  } );
+} );
+
+describe( 'findSharedActivitiesFromWorkflows', () => {
+  it( 'finds shared steps and evaluators from external workflow package roots', () => {
+    const root = join( TEMP_BASE, `external-shared-${Date.now()}` );
+    const pkg = join( root, 'node_modules', '@acme', 'workflow_pkg' );
+    const workflowA = join( pkg, 'workflows', 'a', 'workflow.js' );
+    const workflowB = join( pkg, 'workflows', 'b', 'workflow.js' );
+    const sharedStep = join( pkg, 'shared', 'steps', 'prepare.js' );
+    const sharedEvaluator = join( pkg, 'shared', 'evaluators', 'quality.js' );
+    mkdirSync( dirname( workflowA ), { recursive: true } );
+    mkdirSync( dirname( workflowB ), { recursive: true } );
+    mkdirSync( dirname( sharedStep ), { recursive: true } );
+    mkdirSync( dirname( sharedEvaluator ), { recursive: true } );
+    writeFileSync( join( pkg, 'package.json' ), JSON.stringify( {
+      name: '@acme/workflow_pkg',
+      dependencies: { '@outputai/core': '1.0.0' }
+    } ) );
+    writeFileSync( workflowA, 'export default {};\n' );
+    writeFileSync( workflowB, 'export default {};\n' );
+    writeFileSync( sharedStep, 'export const Prepare = step({ name: "prepare" });\n' );
+    writeFileSync( sharedEvaluator, 'export const Quality = evaluator({ name: "quality" });\n' );
+    writeFileSync( join( pkg, 'shared', 'readme.md' ), '# ignored\n' );
+
+    const found = findSharedActivitiesFromWorkflows( [
+      { path: workflowA },
+      { path: workflowB },
+      { path: join( root, 'local', 'workflow.js' ) }
+    ] );
+    expect( found.map( f => f.path ).sort() ).toEqual( [ sharedEvaluator, sharedStep ].sort() );
+  } );
+} );
+
+describe( 'staticMatchers', () => {
+  describe( 'workflowFile', () => {
+    it( 'matches paths ending with path separator and workflow.js', () => {
+      expect( staticMatchers.workflowFile( `${sep}x${sep}y${sep}workflow.js` ) ).toBe( true );
+    } );
+
+    it( 'rejects workflow.ts', () => {
+      expect( staticMatchers.workflowFile( `${sep}a${sep}workflow.ts` ) ).toBe( false );
+    } );
+  } );
+
+  describe( 'workflowPathHasShared', () => {
+    it( 'matches workflow.js under a shared folder segment', () => {
+      expect( staticMatchers.workflowPathHasShared( `${sep}foo${sep}shared${sep}workflow.js` ) ).toBe( true );
+    } );
+
+    it( 'rejects workflow.js not under shared', () => {
+      expect( staticMatchers.workflowPathHasShared( `${sep}foo${sep}workflow.js` ) ).toBe( false );
+    } );
+  } );
+
+  describe( 'sharedStepsDir', () => {
     it( 'matches .js files inside shared/steps/', () => {
       expect( staticMatchers.sharedStepsDir( `${sep}app${sep}dist${sep}shared${sep}steps${sep}tools.js` ) ).toBe( true );
     } );
@@ -186,7 +599,7 @@ describe( '.staticMatchers', () => {
     } );
   } );
 
-  describe( '.sharedEvaluatorsDir', () => {
+  describe( 'sharedEvaluatorsDir', () => {
     it( 'matches .js files inside shared/evaluators/', () => {
       expect( staticMatchers.sharedEvaluatorsDir( `${sep}app${sep}dist${sep}shared${sep}evaluators${sep}quality.js` ) ).toBe( true );
     } );

--- a/sdk/core/src/worker/webpack_loaders/npm_workflow_export_resolve.js
+++ b/sdk/core/src/worker/webpack_loaders/npm_workflow_export_resolve.js
@@ -55,6 +55,11 @@ export const isBareNpmSpecifier = specifier => {
 const absolutePathIsWorkflowJsFile = absolutePath =>
   isWorkflowPath( absolutePath.replace( /\\/g, '/' ) );
 
+const unsupportedNamespaceWorkflowImportError = specifier => new Error(
+  `Namespace imports from workflow package "${specifier}" are not supported. ` +
+  `Use named imports instead, e.g. import { myWorkflow } from '${specifier}'.`
+);
+
 /**
  * Split a bare npm specifier into its package name and package export subpath.
  *
@@ -261,6 +266,47 @@ const resolveNamedExportThroughReexports = (
 };
 
 /**
+ * Returns true when a module is itself a workflow.js file or re-exports a module that is.
+ *
+ * @param {string} moduleAbsPath
+ * @param {Set<string>} [visited]
+ * @returns {boolean}
+ */
+const moduleMayExportWorkflows = ( moduleAbsPath, visited = new Set() ) => {
+  if ( visited.has( moduleAbsPath ) ) {
+    return false;
+  }
+  visited.add( moduleAbsPath );
+  if ( absolutePathIsWorkflowJsFile( moduleAbsPath ) ) {
+    return true;
+  }
+  const ast = ( () => {
+    try {
+      return parse( readFileSync( moduleAbsPath, 'utf8' ), moduleAbsPath );
+    } catch {
+      return null;
+    }
+  } )();
+  if ( !ast ) {
+    return false;
+  }
+  const moduleDir = dirname( moduleAbsPath );
+  for ( const node of ast.program.body ) {
+    if ( isExportAllDeclaration( node ) && isStringLiteral( node.source ) ) {
+      if ( moduleMayExportWorkflows( resolvePath( moduleDir, node.source.value ), visited ) ) {
+        return true;
+      }
+    }
+    if ( isExportNamedDeclaration( node ) && isStringLiteral( node.source ) ) {
+      if ( moduleMayExportWorkflows( resolvePath( moduleDir, node.source.value ), visited ) ) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+/**
  * Resolve the package entry (or subpath) for `specifier` from `fromAbsoluteFile`, then follow
  * re-exports until `workflow.js` is reached.
  *
@@ -293,6 +339,7 @@ const resolveBareSpecifierToFirstModule = ( fromAbsoluteFile, specifier ) => {
  * @param {Map<string, {default: (string|null), named: Map<string,string>}>} params.workflowNameCache
  * @returns {{ type: 'all', bindings: Array<{ localName: string, workflowName: string }> } |
  *   { type: 'none' } | { type: 'partial' }}
+ * @throws {Error} When a namespace import targets a workflow package.
  */
 export const resolveBareImportSpecifiersAsWorkflows = ( {
   fromAbsoluteFile,
@@ -306,6 +353,9 @@ export const resolveBareImportSpecifiersAsWorkflows = ( {
   }
 
   if ( specifiers.some( isImportNamespaceSpecifier ) ) {
+    if ( moduleMayExportWorkflows( entry ) ) {
+      throw unsupportedNamespaceWorkflowImportError( specifier );
+    }
     return { type: 'none' };
   }
 

--- a/sdk/core/src/worker/webpack_loaders/npm_workflow_export_resolve.js
+++ b/sdk/core/src/worker/webpack_loaders/npm_workflow_export_resolve.js
@@ -1,0 +1,424 @@
+import { createRequire } from 'node:module';
+import { dirname, resolve as resolvePath } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  isExportAllDeclaration,
+  isExportNamedDeclaration,
+  isExportSpecifier,
+  isIdentifier,
+  isImportDefaultSpecifier,
+  isImportNamespaceSpecifier,
+  isImportSpecifier,
+  isStringLiteral
+} from '@babel/types';
+import { existsSync, readFileSync } from 'node:fs';
+import { parse, isWorkflowPath, buildWorkflowNameMap } from './tools.js';
+
+/**
+ * Resolves bare npm imports to workflow runtime names:
+ * - `require.resolve` from the importing file locates the package entry or subpath.
+ * - Follows `export { ... } from` and `export * from` until a module whose path ends in `workflow.js`.
+ * - Reads declared names via {@link buildWorkflowNameMap} on that terminal file.
+ *
+ * The rewriter applies this only when the importing resource is `workflow.js` (see collect_target_imports).
+ * The workflow validator also uses it for steps/evaluators so catalog imports are recognized in `fn`.
+ */
+
+/**
+ * True for npm-style bare specifiers we may resolve with `require.resolve`.
+ * Excludes relative paths, absolute paths, and built-in / URL protocols.
+ *
+ * @param {string} specifier - ESM import source or `require()` string.
+ * @returns {boolean}
+ */
+export const isBareNpmSpecifier = specifier => {
+  if ( typeof specifier !== 'string' || specifier.length === 0 ) {
+    return false;
+  }
+  if ( specifier.startsWith( '.' ) || specifier.startsWith( '/' ) ) {
+    return false;
+  }
+  if ( specifier.startsWith( 'node:' ) || specifier.startsWith( 'file:' ) ||
+    specifier.startsWith( 'data:' ) || specifier.startsWith( 'http:' ) ||
+    specifier.startsWith( 'https:' ) ) {
+    return false;
+  }
+  return true;
+};
+
+/**
+ * True when the absolute path ends with a `workflow.js` segment (same rule as path-based workflow files).
+ *
+ * @param {string} absolutePath - Resolved absolute file path.
+ * @returns {boolean}
+ */
+const absolutePathIsWorkflowJsFile = absolutePath =>
+  isWorkflowPath( absolutePath.replace( /\\/g, '/' ) );
+
+/**
+ * Split a bare npm specifier into its package name and package export subpath.
+ *
+ * Handles both unscoped packages (`pkg/path`) and scoped packages (`@scope/pkg/path`).
+ *
+ * @param {string} specifier - Bare npm specifier from an import or require call.
+ * @returns {{ packageName: string, subpath: string }} Package name and exports-style subpath.
+ */
+const packagePartsFromSpecifier = specifier => {
+  const parts = specifier.split( '/' );
+  if ( specifier.startsWith( '@' ) ) {
+    return {
+      packageName: parts.slice( 0, 2 ).join( '/' ),
+      subpath: parts.length > 2 ? `./${parts.slice( 2 ).join( '/' )}` : '.'
+    };
+  }
+  return {
+    packageName: parts[0],
+    subpath: parts.length > 1 ? `./${parts.slice( 1 ).join( '/' )}` : '.'
+  };
+};
+
+/**
+ * Walk upward from a source directory to find the package.json for an installed dependency.
+ *
+ * Mirrors Node's nearest `node_modules` lookup so temporary tests and nested workspace layouts resolve consistently.
+ *
+ * @param {string} fromDir - Directory where package resolution starts.
+ * @param {string} packageName - Bare package name, including scope for scoped packages.
+ * @returns {string|null} Absolute package.json path, or null when the package is not installed.
+ */
+const findPackageJson = ( fromDir, packageName ) => {
+  const candidate = resolvePath( fromDir, 'node_modules', packageName, 'package.json' );
+  if ( existsSync( candidate ) ) {
+    return candidate;
+  }
+  const parent = dirname( fromDir );
+  return parent !== fromDir ? findPackageJson( parent, packageName ) : null;
+};
+
+/**
+ * Choose the best concrete file target from a package exports target.
+ *
+ * Prefers the workflow-specific webpack condition, then the same fallback conditions used by
+ * `webpackConfigHook`.
+ *
+ * @param {string|Array|object|null|undefined} target - Value from package.json `exports`.
+ * @returns {string|null} Relative file target, or null when no supported condition resolves.
+ */
+const resolveConditionalExportTarget = target => {
+  if ( typeof target === 'string' ) {
+    return target;
+  }
+  if ( Array.isArray( target ) ) {
+    for ( const item of target ) {
+      const resolved = resolveConditionalExportTarget( item );
+      if ( resolved ) {
+        return resolved;
+      }
+    }
+    return null;
+  }
+  if ( !target || typeof target !== 'object' ) {
+    return null;
+  }
+
+  for ( const condition of [ 'output-workflow-bundle', 'import', 'module', 'webpack', 'default' ] ) {
+    if ( condition in target ) {
+      const resolved = resolveConditionalExportTarget( target[condition] );
+      if ( resolved ) {
+        return resolved;
+      }
+    }
+  }
+  return null;
+};
+
+/**
+ * Resolve a bare package specifier using the `output-workflow-bundle` export condition when present.
+ *
+ * This keeps AST workflow import resolution aligned with webpack's configured condition order before
+ * falling back to Node's `require.resolve`.
+ *
+ * @param {string} fromAbsoluteFile - Absolute path to the importing module.
+ * @param {string} specifier - Bare npm package specifier.
+ * @returns {string|null} Absolute module path selected from package exports, or null when unsupported.
+ */
+const resolveBareSpecifierWithOutputCondition = ( fromAbsoluteFile, specifier ) => {
+  const { packageName, subpath } = packagePartsFromSpecifier( specifier );
+  const pkgJsonPath = findPackageJson( dirname( fromAbsoluteFile ), packageName );
+  if ( !pkgJsonPath ) {
+    return null;
+  }
+
+  const pkgRoot = dirname( pkgJsonPath );
+  const pkg = ( () => {
+    try {
+      return JSON.parse( readFileSync( pkgJsonPath, 'utf8' ) );
+    } catch {
+      return {};
+    }
+  } )();
+  const exportsIsRootConditionMap = pkg.exports && typeof pkg.exports === 'object' && !Array.isArray( pkg.exports ) &&
+    Object.keys( pkg.exports ).every( key => !key.startsWith( '.' ) );
+  const exportTarget = ( () => {
+    if ( typeof pkg.exports === 'string' && subpath === '.' ) {
+      return pkg.exports;
+    }
+    if ( subpath === '.' && exportsIsRootConditionMap ) {
+      return pkg.exports;
+    }
+    if ( pkg.exports && typeof pkg.exports === 'object' ) {
+      return pkg.exports[subpath];
+    }
+    return null;
+  } )();
+  const conditionTarget = resolveConditionalExportTarget( exportTarget );
+  return conditionTarget ? resolvePath( pkgRoot, conditionTarget ) : null;
+};
+
+/**
+ * @param {import('@babel/types').Identifier | import('@babel/types').StringLiteral} node
+ * @returns {string}
+ */
+const exportSpecifierName = node => ( isIdentifier( node ) ? node.name : node.value );
+
+/**
+ * Resolve a named export by following `export { ... } from` and `export * from` chains until
+ * a `workflow.js` module is reached, then read the workflow runtime name via {@link buildWorkflowNameMap}.
+ *
+ * @param {string} moduleAbsPath - Absolute path to the current module file.
+ * @param {string} soughtExportedName - Public export name (`'default'` for default export).
+ * @param {Set<string>} visited - Cycle guard keys `path::exportName`.
+ * @param {Map<string, {default: (string|null), named: Map<string,string>}>} workflowNameCache
+ * @returns {string|null} Declared workflow `name` or null if not resolved as a workflow.
+ */
+const resolveNamedExportThroughReexports = (
+  moduleAbsPath, soughtExportedName, visited, workflowNameCache
+) => {
+  const visitKey = `${moduleAbsPath}::${soughtExportedName}`;
+  if ( visited.has( visitKey ) ) {
+    return null;
+  }
+  visited.add( visitKey );
+
+  if ( absolutePathIsWorkflowJsFile( moduleAbsPath ) ) {
+    const wfMap = buildWorkflowNameMap( moduleAbsPath, workflowNameCache );
+    if ( soughtExportedName === 'default' ) {
+      return wfMap.default;
+    }
+    return wfMap.named.get( soughtExportedName ) ?? null;
+  }
+
+  const ast = ( () => {
+    try {
+      return parse( readFileSync( moduleAbsPath, 'utf8' ), moduleAbsPath );
+    } catch {
+      return null;
+    }
+  } )();
+  if ( !ast ) {
+    return null;
+  }
+  const moduleDir = dirname( moduleAbsPath );
+
+  for ( const node of ast.program.body ) {
+    if ( !isExportNamedDeclaration( node ) || !node.source ) {
+      continue;
+    }
+    const targetAbs = resolvePath( moduleDir, node.source.value );
+    for ( const spec of node.specifiers ) {
+      if ( !isExportSpecifier( spec ) ) {
+        continue;
+      }
+      const exported = exportSpecifierName( spec.exported );
+      if ( exported !== soughtExportedName ) {
+        continue;
+      }
+      const remoteName = exportSpecifierName( spec.local );
+      const inner = remoteName === 'default' ? 'default' : remoteName;
+      const resolved = resolveNamedExportThroughReexports(
+        targetAbs, inner, visited, workflowNameCache
+      );
+      if ( resolved ) {
+        return resolved;
+      }
+    }
+  }
+
+  for ( const node of ast.program.body ) {
+    if ( !isExportAllDeclaration( node ) || !isStringLiteral( node.source ) ) {
+      continue;
+    }
+    const targetAbs = resolvePath( moduleDir, node.source.value );
+    const resolved = resolveNamedExportThroughReexports(
+      targetAbs, soughtExportedName, visited, workflowNameCache
+    );
+    if ( resolved ) {
+      return resolved;
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Resolve the package entry (or subpath) for `specifier` from `fromAbsoluteFile`, then follow
+ * re-exports until `workflow.js` is reached.
+ *
+ * @param {string} fromAbsoluteFile - Absolute path to the importing file (e.g. `workflow.js`).
+ * @param {string} specifier - Bare npm specifier or subpath import.
+ * @returns {string|null} Absolute path to the resolved entry file, or null on failure.
+ */
+const resolveBareSpecifierToFirstModule = ( fromAbsoluteFile, specifier ) => {
+  const conditionalEntry = resolveBareSpecifierWithOutputCondition( fromAbsoluteFile, specifier );
+  if ( conditionalEntry ) {
+    return conditionalEntry;
+  }
+  try {
+    const req = createRequire( pathToFileURL( fromAbsoluteFile ).href );
+    return req.resolve( specifier );
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * For each ESM import specifier from a bare npm module, resolve the bound workflow runtime name.
+ * All specifiers must resolve as workflows; otherwise returns `none` (caller leaves the import alone)
+ * or `partial` (caller should throw).
+ *
+ * @param {object} params
+ * @param {string} params.fromAbsoluteFile - Absolute path to the importing `workflow.js`.
+ * @param {string} params.specifier - Bare npm import source.
+ * @param {readonly import('@babel/types').ImportDeclaration['specifiers']} params.specifiers
+ * @param {Map<string, {default: (string|null), named: Map<string,string>}>} params.workflowNameCache
+ * @returns {{ type: 'all', bindings: Array<{ localName: string, workflowName: string }> } |
+ *   { type: 'none' } | { type: 'partial' }}
+ */
+export const resolveBareImportSpecifiersAsWorkflows = ( {
+  fromAbsoluteFile,
+  specifier,
+  specifiers,
+  workflowNameCache
+} ) => {
+  const entry = resolveBareSpecifierToFirstModule( fromAbsoluteFile, specifier );
+  if ( !entry ) {
+    return { type: 'none' };
+  }
+
+  if ( specifiers.some( isImportNamespaceSpecifier ) ) {
+    return { type: 'none' };
+  }
+
+  const rows = [];
+  const visited = new Set();
+
+  for ( const sp of specifiers ) {
+    const binding = ( () => {
+      if ( isImportDefaultSpecifier( sp ) ) {
+        return { soughtExport: 'default', localName: sp.local.name };
+      }
+      if ( isImportSpecifier( sp ) ) {
+        return { soughtExport: sp.imported.name, localName: sp.local.name };
+      }
+      return null;
+    } )();
+    if ( !binding ) {
+      return { type: 'none' };
+    }
+    const { soughtExport, localName } = binding;
+
+    const workflowName = resolveNamedExportThroughReexports(
+      entry, soughtExport, visited, workflowNameCache
+    );
+    rows.push( { localName, workflowName } );
+  }
+
+  const resolvedCount = rows.filter( r => r.workflowName ).length;
+  if ( resolvedCount === 0 ) {
+    return { type: 'none' };
+  }
+  if ( resolvedCount !== rows.length ) {
+    return { type: 'partial' };
+  }
+  return { type: 'all', bindings: rows };
+};
+
+/**
+ * Resolves `const { a, b } = require('bare')` the same way as ESM imports (all keys must be workflows).
+ *
+ * @param {object} params
+ * @param {string} params.fromAbsoluteFile
+ * @param {string} params.specifier
+ * @param {readonly import('@babel/types').ObjectPattern['properties']} params.properties
+ * @param {Map<string, {default: (string|null), named: Map<string,string>}>} params.workflowNameCache
+ * @returns {{ type: 'all', bindings: Array<{ localName: string, workflowName: string }> } |
+ *   { type: 'none' } | { type: 'partial' }}
+ */
+export const resolveBareDestructuredRequireAsWorkflows = ( {
+  fromAbsoluteFile,
+  specifier,
+  properties,
+  workflowNameCache
+} ) => {
+  const entry = resolveBareSpecifierToFirstModule( fromAbsoluteFile, specifier );
+  if ( !entry ) {
+    return { type: 'none' };
+  }
+
+  const rows = [];
+  const visited = new Set();
+
+  for ( const prop of properties ) {
+    if ( prop.type !== 'ObjectProperty' || !isIdentifier( prop.key ) ) {
+      continue;
+    }
+    const importedName = prop.key.name;
+    const val = prop.value;
+    const localName = isIdentifier( val ) ? val.name : null;
+    if ( !localName ) {
+      return { type: 'partial' };
+    }
+    const workflowName = resolveNamedExportThroughReexports(
+      entry, importedName, visited, workflowNameCache
+    );
+    rows.push( { localName, workflowName } );
+  }
+
+  if ( rows.length === 0 ) {
+    return { type: 'none' };
+  }
+  const resolvedCount = rows.filter( r => r.workflowName ).length;
+  if ( resolvedCount === 0 ) {
+    return { type: 'none' };
+  }
+  if ( resolvedCount !== rows.length ) {
+    return { type: 'partial' };
+  }
+  return { type: 'all', bindings: rows };
+};
+
+/**
+ * Default `require('bare')` as a single default workflow binding.
+ *
+ * @param {string} fromAbsoluteFile
+ * @param {string} specifier
+ * @param {string} localName
+ * @param {Map<string, {default: (string|null), named: Map<string,string>}>} workflowNameCache
+ * @returns {{ type: 'binding', localName: string, workflowName: string } | { type: 'none' } | { type: 'partial' }}
+ */
+export const resolveBareDefaultRequireAsWorkflow = (
+  fromAbsoluteFile, specifier, localName, workflowNameCache
+) => {
+  const entry = resolveBareSpecifierToFirstModule( fromAbsoluteFile, specifier );
+  if ( !entry ) {
+    return { type: 'none' };
+  }
+  const visited = new Set();
+  const workflowName = resolveNamedExportThroughReexports(
+    entry, 'default', visited, workflowNameCache
+  );
+  if ( !workflowName ) {
+    return { type: 'none' };
+  }
+  return { type: 'binding', localName, workflowName };
+};

--- a/sdk/core/src/worker/webpack_loaders/npm_workflow_export_resolve.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/npm_workflow_export_resolve.spec.js
@@ -1,0 +1,353 @@
+import { describe, it, expect } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { parse } from './tools.js';
+import {
+  isBareNpmSpecifier,
+  resolveBareImportSpecifiersAsWorkflows,
+  resolveBareDestructuredRequireAsWorkflows,
+  resolveBareDefaultRequireAsWorkflow
+} from './npm_workflow_export_resolve.js';
+
+/**
+ * @param {(dir: string) => void} fn
+ */
+const withTempProjectDir = fn => {
+  const dir = mkdtempSync( join( tmpdir(), 'npm-resolve-' ) );
+  try {
+    fn( dir );
+  } finally {
+    rmSync( dir, { recursive: true, force: true } );
+  }
+};
+
+/**
+ * @param {string} source - Single import declaration source line (no newline required).
+ * @returns {import('@babel/types').ImportDeclaration['specifiers']}
+ */
+const importSpecifiersFromSource = source => {
+  const ast = parse( `${source}\n`, 'stub.js' );
+  const decl = ast.program.body[0];
+  if ( decl.type !== 'ImportDeclaration' ) {
+    throw new Error( 'expected ImportDeclaration' );
+  }
+  return decl.specifiers;
+};
+
+/**
+ * @param {string} source - `const { ... } = require('...');`
+ */
+const destructuredRequirePropertiesFromSource = source => {
+  const ast = parse( `${source}\n`, 'stub.js' );
+  const stmt = ast.program.body[0];
+  if ( stmt.type !== 'VariableDeclaration' || !stmt.declarations[0] ) {
+    throw new Error( 'expected VariableDeclaration' );
+  }
+  const pat = stmt.declarations[0].id;
+  if ( pat.type !== 'ObjectPattern' ) {
+    throw new Error( 'expected ObjectPattern' );
+  }
+  return pat.properties;
+};
+
+/**
+ * Writes a minimal package under `root/node_modules/<name>` with given files (relative paths).
+ *
+ * @param {string} root - Project root containing `node_modules`.
+ * @param {string} name - Package name e.g. `@test/catalog`.
+ * @param {string} main - Relative main entry from package root.
+ * @param {Record<string, string>} files - Relative path -> file contents.
+ * @param {object} [extraPackageJson] - Extra fields to merge into package.json.
+ */
+const writeNodeModulesPackage = ( root, name, main, files, extraPackageJson = {} ) => {
+  const pkgRoot = name.startsWith( '@' ) ?
+    join( root, 'node_modules', ...name.split( '/' ) ) :
+    join( root, 'node_modules', name );
+  mkdirSync( pkgRoot, { recursive: true } );
+  writeFileSync(
+    join( pkgRoot, 'package.json' ),
+    JSON.stringify( { name, version: '1.0.0', main, ...extraPackageJson }, null, 2 )
+  );
+  for ( const [ rel, content ] of Object.entries( files ) ) {
+    const abs = join( pkgRoot, rel );
+    mkdirSync( dirname( abs ), { recursive: true } );
+    writeFileSync( abs, content );
+  }
+  return pkgRoot;
+};
+
+describe( 'isBareNpmSpecifier', () => {
+  it( 'returns false for empty or non-string', () => {
+    expect( isBareNpmSpecifier( '' ) ).toBe( false );
+    expect( isBareNpmSpecifier( undefined ) ).toBe( false );
+  } );
+
+  it( 'returns false for relative and absolute paths', () => {
+    expect( isBareNpmSpecifier( './x' ) ).toBe( false );
+    expect( isBareNpmSpecifier( '../x' ) ).toBe( false );
+    expect( isBareNpmSpecifier( '/abs' ) ).toBe( false );
+  } );
+
+  it( 'returns false for node:, file:, data:, http(s):', () => {
+    expect( isBareNpmSpecifier( 'node:fs' ) ).toBe( false );
+    expect( isBareNpmSpecifier( 'file:///x' ) ).toBe( false );
+    expect( isBareNpmSpecifier( 'data:,x' ) ).toBe( false );
+    expect( isBareNpmSpecifier( 'http://x' ) ).toBe( false );
+    expect( isBareNpmSpecifier( 'https://x' ) ).toBe( false );
+  } );
+
+  it( 'returns true for bare package names', () => {
+    expect( isBareNpmSpecifier( 'lodash' ) ).toBe( true );
+    expect( isBareNpmSpecifier( '@scope/pkg' ) ).toBe( true );
+  } );
+} );
+
+describe( 'resolveBareImportSpecifiersAsWorkflows', () => {
+  it( 'returns none when the specifier does not resolve', () => {
+    withTempProjectDir( dir => {
+      const wf = join( dir, 'workflow.js' );
+      writeFileSync( wf, 'export default workflow({ name: \'local\' });\n' );
+
+      const out = resolveBareImportSpecifiersAsWorkflows( {
+        fromAbsoluteFile: wf,
+        specifier: '@missing-scope/missing-pkg-xyz',
+        specifiers: importSpecifiersFromSource( 'import x from \'@missing-scope/missing-pkg-xyz\'' ),
+        workflowNameCache: new Map()
+      } );
+      expect( out ).toEqual( { type: 'none' } );
+    } );
+  } );
+
+  it( 'returns none for namespace imports', () => {
+    withTempProjectDir( dir => {
+      const wf = join( dir, 'workflow.js' );
+      writeFileSync( wf, 'export default workflow({ name: \'local\' });\n' );
+      writeNodeModulesPackage( dir, '@test/ns', './workflow.js', {
+        'workflow.js': 'export default workflow({ name: \'ns.wf\' });\n'
+      } );
+
+      const out = resolveBareImportSpecifiersAsWorkflows( {
+        fromAbsoluteFile: wf,
+        specifier: '@test/ns',
+        specifiers: importSpecifiersFromSource( 'import * as ns from \'@test/ns\'' ),
+        workflowNameCache: new Map()
+      } );
+      expect( out ).toEqual( { type: 'none' } );
+    } );
+  } );
+
+  it( 'resolves default import to the package default workflow name', () => {
+    withTempProjectDir( dir => {
+      const importing = join( dir, 'workflow.js' );
+      writeFileSync( importing, 'export default workflow({ name: \'local\' });\n' );
+      writeNodeModulesPackage( dir, '@test/wfdef', './workflow.js', {
+        'workflow.js': 'export default workflow({ name: \'pkg.default\' });\n'
+      } );
+
+      const out = resolveBareImportSpecifiersAsWorkflows( {
+        fromAbsoluteFile: importing,
+        specifier: '@test/wfdef',
+        specifiers: importSpecifiersFromSource( 'import PkgDef from \'@test/wfdef\'' ),
+        workflowNameCache: new Map()
+      } );
+      expect( out ).toEqual( {
+        type: 'all',
+        bindings: [ { localName: 'PkgDef', workflowName: 'pkg.default' } ]
+      } );
+    } );
+  } );
+
+  it( 'prefers the output workflow bundle export condition over the default entry', () => {
+    withTempProjectDir( dir => {
+      const importing = join( dir, 'workflow.js' );
+      writeFileSync( importing, 'export default workflow({ name: \'local\' });\n' );
+      writeNodeModulesPackage( dir, '@test/conditional', './node-entry.js', {
+        'node-entry.js': 'export const helper = () => 1;\n',
+        'bundle/workflow.js': 'export default workflow({ name: \'bundle.workflow\' });\n'
+      }, {
+        exports: {
+          '.': {
+            'output-workflow-bundle': './bundle/workflow.js',
+            default: './node-entry.js'
+          }
+        }
+      } );
+
+      const out = resolveBareImportSpecifiersAsWorkflows( {
+        fromAbsoluteFile: importing,
+        specifier: '@test/conditional',
+        specifiers: importSpecifiersFromSource( 'import BundleWorkflow from \'@test/conditional\'' ),
+        workflowNameCache: new Map()
+      } );
+      expect( out ).toEqual( {
+        type: 'all',
+        bindings: [ { localName: 'BundleWorkflow', workflowName: 'bundle.workflow' } ]
+      } );
+    } );
+  } );
+
+  it( 'supports root conditional exports without an explicit dot key', () => {
+    withTempProjectDir( dir => {
+      const importing = join( dir, 'workflow.js' );
+      writeFileSync( importing, 'export default workflow({ name: \'local\' });\n' );
+      writeNodeModulesPackage( dir, '@test/root-conditional', './node-entry.js', {
+        'node-entry.js': 'export const helper = () => 1;\n',
+        'workflow.js': 'export default workflow({ name: \'root.conditional\' });\n'
+      }, {
+        exports: {
+          'output-workflow-bundle': './workflow.js',
+          default: './node-entry.js'
+        }
+      } );
+
+      const out = resolveBareImportSpecifiersAsWorkflows( {
+        fromAbsoluteFile: importing,
+        specifier: '@test/root-conditional',
+        specifiers: importSpecifiersFromSource( 'import RootWorkflow from \'@test/root-conditional\'' ),
+        workflowNameCache: new Map()
+      } );
+      expect( out ).toEqual( {
+        type: 'all',
+        bindings: [ { localName: 'RootWorkflow', workflowName: 'root.conditional' } ]
+      } );
+    } );
+  } );
+
+  it( 'uses webpack export condition when workflow bundle condition is absent', () => {
+    withTempProjectDir( dir => {
+      const importing = join( dir, 'workflow.js' );
+      writeFileSync( importing, 'export default workflow({ name: \'local\' });\n' );
+      writeNodeModulesPackage( dir, '@test/webpack-conditional', './node-entry.js', {
+        'node-entry.js': 'export const helper = () => 1;\n',
+        'webpack/workflow.js': 'export default workflow({ name: \'webpack.workflow\' });\n'
+      }, {
+        exports: {
+          '.': {
+            webpack: './webpack/workflow.js',
+            default: './node-entry.js'
+          }
+        }
+      } );
+
+      const out = resolveBareImportSpecifiersAsWorkflows( {
+        fromAbsoluteFile: importing,
+        specifier: '@test/webpack-conditional',
+        specifiers: importSpecifiersFromSource( 'import WebpackWorkflow from \'@test/webpack-conditional\'' ),
+        workflowNameCache: new Map()
+      } );
+      expect( out ).toEqual( {
+        type: 'all',
+        bindings: [ { localName: 'WebpackWorkflow', workflowName: 'webpack.workflow' } ]
+      } );
+    } );
+  } );
+
+  it( 'follows re-exports to workflow.js for a named import', () => {
+    withTempProjectDir( dir => {
+      const importing = join( dir, 'workflow.js' );
+      writeFileSync( importing, 'export default workflow({ name: \'local\' });\n' );
+      writeNodeModulesPackage( dir, '@test/catalog', './src/index.js', {
+        'src/index.js': 'export { default as sumNumbers } from \'./wf/workflow.js\';\n',
+        'src/wf/workflow.js': 'export default workflow({ name: \'sum.numbers\' });\n'
+      } );
+
+      const out = resolveBareImportSpecifiersAsWorkflows( {
+        fromAbsoluteFile: importing,
+        specifier: '@test/catalog',
+        specifiers: importSpecifiersFromSource( 'import { sumNumbers } from \'@test/catalog\'' ),
+        workflowNameCache: new Map()
+      } );
+      expect( out ).toEqual( {
+        type: 'all',
+        bindings: [ { localName: 'sumNumbers', workflowName: 'sum.numbers' } ]
+      } );
+    } );
+  } );
+
+  it( 'returns partial when one named import does not resolve to a workflow', () => {
+    withTempProjectDir( dir => {
+      const importing = join( dir, 'workflow.js' );
+      writeFileSync( importing, 'export default workflow({ name: \'local\' });\n' );
+      writeNodeModulesPackage( dir, '@test/partial', './index.js', {
+        'index.js': 'export { default as Good } from \'./wf/workflow.js\';\n',
+        'wf/workflow.js': 'export default workflow({ name: \'good.def\' });\n'
+      } );
+
+      const out = resolveBareImportSpecifiersAsWorkflows( {
+        fromAbsoluteFile: importing,
+        specifier: '@test/partial',
+        specifiers: importSpecifiersFromSource( 'import { Good, MissingExport } from \'@test/partial\'' ),
+        workflowNameCache: new Map()
+      } );
+      expect( out.type ).toBe( 'partial' );
+    } );
+  } );
+} );
+
+describe( 'resolveBareDestructuredRequireAsWorkflows', () => {
+  it( 'resolves destructured keys to workflow names', () => {
+    withTempProjectDir( dir => {
+      const importing = join( dir, 'workflow.js' );
+      writeFileSync( importing, 'export default workflow({ name: \'local\' });\n' );
+      writeNodeModulesPackage( dir, '@test/destr', './index.js', {
+        'index.js': 'export { default as alpha } from \'./wf/workflow.js\';\n',
+        'wf/workflow.js': 'export default workflow({ name: \'alpha.wf\' });\n'
+      } );
+
+      const props = destructuredRequirePropertiesFromSource(
+        'const { alpha: A } = require(\'@test/destr\');'
+      );
+      const out = resolveBareDestructuredRequireAsWorkflows( {
+        fromAbsoluteFile: importing,
+        specifier: '@test/destr',
+        properties: props,
+        workflowNameCache: new Map()
+      } );
+      expect( out ).toEqual( {
+        type: 'all',
+        bindings: [ { localName: 'A', workflowName: 'alpha.wf' } ]
+      } );
+    } );
+  } );
+} );
+
+describe( 'resolveBareDefaultRequireAsWorkflow', () => {
+  it( 'returns binding when default resolves to a workflow', () => {
+    withTempProjectDir( dir => {
+      const importing = join( dir, 'workflow.js' );
+      writeFileSync( importing, 'export default workflow({ name: \'local\' });\n' );
+      writeNodeModulesPackage( dir, '@test/defreq', './entry.js', {
+        'entry.js': 'export { default } from \'./wf/workflow.js\';\n',
+        'wf/workflow.js': 'export default workflow({ name: \'chain.def\' });\n'
+      } );
+
+      const out = resolveBareDefaultRequireAsWorkflow(
+        importing,
+        '@test/defreq',
+        'Cat',
+        new Map()
+      );
+      expect( out ).toEqual( {
+        type: 'binding',
+        localName: 'Cat',
+        workflowName: 'chain.def'
+      } );
+    } );
+  } );
+
+  it( 'returns none when nothing resolves', () => {
+    withTempProjectDir( dir => {
+      const importing = join( dir, 'workflow.js' );
+      writeFileSync( importing, 'export default workflow({ name: \'local\' });\n' );
+
+      const out = resolveBareDefaultRequireAsWorkflow(
+        importing,
+        '@ghost/no-such-pkg',
+        'X',
+        new Map()
+      );
+      expect( out ).toEqual( { type: 'none' } );
+    } );
+  } );
+} );

--- a/sdk/core/src/worker/webpack_loaders/npm_workflow_export_resolve.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/npm_workflow_export_resolve.spec.js
@@ -119,18 +119,39 @@ describe( 'resolveBareImportSpecifiersAsWorkflows', () => {
     } );
   } );
 
-  it( 'returns none for namespace imports', () => {
+  it( 'throws for namespace imports from workflow packages', () => {
     withTempProjectDir( dir => {
       const wf = join( dir, 'workflow.js' );
       writeFileSync( wf, 'export default workflow({ name: \'local\' });\n' );
-      writeNodeModulesPackage( dir, '@test/ns', './workflow.js', {
+      writeNodeModulesPackage( dir, '@test/ns', './index.js', {
+        'index.js': 'export { default as nsWorkflow } from \'./workflow.js\';\n',
         'workflow.js': 'export default workflow({ name: \'ns.wf\' });\n'
+      } );
+
+      expect( () => resolveBareImportSpecifiersAsWorkflows( {
+        fromAbsoluteFile: wf,
+        specifier: '@test/ns',
+        specifiers: importSpecifiersFromSource( 'import * as ns from \'@test/ns\'' ),
+        workflowNameCache: new Map()
+      } ) ).toThrow(
+        'Namespace imports from workflow package "@test/ns" are not supported. ' +
+        'Use named imports instead, e.g. import { myWorkflow } from \'@test/ns\'.'
+      );
+    } );
+  } );
+
+  it( 'returns none for namespace imports from non-workflow packages', () => {
+    withTempProjectDir( dir => {
+      const wf = join( dir, 'workflow.js' );
+      writeFileSync( wf, 'export default workflow({ name: \'local\' });\n' );
+      writeNodeModulesPackage( dir, '@test/helper', './index.js', {
+        'index.js': 'export const helper = () => 1;\n'
       } );
 
       const out = resolveBareImportSpecifiersAsWorkflows( {
         fromAbsoluteFile: wf,
-        specifier: '@test/ns',
-        specifiers: importSpecifiersFromSource( 'import * as ns from \'@test/ns\'' ),
+        specifier: '@test/helper',
+        specifiers: importSpecifiersFromSource( 'import * as helper from \'@test/helper\'' ),
         workflowNameCache: new Map()
       } );
       expect( out ).toEqual( { type: 'none' } );

--- a/sdk/core/src/worker/webpack_loaders/tools.js
+++ b/sdk/core/src/worker/webpack_loaders/tools.js
@@ -1,7 +1,5 @@
 import parser from '@babel/parser';
-import { createRequire } from 'node:module';
-import { dirname, resolve as resolvePath } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { resolve as resolvePath } from 'node:path';
 import { readFileSync } from 'node:fs';
 import {
   blockStatement,
@@ -13,7 +11,6 @@ import {
   isBlockStatement,
   isCallExpression,
   isExportNamedDeclaration,
-  isExportSpecifier,
   isFunctionExpression,
   isIdentifier,
   isVariableDeclarator,
@@ -36,57 +33,6 @@ const EVALUATORS_FILE_REGEX = /(^|\/)evaluators\.js$/;
 const EVALUATORS_FOLDER_REGEX = /\/evaluators\/[^/]+\.js$/;
 const PATH_TRAVERSAL_REGEX = /\.\.\//;
 const SHARED_PATH_REGEX = /\/shared\//;
-
-/**
- * npm package names (bare specifiers) for published workflow catalogs: their entry re-exports
- * `workflow()` modules. Imports of these packages are rewritten and validated like local `workflow.js`
- */
-export const EXTERNAL_WORKFLOW_PACKAGE_NAMES = Object.freeze( [
-  '@growthxlabs/workflows_catalog'
-] );
-
-const escapeForRegExp = s => s.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
-
-const EXTERNAL_WORKFLOW_PACKAGE_PATH_REGEX = new RegExp(
-  `[\\\\/]node_modules[\\\\/](?:${
-    EXTERNAL_WORKFLOW_PACKAGE_NAMES
-      .map( name => name.split( '/' ).map( escapeForRegExp ).join( '[\\\\/]' ) )
-      .join( '|' )
-  })[\\\\/]`
-);
-
-/**
- * True when `resource` is under `node_modules/<one of EXTERNAL_WORKFLOW_PACKAGE_NAMES>/`.
- * Used by webpack `exclude` so loaders run on these packages only.
- * @param {string} resource - Absolute or normalized module path (webpack `resource`).
- * @returns {boolean}
- */
-export const isExternalWorkflowPackagePath = resource =>
-  EXTERNAL_WORKFLOW_PACKAGE_PATH_REGEX.test( resource );
-
-/**
- * True when the import / `require()` string is a known external workflow package (exact specifier).
- * @param {string} value - ESM import source or `require` string.
- * @returns {boolean}
- */
-export const isExternalWorkflowPackageSpecifier = value =>
-  EXTERNAL_WORKFLOW_PACKAGE_NAMES.includes( value );
-
-/**
- * Resolve a known external workflow package entry (main module) from the consumer file.
- * @param {string} resourcePath - Absolute path to the file doing the import (e.g. webpack `resourcePath`).
- * @param {string} specifier - Bare package name; must be listed in {@link EXTERNAL_WORKFLOW_PACKAGE_NAMES}.
- * @returns {string} Absolute path to the package entry file.
- */
-export const resolveExternalWorkflowPackageEntryPath = ( resourcePath, specifier ) => {
-  if ( !EXTERNAL_WORKFLOW_PACKAGE_NAMES.includes( specifier ) ) {
-    throw new Error(
-      `resolveExternalWorkflowPackageEntryPath: unknown external workflow package '${specifier}'`
-    );
-  }
-  const req = createRequire( pathToFileURL( resourcePath ).href );
-  return req.resolve( specifier );
-};
 
 /**
  * Resolve a relative module specifier against a base directory.
@@ -248,6 +194,15 @@ export const isAnyEvaluatorsPath = value =>
  * @returns {boolean} True if it matches workflow.js.
  */
 export const isWorkflowPath = value => /(^|\/)workflow\.js$/.test( value );
+
+/**
+ * True when `resourcePath` is an absolute path to a `workflow.js` file (slashes normalized).
+ *
+ * @param {string|null|undefined} resourcePath - Webpack `resourcePath` or similar.
+ * @returns {boolean}
+ */
+export const isAbsoluteWorkflowJsResource = resourcePath =>
+  typeof resourcePath === 'string' && isWorkflowPath( resourcePath.replace( /\\/g, '/' ) );
 
 /**
  * Check if a path is a component file (steps, evaluators, or workflow).
@@ -509,56 +464,6 @@ export const buildWorkflowNameMap = ( path, cache ) => {
 
   cache.set( path, result );
   return result;
-};
-
-const externalWorkflowPackageExportNameCache = new Map();
-
-/**
- * Build map of package public export name → workflow runtime name by parsing the package index and
- * delegating to {@link buildWorkflowNameMap} for each re-export target.
- * @param {string} catalogIndexPath - Absolute path to the package entry (e.g. index.js).
- * @param {Map<string, {default: (string|null), named: Map<string,string>}>} workflowNameCache - Workflow file cache.
- * @returns {Map<string, string>} Exported symbol → workflow `name:` string.
- */
-export const buildWorkflowCatalogExportNameMap = ( catalogIndexPath, workflowNameCache ) => {
-  if ( externalWorkflowPackageExportNameCache.has( catalogIndexPath ) ) {
-    return externalWorkflowPackageExportNameCache.get( catalogIndexPath );
-  }
-  const text = readFileSync( catalogIndexPath, 'utf8' );
-  const ast = parse( text, catalogIndexPath );
-  const catalogDir = dirname( catalogIndexPath );
-  /** @type {Map<string, string>} */
-  const exportToWorkflowName = new Map();
-
-  for ( const node of ast.program.body ) {
-    if ( !isExportNamedDeclaration( node ) || !node.source ) {
-      continue;
-    }
-    const absTarget = resolvePath( catalogDir, node.source.value );
-    for ( const spec of node.specifiers ) {
-      if ( !isExportSpecifier( spec ) ) {
-        continue;
-      }
-      const exportedPublicName = isIdentifier( spec.exported ) ?
-        spec.exported.name :
-        spec.exported.value;
-      const importedFromTarget = spec.local.name;
-      const wfMap = buildWorkflowNameMap( absTarget, workflowNameCache );
-      const workflowName = importedFromTarget === 'default' ?
-        wfMap.default :
-        wfMap.named.get( importedFromTarget );
-      if ( !workflowName ) {
-        throw new Error(
-          `External workflow package '${catalogIndexPath}': cannot resolve re-export '${exportedPublicName}' ` +
-          `from '${absTarget}' (expected default or named workflow() export).`
-        );
-      }
-      exportToWorkflowName.set( exportedPublicName, workflowName );
-    }
-  }
-
-  externalWorkflowPackageExportNameCache.set( catalogIndexPath, exportToWorkflowName );
-  return exportToWorkflowName;
 };
 
 /**

--- a/sdk/core/src/worker/webpack_loaders/tools.js
+++ b/sdk/core/src/worker/webpack_loaders/tools.js
@@ -1,5 +1,7 @@
 import parser from '@babel/parser';
-import { resolve as resolvePath } from 'node:path';
+import { createRequire } from 'node:module';
+import { dirname, resolve as resolvePath } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { readFileSync } from 'node:fs';
 import {
   blockStatement,
@@ -11,6 +13,7 @@ import {
   isBlockStatement,
   isCallExpression,
   isExportNamedDeclaration,
+  isExportSpecifier,
   isFunctionExpression,
   isIdentifier,
   isVariableDeclarator,
@@ -33,6 +36,57 @@ const EVALUATORS_FILE_REGEX = /(^|\/)evaluators\.js$/;
 const EVALUATORS_FOLDER_REGEX = /\/evaluators\/[^/]+\.js$/;
 const PATH_TRAVERSAL_REGEX = /\.\.\//;
 const SHARED_PATH_REGEX = /\/shared\//;
+
+/**
+ * npm package names (bare specifiers) for published workflow catalogs: their entry re-exports
+ * `workflow()` modules. Imports of these packages are rewritten and validated like local `workflow.js`
+ */
+export const EXTERNAL_WORKFLOW_PACKAGE_NAMES = Object.freeze( [
+  '@growthxlabs/workflows_catalog'
+] );
+
+const escapeForRegExp = s => s.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+
+const EXTERNAL_WORKFLOW_PACKAGE_PATH_REGEX = new RegExp(
+  `[\\\\/]node_modules[\\\\/](?:${
+    EXTERNAL_WORKFLOW_PACKAGE_NAMES
+      .map( name => name.split( '/' ).map( escapeForRegExp ).join( '[\\\\/]' ) )
+      .join( '|' )
+  })[\\\\/]`
+);
+
+/**
+ * True when `resource` is under `node_modules/<one of EXTERNAL_WORKFLOW_PACKAGE_NAMES>/`.
+ * Used by webpack `exclude` so loaders run on these packages only.
+ * @param {string} resource - Absolute or normalized module path (webpack `resource`).
+ * @returns {boolean}
+ */
+export const isExternalWorkflowPackagePath = resource =>
+  EXTERNAL_WORKFLOW_PACKAGE_PATH_REGEX.test( resource );
+
+/**
+ * True when the import / `require()` string is a known external workflow package (exact specifier).
+ * @param {string} value - ESM import source or `require` string.
+ * @returns {boolean}
+ */
+export const isExternalWorkflowPackageSpecifier = value =>
+  EXTERNAL_WORKFLOW_PACKAGE_NAMES.includes( value );
+
+/**
+ * Resolve a known external workflow package entry (main module) from the consumer file.
+ * @param {string} resourcePath - Absolute path to the file doing the import (e.g. webpack `resourcePath`).
+ * @param {string} specifier - Bare package name; must be listed in {@link EXTERNAL_WORKFLOW_PACKAGE_NAMES}.
+ * @returns {string} Absolute path to the package entry file.
+ */
+export const resolveExternalWorkflowPackageEntryPath = ( resourcePath, specifier ) => {
+  if ( !EXTERNAL_WORKFLOW_PACKAGE_NAMES.includes( specifier ) ) {
+    throw new Error(
+      `resolveExternalWorkflowPackageEntryPath: unknown external workflow package '${specifier}'`
+    );
+  }
+  const req = createRequire( pathToFileURL( resourcePath ).href );
+  return req.resolve( specifier );
+};
 
 /**
  * Resolve a relative module specifier against a base directory.
@@ -455,6 +509,56 @@ export const buildWorkflowNameMap = ( path, cache ) => {
 
   cache.set( path, result );
   return result;
+};
+
+const externalWorkflowPackageExportNameCache = new Map();
+
+/**
+ * Build map of package public export name → workflow runtime name by parsing the package index and
+ * delegating to {@link buildWorkflowNameMap} for each re-export target.
+ * @param {string} catalogIndexPath - Absolute path to the package entry (e.g. index.js).
+ * @param {Map<string, {default: (string|null), named: Map<string,string>}>} workflowNameCache - Workflow file cache.
+ * @returns {Map<string, string>} Exported symbol → workflow `name:` string.
+ */
+export const buildWorkflowCatalogExportNameMap = ( catalogIndexPath, workflowNameCache ) => {
+  if ( externalWorkflowPackageExportNameCache.has( catalogIndexPath ) ) {
+    return externalWorkflowPackageExportNameCache.get( catalogIndexPath );
+  }
+  const text = readFileSync( catalogIndexPath, 'utf8' );
+  const ast = parse( text, catalogIndexPath );
+  const catalogDir = dirname( catalogIndexPath );
+  /** @type {Map<string, string>} */
+  const exportToWorkflowName = new Map();
+
+  for ( const node of ast.program.body ) {
+    if ( !isExportNamedDeclaration( node ) || !node.source ) {
+      continue;
+    }
+    const absTarget = resolvePath( catalogDir, node.source.value );
+    for ( const spec of node.specifiers ) {
+      if ( !isExportSpecifier( spec ) ) {
+        continue;
+      }
+      const exportedPublicName = isIdentifier( spec.exported ) ?
+        spec.exported.name :
+        spec.exported.value;
+      const importedFromTarget = spec.local.name;
+      const wfMap = buildWorkflowNameMap( absTarget, workflowNameCache );
+      const workflowName = importedFromTarget === 'default' ?
+        wfMap.default :
+        wfMap.named.get( importedFromTarget );
+      if ( !workflowName ) {
+        throw new Error(
+          `External workflow package '${catalogIndexPath}': cannot resolve re-export '${exportedPublicName}' ` +
+          `from '${absTarget}' (expected default or named workflow() export).`
+        );
+      }
+      exportToWorkflowName.set( exportedPublicName, workflowName );
+    }
+  }
+
+  externalWorkflowPackageExportNameCache.set( catalogIndexPath, exportToWorkflowName );
+  return exportToWorkflowName;
 };
 
 /**

--- a/sdk/core/src/worker/webpack_loaders/tools.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/tools.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve as resolvePath } from 'node:path';
+import { join, resolve as resolvePath } from 'node:path';
 import * as t from '@babel/types';
 import {
   toAbsolutePath,
@@ -16,11 +16,7 @@ import {
   isEvaluatorsPath,
   isSharedEvaluatorsPath,
   isWorkflowPath,
-  EXTERNAL_WORKFLOW_PACKAGE_NAMES,
-  isExternalWorkflowPackagePath,
-  isExternalWorkflowPackageSpecifier,
-  resolveExternalWorkflowPackageEntryPath,
-  buildWorkflowCatalogExportNameMap,
+  isAbsoluteWorkflowJsResource,
   createThisMethodCall,
   resolveNameFromArg,
   resolveNameFromOptions,
@@ -196,47 +192,10 @@ describe( 'workflow_rewriter tools', () => {
     expect( isWorkflowPath( 'steps.js' ) ).toBe( false );
   } );
 
-  it( 'EXTERNAL_WORKFLOW_PACKAGE_NAMES lists known published workflow bundles', () => {
-    expect( EXTERNAL_WORKFLOW_PACKAGE_NAMES ).toContain( '@growthxlabs/workflows_catalog' );
-  } );
-
-  it( 'isExternalWorkflowPackagePath matches node_modules paths for listed packages', () => {
-    expect( isExternalWorkflowPackagePath( '/app/node_modules/@growthxlabs/workflows_catalog/src/x.js' ) ).toBe( true );
-    expect( isExternalWorkflowPackagePath( '/app/node_modules/other/pkg/x.js' ) ).toBe( false );
-  } );
-
-  it( 'isExternalWorkflowPackageSpecifier: matches only exact known package names', () => {
-    expect( isExternalWorkflowPackageSpecifier( '@growthxlabs/workflows_catalog' ) ).toBe( true );
-    expect( isExternalWorkflowPackageSpecifier( '@growthxlabs/workflows_catalog/foo' ) ).toBe( false );
-    expect( isExternalWorkflowPackageSpecifier( 'workflow.js' ) ).toBe( false );
-  } );
-
-  it( 'resolveExternalWorkflowPackageEntryPath + buildWorkflowCatalogExportNameMap: resolve via node_modules', () => {
-    const dir = mkdtempSync( join( tmpdir(), 'tools-catalog-' ) );
-    const pkgRoot = join( dir, 'node_modules', '@growthxlabs', 'workflows_catalog' );
-    const srcDir = join( pkgRoot, 'src' );
-    mkdirSync( join( pkgRoot, 'src', 'workflows', 'wf' ), { recursive: true } );
-    writeFileSync( join( pkgRoot, 'package.json' ), JSON.stringify( {
-      name: '@growthxlabs/workflows_catalog',
-      type: 'module',
-      main: './src/index.js'
-    } ) );
-    writeFileSync( join( srcDir, 'index.js' ), 'export { default as sumNumbers } from \'./workflows/wf/workflow.js\';\n' );
-    writeFileSync( join( srcDir, 'workflows', 'wf', 'workflow.js' ), 'export default workflow({ name: \'__sum_numbers\' });\n' );
-    const consumer = join( dir, 'proj', 'workflow.js' );
-    mkdirSync( dirname( consumer ), { recursive: true } );
-    writeFileSync( consumer, 'export default workflow({ name: \'x\' });\n' );
-
-    const entry = resolveExternalWorkflowPackageEntryPath(
-      consumer,
-      '@growthxlabs/workflows_catalog'
-    );
-    expect( entry ).toBe( join( srcDir, 'index.js' ) );
-
-    const map = buildWorkflowCatalogExportNameMap( entry, new Map() );
-    expect( map.get( 'sumNumbers' ) ).toBe( '__sum_numbers' );
-
-    rmSync( dir, { recursive: true, force: true } );
+  it( 'isAbsoluteWorkflowJsResource: normalizes slashes', () => {
+    expect( isAbsoluteWorkflowJsResource( '/a/b/workflow.js' ) ).toBe( true );
+    expect( isAbsoluteWorkflowJsResource( 'C:\\\\a\\\\workflow.js' ) ).toBe( true );
+    expect( isAbsoluteWorkflowJsResource( '/a/b/steps.js' ) ).toBe( false );
   } );
 
   it( 'isEvaluatorsPath: matches local evaluators.js but excludes shared', () => {

--- a/sdk/core/src/worker/webpack_loaders/tools.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/tools.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, resolve as resolvePath } from 'node:path';
+import { dirname, join, resolve as resolvePath } from 'node:path';
 import * as t from '@babel/types';
 import {
   toAbsolutePath,
@@ -16,6 +16,11 @@ import {
   isEvaluatorsPath,
   isSharedEvaluatorsPath,
   isWorkflowPath,
+  EXTERNAL_WORKFLOW_PACKAGE_NAMES,
+  isExternalWorkflowPackagePath,
+  isExternalWorkflowPackageSpecifier,
+  resolveExternalWorkflowPackageEntryPath,
+  buildWorkflowCatalogExportNameMap,
   createThisMethodCall,
   resolveNameFromArg,
   resolveNameFromOptions,
@@ -189,6 +194,49 @@ describe( 'workflow_rewriter tools', () => {
     expect( isWorkflowPath( '/a/b/workflow.js' ) ).toBe( true );
     expect( isWorkflowPath( 'workflow.ts' ) ).toBe( false );
     expect( isWorkflowPath( 'steps.js' ) ).toBe( false );
+  } );
+
+  it( 'EXTERNAL_WORKFLOW_PACKAGE_NAMES lists known published workflow bundles', () => {
+    expect( EXTERNAL_WORKFLOW_PACKAGE_NAMES ).toContain( '@growthxlabs/workflows_catalog' );
+  } );
+
+  it( 'isExternalWorkflowPackagePath matches node_modules paths for listed packages', () => {
+    expect( isExternalWorkflowPackagePath( '/app/node_modules/@growthxlabs/workflows_catalog/src/x.js' ) ).toBe( true );
+    expect( isExternalWorkflowPackagePath( '/app/node_modules/other/pkg/x.js' ) ).toBe( false );
+  } );
+
+  it( 'isExternalWorkflowPackageSpecifier: matches only exact known package names', () => {
+    expect( isExternalWorkflowPackageSpecifier( '@growthxlabs/workflows_catalog' ) ).toBe( true );
+    expect( isExternalWorkflowPackageSpecifier( '@growthxlabs/workflows_catalog/foo' ) ).toBe( false );
+    expect( isExternalWorkflowPackageSpecifier( 'workflow.js' ) ).toBe( false );
+  } );
+
+  it( 'resolveExternalWorkflowPackageEntryPath + buildWorkflowCatalogExportNameMap: resolve via node_modules', () => {
+    const dir = mkdtempSync( join( tmpdir(), 'tools-catalog-' ) );
+    const pkgRoot = join( dir, 'node_modules', '@growthxlabs', 'workflows_catalog' );
+    const srcDir = join( pkgRoot, 'src' );
+    mkdirSync( join( pkgRoot, 'src', 'workflows', 'wf' ), { recursive: true } );
+    writeFileSync( join( pkgRoot, 'package.json' ), JSON.stringify( {
+      name: '@growthxlabs/workflows_catalog',
+      type: 'module',
+      main: './src/index.js'
+    } ) );
+    writeFileSync( join( srcDir, 'index.js' ), 'export { default as sumNumbers } from \'./workflows/wf/workflow.js\';\n' );
+    writeFileSync( join( srcDir, 'workflows', 'wf', 'workflow.js' ), 'export default workflow({ name: \'__sum_numbers\' });\n' );
+    const consumer = join( dir, 'proj', 'workflow.js' );
+    mkdirSync( dirname( consumer ), { recursive: true } );
+    writeFileSync( consumer, 'export default workflow({ name: \'x\' });\n' );
+
+    const entry = resolveExternalWorkflowPackageEntryPath(
+      consumer,
+      '@growthxlabs/workflows_catalog'
+    );
+    expect( entry ).toBe( join( srcDir, 'index.js' ) );
+
+    const map = buildWorkflowCatalogExportNameMap( entry, new Map() );
+    expect( map.get( 'sumNumbers' ) ).toBe( '__sum_numbers' );
+
+    rmSync( dir, { recursive: true, force: true } );
   } );
 
   it( 'isEvaluatorsPath: matches local evaluators.js but excludes shared', () => {

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.js
@@ -1,16 +1,20 @@
+import { join } from 'node:path';
 import traverseModule from '@babel/traverse';
 import {
+  buildWorkflowCatalogExportNameMap,
   buildWorkflowNameMap,
+  buildEvaluatorsNameMap,
+  buildSharedEvaluatorsNameMap,
+  buildSharedStepsNameMap,
+  buildStepsNameMap,
   getLocalNameFromDestructuredProperty,
   isEvaluatorsPath,
   isSharedEvaluatorsPath,
   isSharedStepsPath,
   isStepsPath,
+  isExternalWorkflowPackageSpecifier,
   isWorkflowPath,
-  buildStepsNameMap,
-  buildSharedStepsNameMap,
-  buildEvaluatorsNameMap,
-  buildSharedEvaluatorsNameMap,
+  resolveExternalWorkflowPackageEntryPath,
   toAbsolutePath
 } from '../tools.js';
 import {
@@ -34,6 +38,18 @@ const unresolvedImportError = ( name, fileLabel, filePath ) =>
     'Use the matching factory function for the file ' +
     '(e.g. step() in steps files, evaluator() in evaluators files, workflow() in workflow files).'
   );
+
+/**
+ * @param {string} resolutionPath - Absolute path used for Node resolution (resource path or synthetic).
+ * @param {string} specifier - Bare package name from import/require.
+ * @param {Map<string, {default: (string|null), named: Map<string,string>}>} workflowNameCache
+ * @returns {{ indexPath: string, exportNameMap: Map<string, string> }}
+ */
+const resolveExternalWorkflowExportNameMap = ( resolutionPath, specifier, workflowNameCache ) => {
+  const indexPath = resolveExternalWorkflowPackageEntryPath( resolutionPath, specifier );
+  const exportNameMap = buildWorkflowCatalogExportNameMap( indexPath, workflowNameCache );
+  return { indexPath, exportNameMap };
+};
 
 const removeRequireDeclarator = path => {
   if ( isVariableDeclaration( path.parent ) && path.parent.declarations.length === 1 ) {
@@ -77,13 +93,17 @@ const collectDestructuredRequires = ( path, absolutePath, req, descriptors ) => 
  * @param {string} fileDir - Absolute directory of the file represented by `ast`.
  * @param {{ stepsNameCache: Map<string,Map<string,string>>, workflowNameCache: Map<string,{default:(string|null),named:Map<string,string>}> }} caches
  *  Resolved-name caches to avoid re-reading same modules.
+ * @param {string} [resourcePath] - Absolute path of the file being transformed; used to resolve
+ *  external workflow packages from the consumer's `node_modules`.
  * @returns {{ stepImports: Array<{localName:string,stepName:string}>,
  *  flowImports: Array<{localName:string,workflowName:string}> }} Collected info mappings.
  */
 export default function collectTargetImports(
   ast, fileDir,
-  { stepsNameCache, workflowNameCache, evaluatorsNameCache, sharedStepsNameCache, sharedEvaluatorsNameCache }
+  { stepsNameCache, workflowNameCache, evaluatorsNameCache, sharedStepsNameCache, sharedEvaluatorsNameCache },
+  resourcePath
 ) {
+  const resolutionPath = resourcePath ?? join( fileDir, 'file.js' );
   const stepImports = [];
   const sharedStepImports = [];
   const flowImports = [];
@@ -95,7 +115,8 @@ export default function collectTargetImports(
       const src = path.node.source.value;
       // Ignore other imports
       const isTargetImport = isStepsPath( src ) || isSharedStepsPath( src ) ||
-        isWorkflowPath( src ) || isEvaluatorsPath( src ) || isSharedEvaluatorsPath( src );
+        isWorkflowPath( src ) || isExternalWorkflowPackageSpecifier( src ) ||
+        isEvaluatorsPath( src ) || isSharedEvaluatorsPath( src );
       if ( !isTargetImport ) {
         return;
       }
@@ -127,6 +148,29 @@ export default function collectTargetImports(
         isSharedEvaluatorsPath( src ), buildSharedEvaluatorsNameMap,
         sharedEvaluatorsNameCache, sharedEvaluatorImports, 'evaluatorName', 'shared evaluators'
       );
+      if ( isExternalWorkflowPackageSpecifier( src ) ) {
+        const { indexPath, exportNameMap } = resolveExternalWorkflowExportNameMap(
+          resolutionPath, src, workflowNameCache
+        );
+        for ( const s of path.node.specifiers ) {
+          if ( isImportDefaultSpecifier( s ) ) {
+            throw new Error(
+              `Default import from '${src}' is not supported; import named workflow exports ` +
+              `(e.g. import { myFlow } from '${src}').`
+            );
+          }
+          if ( isImportSpecifier( s ) ) {
+            const importedName = s.imported.name;
+            const localName = s.local.name;
+            const workflowName = exportNameMap.get( importedName );
+            if ( workflowName ) {
+              flowImports.push( { localName, workflowName } );
+            } else {
+              throw unresolvedImportError( importedName, 'workflow catalog', indexPath );
+            }
+          }
+        }
+      }
       if ( isWorkflowPath( src ) ) {
         const { named, default: defName } = buildWorkflowNameMap( absolutePath, workflowNameCache );
         for ( const s of path.node.specifiers ) {
@@ -162,7 +206,8 @@ export default function collectTargetImports(
 
       const req = firstArgument.value;
       const isTargetRequire = isStepsPath( req ) || isSharedStepsPath( req ) ||
-        isWorkflowPath( req ) || isEvaluatorsPath( req ) || isSharedEvaluatorsPath( req );
+        isWorkflowPath( req ) || isExternalWorkflowPackageSpecifier( req ) ||
+        isEvaluatorsPath( req ) || isSharedEvaluatorsPath( req );
       if ( !isTargetRequire ) {
         return;
       }
@@ -171,6 +216,27 @@ export default function collectTargetImports(
 
       // Destructured requires: const { X } = require('./steps.js')
       if ( isObjectPattern( path.node.id ) ) {
+        // External workflows are installed as a single project and export from index.js, hence the destruction
+        if ( isExternalWorkflowPackageSpecifier( req ) ) {
+          const { indexPath, exportNameMap } = resolveExternalWorkflowExportNameMap(
+            resolutionPath, req, workflowNameCache
+          );
+          const propFilter = p => isObjectProperty( p ) && isIdentifier( p.key );
+          for ( const prop of path.node.id.properties.filter( propFilter ) ) {
+            const importedName = prop.key.name;
+            const localName = getLocalNameFromDestructuredProperty( prop );
+            if ( localName ) {
+              const workflowName = exportNameMap.get( importedName );
+              if ( workflowName ) {
+                flowImports.push( { localName, workflowName } );
+              } else {
+                throw unresolvedImportError( importedName, 'workflow catalog', indexPath );
+              }
+            }
+          }
+          removeRequireDeclarator( path );
+          return;
+        }
         const cjsDescriptors = [
           {
             match: isStepsPath, buildMap: buildStepsNameMap,
@@ -208,6 +274,12 @@ export default function collectTargetImports(
       }
 
       // Default workflow require: const WF = require('./workflow.js')
+      if ( isExternalWorkflowPackageSpecifier( req ) && isIdentifier( path.node.id ) ) {
+        throw new Error(
+          `Default require() from '${req}' is not supported; use destructuring ` +
+          `(e.g. const { myFlow } = require('${req}')).`
+        );
+      }
       if ( isWorkflowPath( req ) && isIdentifier( path.node.id ) ) {
         const { default: defName } = buildWorkflowNameMap( absolutePath, workflowNameCache );
         const localName = path.node.id.name;

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.js
@@ -1,22 +1,27 @@
 import { join } from 'node:path';
 import traverseModule from '@babel/traverse';
 import {
-  buildWorkflowCatalogExportNameMap,
   buildWorkflowNameMap,
   buildEvaluatorsNameMap,
   buildSharedEvaluatorsNameMap,
   buildSharedStepsNameMap,
   buildStepsNameMap,
   getLocalNameFromDestructuredProperty,
+  isAbsoluteWorkflowJsResource,
   isEvaluatorsPath,
   isSharedEvaluatorsPath,
   isSharedStepsPath,
   isStepsPath,
-  isExternalWorkflowPackageSpecifier,
   isWorkflowPath,
-  resolveExternalWorkflowPackageEntryPath,
   toAbsolutePath
 } from '../tools.js';
+import {
+  isBareNpmSpecifier,
+  resolveBareImportSpecifiersAsWorkflows,
+  resolveBareDestructuredRequireAsWorkflows,
+  resolveBareDefaultRequireAsWorkflow
+} from '../npm_workflow_export_resolve.js';
+
 import {
   isCallExpression,
   isIdentifier,
@@ -39,17 +44,11 @@ const unresolvedImportError = ( name, fileLabel, filePath ) =>
     '(e.g. step() in steps files, evaluator() in evaluators files, workflow() in workflow files).'
   );
 
-/**
- * @param {string} resolutionPath - Absolute path used for Node resolution (resource path or synthetic).
- * @param {string} specifier - Bare package name from import/require.
- * @param {Map<string, {default: (string|null), named: Map<string,string>}>} workflowNameCache
- * @returns {{ indexPath: string, exportNameMap: Map<string, string> }}
- */
-const resolveExternalWorkflowExportNameMap = ( resolutionPath, specifier, workflowNameCache ) => {
-  const indexPath = resolveExternalWorkflowPackageEntryPath( resolutionPath, specifier );
-  const exportNameMap = buildWorkflowCatalogExportNameMap( indexPath, workflowNameCache );
-  return { indexPath, exportNameMap };
-};
+const mixedBareWorkflowImportError = ( specifier, resourcePath ) => new Error(
+  `Workflow file '${resourcePath}': import from '${specifier}' mixes workflow exports with ` +
+  'non-workflow exports, or could not resolve every binding to a workflow.js module. ' +
+  'Split npm imports so each declaration only imports workflows, or only non-workflows.'
+);
 
 const removeRequireDeclarator = path => {
   if ( isVariableDeclaration( path.parent ) && path.parent.declarations.length === 1 ) {
@@ -94,7 +93,7 @@ const collectDestructuredRequires = ( path, absolutePath, req, descriptors ) => 
  * @param {{ stepsNameCache: Map<string,Map<string,string>>, workflowNameCache: Map<string,{default:(string|null),named:Map<string,string>}> }} caches
  *  Resolved-name caches to avoid re-reading same modules.
  * @param {string} [resourcePath] - Absolute path of the file being transformed; used to resolve
- *  external workflow packages from the consumer's `node_modules`.
+ *  npm package imports from `workflow.js` via Node resolution and export following.
  * @returns {{ stepImports: Array<{localName:string,stepName:string}>,
  *  flowImports: Array<{localName:string,workflowName:string}> }} Collected info mappings.
  */
@@ -113,9 +112,28 @@ export default function collectTargetImports(
   traverse( ast, {
     ImportDeclaration: path => {
       const src = path.node.source.value;
-      // Ignore other imports
+
+      if ( isBareNpmSpecifier( src ) && isAbsoluteWorkflowJsResource( resolutionPath ) ) {
+        const outcome = resolveBareImportSpecifiersAsWorkflows( {
+          fromAbsoluteFile: resolutionPath,
+          specifier: src,
+          specifiers: path.node.specifiers,
+          workflowNameCache
+        } );
+        if ( outcome.type === 'partial' ) {
+          throw mixedBareWorkflowImportError( src, resolutionPath );
+        }
+        if ( outcome.type === 'all' ) {
+          for ( const { localName, workflowName } of outcome.bindings ) {
+            flowImports.push( { localName, workflowName } );
+          }
+          path.remove();
+          return;
+        }
+      }
+
       const isTargetImport = isStepsPath( src ) || isSharedStepsPath( src ) ||
-        isWorkflowPath( src ) || isExternalWorkflowPackageSpecifier( src ) ||
+        isWorkflowPath( src ) ||
         isEvaluatorsPath( src ) || isSharedEvaluatorsPath( src );
       if ( !isTargetImport ) {
         return;
@@ -148,29 +166,6 @@ export default function collectTargetImports(
         isSharedEvaluatorsPath( src ), buildSharedEvaluatorsNameMap,
         sharedEvaluatorsNameCache, sharedEvaluatorImports, 'evaluatorName', 'shared evaluators'
       );
-      if ( isExternalWorkflowPackageSpecifier( src ) ) {
-        const { indexPath, exportNameMap } = resolveExternalWorkflowExportNameMap(
-          resolutionPath, src, workflowNameCache
-        );
-        for ( const s of path.node.specifiers ) {
-          if ( isImportDefaultSpecifier( s ) ) {
-            throw new Error(
-              `Default import from '${src}' is not supported; import named workflow exports ` +
-              `(e.g. import { myFlow } from '${src}').`
-            );
-          }
-          if ( isImportSpecifier( s ) ) {
-            const importedName = s.imported.name;
-            const localName = s.local.name;
-            const workflowName = exportNameMap.get( importedName );
-            if ( workflowName ) {
-              flowImports.push( { localName, workflowName } );
-            } else {
-              throw unresolvedImportError( importedName, 'workflow catalog', indexPath );
-            }
-          }
-        }
-      }
       if ( isWorkflowPath( src ) ) {
         const { named, default: defName } = buildWorkflowNameMap( absolutePath, workflowNameCache );
         for ( const s of path.node.specifiers ) {
@@ -205,8 +200,39 @@ export default function collectTargetImports(
       }
 
       const req = firstArgument.value;
+
+      if ( isBareNpmSpecifier( req ) && isAbsoluteWorkflowJsResource( resolutionPath ) ) {
+        if ( isObjectPattern( path.node.id ) ) {
+          const outcome = resolveBareDestructuredRequireAsWorkflows( {
+            fromAbsoluteFile: resolutionPath,
+            specifier: req,
+            properties: path.node.id.properties,
+            workflowNameCache
+          } );
+          if ( outcome.type === 'partial' ) {
+            throw mixedBareWorkflowImportError( req, resolutionPath );
+          }
+          if ( outcome.type === 'all' ) {
+            for ( const { localName, workflowName } of outcome.bindings ) {
+              flowImports.push( { localName, workflowName } );
+            }
+            removeRequireDeclarator( path );
+            return;
+          }
+        } else if ( isIdentifier( path.node.id ) ) {
+          const outcome = resolveBareDefaultRequireAsWorkflow(
+            resolutionPath, req, path.node.id.name, workflowNameCache
+          );
+          if ( outcome.type === 'binding' ) {
+            flowImports.push( { localName: outcome.localName, workflowName: outcome.workflowName } );
+            removeRequireDeclarator( path );
+            return;
+          }
+        }
+      }
+
       const isTargetRequire = isStepsPath( req ) || isSharedStepsPath( req ) ||
-        isWorkflowPath( req ) || isExternalWorkflowPackageSpecifier( req ) ||
+        isWorkflowPath( req ) ||
         isEvaluatorsPath( req ) || isSharedEvaluatorsPath( req );
       if ( !isTargetRequire ) {
         return;
@@ -214,29 +240,7 @@ export default function collectTargetImports(
 
       const absolutePath = toAbsolutePath( fileDir, req );
 
-      // Destructured requires: const { X } = require('./steps.js')
       if ( isObjectPattern( path.node.id ) ) {
-        // External workflows are installed as a single project and export from index.js, hence the destruction
-        if ( isExternalWorkflowPackageSpecifier( req ) ) {
-          const { indexPath, exportNameMap } = resolveExternalWorkflowExportNameMap(
-            resolutionPath, req, workflowNameCache
-          );
-          const propFilter = p => isObjectProperty( p ) && isIdentifier( p.key );
-          for ( const prop of path.node.id.properties.filter( propFilter ) ) {
-            const importedName = prop.key.name;
-            const localName = getLocalNameFromDestructuredProperty( prop );
-            if ( localName ) {
-              const workflowName = exportNameMap.get( importedName );
-              if ( workflowName ) {
-                flowImports.push( { localName, workflowName } );
-              } else {
-                throw unresolvedImportError( importedName, 'workflow catalog', indexPath );
-              }
-            }
-          }
-          removeRequireDeclarator( path );
-          return;
-        }
         const cjsDescriptors = [
           {
             match: isStepsPath, buildMap: buildStepsNameMap,
@@ -273,13 +277,6 @@ export default function collectTargetImports(
         return;
       }
 
-      // Default workflow require: const WF = require('./workflow.js')
-      if ( isExternalWorkflowPackageSpecifier( req ) && isIdentifier( path.node.id ) ) {
-        throw new Error(
-          `Default require() from '${req}' is not supported; use destructuring ` +
-          `(e.g. const { myFlow } = require('${req}')).`
-        );
-      }
       if ( isWorkflowPath( req ) && isIdentifier( path.node.id ) ) {
         const { default: defName } = buildWorkflowNameMap( absolutePath, workflowNameCache );
         const localName = path.node.id.name;
@@ -290,4 +287,4 @@ export default function collectTargetImports(
   } );
 
   return { stepImports, sharedStepImports, evaluatorImports, sharedEvaluatorImports, flowImports };
-};
+}

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.spec.js
@@ -332,5 +332,70 @@ const obj = {};`;
 
     rmSync( dir, { recursive: true, force: true } );
   } );
+
+  it( 'collects ESM imports from @growthxlabs/workflows_catalog', () => {
+    const dir = mkdtempSync( join( tmpdir(), 'collect-cat-esm-' ) );
+    const pkgRoot = join( dir, 'node_modules', '@growthxlabs', 'workflows_catalog' );
+    const srcDir = join( pkgRoot, 'src' );
+    mkdirSync( join( srcDir, 'workflows', 'wf' ), { recursive: true } );
+    writeFileSync( join( pkgRoot, 'package.json' ), JSON.stringify( {
+      name: '@growthxlabs/workflows_catalog',
+      type: 'module',
+      main: './src/index.js'
+    } ) );
+    writeFileSync( join( srcDir, 'index.js' ), 'export { default as sumNumbers } from \'./workflows/wf/workflow.js\';\n' );
+    writeFileSync( join( srcDir, 'workflows', 'wf', 'workflow.js' ), 'export default workflow({ name: \'cat.flow\' });\n' );
+
+    const fileDir = join( dir, 'consumer' );
+    mkdirSync( fileDir, { recursive: true } );
+    const resourcePath = join( fileDir, 'workflow.js' );
+
+    const source = `
+import { sumNumbers as SN } from '@growthxlabs/workflows_catalog';
+const x = 1;`;
+    const ast = makeAst( source, resourcePath );
+
+    const { flowImports } = collectTargetImports(
+      ast,
+      fileDir,
+      { stepsNameCache: new Map(), evaluatorsNameCache: new Map(), workflowNameCache: new Map() },
+      resourcePath
+    );
+    expect( flowImports ).toEqual( [ { localName: 'SN', workflowName: 'cat.flow' } ] );
+    expect( ast.program.body.find( n => n.type === 'ImportDeclaration' ) ).toBeUndefined();
+
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'collects CJS destructured require from @growthxlabs/workflows_catalog', () => {
+    const dir = mkdtempSync( join( tmpdir(), 'collect-cat-cjs-' ) );
+    const pkgRoot = join( dir, 'node_modules', '@growthxlabs', 'workflows_catalog' );
+    const srcDir = join( pkgRoot, 'src' );
+    mkdirSync( join( srcDir, 'workflows', 'wf' ), { recursive: true } );
+    writeFileSync( join( pkgRoot, 'package.json' ), JSON.stringify( {
+      name: '@growthxlabs/workflows_catalog',
+      type: 'module',
+      main: './src/index.js'
+    } ) );
+    writeFileSync( join( srcDir, 'index.js' ), 'export { default as sumNumbers } from \'./workflows/wf/workflow.js\';\n' );
+    writeFileSync( join( srcDir, 'workflows', 'wf', 'workflow.js' ), 'export default workflow({ name: \'cat.flow2\' });\n' );
+
+    const fileDir = join( dir, 'consumer' );
+    mkdirSync( fileDir, { recursive: true } );
+    const resourcePath = join( fileDir, 'workflow.js' );
+
+    const source = 'const { sumNumbers } = require( \'@growthxlabs/workflows_catalog\' );\nconst x = 1;';
+    const ast = makeAst( source, resourcePath );
+
+    const { flowImports } = collectTargetImports(
+      ast,
+      fileDir,
+      { stepsNameCache: new Map(), evaluatorsNameCache: new Map(), workflowNameCache: new Map() },
+      resourcePath
+    );
+    expect( flowImports ).toEqual( [ { localName: 'sumNumbers', workflowName: 'cat.flow2' } ] );
+
+    rmSync( dir, { recursive: true, force: true } );
+  } );
 } );
 

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.spec.js
@@ -341,7 +341,8 @@ const obj = {};`;
     writeFileSync( join( pkgRoot, 'package.json' ), JSON.stringify( {
       name: '@growthxlabs/workflows_catalog',
       type: 'module',
-      main: './src/index.js'
+      main: './src/index.js',
+      dependencies: { '@outputai/core': '1.0.0' }
     } ) );
     writeFileSync( join( srcDir, 'index.js' ), 'export { default as sumNumbers } from \'./workflows/wf/workflow.js\';\n' );
     writeFileSync( join( srcDir, 'workflows', 'wf', 'workflow.js' ), 'export default workflow({ name: \'cat.flow\' });\n' );
@@ -375,7 +376,8 @@ const x = 1;`;
     writeFileSync( join( pkgRoot, 'package.json' ), JSON.stringify( {
       name: '@growthxlabs/workflows_catalog',
       type: 'module',
-      main: './src/index.js'
+      main: './src/index.js',
+      dependencies: { '@outputai/core': '1.0.0' }
     } ) );
     writeFileSync( join( srcDir, 'index.js' ), 'export { default as sumNumbers } from \'./workflows/wf/workflow.js\';\n' );
     writeFileSync( join( srcDir, 'workflows', 'wf', 'workflow.js' ), 'export default workflow({ name: \'cat.flow2\' });\n' );

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.mjs
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.mjs
@@ -34,7 +34,8 @@ export default function stepImportRewriterAstLoader( source, inputMap ) {
     const filename = this.resourcePath;
     const ast = parse( String( source ), filename );
     const fileDir = dirname( filename );
-    const { stepImports, sharedStepImports, evaluatorImports, sharedEvaluatorImports, flowImports } = collectTargetImports( ast, fileDir, cache );
+    const { stepImports, sharedStepImports, evaluatorImports, sharedEvaluatorImports, flowImports } =
+      collectTargetImports( ast, fileDir, cache, filename );
 
     // No imports
     if ( [].concat( stepImports, sharedStepImports, evaluatorImports, sharedEvaluatorImports, flowImports ).length === 0 ) {

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.spec.js
@@ -204,7 +204,8 @@ const obj = {
     writeFileSync( join( pkgRoot, 'package.json' ), JSON.stringify( {
       name: '@growthxlabs/workflows_catalog',
       type: 'module',
-      main: './src/index.js'
+      main: './src/index.js',
+      dependencies: { '@outputai/core': '1.0.0' }
     } ) );
     writeFileSync( join( srcDir, 'index.js' ), 'export { default as sumNumbers } from \'./workflows/wf/workflow.js\';\n' );
     writeFileSync( join( srcDir, 'workflows', 'wf', 'workflow.js' ), 'export default workflow({ name: \'nest.cat\' });\n' );
@@ -225,6 +226,44 @@ const obj = {
 
     expect( code ).not.toMatch( /@growthxlabs\/workflows_catalog/ );
     expect( code ).toMatch( /this\.startWorkflow\('nest\.cat',\s*1\)/ );
+
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'rewrites imports through the output workflow bundle export condition', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'ast-loader-catalog-condition-' ) );
+    const pkgRoot = join( dir, 'node_modules', '@test', 'conditional_catalog' );
+    mkdirSync( join( pkgRoot, 'bundle' ), { recursive: true } );
+    writeFileSync( join( pkgRoot, 'package.json' ), JSON.stringify( {
+      name: '@test/conditional_catalog',
+      type: 'module',
+      main: './node-entry.js',
+      exports: {
+        '.': {
+          'output-workflow-bundle': './bundle/workflow.js',
+          default: './node-entry.js'
+        }
+      }
+    } ) );
+    writeFileSync( join( pkgRoot, 'node-entry.js' ), 'export const helper = () => 1;\n' );
+    writeFileSync( join( pkgRoot, 'bundle', 'workflow.js' ), 'export default workflow({ name: \'bundle.cat\' });\n' );
+
+    const resourcePath = join( dir, 'workflows', 'mine', 'workflow.js' );
+    mkdirSync( dirname( resourcePath ), { recursive: true } );
+
+    const source = `
+import BundleCatalog from '@test/conditional_catalog';
+
+const obj = {
+  fn: async () => {
+    BundleCatalog( 1 );
+  }
+}`;
+
+    const { code } = await runLoader( source, resourcePath );
+
+    expect( code ).not.toMatch( /@test\/conditional_catalog/ );
+    expect( code ).toMatch( /this\.startWorkflow\('bundle\.cat',\s*1\)/ );
 
     rmSync( dir, { recursive: true, force: true } );
   } );

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import loader from './index.mjs';
 
 function runLoader( source, resourcePath ) {
@@ -192,6 +192,39 @@ const obj = {
     expect( code ).not.toMatch( /require\('\.\.\/\.\.\/shared\/evaluators\/common\.js'\)/ );
     expect( code ).toMatch( /fn:\s*async function \(y\)/ );
     expect( code ).toMatch( /this\.invokeSharedEvaluator\('shared\.eval'\)/ );
+
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'rewrites ESM imports from @growthxlabs/workflows_catalog to startWorkflow', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'ast-loader-catalog-' ) );
+    const pkgRoot = join( dir, 'node_modules', '@growthxlabs', 'workflows_catalog' );
+    const srcDir = join( pkgRoot, 'src' );
+    mkdirSync( join( srcDir, 'workflows', 'wf' ), { recursive: true } );
+    writeFileSync( join( pkgRoot, 'package.json' ), JSON.stringify( {
+      name: '@growthxlabs/workflows_catalog',
+      type: 'module',
+      main: './src/index.js'
+    } ) );
+    writeFileSync( join( srcDir, 'index.js' ), 'export { default as sumNumbers } from \'./workflows/wf/workflow.js\';\n' );
+    writeFileSync( join( srcDir, 'workflows', 'wf', 'workflow.js' ), 'export default workflow({ name: \'nest.cat\' });\n' );
+
+    const resourcePath = join( dir, 'workflows', 'mine', 'workflow.js' );
+    mkdirSync( dirname( resourcePath ), { recursive: true } );
+
+    const source = `
+import { sumNumbers } from '@growthxlabs/workflows_catalog';
+
+const obj = {
+  fn: async () => {
+    sumNumbers( 1 );
+  }
+}`;
+
+    const { code } = await runLoader( source, resourcePath );
+
+    expect( code ).not.toMatch( /@growthxlabs\/workflows_catalog/ );
+    expect( code ).toMatch( /this\.startWorkflow\('nest\.cat',\s*1\)/ );
 
     rmSync( dir, { recursive: true, force: true } );
   } );

--- a/sdk/core/src/worker/webpack_loaders/workflow_validator/index.mjs
+++ b/sdk/core/src/worker/webpack_loaders/workflow_validator/index.mjs
@@ -1,6 +1,14 @@
 import traverseModule from '@babel/traverse';
 import { dirname } from 'node:path';
-import { parse, toAbsolutePath, getFileKind, isAnyStepsPath, isAnyEvaluatorsPath, isWorkflowPath } from '../tools.js';
+import {
+  parse,
+  toAbsolutePath,
+  getFileKind,
+  isAnyStepsPath,
+  isAnyEvaluatorsPath,
+  isWorkflowPath,
+  isExternalWorkflowPackageSpecifier
+} from '../tools.js';
 import { ComponentFile } from '../consts.js';
 import {
   isCallExpression,
@@ -95,6 +103,15 @@ export default function workflowValidatorLoader( source, inputMap ) {
       ImportDeclaration: path => {
         const specifier = path.node.source.value;
 
+        if ( isExternalWorkflowPackageSpecifier( specifier ) ) {
+          for ( const s of path.node.specifiers ) {
+            if ( isImportSpecifier( s ) || isImportDefaultSpecifier( s ) ) {
+              importedWorkflowIds.add( s.local.name );
+            }
+          }
+          return;
+        }
+
         // Collect imported identifiers for later call checks
         const importedKind = getFileKind( specifier );
         const accumulator = ( {
@@ -140,6 +157,18 @@ export default function workflowValidatorLoader( source, inputMap ) {
             return;
           }
           const req = firstArg.value;
+
+          if ( isExternalWorkflowPackageSpecifier( req ) ) {
+            if ( isObjectPattern( path.node.id ) ) {
+              for ( const prop of path.node.id.properties ) {
+                if ( isObjectProperty( prop ) && isIdentifier( prop.value ) ) {
+                  importedWorkflowIds.add( prop.value.name );
+                }
+              }
+            } else if ( isIdentifier( path.node.id ) ) {
+              importedWorkflowIds.add( path.node.id.name );
+            }
+          }
 
           // Collect imported identifiers from require patterns
           const reqType = getFileKind( toAbsolutePath( fileDir, req ) );

--- a/sdk/core/src/worker/webpack_loaders/workflow_validator/index.mjs
+++ b/sdk/core/src/worker/webpack_loaders/workflow_validator/index.mjs
@@ -7,8 +7,27 @@ import {
   isAnyStepsPath,
   isAnyEvaluatorsPath,
   isWorkflowPath,
-  isExternalWorkflowPackageSpecifier
+  isAbsoluteWorkflowJsResource
 } from '../tools.js';
+
+/**
+ * Files where a bare npm import may bind to child workflows (catalog packages, etc.).
+ * Matches {@link collectTargetImports} for `workflow.js`; steps/evaluators need the same
+ * binding knowledge for fn-body validation only.
+ * @param {string} filename - Absolute resource path.
+ * @returns {boolean}
+ */
+const fileMayBindBareNpmWorkflowImports = filename => {
+  const n = filename.replace( /\\/g, '/' );
+  return isAbsoluteWorkflowJsResource( filename ) ||
+    isAnyStepsPath( n ) || isAnyEvaluatorsPath( n );
+};
+import {
+  isBareNpmSpecifier,
+  resolveBareImportSpecifiersAsWorkflows,
+  resolveBareDestructuredRequireAsWorkflows,
+  resolveBareDefaultRequireAsWorkflow
+} from '../npm_workflow_export_resolve.js';
 import { ComponentFile } from '../consts.js';
 import {
   isCallExpression,
@@ -103,10 +122,16 @@ export default function workflowValidatorLoader( source, inputMap ) {
       ImportDeclaration: path => {
         const specifier = path.node.source.value;
 
-        if ( isExternalWorkflowPackageSpecifier( specifier ) ) {
-          for ( const s of path.node.specifiers ) {
-            if ( isImportSpecifier( s ) || isImportDefaultSpecifier( s ) ) {
-              importedWorkflowIds.add( s.local.name );
+        if ( isBareNpmSpecifier( specifier ) && fileMayBindBareNpmWorkflowImports( filename ) ) {
+          const outcome = resolveBareImportSpecifiersAsWorkflows( {
+            fromAbsoluteFile: filename,
+            specifier,
+            specifiers: path.node.specifiers,
+            workflowNameCache: new Map()
+          } );
+          if ( outcome.type === 'all' ) {
+            for ( const { localName } of outcome.bindings ) {
+              importedWorkflowIds.add( localName );
             }
           }
           return;
@@ -158,15 +183,26 @@ export default function workflowValidatorLoader( source, inputMap ) {
           }
           const req = firstArg.value;
 
-          if ( isExternalWorkflowPackageSpecifier( req ) ) {
+          if ( isBareNpmSpecifier( req ) && fileMayBindBareNpmWorkflowImports( filename ) ) {
             if ( isObjectPattern( path.node.id ) ) {
-              for ( const prop of path.node.id.properties ) {
-                if ( isObjectProperty( prop ) && isIdentifier( prop.value ) ) {
-                  importedWorkflowIds.add( prop.value.name );
+              const outcome = resolveBareDestructuredRequireAsWorkflows( {
+                fromAbsoluteFile: filename,
+                specifier: req,
+                properties: path.node.id.properties,
+                workflowNameCache: new Map()
+              } );
+              if ( outcome.type === 'all' ) {
+                for ( const { localName } of outcome.bindings ) {
+                  importedWorkflowIds.add( localName );
                 }
               }
             } else if ( isIdentifier( path.node.id ) ) {
-              importedWorkflowIds.add( path.node.id.name );
+              const outcome = resolveBareDefaultRequireAsWorkflow(
+                filename, req, path.node.id.name, new Map()
+              );
+              if ( outcome.type === 'binding' ) {
+                importedWorkflowIds.add( outcome.localName );
+              }
             }
           }
 

--- a/sdk/core/src/worker/webpack_loaders/workflow_validator/index.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_validator/index.spec.js
@@ -4,6 +4,28 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import validatorLoader from './index.mjs';
 
+/**
+ * Minimal published catalog under `dir/node_modules` so `require.resolve` / export following works.
+ * @param {string} dir - Temp project root containing `steps.js` / `workflow.js` under test.
+ * @param {string} workflowName - Declared workflow `name` in the leaf `workflow.js`.
+ */
+const writeMockGrowthxlabsCatalog = ( dir, workflowName ) => {
+  const pkgRoot = join( dir, 'node_modules', '@growthxlabs', 'workflows_catalog' );
+  const srcDir = join( pkgRoot, 'src' );
+  mkdirSync( join( srcDir, 'workflows', 'wf' ), { recursive: true } );
+  writeFileSync( join( pkgRoot, 'package.json' ), JSON.stringify( {
+    name: '@growthxlabs/workflows_catalog',
+    type: 'module',
+    main: './src/index.js',
+    dependencies: { '@outputai/core': '1.0.0' }
+  } ) );
+  writeFileSync( join( srcDir, 'index.js' ), 'export { default as sumNumbers } from \'./workflows/wf/workflow.js\';\n' );
+  writeFileSync(
+    join( srcDir, 'workflows', 'wf', 'workflow.js' ),
+    `export default workflow({ name: '${workflowName}' });\n`
+  );
+};
+
 function runLoader( filename, source ) {
   return new Promise( ( resolve, reject ) => {
     const warnings = [];
@@ -78,6 +100,7 @@ describe( 'workflow_validator loader', () => {
 
   it( 'steps.js: warns when calling imported catalog workflow inside fn', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'steps-catalog-warn-' ) );
+    writeMockGrowthxlabsCatalog( dir, 'cat.warn' );
     const src = [
       'import { sumNumbers } from "@growthxlabs/workflows_catalog";',
       'const A = step({ name: "a", fn: async () => ({}) });',
@@ -91,6 +114,7 @@ describe( 'workflow_validator loader', () => {
 
   it( 'evaluators.js: warns when calling catalog workflow inside fn (require)', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'evals-catalog-warn-' ) );
+    writeMockGrowthxlabsCatalog( dir, 'cat.warn.req' );
     const src = [
       'const { sumNumbers } = require("@growthxlabs/workflows_catalog");',
       'const E = evaluator({ name: "e", fn: async () => ({ value: 1 }) });',
@@ -104,6 +128,7 @@ describe( 'workflow_validator loader', () => {
 
   it( 'workflow.js: allows import from @growthxlabs/workflows_catalog', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'wf-catalog-allow-' ) );
+    writeMockGrowthxlabsCatalog( dir, 'cat.allow' );
     const src = [
       'import { sumNumbers } from "@growthxlabs/workflows_catalog";',
       'const x = 1;'

--- a/sdk/core/src/worker/webpack_loaders/workflow_validator/index.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_validator/index.spec.js
@@ -76,6 +76,43 @@ describe( 'workflow_validator loader', () => {
     rmSync( dir, { recursive: true, force: true } );
   } );
 
+  it( 'steps.js: warns when calling imported catalog workflow inside fn', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'steps-catalog-warn-' ) );
+    const src = [
+      'import { sumNumbers } from "@growthxlabs/workflows_catalog";',
+      'const A = step({ name: "a", fn: async () => ({}) });',
+      'const obj = { fn: function() { sumNumbers(); } };'
+    ].join( '\n' );
+    const result = await runLoader( join( dir, 'steps.js' ), src );
+    expect( result.warnings ).toHaveLength( 1 );
+    expect( result.warnings[0].message ).toMatch( /Invalid call in .*steps\.js fn: calling a workflow/ );
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'evaluators.js: warns when calling catalog workflow inside fn (require)', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'evals-catalog-warn-' ) );
+    const src = [
+      'const { sumNumbers } = require("@growthxlabs/workflows_catalog");',
+      'const E = evaluator({ name: "e", fn: async () => ({ value: 1 }) });',
+      'const obj = { fn: function() { sumNumbers(); } };'
+    ].join( '\n' );
+    const result = await runLoader( join( dir, 'evaluators.js' ), src );
+    expect( result.warnings ).toHaveLength( 1 );
+    expect( result.warnings[0].message ).toMatch( /Invalid call in .*evaluators\.js fn: calling a workflow/ );
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'workflow.js: allows import from @growthxlabs/workflows_catalog', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'wf-catalog-allow-' ) );
+    const src = [
+      'import { sumNumbers } from "@growthxlabs/workflows_catalog";',
+      'const x = 1;'
+    ].join( '\n' );
+    const result = await runLoader( join( dir, 'workflow.js' ), src );
+    expect( result.warnings ).toHaveLength( 0 );
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
   it( 'steps.js: warns when calling another step inside fn', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'steps-call-reject-' ) );
     // Can only test same-type components since cross-type declarations are now blocked by instantiation validation

--- a/test_workflows/package.json
+++ b/test_workflows/package.json
@@ -12,6 +12,7 @@
     "output:worker:watch": "npx nodemon --watch src --watch package.json --ext ts,js,json,prompt,md --ignore 'dist/**' --ignore '**/*.test.*' --exec 'npm run output:worker'"
   },
   "dependencies": {
+    "@growthxlabs/workflows_catalog": "0.0.3",
     "@outputai/core": "workspace:^",
     "@outputai/credentials": "workspace:^",
     "@outputai/evals": "workspace:^",

--- a/test_workflows/package.json
+++ b/test_workflows/package.json
@@ -21,7 +21,7 @@
     "@temporalio/workflow": "catalog:",
     "nodemon": "3.1.14"
   },
-  "output": {
+  "@outputai/config": {
     "hookFiles": [
       "./src/hooks.js"
     ]

--- a/test_workflows/package.json
+++ b/test_workflows/package.json
@@ -21,7 +21,7 @@
     "@temporalio/workflow": "catalog:",
     "nodemon": "3.1.14"
   },
-  "@outputai/config": {
+  "outputai": {
     "hookFiles": [
       "./src/hooks.js"
     ]

--- a/test_workflows/package.json
+++ b/test_workflows/package.json
@@ -12,7 +12,7 @@
     "output:worker:watch": "npx nodemon --watch src --watch package.json --ext ts,js,json,prompt,md --ignore 'dist/**' --ignore '**/*.test.*' --exec 'npm run output:worker'"
   },
   "dependencies": {
-    "@growthxlabs/workflows_catalog": "0.0.3",
+    "@growthxlabs/workflows_catalog": "0.0.12",
     "@outputai/core": "workspace:^",
     "@outputai/credentials": "workspace:^",
     "@outputai/evals": "workspace:^",

--- a/test_workflows/src/workflows/nested_external/workflow.ts
+++ b/test_workflows/src/workflows/nested_external/workflow.ts
@@ -1,0 +1,19 @@
+import { workflow, z } from '@outputai/core';
+import { sumNumbers } from '@growthxlabs/workflows_catalog';
+
+export default workflow( {
+  name: 'nested_external',
+  description: 'A workflow to test nested external workflows workflows',
+  outputSchema: z.object( {
+    values: z.array( z.number() ),
+    result: z.array( z.number() )
+  } ),
+  fn: async () => {
+    const values = [ 3, 2, 1 ];
+    const result : number[] = [];
+
+    result.push( ( await sumNumbers( { values } ) ).result );
+
+    return { values, result };
+  }
+} );

--- a/test_workflows/src/workflows/nested_external/workflow.ts
+++ b/test_workflows/src/workflows/nested_external/workflow.ts
@@ -1,19 +1,19 @@
 import { workflow, z } from '@outputai/core';
-import { sumNumbers } from '@growthxlabs/workflows_catalog';
+import { processNumbers } from '@growthxlabs/workflows_catalog';
 
 export default workflow( {
   name: 'nested_external',
   description: 'A workflow to test nested external workflows workflows',
   outputSchema: z.object( {
     values: z.array( z.number() ),
-    result: z.array( z.number() )
+    summation: z.number(),
+    subtraction: z.number()
   } ),
   fn: async () => {
     const values = [ 3, 2, 1 ];
-    const result : number[] = [];
 
-    result.push( ( await sumNumbers( { values } ) ).result );
+    const { summation, subtraction } = await processNumbers( { values } );
 
-    return { values, result };
+    return { values, summation, subtraction };
   }
 } );


### PR DESCRIPTION
## Summary

Adding support to run workflows imported from installed packages:
```js
import { someWorkflow } from 'some-package';
import { workflow } from '@outputai/core';

export default workflow( {
  name: 'myWorkflow',
  fn: async ( ) => {
    await someWorkflow();
  }
} );

```

When the worker starts, it will look for all packages that have `output.workflows.expose: true` config flag in their `package.json`. For each package, it will load all workflows, activities and shared activities (steps/evaluators), the same way it loads for the local code.

If the same workflow is resolved from multiple dependencies (via symlinks) they are de-duplicated.

Workflow and shared activities can still collided with local ones if they have the same name. I evaluated the idea of creating sub namespaces for them, but I took the stance to first check if this is indeed a problem in the real world, as workflow packages will likely have their own name schema.

In order to create a project that exposes workflows, it just need to:
1. Follow the standard convetion for Output projects: `workflow.js`, `steps.js`, etc;
2. Exports the workflows, this can be a barrel export, or named exports;
3. Add this to the `package.json`:
```json
{
   ...
   "output": {
     "workflows": {
       "expose": true
     }
   }
}
```
4. Add a build step that builds it to `.js` with `.d.ts` files.

### Worker load logs
#### External workflows
<img width="1512" height="190" alt="image" src="https://github.com/user-attachments/assets/91cf1f42-edde-430b-8339-631fa1d810e3" />

#### External activities
<img width="1512" height="190" alt="image" src="https://github.com/user-attachments/assets/39f63665-8300-4925-af31-b8b1e85b823b" />


## Test plan

[x] Manual
[x] Unit
[x] e2e
