### PR TITLE
chore(docs): add Google Analytics 4 to Mintlify docs

### DIFF
--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -207,5 +207,10 @@
       "website": "https://output.ai/",
       "github": "https://github.com/growthxai/output"
     }
+  },
+  "integrations": {
+    "ga4": {
+      "measurementId": "G-NRX7GB4VG8"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds GA4 integration block to `docs/guides/docs.json` with measurement ID `G-NRX7GB4VG8`
- Follows Mintlify's [Google Analytics integration](https://www.mintlify.com/docs/integrations/analytics/google-analytics) configuration

## Test plan
- [ ] Verify pageviews appear in Google Analytics property after next Mintlify deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)