### PR TITLE
fix(cli): Surfacing docker compose startup failures in output dev

### DIFF
--- a/.changeset/quiet-dragons-wait.md
+++ b/.changeset/quiet-dragons-wait.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Fixed `output dev` hanging until the health timeout when `docker compose up` exited before creating containers. The CLI now drains and captures recent Compose output, reports early Compose exits immediately, polls status with the same project directory used to start the stack, and only treats running containers as healthy.

--- a/sdk/cli/src/commands/dev/index.spec.ts
+++ b/sdk/cli/src/commands/dev/index.spec.ts
@@ -1,6 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs/promises';
+import type { ChildProcess } from 'node:child_process';
+import { render } from 'ink';
 import * as dockerService from '#services/docker.js';
 import * as codingAgentsService from '#services/coding_agents.js';
 import Dev from './index.js';
@@ -52,14 +55,43 @@ vi.mock( '#views/dev/dev_app.js', () => ( {
   DevApp: () => null
 } ) );
 
-const createMockDockerProcess = (): dockerService.DockerComposeProcess => ( {
-  process: {
-    on: vi.fn(),
-    kill: vi.fn(),
-    stdout: { on: vi.fn() },
-    stderr: { on: vi.fn() }
-  } as any
-} );
+const createMockDockerProcess = (): ChildProcess => ( {
+  on: vi.fn(),
+  kill: vi.fn(),
+  stdout: { on: vi.fn() },
+  stderr: { on: vi.fn() }
+} as any );
+
+const getStartDockerComposeOptions = (): dockerService.StartDockerComposeOptions => {
+  const options = vi.mocked( dockerService.startDockerCompose ).mock.calls.at( -1 )?.[0];
+  if ( !options ) {
+    throw new Error( 'Expected startDockerCompose to receive options' );
+  }
+  return options;
+};
+
+const createControllableInkInstance = () => {
+  const deferred: {
+    promise: Promise<void>;
+    resolve: () => void;
+    reject: ( reason?: unknown ) => void;
+  } = {} as any;
+  deferred.promise = new Promise<void>( ( resolve, reject ) => {
+    deferred.resolve = resolve;
+    deferred.reject = reject;
+  } );
+  const instance = {
+    waitUntilExit: vi.fn( () => deferred.promise ),
+    unmount: vi.fn( ( error?: Error ) => {
+      if ( error ) {
+        deferred.reject( error );
+        return;
+      }
+      deferred.resolve();
+    } )
+  };
+  return instance;
+};
 
 describe( 'dev command', () => {
   beforeEach( () => {
@@ -225,8 +257,12 @@ describe( 'dev command', () => {
       await new Promise( resolve => setImmediate( resolve ) );
 
       expect( dockerService.startDockerCompose ).toHaveBeenCalledWith(
-        '/path/to/docker-compose-dev.yml',
-        'always' // default pull policy
+        expect.objectContaining( {
+          dockerComposePath: '/path/to/docker-compose-dev.yml',
+          pullPolicy: 'always',
+          onError: expect.any( Function ),
+          onExit: expect.any( Function )
+        } )
       );
 
       // Cancel the promise (it will be rejected but we don't care)
@@ -260,6 +296,68 @@ describe( 'dev command', () => {
 
       expect( cmd.error ).toHaveBeenCalledWith( 'Docker error', { exit: 1 } );
     } );
+
+    it( 'should surface docker compose exit failures with recent output', async () => {
+      const dockerProcess = createMockDockerProcess();
+      vi.mocked( dockerService.startDockerCompose ).mockResolvedValue( dockerProcess );
+      const inkInstance = createControllableInkInstance();
+      vi.mocked( render ).mockReturnValue( inkInstance as any );
+
+      const cmd = new Dev( [], {} as any );
+      cmd.log = vi.fn() as any;
+      cmd.error = vi.fn() as any;
+
+      Object.defineProperty( cmd, 'parse', {
+        value: vi.fn().mockResolvedValue( { flags: { 'compose-file': undefined, 'image-pull-policy': 'always' }, args: {} } ),
+        configurable: true
+      } );
+
+      const runPromise = cmd.run();
+      await new Promise( resolve => setImmediate( resolve ) );
+
+      getStartDockerComposeOptions().onExit?.( 1, null, 'failed to bind host port' );
+      await runPromise;
+
+      expect( inkInstance.unmount ).toHaveBeenCalledWith( expect.objectContaining( {
+        message: expect.stringContaining( 'Docker compose exited with code 1' )
+      } ) );
+      expect( cmd.error ).toHaveBeenCalledWith(
+        expect.stringContaining( 'Recent Docker output:\nfailed to bind host port' ),
+        { exit: 1 }
+      );
+    } );
+
+    it( 'should ignore docker compose exits triggered by cleanup', async () => {
+      const dockerProcess = createMockDockerProcess();
+      vi.mocked( dockerService.startDockerCompose ).mockResolvedValue( dockerProcess );
+      const inkInstance = createControllableInkInstance();
+      vi.mocked( render ).mockReturnValue( inkInstance as any );
+
+      const cmd = new Dev( [], {} as any );
+      cmd.log = vi.fn() as any;
+      cmd.error = vi.fn() as any;
+
+      Object.defineProperty( cmd, 'parse', {
+        value: vi.fn().mockResolvedValue( { flags: { 'compose-file': undefined, 'image-pull-policy': 'always' }, args: {} } ),
+        configurable: true
+      } );
+
+      const runPromise = cmd.run();
+      await new Promise( resolve => setImmediate( resolve ) );
+
+      const appElement = vi.mocked( render ).mock.calls[0]?.[0];
+      if ( !React.isValidElement<{ onCleanup: () => Promise<void> }>( appElement ) ) {
+        throw new Error( 'Expected render to receive a React element' );
+      }
+      const appProps = appElement.props;
+      await appProps.onCleanup();
+      getStartDockerComposeOptions().onExit?.( null, 'SIGTERM', 'compose stopped' );
+      inkInstance.unmount();
+      await runPromise;
+
+      expect( inkInstance.unmount ).not.toHaveBeenCalledWith( expect.any( Error ) );
+      expect( cmd.error ).not.toHaveBeenCalled();
+    } );
   } );
 
   describe( 'image pull policy', () => {
@@ -281,8 +379,12 @@ describe( 'dev command', () => {
       await new Promise( resolve => setImmediate( resolve ) );
 
       expect( dockerService.startDockerCompose ).toHaveBeenCalledWith(
-        '/path/to/docker-compose-dev.yml',
-        'missing'
+        expect.objectContaining( {
+          dockerComposePath: '/path/to/docker-compose-dev.yml',
+          pullPolicy: 'missing',
+          onError: expect.any( Function ),
+          onExit: expect.any( Function )
+        } )
       );
 
       // Cancel the promise (it will be rejected but we don't care)
@@ -307,8 +409,12 @@ describe( 'dev command', () => {
       await new Promise( resolve => setImmediate( resolve ) );
 
       expect( dockerService.startDockerCompose ).toHaveBeenCalledWith(
-        '/path/to/docker-compose-dev.yml',
-        'never'
+        expect.objectContaining( {
+          dockerComposePath: '/path/to/docker-compose-dev.yml',
+          pullPolicy: 'never',
+          onError: expect.any( Function ),
+          onExit: expect.any( Function )
+        } )
       );
 
       // Cancel the promise (it will be rejected but we don't care)

--- a/sdk/cli/src/commands/dev/index.ts
+++ b/sdk/cli/src/commands/dev/index.ts
@@ -85,7 +85,12 @@ export default class Dev extends Command {
       return;
     }
 
+    const state = {
+      cleaningUp: false
+    };
+
     const cleanup = async () => {
+      state.cleaningUp = true;
       this.log( '\n' );
       if ( this.dockerProcess ) {
         this.dockerProcess.kill( 'SIGTERM' );
@@ -142,13 +147,6 @@ export default class Dev extends Command {
     process.on( 'SIGTERM', handleSignal );
 
     try {
-      const { process: dockerProc } = await startDockerCompose(
-        dockerComposePath,
-        pullPolicy
-      );
-
-      this.dockerProcess = dockerProc;
-
       enterAltScreen();
 
       const instance = render(
@@ -157,13 +155,33 @@ export default class Dev extends Command {
       );
       instanceRef.current = instance;
 
-      dockerProc.on( 'error', error => {
-        instance.unmount( new Error( `Docker process error: ${getErrorMessage( error )}` ) );
+      const dockerProc = await startDockerCompose( {
+        dockerComposePath,
+        pullPolicy,
+        onError: error => {
+          instance.unmount( new Error( `Docker process error: ${getErrorMessage( error )}` ) );
+        },
+        onExit: ( code, signal, output ) => {
+          if ( state.cleaningUp ) {
+            return;
+          }
+          if ( code === 0 ) {
+            instance.unmount();
+            return;
+          }
+
+          const exitReason = signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`;
+          const detail = output ? `\n\nRecent Docker output:\n${output}` : '';
+          instance.unmount( new Error( `Docker compose exited with ${exitReason}.${detail}` ) );
+        }
       } );
+
+      this.dockerProcess = dockerProc;
 
       await instance.waitUntilExit();
       exitAltScreenOnce();
     } catch ( error ) {
+      instanceRef.current?.unmount();
       exitAltScreenOnce();
       this.error( getErrorMessage( error ), { exit: 1 } );
     }

--- a/sdk/cli/src/services/docker.spec.ts
+++ b/sdk/cli/src/services/docker.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { execFileSync, spawn } from 'node:child_process';
+import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
 import {
   parseServiceStatus, getServiceStatus,
   startDockerCompose, startDockerComposeDetached, stopDockerCompose,
@@ -12,6 +12,8 @@ vi.mock( 'node:child_process', () => ( {
   spawn: vi.fn()
 } ) );
 
+const mockChildProcess = ( process: unknown ): ChildProcess => process as ChildProcess;
+
 vi.mock( 'log-update', () => {
   const fn = vi.fn() as ReturnType<typeof vi.fn> & { done: ReturnType<typeof vi.fn> };
   fn.done = vi.fn();
@@ -21,6 +23,11 @@ vi.mock( 'log-update', () => {
 describe( 'docker service', () => {
   beforeEach( () => {
     vi.clearAllMocks();
+    vi.mocked( spawn ).mockReturnValue( mockChildProcess( {
+      on: vi.fn(),
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() }
+    } ) );
   } );
 
   afterEach( () => {
@@ -106,7 +113,12 @@ describe( 'docker service', () => {
 
       expect( execFileSync ).toHaveBeenCalledWith(
         'docker',
-        [ 'compose', '-f', '/path/to/docker-compose.yml', '--project-name', 'output-sdk', 'ps', '--all', '--format', 'json' ],
+        [
+          'compose', '-f', '/path/to/docker-compose.yml',
+          '--project-directory', process.cwd(),
+          '--project-name', 'output-sdk',
+          'ps', '--all', '--format', 'json'
+        ],
         expect.objectContaining( { encoding: 'utf-8' } )
       );
     } );
@@ -132,7 +144,7 @@ describe( 'docker service', () => {
 
   describe( 'startDockerCompose', () => {
     it( 'should pass --project-name to docker compose up', async () => {
-      await startDockerCompose( '/path/to/docker-compose.yml' );
+      await startDockerCompose( { dockerComposePath: '/path/to/docker-compose.yml' } );
       expect( spawn ).toHaveBeenCalledWith(
         'docker',
         [
@@ -146,7 +158,7 @@ describe( 'docker service', () => {
     } );
 
     it( 'should append --pull when pullPolicy is provided', async () => {
-      await startDockerCompose( '/path/to/docker-compose.yml', 'always' );
+      await startDockerCompose( { dockerComposePath: '/path/to/docker-compose.yml', pullPolicy: 'always' } );
       expect( spawn ).toHaveBeenCalledWith(
         'docker',
         [
@@ -157,6 +169,63 @@ describe( 'docker service', () => {
         ],
         expect.objectContaining( { stdio: [ 'ignore', 'pipe', 'pipe' ], cwd: process.cwd() } )
       );
+    } );
+
+    it( 'should attach docker process handlers and pass captured output', async () => {
+      const onError = vi.fn();
+      const onExit = vi.fn();
+      const processHandlers: {
+        error?: ( error: Error ) => void;
+        exit?: ( code: number | null, signal: NodeJS.Signals | null ) => void;
+      } = {};
+      const streamHandlers: {
+        stdout?: ( chunk: Buffer ) => void;
+        stderr?: ( chunk: Buffer ) => void;
+      } = {};
+      const process = {
+        on: vi.fn( ( event: 'error' | 'exit',
+          handler: ( ( error: Error ) => void ) | ( ( code: number | null, signal: NodeJS.Signals | null ) => void ) ) => {
+          if ( event === 'error' ) {
+            processHandlers.error = handler as ( error: Error ) => void;
+          } else {
+            processHandlers.exit = handler as ( code: number | null, signal: NodeJS.Signals | null ) => void;
+          }
+          return process;
+        } ),
+        stdout: {
+          on: vi.fn( ( event: 'data', handler: ( chunk: Buffer ) => void ) => {
+            streamHandlers.stdout = handler;
+            return process.stdout;
+          } )
+        },
+        stderr: {
+          on: vi.fn( ( event: 'data', handler: ( chunk: Buffer ) => void ) => {
+            streamHandlers.stderr = handler;
+            return process.stderr;
+          } )
+        }
+      };
+      vi.mocked( spawn ).mockReturnValue( mockChildProcess( process ) );
+
+      const dockerProcess = await startDockerCompose( {
+        dockerComposePath: '/path/to/docker-compose.yml',
+        pullPolicy: 'always',
+        onError,
+        onExit
+      } );
+
+      expect( dockerProcess.on ).toHaveBeenCalledWith( 'error', expect.any( Function ) );
+      expect( dockerProcess.on ).toHaveBeenCalledWith( 'exit', expect.any( Function ) );
+
+      streamHandlers.stdout?.( Buffer.from( 'starting services\n' ) );
+      streamHandlers.stderr?.( Buffer.from( 'compose failed\n' ) );
+      const error = new Error( 'Docker failed' );
+
+      processHandlers.error?.( error );
+      processHandlers.exit?.( 1, null );
+
+      expect( onError ).toHaveBeenCalledWith( error, 'starting services\ncompose failed' );
+      expect( onExit ).toHaveBeenCalledWith( 1, null, 'starting services\ncompose failed' );
     } );
   } );
 
@@ -252,6 +321,10 @@ describe( 'docker service', () => {
 
     it( 'should return false for an exited service with health: unhealthy', () => {
       expect( isServiceHealthy( { name: 'worker', state: 'exited', health: 'unhealthy', ports: [] } ) ).toBe( false );
+    } );
+
+    it( 'should return false for a created service with no health check', () => {
+      expect( isServiceHealthy( { name: 'api', state: 'created', health: 'none', ports: [] } ) ).toBe( false );
     } );
 
     it( 'should return false for a service with health: starting', () => {

--- a/sdk/cli/src/services/docker.ts
+++ b/sdk/cli/src/services/docker.ts
@@ -16,6 +16,7 @@ export const SERVICE_HEALTH = {
 
 export const SERVICE_STATE = {
   RUNNING: 'running',
+  CREATED: 'created',
   EXITED: 'exited'
 } as const;
 
@@ -144,7 +145,13 @@ export function parseServiceStatus( jsonOutput: string ): ServiceStatus[] {
 export async function getServiceStatus( dockerComposePath: string ): Promise<ServiceStatus[]> {
   const result = execFileSync(
     'docker',
-    [ 'compose', '-f', dockerComposePath, '--project-name', config.dockerServiceName, 'ps', '--all', '--format', 'json' ],
+    [
+      'compose',
+      '-f', dockerComposePath,
+      '--project-directory', process.cwd(),
+      '--project-name', config.dockerServiceName,
+      'ps', '--all', '--format', 'json'
+    ],
     { encoding: 'utf-8', cwd: process.cwd() }
   );
 
@@ -152,7 +159,7 @@ export async function getServiceStatus( dockerComposePath: string ): Promise<Ser
 }
 
 export function isServiceHealthy( service: ServiceStatus ): boolean {
-  return service.state !== SERVICE_STATE.EXITED &&
+  return service.state === SERVICE_STATE.RUNNING &&
     ( service.health === SERVICE_HEALTH.HEALTHY || service.health === SERVICE_HEALTH.NONE );
 }
 
@@ -180,16 +187,24 @@ export async function waitForServicesHealthy(
   throw new Error( 'Timeout waiting for services to become healthy' );
 }
 
-export interface DockerComposeProcess {
-  process: ChildProcess;
+export interface DockerComposeHandlers {
+  onError?: ( error: Error, output: string ) => void;
+  onExit?: ( code: number | null, signal: NodeJS.Signals | null, output: string ) => void;
 }
 
 export type PullPolicy = 'always' | 'missing' | 'never';
 
-export async function startDockerCompose(
-  dockerComposePath: string,
-  pullPolicy?: PullPolicy
-): Promise<DockerComposeProcess> {
+export interface StartDockerComposeOptions extends DockerComposeHandlers {
+  dockerComposePath: string;
+  pullPolicy?: PullPolicy;
+}
+
+export async function startDockerCompose( {
+  dockerComposePath,
+  pullPolicy,
+  onError,
+  onExit
+}: StartDockerComposeOptions ): Promise<ChildProcess> {
   const args = [
     'compose',
     '-f', dockerComposePath,
@@ -202,12 +217,30 @@ export async function startDockerCompose(
     args.push( '--pull', pullPolicy );
   }
 
+  const output = {
+    value: ''
+  };
+  const appendOutput = ( chunk: Buffer ): void => {
+    output.value = `${output.value}${chunk.toString()}`.slice( -20000 ).trimStart();
+  };
+
   const dockerProcess = spawn( 'docker', args, {
     cwd: process.cwd(),
+    // The Ink dev UI owns the terminal. Drain compose output so Docker cannot
+    // block on a full pipe, while keeping recent output for startup failures.
     stdio: [ 'ignore', 'pipe', 'pipe' ]
   } );
 
-  return { process: dockerProcess };
+  dockerProcess.stdout?.on( 'data', appendOutput );
+  dockerProcess.stderr?.on( 'data', appendOutput );
+  if ( onError ) {
+    dockerProcess.on( 'error', error => onError( error, output.value.trimEnd() ) );
+  }
+  if ( onExit ) {
+    dockerProcess.on( 'exit', ( code, signal ) => onExit( code, signal, output.value.trimEnd() ) );
+  }
+
+  return dockerProcess;
 }
 
 export function startDockerComposeDetached(


### PR DESCRIPTION
## Summary

Fixes `output dev` appearing to hang until the health timeout when `docker compose up` fails before creating containers.

Previously, the dev command started Compose and then relied on `docker compose ps` polling from the Ink UI. If Compose exited early, there were no containers to poll, so the UI kept waiting and eventually timed out without showing the real Compose error.

## Changes

- Captures and drains `docker compose up` stdout/stderr while the Ink UI owns the terminal.
- Reports Compose process failures immediately through the dev UI instead of waiting for the service health timeout.
- Includes recent Compose output in the surfaced error, so failures such as invalid config or host port conflicts are visible.
- Makes `docker compose ps` use the same `--project-directory` as `docker compose up`, so status polling checks the same Compose project context that was started.
- Tightens service health checks so only `running` containers can be considered healthy. Containers in `created` state no longer pass just because they have no healthcheck.
- Refactors `startDockerCompose` to accept an options object and return the `ChildProcess` directly. The Docker service now owns output capture and injects captured output into `onError` / `onExit` callbacks.

## Why

The root bug was observability around early Compose startup failure. `output dev` could fail to create any containers, but the CLI only showed a generic timeout because the actual Compose process exit and output were not surfaced to the user.

The fix keeps the TUI clean while still preserving the important startup diagnostics. Compose output is not written directly over Ink, but recent output is retained and shown when Compose exits with an error.

## Tests plan

Added regression coverage for:

- Compose exit failures surfacing recent output through `output dev`.
- Cleanup-triggered Compose exits being ignored.
- `startDockerCompose` wiring process handlers and passing captured stdout/stderr to callbacks.
- Status polling using `--project-directory`.
- `created` containers not counting as healthy.

Plus, tested and passing:
- manual testing (executing workflows);
- unit tests (all);
- e2e test
