### PR TITLE
fix(core): Fixing core types and moving zod as a peer dependency

### DIFF
--- a/.changeset/spotty-humans-like.md
+++ b/.changeset/spotty-humans-like.md
@@ -1,0 +1,7 @@
+---
+"@outputai/core": patch
+---
+
+- Fix TypeScript declaration emit for exported workflows that use Zod schemas.
+- Allow TypeScript to generate `.d.ts` files for these workflows without non-portable Zod references.
+- Treat Zod as a peer dependency and avoid leaking schema-specific workflow context types through the invocation config.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,6 +323,7 @@ importers:
       winston:
         specifier: 'catalog:'
         version: 3.19.0
+    devDependencies:
       zod:
         specifier: 'catalog:'
         version: 4.3.6

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -48,7 +48,12 @@
     "redis": "5.12.1",
     "stacktrace-parser": "0.1.11",
     "undici": "catalog:",
-    "winston": "catalog:",
+    "winston": "catalog:"
+  },
+  "peerDependencies": {
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
     "zod": "catalog:"
   },
   "license": "Apache-2.0",

--- a/sdk/core/src/interface/workflow.d.ts
+++ b/sdk/core/src/interface/workflow.d.ts
@@ -139,9 +139,9 @@ export type WorkflowFunction<
  */
 export type WorkflowFunctionWrapper<WorkflowFunction> =
   [Parameters<WorkflowFunction>[0]] extends [undefined | null] ?
-    ( input?: undefined | null, config?: WorkflowInvocationConfiguration<Parameters<WorkflowFunction>[1]> ) =>
+    ( input?: undefined | null, config?: WorkflowInvocationConfiguration ) =>
     ReturnType<WorkflowFunction> :
-    ( input: Parameters<WorkflowFunction>[0], config?: WorkflowInvocationConfiguration<Parameters<WorkflowFunction>[1]> ) =>
+    ( input: Parameters<WorkflowFunction>[0], config?: WorkflowInvocationConfiguration ) =>
     ReturnType<WorkflowFunction>;
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes non-portable TypeScript declaration output for workflows that use Zod schemas through `@outputai/core`.

When downstream projects enable `declaration: true`, TypeScript needs to emit named types for exported workflows like `export default workflow(...)`. The previous `workflow` return type included the full schema-specialized `WorkflowContext<InputSchema, OutputSchema>` in the callable's optional invocation config. That caused TypeScript to serialize concrete Zod internals and produce errors such as:

```text
TS2742: The inferred type of 'default' cannot be named without a reference to '@outputai/core/node_modules/zod/v4/core'
```

The fix keeps workflow authoring strongly typed while avoiding that type leak in exported declarations.
## Changes

- Declares `zod` as a peer dependency instead of a direct runtime dependency. This lets consuming projects provide one shared Zod version, avoids nested installs under `@outputai/core`, and prevents TypeScript from seeing multiple Zod type identities when emitting declarations.
- Adds `zod` as a dev dependency for the SDK workspace. This keeps local development, tests, and typechecking self-contained while still requiring consumers to provide their own compatible Zod version.
- Simplifies the exported `workflow(...)` callable type by removing schema-specific `WorkflowContext<InputSchema, OutputSchema>` details from the optional invocation config. The callable still infers the workflow input and output types, but its test/runtime config no longer forces TypeScript to print concrete Zod schema internals.


## Changes

- Declares `zod` as a peer dependency instead of a direct runtime dependency. This lets consuming projects provide one shared Zod version, avoids nested installs under `@outputai/core`, and prevents TypeScript from seeing multiple Zod type identities when emitting declarations.
- Adds `zod` as a dev dependency for the SDK workspace. This keeps local development, tests, and typechecking self-contained while still requiring consumers to provide their own compatible Zod version.
- Simplifies the exported `workflow(...)` callable type by removing schema-specific `WorkflowContext<InputSchema, OutputSchema>` details from the optional invocation config. The callable still infers the workflow input and output types, but its test/runtime config no longer forces TypeScript to print concrete Zod schema internals.

The generalized surface is the optional `context` override passed as the second argument when invoking a workflow directly in tests. In practice, this is only used to inject workflow context behavior such as `continueAsNew`; normal workflow execution builds that context internally:

```ts
await myWorkflow(input, {
  context: {
    control: {
      // Test-only override. This is now typed from the general WorkflowContext
      // shape, not from this workflow's concrete Zod schemas.
      continueAsNew: async nextInput => nextInput,
    },
  },
});
```

The workflow definition itself remains tightly typed from its schemas:

```ts
export default workflow({
  inputSchema,
  outputSchema,
  fn: async (input, context) => {
    // input is inferred from inputSchema.
    // continueAsNew accepts the same typed input and returns the outputSchema type.
    return context.control.continueAsNew(input);
  },
});
```

## Why

The main use case is generated workflow projects that emit `.d.ts` files. They should be able to export workflows without adding manual type annotations just to work around SDK internals.

This change keeps the public API clean and portable while preserving the existing developer experience for defining and running workflows.

## Test plan

[x] manual
[x] unit
[x] e2e
