### PR TITLE
fix(cli): skip re-encrypting credentials when no changes made

### DIFF
--- a/.changeset/credentials-edit-noop.md
+++ b/.changeset/credentials-edit-noop.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Fixed `output credentials edit` modifying the encrypted credentials file on disk even when the user made no changes in their editor. Because AES-GCM uses a fresh nonce per encryption, the unconditional re-write produced new ciphertext bytes and left the file dirty in git on every invocation. The command now skips the write when the post-editor plaintext is identical to the original.

--- a/sdk/cli/src/commands/credentials/edit.spec.ts
+++ b/sdk/cli/src/commands/credentials/edit.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
 import * as credentialsService from '#services/credentials_service.js';
 import CredentialsEdit from './edit.js';
 
@@ -84,6 +85,34 @@ describe( 'credentials edit command', () => {
       const cmd = createTestCommand();
 
       await expect( cmd.run() ).rejects.toThrow( 'No credentials file found' );
+    } );
+  } );
+
+  // Regression: OUT-441 — editing without making changes must not re-encrypt
+  // the file. AES-GCM uses a fresh nonce per encrypt, so an unconditional
+  // re-write produces a new ciphertext and leaves the file dirty in git.
+  describe( 'no-op edit (OUT-441)', () => {
+    it( 'should NOT call writeEncrypted when the editor returns unchanged plaintext', async () => {
+      const original = 'anthropic:\n  api_key: sk-test\n';
+      vi.mocked( credentialsService.decryptCredentials ).mockReturnValue( original );
+      vi.mocked( fs.readFileSync ).mockReturnValue( original );
+
+      const cmd = createTestCommand();
+      await cmd.run();
+
+      expect( credentialsService.writeEncrypted ).not.toHaveBeenCalled();
+    } );
+
+    it( 'should still call writeEncrypted when the editor returns modified plaintext', async () => {
+      const original = 'anthropic:\n  api_key: sk-test\n';
+      const modified = 'anthropic:\n  api_key: sk-NEW\n';
+      vi.mocked( credentialsService.decryptCredentials ).mockReturnValue( original );
+      vi.mocked( fs.readFileSync ).mockReturnValue( modified );
+
+      const cmd = createTestCommand();
+      await cmd.run();
+
+      expect( credentialsService.writeEncrypted ).toHaveBeenCalledWith( undefined, modified, undefined );
     } );
   } );
 } );

--- a/sdk/cli/src/commands/credentials/edit.ts
+++ b/sdk/cli/src/commands/credentials/edit.ts
@@ -69,6 +69,14 @@ export default class CredentialsEdit extends Command {
       // Validate YAML before saving
       parseYaml( edited );
 
+      // AES-GCM uses a fresh nonce per encrypt, so re-encrypting unchanged
+      // plaintext produces a new ciphertext. Skip the write when nothing
+      // changed to avoid leaving the file dirty in git.
+      if ( edited === plaintext ) {
+        this.log( 'No changes detected. Credentials unchanged.' );
+        return;
+      }
+
       writeEncrypted( environment, edited, workflow );
       this.log( 'Credentials saved successfully.' );
     } finally {

--- a/sdk/cli/src/services/credentials_service.integration.test.ts
+++ b/sdk/cli/src/services/credentials_service.integration.test.ts
@@ -4,6 +4,11 @@ import path from 'node:path';
 import os from 'node:os';
 import { load as parseYaml } from 'js-yaml';
 import { encrypt, decrypt, generateKey } from '@outputai/credentials';
+import {
+  initCredentials,
+  decryptCredentials,
+  writeEncrypted
+} from './credentials_service.js';
 
 describe( 'credentials service integration', () => {
   const tmpDir = fs.mkdtempSync( path.join( os.tmpdir(), 'output-creds-' ) );
@@ -82,5 +87,86 @@ describe( 'credentials service integration', () => {
       expect( parsed.anthropic.api_key ).toBe( 'sk-new-key-456' );
       expect( parsed.openai.api_key ).toBe( 'sk-openai-789' );
     } );
+  } );
+
+  // Reproduction: editing the dev credential must not touch the production
+  // credential. Reported as a partial bug report — these tests pin the
+  // cross-environment isolation invariant.
+  describe( 'multi-environment isolation', () => {
+    const withIsolatedProject = ( body: () => void ): void => {
+      const originalCwd = process.cwd();
+      const projectDir = fs.mkdtempSync( path.join( os.tmpdir(), 'output-creds-multi-env-' ) );
+      process.chdir( projectDir );
+      try {
+        body();
+      } finally {
+        process.chdir( originalCwd );
+        fs.rmSync( projectDir, { recursive: true, force: true } );
+      }
+    };
+
+    it( 'editing the development credential does not modify the production credential', () => withIsolatedProject( () => {
+      const prod = initCredentials( 'production' );
+      const dev = initCredentials( 'development' );
+
+      const prodKeyBefore = fs.readFileSync( prod.keyPath );
+      const prodCredBefore = fs.readFileSync( prod.credPath );
+      const devKeyBefore = fs.readFileSync( dev.keyPath );
+
+      writeEncrypted(
+        'development',
+        'anthropic:\n  api_key: sk-DEV-EDITED\nopenai:\n  api_key: sk-DEV-EDITED-2\n'
+      );
+
+      // Production must be byte-for-byte identical
+      expect( fs.readFileSync( prod.keyPath ).equals( prodKeyBefore ) ).toBe( true );
+      expect( fs.readFileSync( prod.credPath ).equals( prodCredBefore ) ).toBe( true );
+
+      // Dev key must not have been regenerated
+      expect( fs.readFileSync( dev.keyPath ).equals( devKeyBefore ) ).toBe( true );
+
+      // Dev credential should now contain the edited plaintext
+      expect( decryptCredentials( 'development' ) ).toContain( 'sk-DEV-EDITED' );
+
+      // Production credential should still be the original template (empty values)
+      const prodPlain = decryptCredentials( 'production' );
+      const prodParsed = parseYaml( prodPlain ) as Record<string, Record<string, string>>;
+      expect( prodParsed.anthropic.api_key ).toBe( '' );
+      expect( prodParsed.openai.api_key ).toBe( '' );
+    } ) );
+
+    it( 'editing production does not bleed into development', () => withIsolatedProject( () => {
+      const prod = initCredentials( 'production' );
+      const dev = initCredentials( 'development' );
+
+      const devKeyBefore = fs.readFileSync( dev.keyPath );
+      const devCredBefore = fs.readFileSync( dev.credPath );
+
+      writeEncrypted(
+        'production',
+        'anthropic:\n  api_key: sk-PROD-EDITED\nopenai:\n  api_key: sk-PROD-EDITED-2\n'
+      );
+
+      expect( fs.readFileSync( dev.keyPath ).equals( devKeyBefore ) ).toBe( true );
+      expect( fs.readFileSync( dev.credPath ).equals( devCredBefore ) ).toBe( true );
+
+      expect( decryptCredentials( 'production' ) ).toContain( 'sk-PROD-EDITED' );
+      expect( decryptCredentials( 'development' ) ).not.toContain( 'sk-PROD-EDITED' );
+
+      // Sanity: prod and dev still resolved to different paths/keys
+      expect( prod.keyPath ).not.toBe( dev.keyPath );
+      expect( prod.credPath ).not.toBe( dev.credPath );
+    } ) );
+
+    it( 'initializing a second environment does not mutate the first', () => withIsolatedProject( () => {
+      const prod = initCredentials( 'production' );
+      const prodKeyBytes = fs.readFileSync( prod.keyPath );
+      const prodCredBytes = fs.readFileSync( prod.credPath );
+
+      initCredentials( 'development' );
+
+      expect( fs.readFileSync( prod.keyPath ).equals( prodKeyBytes ) ).toBe( true );
+      expect( fs.readFileSync( prod.credPath ).equals( prodCredBytes ) ).toBe( true );
+    } ) );
   } );
 } );


### PR DESCRIPTION
## Overview

Fixes [OUT-441](https://linear.app/growthx/issue/OUT-441/credentials-edit-modifies-creds-files-without-changes). `output credentials edit` modified the encrypted credentials file on disk on every invocation — even when the user opened the editor and quit without making any changes — leaving the file dirty in `git status`.

## Problem

Two facts compose into the bug:

- AES-GCM uses a fresh random nonce per encryption. Our wrapper (`sdk/credentials/src/encryption.ts`) uses `managedNonce(gcm)`, so the same plaintext + same key produces different ciphertext every time.
- `credentials edit` always re-encrypted and wrote the file (`sdk/cli/src/commands/credentials/edit.ts`), regardless of whether the user touched anything.

Result: opening the file and quitting was enough to produce new ciphertext bytes on disk → unstaged change in git on every read. This also created a misleading impression of cross-environment bleed, since running `edit -e production` then `edit -e development` with no real edits left both files dirty.

## Solution

Short-circuit the write in `edit.ts` when the post-editor plaintext is byte-identical to the pre-editor plaintext. Logs `No changes detected. Credentials unchanged.` in that case.

Added:
- Unit tests in `edit.spec.ts` for both the no-op short-circuit and the modified-plaintext path.
- Integration tests in `credentials_service.integration.test.ts` pinning cross-environment isolation (editing dev does not touch prod, and vice versa).

## Test plan

- [x] `npx vitest run src/commands/credentials/` — 40 passing
- [x] `npx vitest run --config ../../vitest.integration.config.js src/services/credentials_service.integration.test.ts` — 9 passing
- [x] `npm run lint` clean
- [ ] Manual: `output credentials edit -e development`, `:q` without changes, confirm `git status` is clean