### PR TITLE
fix(core): Temporal workflow cancellation was being converted to a failure [OUT-401]

### DIFF
--- a/.changeset/tame-banks-yawn.md
+++ b/.changeset/tame-banks-yawn.md
@@ -1,0 +1,5 @@
+---
+"@outputai/core": patch
+---
+
+Fixed workflows having the status 'failed' when cancelled via the API/UI. Now they are correctly marked as 'cancelled'.

--- a/docs/guides/operations/tracing.mdx
+++ b/docs/guides/operations/tracing.mdx
@@ -204,7 +204,7 @@ Child workflows appear as `kind: "workflow"` children with their own nested tree
 
 ### Continue-as-New
 
-When a workflow calls [continueAsNew](/workflows/context#continueasnew), the trace records `"<continued_as_new>"` as the output for that run. The new run keeps the same workflow ID but gets a new start time — each run produces its own trace file. To see the full chain, list trace files for that workflow name and match by workflow ID; sort by timestamp for order.
+When a workflow calls [continueAsNew](/workflows/context#continueasnew), the trace records `"<<continued_as_new>>"` as the output for that run. The new run keeps the same workflow ID but gets a new start time — each run produces its own trace file. To see the full chain, list trace files for that workflow name and match by workflow ID; sort by timestamp for order.
 
 ## Accessing Traces
 

--- a/sdk/core/src/consts.js
+++ b/sdk/core/src/consts.js
@@ -32,3 +32,7 @@ export const BusEventType = {
 
   RUNTIME_ERROR: 'runtime_error'
 };
+
+export const WorkflowSpecialOutput = {
+  CONTINUED_AS_NEW: '<<continued_as_new>>'
+};

--- a/sdk/core/src/worker/interceptors/workflow.js
+++ b/sdk/core/src/worker/interceptors/workflow.js
@@ -1,8 +1,8 @@
 // THIS RUNS IN THE TEMPORAL'S SANDBOX ENVIRONMENT
-import { workflowInfo, proxySinks, ApplicationFailure, ContinueAsNew } from '@temporalio/workflow';
+import { workflowInfo, proxySinks, ApplicationFailure, ContinueAsNew, isCancellation } from '@temporalio/workflow';
 import { memoToHeaders } from '../sandboxed_utils.js';
 import { deepMerge } from '#utils';
-import { METADATA_ACCESS_SYMBOL } from '#consts';
+import { METADATA_ACCESS_SYMBOL, WorkflowSpecialOutput } from '#consts';
 // this is a dynamic generated file with activity configs overwrites
 import stepOptions from '../temp/__activity_options.js';
 
@@ -44,7 +44,12 @@ class WorkflowExecutionInterceptor {
        * a new trace file will be generated
        */
       if ( error instanceof ContinueAsNew ) {
-        sinks.workflow.end( '<continued_as_new>' );
+        sinks.workflow.end( WorkflowSpecialOutput.CONTINUED_AS_NEW );
+        throw error;
+      }
+
+      if ( isCancellation( error ) ) {
+        sinks.workflow.error( error );
         throw error;
       }
 

--- a/sdk/core/src/worker/interceptors/workflow.spec.js
+++ b/sdk/core/src/worker/interceptors/workflow.spec.js
@@ -6,6 +6,7 @@ const workflowInfoMock = vi.fn();
 const workflowStartMock = vi.fn();
 const workflowEndMock = vi.fn();
 const workflowErrorMock = vi.fn();
+const isCancellationMock = vi.fn();
 vi.mock( '@temporalio/workflow', () => ( {
   workflowInfo: ( ...args ) => workflowInfoMock( ...args ),
   proxySinks: () => ( {
@@ -26,7 +27,8 @@ vi.mock( '@temporalio/workflow', () => ( {
       super( 'ContinueAsNew' );
       this.name = 'ContinueAsNew';
     }
-  }
+  },
+  isCancellation: ( ...args ) => isCancellationMock( ...args )
 } ) );
 
 const memoToHeadersMock = vi.fn( memo => ( memo ? { ...memo, __asHeaders: true } : {} ) );
@@ -50,6 +52,7 @@ vi.mock( '../temp/__activity_options.js', () => ( { default: stepOptionsDefault 
 describe( 'workflow interceptors', () => {
   beforeEach( () => {
     vi.clearAllMocks();
+    isCancellationMock.mockReturnValue( false );
     workflowInfoMock.mockReturnValue( { workflowType: 'MyWorkflow', memo: { executionContext: { id: 'ctx-1' } } } );
   } );
 
@@ -151,8 +154,25 @@ describe( 'workflow interceptors', () => {
       expect( error.details ).toEqual( [ meta ] );
     } );
 
+    it( 'calls sinks.workflow.error and rethrows cancellation errors without wrapping', async () => {
+      const { interceptors } = await import( './workflow.js' );
+      const { ApplicationFailure } = await import( '@temporalio/workflow' );
+      const { inbound } = interceptors();
+      const interceptor = inbound[0];
+      const cancellation = new Error( 'Workflow cancelled' );
+      const next = vi.fn().mockRejectedValue( cancellation );
+      isCancellationMock.mockReturnValue( true );
+
+      await expect( interceptor.execute( { args: [ {} ] }, next ) ).rejects.toBe( cancellation );
+      expect( isCancellationMock ).toHaveBeenCalledWith( cancellation );
+      expect( cancellation ).not.toBeInstanceOf( ApplicationFailure );
+      expect( workflowErrorMock ).toHaveBeenCalledWith( cancellation );
+      expect( workflowEndMock ).not.toHaveBeenCalled();
+    } );
+
     it( 'on ContinueAsNew calls sinks.trace.addWorkflowEventEnd and rethrows', async () => {
       const { ContinueAsNew } = await import( '@temporalio/workflow' );
+      const { WorkflowSpecialOutput } = await import( '#consts' );
       const { interceptors } = await import( './workflow.js' );
       const { inbound } = interceptors();
       const interceptor = inbound[0];
@@ -160,7 +180,7 @@ describe( 'workflow interceptors', () => {
       const next = vi.fn().mockRejectedValue( continueErr );
 
       await expect( interceptor.execute( { args: [ {} ] }, next ) ).rejects.toThrow( ContinueAsNew );
-      expect( workflowEndMock ).toHaveBeenCalledWith( '<continued_as_new>' );
+      expect( workflowEndMock ).toHaveBeenCalledWith( WorkflowSpecialOutput.CONTINUED_AS_NEW );
       expect( workflowErrorMock ).not.toHaveBeenCalled();
     } );
   } );

--- a/test_workflows/src/hooks.js
+++ b/test_workflows/src/hooks.js
@@ -1,16 +1,18 @@
 import { onError, on, onBeforeWorkerStart, onWorkflowStart, onWorkflowEnd, onWorkflowError } from '@outputai/core/hooks';
 
+const colorize = message => `\x1b[45;30m[HOOK]\x1b[0;35;1m ${message}\x1b[0m`;
+
 // custom + sub modules
-on( 'custom_event', async payload => console.log( '>>> on(custom_event) >>>', payload ) );
-on( 'cost:llm:request', payload => console.log( '>>> on(cost:llm:request) >>>', payload ) );
+on( 'custom_event', async payload => console.log( colorize( 'on(custom_event)' ), payload ) );
+on( 'cost:llm:request', payload => console.log( colorize( 'on(cost:llm:request)' ), payload ) );
 
 // Generic on error
-onError( ( { source, error, workflowName, activityName } ) => console.log( '>>> onError() >>>', { source, error, workflowName, activityName } ) );
+onError( payload => console.log( colorize( 'onError()' ), payload ) );
 
 // Worker start
-onBeforeWorkerStart( payload => console.log( '>>> onBeforeWorkerStart() >>>', payload ) );
+onBeforeWorkerStart( () => console.log( colorize( 'onBeforeWorkerStart()' ) ) );
 
 // Workflow lifecycle
-onWorkflowStart( payload => console.log( '>>> onWorkflowStart() >>>', payload ) );
-onWorkflowEnd( payload => console.log( '>>> onWorkflowEnd() >>>', payload ) );
-onWorkflowError( payload => console.log( '>>> onWorkflowError() >>>', payload ) );
+onWorkflowStart( payload => console.log( colorize( 'onWorkflowStart()' ), payload ) );
+onWorkflowEnd( payload => console.log( colorize( 'onWorkflowEnd()' ), payload ) );
+onWorkflowError( payload => console.log( colorize( 'onWorkflowError()' ), payload ) );

--- a/test_workflows/src/workflows/slow/workflow.ts
+++ b/test_workflows/src/workflows/slow/workflow.ts
@@ -1,11 +1,11 @@
-import { workflow, z } from '@outputai/core';
+import { sleep, workflow, z } from '@outputai/core';
 
 export default workflow( {
   name: 'slow',
   description: 'A workflow simulating a slow task',
   outputSchema: z.number(),
   fn: async () => {
-    await new Promise( resolve => setTimeout( resolve, 10_000 ) );
+    await sleep( '30s' );
     return 1;
   }
 } );


### PR DESCRIPTION
## Summary

When cancelling a workflow via the Temporal UI or API, it was being set as "Failed" instead of "Cancelled". This was because the error was being wrapped with an `ApplicationFailure` wrapper. This PR fixes that, plus:

- Add nice looking hooks logs in the `test_workflows/`, as a minor cosmetic improvement to test locally;
- Convert the workflow response `<continued_as_new>` to a const, this response is used when the workflow terminates upon triggering `continueAsNew()`. It is used in the trace files.

## Test plan

[x] Manual
[x] Unit
[x] e2e
