### PR TITLE
ci(ops): publish api docker image for amd64 and arm64

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,12 @@ jobs:
           node-version: '24.15.0'
           cache: 'pnpm'
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Publish API
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/publish_dev.yml
+++ b/.github/workflows/publish_dev.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Bumping version
         run: ./ops/bump_prerelease.sh "dev.${GITHUB_SHA:0:7}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Publish API
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/publish_next.yml
+++ b/.github/workflows/publish_next.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Bumping version
         run: ./ops/bump_prerelease.sh "next.${GITHUB_SHA:0:7}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Publish API
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/ops/publish_api.sh
+++ b/ops/publish_api.sh
@@ -40,8 +40,10 @@ if [[ -z "$DOCKERHUB_USERNAME" || -z "$DOCKERHUB_TOKEN" ]]; then ./alert.sh "err
 
 image_name=$DOCKERHUB_USERNAME/api
 version=$(cat ../api/package.json | grep \"version\" | cut -d'"' -f 4)
+platforms="linux/amd64,linux/arm64"
 
 print "API Image tag: $version"
+print "Target platforms: $platforms"
 
 print "Authenticating with Dockerhub"
 echo "$DOCKERHUB_TOKEN" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
@@ -52,16 +54,28 @@ if is_tag_already_pushed "$version"; then
   exit 0
 fi
 
-print "Building image"
+# Collect tags
+tag_args=(-t "$image_name:$version")
 if [[ $no_aliases == false ]]; then
-  # Parse semver components
   IFS='.' read -r major minor _patch <<< "$version"
-  docker build ../ --file ./api.Dockerfile -t "$image_name:$version" -t "$image_name:$major" -t "$image_name:$major.$minor" -t "$image_name:latest"
-else
-  docker build ../ --file ./api.Dockerfile -t "$image_name:$version"
+  tag_args+=(-t "$image_name:$major" -t "$image_name:$major.$minor" -t "$image_name:latest")
 fi
 
-print "Publishing"
-if [[ "$dry_run" == true ]]; then printf "\e[0;33mDry run mode, skipping\n"; else docker push --all-tags $image_name; fi
+# In dry-run mode, build for all platforms but don't push.
+# Multi-platform images can't be loaded into the local docker engine, so the
+# build output goes to the build cache only — which still validates that each
+# target architecture builds successfully.
+output_args=(--push)
+if [[ "$dry_run" == true ]]; then
+  printf "\e[0;33mDry run mode, skipping push\n"
+  output_args=()
+fi
+
+print "Building and publishing image"
+docker buildx build ../ \
+  --file ./api.Dockerfile \
+  --platform "$platforms" \
+  "${tag_args[@]}" \
+  "${output_args[@]}"
 
 print "Publish Complete" "OK"


### PR DESCRIPTION
## Problem

The published `outputai/api` image is built only for the architecture of the GitHub Actions runner (`ubuntu-latest` → `linux/amd64`). Pulling it on `linux/arm64` hosts (Apple Silicon dev machines, ARM cloud nodes) silently falls back to QEMU emulation — slow, and outright broken in environments where emulation isn't available.

`ops/publish_api.sh` calls plain `docker build` + `docker push --all-tags`, neither of which produces a multi-arch manifest list.

## Solution

- **`ops/publish_api.sh`** — replaced `docker build` + `docker push --all-tags` with a single `docker buildx build --platform linux/amd64,linux/arm64 ... --push`. In `--dry-run` mode the `--push` is omitted but both architectures still build (validates the cross-arch path without touching the registry).
- **`publish.yml`, `publish_dev.yml`, `publish_next.yml`** — added `docker/setup-qemu-action@v3` and `docker/setup-buildx-action@v3` ahead of the `Publish API` step. QEMU is required for arm64 emulation on the amd64 runner; the buildx action provisions a `docker-container` driver builder (the default `docker` driver doesn't support multi-platform builds).

`mint.Dockerfile` is intentionally left alone — it's only built locally by `run.sh`, never published.

Closes OUT-435

## Test plan

- [x] `bash -n ops/publish_api.sh` — syntax clean
- [x] `npm run lint` — passes
- [x] Local cross-arch build via `docker buildx build . --file ops/api.Dockerfile --platform linux/amd64,linux/arm64` — both architectures complete the full build (pnpm install, COPY, etc.)
- [x] `Publish Dev` dispatched on this branch ([run 25396241445](https://github.com/growthxai/output/actions/runs/25396241445)) — all steps green; published `outputai/api:0.2.1-dev.82acd68.0` is a multi-arch manifest with `linux/amd64` (`sha256:5b71de52…`) and `linux/arm64` (`sha256:a930b44f…`) entries verified via `docker buildx imagetools inspect`

Ref: [OUT-435](https://linear.app/growthx/issue/OUT-435/docker-images-not-built-for-multiple-architectures)