### PR TITLE
chore(llm): bump entities to v8

### DIFF
--- a/.changeset/large-crews-tease.md
+++ b/.changeset/large-crews-tease.md
@@ -1,0 +1,5 @@
+---
+"@outputai/llm": patch
+---
+
+Bump `entities` dependency from v6 to v8. The API surface used (`encodeXML` / `decodeXML`) is unchanged, and v8's ESM-only / Node ≥ 20.19 requirements are already satisfied by this package.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -424,8 +424,8 @@ importers:
         specifier: 10.6.0
         version: 10.6.0
       entities:
-        specifier: 6.0.1
-        version: 6.0.1
+        specifier: 8.0.0
+        version: 8.0.0
       gray-matter:
         specifier: 4.0.3
         version: 4.0.3
@@ -4038,6 +4038,10 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -12079,6 +12083,8 @@ snapshots:
   entities@4.5.0: {}
 
   entities@6.0.1: {}
+
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 

--- a/sdk/llm/package.json
+++ b/sdk/llm/package.json
@@ -21,7 +21,7 @@
     "@tavily/ai-sdk": "0.4.1",
     "ai": "6.0.168",
     "decimal.js": "10.6.0",
-    "entities": "6.0.1",
+    "entities": "8.0.0",
     "gray-matter": "4.0.3",
     "liquidjs": "10.25.7"
   },


### PR DESCRIPTION
## Overview

Follow-up to #188 — bump the `entities` dependency in `@outputai/llm` from `6.0.1` to `8.0.0`.

## Problem / Solution

#188 added `entities` at v6 even though v8 was already published. This PR ships on the current major instead of an already-superseded one.

- The only consumer is [`sdk/llm/src/prompt_loader.js`](https://github.com/growthxai/output/blob/main/sdk/llm/src/prompt_loader.js) (`import { encodeXML, decodeXML } from 'entities'`). Both functions are still exported from v8 with the same single-string signature we use, so no source changes are required.
- v8's breaking changes are non-issues here:
  - **ESM-only** — `@outputai/llm` is already ESM (`"type": "module"`).
  - **Node ≥ 20.19** — repo targets Node 24.x.
  - **Removed deprecated functions** — none of them are referenced.

## Test plan

- [x] `npm run lint` — passes
- [x] `npm run build:packages` — passes
- [x] `npm test` — full suite passes (1767 tests across 147 files), including the 34 prompt-loader tests added in #188 (`sdk/llm/src/prompt_loader.spec.js`)
- [x] `pnpm why entities --filter @outputai/llm` — resolves to `entities@8.0.0`

## Notes for reviewers

- Transitive `entities@4.5.0` (via `markdown-it`/`typedoc`) and `entities@6.0.1` (via `parse5`/`mintlify`) remain in the lockfile because upstream packages haven't bumped — they're separate from our direct dep and not in our control.