### PR TITLE
fix: quote SKILL.md description containing colon

### DIFF
--- a/coding_assistants/claude/plugins/outputai/skills/output-credentials-env-vars/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-credentials-env-vars/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: output-credentials-env-vars
-description: Wire encrypted credentials to environment variables using the credential: convention. Use when setting up LLM provider keys (ANTHROPIC_API_KEY, OPENAI_API_KEY) or any env var that should come from encrypted credentials.
+description: "Wire encrypted credentials to environment variables using the credential: convention. Use when setting up LLM provider keys (ANTHROPIC_API_KEY, OPENAI_API_KEY) or any env var that should come from encrypted credentials."
 allowed-tools: [Read, Edit, Bash, Glob]
 ---
 


### PR DESCRIPTION
The frontmatter description in `coding_assistants/claude/plugins/outputai/skills/output-credentials-env-vars/SKILL.md` contains an unquoted colon (`credential:` mid-sentence), which YAML parses as a nested mapping rather than a plain scalar. Strict YAML validators reject the file with:

> YAML Parse error: Unexpected token

Wrapping the description in double quotes makes it parse cleanly while preserving the exact text. All other SKILL.md and agent frontmatter in the plugin parses without changes.

### Diff

```diff
-description: Wire encrypted credentials to environment variables using the credential: convention. ...
+description: "Wire encrypted credentials to environment variables using the credential: convention. ..."
```

### Verification

```ruby
require 'yaml'
content = File.read('skills/output-credentials-env-vars/SKILL.md')
YAML.safe_load(content.split('---', 3)[1])
# => parses cleanly, all fields preserved
```