### PR TITLE
[WIP][DO NOT REVIEW] feat: trace-attributes endpoint + token_usage (cost feature)

### DIFF
--- a/.changeset/cli-docker-compose-trace-mount.md
+++ b/.changeset/cli-docker-compose-trace-mount.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+The `output dev` docker-compose template now bind-mounts `${PWD}/logs:${PWD}/logs:ro` on the `api` service. The new `GET /workflow/{id}/trace-attributes` endpoint reads the host-absolute path stored in `result.trace.destinations.local` via `fs.readFile`; without this mount the api container returned `ENOENT` and the endpoint was unusable in local dev mode. Read-only and dev-only (the same compose file isn't shipped to prod).

--- a/.changeset/runid-on-workflow-context.md
+++ b/.changeset/runid-on-workflow-context.md
@@ -1,0 +1,5 @@
+---
+"@outputai/core": minor
+---
+
+Added `runId` to the workflow context and the workflow-lifecycle hook payloads. `context.info.runId` exposes the Temporal run id for the current execution attempt; `onWorkflowStart`, `onWorkflowEnd`, and `onWorkflowError` payloads now include `runId` alongside `id` (workflow id). `executionContext` also carries `runId`, so any consumer subscribed via `on(...)` to an `emitEvent`-emitted event (e.g., `cost:llm:request`) receives `runId` automatically. Additive — existing consumers ignoring the field continue to work.

--- a/.changeset/token-usage-attribute.md
+++ b/.changeset/token-usage-attribute.md
@@ -1,0 +1,6 @@
+---
+"@outputai/core": minor
+"@outputai/llm": minor
+---
+
+Added `Tracing.Attribute.TOKEN_USAGE` (`'token_usage'`) and a parallel `token_usage:llm:request` event emitted from `endTraceWithSuccess`. LLM trace nodes now carry token usage under `attributes.token_usage` instead of `output.usage`; the duplicate `usage` field is no longer written into the LLM trace `output`. The existing `cost:llm:request` event and `attributes.cost` are unchanged.

--- a/.changeset/trace-attributes-endpoint.md
+++ b/.changeset/trace-attributes-endpoint.md
@@ -1,0 +1,8 @@
+---
+"@outputai/core": minor
+"output-api": minor
+---
+
+Added `GET /workflow/{id}/trace-attributes` and `GET /workflow/{id}/runs/{rid}/trace-attributes`, a new API endpoint pair that returns a single aggregated payload — runtime, start/finish timestamps, cost broken down by emitting event name (`cost:llm:request`, `cost:http:request`, `other`), token-usage totals, and the trace S3 URL — for completed workflow runs. Completion-only: returns 424 while the workflow is still running (matching `/result` and `/trace-log`).
+
+Also added `aggregateTraceAttributes` to `@outputai/core/sdk_tracing_tools`, the helper that walks the persisted trace tree and rolls up `attributes.cost` (grouped by node kind) and `attributes.token_usage` (across LLM nodes, with a fallback read of `output.usage` for legacy trace files). Re-exports `buildTraceTree` from the same entrypoint for callers that want to build a tree before aggregating.

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -242,6 +242,117 @@
           }
         }
       },
+      "TraceAttributesCostComponent": {
+        "type": "object",
+        "required": [
+          "name",
+          "value"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Canonical cost event name (e.g. `cost:llm:request`, `cost:http:request`, `other`)."
+          },
+          "value": {
+            "type": "number",
+            "description": "Summed USD cost for this component bucket."
+          }
+        }
+      },
+      "TraceAttributesResponse": {
+        "type": "object",
+        "description": "Aggregated cost, token usage, and runtime computed by walking the trace tree of a completed workflow run.\nComponent breakdowns under `attributes.cost.components` are grouped by the canonical event name that\nemitted them (inferred from node kind: llm/http/other). Values sum to `attributes.cost.total`.\n",
+        "required": [
+          "workflowId",
+          "runId",
+          "startTime",
+          "finishTime",
+          "runtime",
+          "attributes",
+          "traceUrl"
+        ],
+        "properties": {
+          "workflowId": {
+            "type": "string",
+            "description": "The workflow execution id"
+          },
+          "runId": {
+            "type": "string",
+            "description": "The specific run id this aggregation belongs to"
+          },
+          "startTime": {
+            "type": "integer",
+            "nullable": true,
+            "description": "ms epoch of the root trace node's start"
+          },
+          "finishTime": {
+            "type": "integer",
+            "nullable": true,
+            "description": "ms epoch of the root trace node's end"
+          },
+          "runtime": {
+            "type": "integer",
+            "nullable": true,
+            "description": "ms between finishTime and startTime, null if either timestamp is missing"
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "cost",
+              "tokenUsage"
+            ],
+            "properties": {
+              "cost": {
+                "type": "object",
+                "required": [
+                  "total",
+                  "components"
+                ],
+                "properties": {
+                  "total": {
+                    "type": "number",
+                    "description": "USD; equal to the sum of `components[].value`"
+                  },
+                  "components": {
+                    "type": "array",
+                    "description": "Cost contributions bucketed by canonical event name (llm / http / other).",
+                    "items": {
+                      "$ref": "#/components/schemas/TraceAttributesCostComponent"
+                    }
+                  }
+                }
+              },
+              "tokenUsage": {
+                "type": "object",
+                "required": [
+                  "inputTokens",
+                  "outputTokens",
+                  "cachedInputTokens",
+                  "totalTokens"
+                ],
+                "properties": {
+                  "inputTokens": {
+                    "type": "integer"
+                  },
+                  "outputTokens": {
+                    "type": "integer"
+                  },
+                  "cachedInputTokens": {
+                    "type": "integer"
+                  },
+                  "totalTokens": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          },
+          "traceUrl": {
+            "type": "string",
+            "description": "S3 URL of the underlying trace file (same value `/trace-log` returns under `data` for remote traces)."
+          }
+        }
+      },
       "WorkflowRunInfo": {
         "type": "object",
         "properties": {
@@ -1261,6 +1372,94 @@
                       "$ref": "#/components/schemas/TraceLogLocalResponse"
                     }
                   ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "424": {
+            "$ref": "#/components/responses/FailedDependency"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/workflow/{id}/trace-attributes": {
+      "get": {
+        "summary": "Get aggregated trace attributes for a completed workflow (latest run)",
+        "description": "Returns runtime, cost rolled up by event-name bucket, token-usage totals, and the trace S3 URL\nfor the latest run of the given workflow. Completion-only — returns 424 while the workflow is\nstill running, mirroring `/result` and `/trace-log`. To pin a specific run, use\n`/workflow/{id}/runs/{rid}/trace-attributes`.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The id of the workflow to retrieve trace attributes for"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The aggregated trace attributes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceAttributesResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "424": {
+            "$ref": "#/components/responses/FailedDependency"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/workflow/{id}/runs/{rid}/trace-attributes": {
+      "get": {
+        "summary": "Get aggregated trace attributes for a specific completed workflow run",
+        "description": "Returns runtime, cost rolled up by event-name bucket, token-usage totals, and the trace S3 URL\nfor the pinned workflow run. Completion-only — returns 424 while the run is still in progress.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "rid",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "The specific run id to target"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The aggregated trace attributes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceAttributesResponse"
                 }
               }
             }

--- a/api/package.json
+++ b/api/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "catalog:",
+    "@outputai/core": "workspace:",
     "@temporalio/client": "catalog:",
     "express": "5.2.1",
     "morgan": "1.10.1",

--- a/api/src/handlers/trace_attributes.js
+++ b/api/src/handlers/trace_attributes.js
@@ -3,15 +3,18 @@
  *
  * Returns a single aggregated payload per workflow run — runtime, start/finish
  * timestamps, cost rolled up by event-name bucket, token-usage totals, and the
- * S3 trace URL. Completion-only: 424 when the workflow is still running
- * (via `WorkflowNotCompletedError` from `getWorkflowResult`), 404 when the
- * workflow id is unknown, 404 with `TraceNotAvailableError` when the run
- * completed but produced no remote trace.
+ * underlying trace URL. Completion-only: 424 when the workflow is still
+ * running (via `WorkflowNotCompletedError` from `getWorkflowResult`), 404 when
+ * the workflow id is unknown, 404 with `TraceNotAvailableError` only when the
+ * run produced no trace at all (neither remote nor local). Local-mode traces
+ * are read off disk so `output dev` has parity with production — same as
+ * `/trace-log` already does.
  */
 
+import { readFile } from 'node:fs/promises';
 import { aggregateTraceAttributes } from '@outputai/core/sdk_tracing_tools';
 import { fetchTraceFromS3 } from '../clients/s3_client.js';
-import { TraceNotAvailableError } from '../clients/errors.js';
+import { TraceFileParseError, TraceNotAvailableError } from '../clients/errors.js';
 import { readPinnedRunId } from './utils.js';
 
 /**
@@ -23,12 +26,48 @@ import { readPinnedRunId } from './utils.js';
  * @property {number|null} runtime - ms (finishTime - startTime), null if either is missing
  * @property {{ cost: { total: number, components: Array<{ name: string, value: number }> },
  *              tokenUsage: { inputTokens: number, outputTokens: number, cachedInputTokens: number, totalTokens: number } }} attributes
- * @property {string} traceUrl - S3 URL of the underlying trace file
+ * @property {string} traceUrl - S3 URL or local path of the underlying trace file
  */
 
 const computeRuntime = ( startedAt, endedAt ) => {
   if ( typeof startedAt === 'number' && typeof endedAt === 'number' ) {
     return endedAt - startedAt;
+  }
+  return null;
+};
+
+/**
+ * Read and parse a local trace JSON file written by `output dev`. Throws
+ * `TraceFileParseError` on malformed JSON to match the S3 path's error shape.
+ *
+ * @param {string} localPath
+ * @returns {Promise<object>}
+ */
+const fetchTraceFromLocal = async localPath => {
+  const content = await readFile( localPath, 'utf8' );
+  try {
+    return JSON.parse( content );
+  } catch ( error ) {
+    throw new TraceFileParseError( 'Invalid trace file', localPath, error );
+  }
+};
+
+/**
+ * Resolve the trace tree and its source URL from a workflow result. Mirrors
+ * the destination-precedence in `/trace-log` (remote wins over local) and
+ * returns `null` when neither destination is set so the caller can 404.
+ *
+ * @param {{ trace?: { destinations?: { remote?: string|null, local?: string|null } } }} result
+ * @returns {Promise<{ traceTree: object, traceUrl: string }|null>}
+ */
+const loadTrace = async result => {
+  const remotePath = result?.trace?.destinations?.remote;
+  if ( remotePath ) {
+    return { traceTree: await fetchTraceFromS3( remotePath ), traceUrl: remotePath };
+  }
+  const localPath = result?.trace?.destinations?.local;
+  if ( localPath ) {
+    return { traceTree: await fetchTraceFromLocal( localPath ), traceUrl: localPath };
   }
   return null;
 };
@@ -51,12 +90,11 @@ export function createTraceAttributesHandler( client ) {
       // standard error_handler middleware — same path /result and /trace-log use.
       const result = await client.getWorkflowResult( workflowId, runId );
 
-      const remotePath = result?.trace?.destinations?.remote;
-      if ( !remotePath ) {
+      const trace = await loadTrace( result );
+      if ( !trace ) {
         return next( new TraceNotAvailableError( workflowId ) );
       }
-
-      const traceTree = await fetchTraceFromS3( remotePath );
+      const { traceTree } = trace;
 
       const startTime = typeof traceTree?.startedAt === 'number' ? traceTree.startedAt : null;
       const finishTime = typeof traceTree?.endedAt === 'number' ? traceTree.endedAt : null;
@@ -68,7 +106,7 @@ export function createTraceAttributesHandler( client ) {
         finishTime,
         runtime: computeRuntime( startTime, finishTime ),
         attributes: aggregateTraceAttributes( traceTree ),
-        traceUrl: remotePath
+        traceUrl: trace.traceUrl
       } );
     } catch ( error ) {
       return next( error );

--- a/api/src/handlers/trace_attributes.js
+++ b/api/src/handlers/trace_attributes.js
@@ -1,0 +1,77 @@
+/**
+ * Handler for the trace-attributes endpoint.
+ *
+ * Returns a single aggregated payload per workflow run — runtime, start/finish
+ * timestamps, cost rolled up by event-name bucket, token-usage totals, and the
+ * S3 trace URL. Completion-only: 424 when the workflow is still running
+ * (via `WorkflowNotCompletedError` from `getWorkflowResult`), 404 when the
+ * workflow id is unknown, 404 with `TraceNotAvailableError` when the run
+ * completed but produced no remote trace.
+ */
+
+import { aggregateTraceAttributes } from '@outputai/core/sdk_tracing_tools';
+import { fetchTraceFromS3 } from '../clients/s3_client.js';
+import { TraceNotAvailableError } from '../clients/errors.js';
+import { readPinnedRunId } from './utils.js';
+
+/**
+ * @typedef {object} TraceAttributesResponse
+ * @property {string} workflowId
+ * @property {string} runId
+ * @property {number|null} startTime - ms epoch from the root trace node
+ * @property {number|null} finishTime - ms epoch from the root trace node
+ * @property {number|null} runtime - ms (finishTime - startTime), null if either is missing
+ * @property {{ cost: { total: number, components: Array<{ name: string, value: number }> },
+ *              tokenUsage: { inputTokens: number, outputTokens: number, cachedInputTokens: number, totalTokens: number } }} attributes
+ * @property {string} traceUrl - S3 URL of the underlying trace file
+ */
+
+const computeRuntime = ( startedAt, endedAt ) => {
+  if ( typeof startedAt === 'number' && typeof endedAt === 'number' ) {
+    return endedAt - startedAt;
+  }
+  return null;
+};
+
+/**
+ * Create the trace-attributes handler with an injected temporal client.
+ * Mounted at both the latest-run shortcut and the pinned-run route, mirroring
+ * `/trace-log`.
+ *
+ * @param {object} client - Temporal client (provides `getWorkflowResult`).
+ * @returns {Function} Express request handler
+ */
+export function createTraceAttributesHandler( client ) {
+  return async ( req, res, next ) => {
+    try {
+      const workflowId = req.params.id;
+      const runId = readPinnedRunId( req );
+
+      // 424 (still running) and 404 (unknown id) bubble up from here via the
+      // standard error_handler middleware — same path /result and /trace-log use.
+      const result = await client.getWorkflowResult( workflowId, runId );
+
+      const remotePath = result?.trace?.destinations?.remote;
+      if ( !remotePath ) {
+        return next( new TraceNotAvailableError( workflowId ) );
+      }
+
+      const traceTree = await fetchTraceFromS3( remotePath );
+
+      const startTime = typeof traceTree?.startedAt === 'number' ? traceTree.startedAt : null;
+      const finishTime = typeof traceTree?.endedAt === 'number' ? traceTree.endedAt : null;
+
+      return res.json( {
+        workflowId,
+        runId: result.runId,
+        startTime,
+        finishTime,
+        runtime: computeRuntime( startTime, finishTime ),
+        attributes: aggregateTraceAttributes( traceTree ),
+        traceUrl: remotePath
+      } );
+    } catch ( error ) {
+      return next( error );
+    }
+  };
+}

--- a/api/src/handlers/trace_attributes.spec.js
+++ b/api/src/handlers/trace_attributes.spec.js
@@ -4,10 +4,16 @@ import request from 'supertest';
 
 const RID = '11111111-2222-4333-8444-555555555555';
 const REMOTE_URL = 'https://my-bucket.s3.amazonaws.com/traces/simple/2026-05-13/test-workflow-id.json';
+const LOCAL_PATH = '/Users/ben/Development/repos/growthx/os-workflows/logs/runs/simple/2026-05-13_test-workflow-id.json';
 
 const mockFetchTraceFromS3 = vi.fn();
 vi.mock( '../clients/s3_client.js', () => ( {
   fetchTraceFromS3: ( ...args ) => mockFetchTraceFromS3( ...args )
+} ) );
+
+const mockReadFile = vi.fn();
+vi.mock( 'node:fs/promises', () => ( {
+  readFile: ( ...args ) => mockReadFile( ...args )
 } ) );
 
 // errorHandler pulls in #logger -> #configs; stub both so this spec doesn't
@@ -37,6 +43,7 @@ describe( 'trace_attributes handler', () => {
   beforeEach( () => {
     vi.clearAllMocks();
     mockFetchTraceFromS3.mockReset();
+    mockReadFile.mockReset();
   } );
 
   // Realistic trace tree shape: a workflow node with two LLM children (one new
@@ -222,11 +229,11 @@ describe( 'trace_attributes handler', () => {
       .expect( 404 );
   } );
 
-  it( 'returns 404 with TraceNotAvailableError when the run completed but has no remote trace destination', async () => {
+  it( 'returns 404 with TraceNotAvailableError when the run completed but has no trace destinations at all', async () => {
     mockGetWorkflowResult.mockResolvedValue( {
       workflowId: 'test-workflow-id',
       runId: 'r-no-trace',
-      trace: { destinations: { local: '/tmp/t.json', remote: null } }
+      trace: { destinations: { local: null, remote: null } }
     } );
 
     await request( createApp() )
@@ -238,6 +245,80 @@ describe( 'trace_attributes handler', () => {
       } );
 
     expect( mockFetchTraceFromS3 ).not.toHaveBeenCalled();
+    expect( mockReadFile ).not.toHaveBeenCalled();
+  } );
+
+  it( 'reads the local trace file and returns aggregated attributes when only the local destination is set', async () => {
+    mockGetWorkflowResult.mockResolvedValue( {
+      workflowId: 'test-workflow-id',
+      runId: 'r-local',
+      trace: { destinations: { local: LOCAL_PATH, remote: null } }
+    } );
+    mockReadFile.mockResolvedValue( JSON.stringify( fixtureTrace() ) );
+
+    const res = await request( createApp() )
+      .get( '/workflow/test-workflow-id/trace-attributes' )
+      .expect( 200 );
+
+    expect( res.body ).toMatchObject( {
+      workflowId: 'test-workflow-id',
+      runId: 'r-local',
+      startTime: 1715567000000,
+      finishTime: 1715567027341,
+      runtime: 27341,
+      traceUrl: LOCAL_PATH
+    } );
+
+    expect( res.body.attributes.tokenUsage ).toEqual( {
+      inputTokens: 1500,
+      outputTokens: 300,
+      cachedInputTokens: 50,
+      totalTokens: 1800
+    } );
+
+    const byName = Object.fromEntries(
+      res.body.attributes.cost.components.map( c => [ c.name, c.value ] )
+    );
+    expect( byName['cost:llm:request'] ).toBeCloseTo( 0.3829, 10 );
+    expect( byName['cost:http:request'] ).toBeCloseTo( 0.04, 10 );
+    expect( res.body.attributes.cost.total ).toBeCloseTo( 0.4229, 10 );
+
+    expect( mockReadFile ).toHaveBeenCalledWith( LOCAL_PATH, 'utf8' );
+    expect( mockFetchTraceFromS3 ).not.toHaveBeenCalled();
+  } );
+
+  it( 'prefers the remote destination over local when both are present', async () => {
+    mockGetWorkflowResult.mockResolvedValue( {
+      workflowId: 'test-workflow-id',
+      runId: 'r-both',
+      trace: { destinations: { local: LOCAL_PATH, remote: REMOTE_URL } }
+    } );
+    mockFetchTraceFromS3.mockResolvedValue( fixtureTrace() );
+
+    const res = await request( createApp() )
+      .get( '/workflow/test-workflow-id/trace-attributes' )
+      .expect( 200 );
+
+    expect( res.body.traceUrl ).toBe( REMOTE_URL );
+    expect( mockFetchTraceFromS3 ).toHaveBeenCalledWith( REMOTE_URL );
+    expect( mockReadFile ).not.toHaveBeenCalled();
+  } );
+
+  it( 'forwards local file read errors through the error handler', async () => {
+    mockGetWorkflowResult.mockResolvedValue( {
+      workflowId: 'test-workflow-id',
+      runId: 'r-local',
+      trace: { destinations: { local: LOCAL_PATH, remote: null } }
+    } );
+    mockReadFile.mockRejectedValue( new Error( 'ENOENT: no such file' ) );
+
+    const app = express();
+    app.get( '/workflow/:id/trace-attributes', createTraceAttributesHandler( mockClient ) );
+    app.use( ( err, _req, res, _next ) => res.status( 500 ).json( { error: err.message } ) );
+
+    await request( app )
+      .get( '/workflow/test-workflow-id/trace-attributes' )
+      .expect( 500, { error: 'ENOENT: no such file' } );
   } );
 
   it( 'returns 400 when the pinned rid is not a valid UUID', async () => {

--- a/api/src/handlers/trace_attributes.spec.js
+++ b/api/src/handlers/trace_attributes.spec.js
@@ -1,0 +1,307 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+
+const RID = '11111111-2222-4333-8444-555555555555';
+const REMOTE_URL = 'https://my-bucket.s3.amazonaws.com/traces/simple/2026-05-13/test-workflow-id.json';
+
+const mockFetchTraceFromS3 = vi.fn();
+vi.mock( '../clients/s3_client.js', () => ( {
+  fetchTraceFromS3: ( ...args ) => mockFetchTraceFromS3( ...args )
+} ) );
+
+// errorHandler pulls in #logger -> #configs; stub both so this spec doesn't
+// need production env vars set.
+vi.mock( '#configs', () => ( { isProduction: false } ) );
+vi.mock( '#logger', () => ( {
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), http: vi.fn() }
+} ) );
+
+import { createTraceAttributesHandler } from './trace_attributes.js';
+import errorHandler from '../middleware/error_handler.js';
+import { WorkflowNotCompletedError } from '../clients/errors.js';
+
+describe( 'trace_attributes handler', () => {
+  const mockGetWorkflowResult = vi.fn();
+  const mockClient = { getWorkflowResult: mockGetWorkflowResult };
+
+  const createApp = () => {
+    const app = express();
+    const handler = createTraceAttributesHandler( mockClient );
+    app.get( '/workflow/:id/trace-attributes', handler );
+    app.get( '/workflow/:id/runs/:rid/trace-attributes', handler );
+    app.use( errorHandler );
+    return app;
+  };
+
+  beforeEach( () => {
+    vi.clearAllMocks();
+    mockFetchTraceFromS3.mockReset();
+  } );
+
+  // Realistic trace tree shape: a workflow node with two LLM children (one new
+  // attribute shape, one legacy output.usage shape) and an HTTP child. Same
+  // structure /trace-log already returns from S3.
+  const fixtureTrace = () => ( {
+    id: 'wf',
+    kind: 'workflow',
+    name: 'simple',
+    startedAt: 1715567000000,
+    endedAt: 1715567027341,
+    attributes: {},
+    children: [
+      {
+        id: 'llm-1',
+        kind: 'llm',
+        name: 'llm-call',
+        startedAt: 1715567001000,
+        endedAt: 1715567005000,
+        attributes: {
+          cost: { total: 0.3, components: [ { name: 'input_tokens', value: 0.1 }, { name: 'output_tokens', value: 0.2 } ] },
+          token_usage: { inputTokens: 1000, outputTokens: 200, cachedInputTokens: 50, totalTokens: 1200 }
+        },
+        output: { result: '...' },
+        children: []
+      },
+      {
+        id: 'llm-2-legacy',
+        kind: 'llm',
+        name: 'llm-call-legacy',
+        startedAt: 1715567006000,
+        endedAt: 1715567010000,
+        // No attributes.token_usage on this node — must fall back to output.usage.
+        attributes: { cost: { total: 0.0829 } },
+        output: { result: '...', usage: { inputTokens: 500, outputTokens: 100, totalTokens: 600 } },
+        children: []
+      },
+      {
+        id: 'http-1',
+        kind: 'http',
+        name: 'gx-scraper',
+        startedAt: 1715567011000,
+        endedAt: 1715567012000,
+        attributes: { cost: { total: 0.04 } },
+        children: []
+      }
+    ]
+  } );
+
+  it( 'returns 200 with the full aggregated payload for a completed workflow', async () => {
+    mockGetWorkflowResult.mockResolvedValue( {
+      workflowId: 'test-workflow-id',
+      runId: 'r-remote',
+      trace: { destinations: { local: null, remote: REMOTE_URL } }
+    } );
+    mockFetchTraceFromS3.mockResolvedValue( fixtureTrace() );
+
+    const res = await request( createApp() )
+      .get( '/workflow/test-workflow-id/trace-attributes' )
+      .expect( 200 );
+
+    expect( res.body ).toMatchObject( {
+      workflowId: 'test-workflow-id',
+      runId: 'r-remote',
+      startTime: 1715567000000,
+      finishTime: 1715567027341,
+      runtime: 27341,
+      traceUrl: REMOTE_URL
+    } );
+
+    // tokenUsage sums attributes.token_usage + legacy output.usage on llm nodes
+    expect( res.body.attributes.tokenUsage ).toEqual( {
+      inputTokens: 1500,
+      outputTokens: 300,
+      cachedInputTokens: 50,
+      totalTokens: 1800
+    } );
+
+    // cost.components is grouped by event-name bucket, total = sum of components
+    const byName = Object.fromEntries(
+      res.body.attributes.cost.components.map( c => [ c.name, c.value ] )
+    );
+    expect( byName['cost:llm:request'] ).toBeCloseTo( 0.3829, 10 );
+    expect( byName['cost:http:request'] ).toBeCloseTo( 0.04, 10 );
+    expect( byName.other ).toBe( 0 );
+    expect( res.body.attributes.cost.total ).toBeCloseTo( 0.4229, 10 );
+
+    expect( mockGetWorkflowResult ).toHaveBeenCalledWith( 'test-workflow-id', undefined );
+    expect( mockFetchTraceFromS3 ).toHaveBeenCalledWith( REMOTE_URL );
+  } );
+
+  it( 'returns the same payload shape for the pinned-run route', async () => {
+    mockGetWorkflowResult.mockResolvedValue( {
+      workflowId: 'test-workflow-id',
+      runId: RID,
+      trace: { destinations: { local: null, remote: REMOTE_URL } }
+    } );
+    mockFetchTraceFromS3.mockResolvedValue( fixtureTrace() );
+
+    const res = await request( createApp() )
+      .get( `/workflow/test-workflow-id/runs/${RID}/trace-attributes` )
+      .expect( 200 );
+
+    expect( res.body.runId ).toBe( RID );
+    expect( res.body.traceUrl ).toBe( REMOTE_URL );
+    expect( mockGetWorkflowResult ).toHaveBeenCalledWith( 'test-workflow-id', RID );
+  } );
+
+  it( 'succeeds against a legacy trace file lacking attributes.token_usage by falling back to output.usage', async () => {
+    mockGetWorkflowResult.mockResolvedValue( {
+      workflowId: 'test-workflow-id',
+      runId: 'r-legacy',
+      trace: { destinations: { local: null, remote: REMOTE_URL } }
+    } );
+    mockFetchTraceFromS3.mockResolvedValue( {
+      id: 'wf',
+      kind: 'workflow',
+      name: 'simple',
+      startedAt: 1000,
+      endedAt: 2000,
+      attributes: {},
+      children: [
+        {
+          id: 'llm-legacy',
+          kind: 'llm',
+          name: 'llm',
+          startedAt: 1100,
+          endedAt: 1900,
+          attributes: { cost: { total: 0.10 } },
+          output: { result: '...', usage: { inputTokens: 800, outputTokens: 200, totalTokens: 1000 } },
+          children: []
+        }
+      ]
+    } );
+
+    const res = await request( createApp() )
+      .get( '/workflow/test-workflow-id/trace-attributes' )
+      .expect( 200 );
+
+    expect( res.body.attributes.tokenUsage ).toEqual( {
+      inputTokens: 800,
+      outputTokens: 200,
+      cachedInputTokens: 0,
+      totalTokens: 1000
+    } );
+    expect( res.body.attributes.cost.total ).toBeCloseTo( 0.10, 10 );
+  } );
+
+  it( 'returns 424 when the workflow is still running', async () => {
+    mockGetWorkflowResult.mockRejectedValue( new WorkflowNotCompletedError() );
+
+    await request( createApp() )
+      .get( '/workflow/test-workflow-id/trace-attributes' )
+      .expect( 424, {
+        error: 'WorkflowNotCompletedError',
+        message: 'Workflow execution is not complete.'
+      } );
+
+    expect( mockFetchTraceFromS3 ).not.toHaveBeenCalled();
+  } );
+
+  it( 'returns 424 on the pinned-run route when the run is still running', async () => {
+    mockGetWorkflowResult.mockRejectedValue( new WorkflowNotCompletedError() );
+
+    await request( createApp() )
+      .get( `/workflow/test-workflow-id/runs/${RID}/trace-attributes` )
+      .expect( 424 );
+  } );
+
+  it( 'returns 404 when the workflow id is unknown', async () => {
+    // Mirror the WorkflowNotFoundError shape from @temporalio/client.
+    class WorkflowNotFoundError extends Error {
+      constructor( message ) {
+        super( message );
+        this.name = 'WorkflowNotFoundError';
+      }
+    }
+    Object.defineProperty( WorkflowNotFoundError.prototype.constructor, 'name', { value: 'WorkflowNotFoundError' } );
+    mockGetWorkflowResult.mockRejectedValue( new WorkflowNotFoundError( 'Workflow "unknown-id" not found' ) );
+
+    await request( createApp() )
+      .get( '/workflow/unknown-id/trace-attributes' )
+      .expect( 404 );
+  } );
+
+  it( 'returns 404 with TraceNotAvailableError when the run completed but has no remote trace destination', async () => {
+    mockGetWorkflowResult.mockResolvedValue( {
+      workflowId: 'test-workflow-id',
+      runId: 'r-no-trace',
+      trace: { destinations: { local: '/tmp/t.json', remote: null } }
+    } );
+
+    await request( createApp() )
+      .get( '/workflow/test-workflow-id/trace-attributes' )
+      .expect( 404, {
+        error: 'TraceNotAvailableError',
+        message: 'No trace available for workflow "test-workflow-id".',
+        workflowId: 'test-workflow-id'
+      } );
+
+    expect( mockFetchTraceFromS3 ).not.toHaveBeenCalled();
+  } );
+
+  it( 'returns 400 when the pinned rid is not a valid UUID', async () => {
+    await request( createApp() )
+      .get( '/workflow/test-workflow-id/runs/not-a-uuid/trace-attributes' )
+      .expect( 400 );
+
+    expect( mockGetWorkflowResult ).not.toHaveBeenCalled();
+  } );
+
+  it( 'forwards S3 errors through the error handler', async () => {
+    mockGetWorkflowResult.mockResolvedValue( {
+      workflowId: 'test-workflow-id',
+      runId: 'r-1',
+      trace: { destinations: { local: null, remote: REMOTE_URL } }
+    } );
+    mockFetchTraceFromS3.mockRejectedValue( new Error( 'S3 access denied' ) );
+
+    const app = express();
+    app.get( '/workflow/:id/trace-attributes', createTraceAttributesHandler( mockClient ) );
+    app.use( ( err, _req, res, _next ) => res.status( 500 ).json( { error: err.message } ) );
+
+    await request( app )
+      .get( '/workflow/test-workflow-id/trace-attributes' )
+      .expect( 500, { error: 'S3 access denied' } );
+  } );
+
+  it( 'returns null startTime / finishTime / runtime when the trace root lacks timestamps', async () => {
+    mockGetWorkflowResult.mockResolvedValue( {
+      workflowId: 'test-workflow-id',
+      runId: 'r-1',
+      trace: { destinations: { local: null, remote: REMOTE_URL } }
+    } );
+    mockFetchTraceFromS3.mockResolvedValue( {
+      // Malformed root — no startedAt / endedAt fields at all.
+      id: 'wf',
+      kind: 'workflow',
+      name: 'simple',
+      attributes: {},
+      children: []
+    } );
+
+    const res = await request( createApp() )
+      .get( '/workflow/test-workflow-id/trace-attributes' )
+      .expect( 200 );
+
+    expect( res.body.startTime ).toBeNull();
+    expect( res.body.finishTime ).toBeNull();
+    expect( res.body.runtime ).toBeNull();
+  } );
+
+  it( 'traceUrl matches the S3 URL returned by /trace-log for the same run', async () => {
+    // Both endpoints read result.trace.destinations.remote — same source means same value.
+    mockGetWorkflowResult.mockResolvedValue( {
+      workflowId: 'test-workflow-id',
+      runId: 'r-1',
+      trace: { destinations: { local: null, remote: REMOTE_URL } }
+    } );
+    mockFetchTraceFromS3.mockResolvedValue( fixtureTrace() );
+
+    const res = await request( createApp() )
+      .get( '/workflow/test-workflow-id/trace-attributes' )
+      .expect( 200 );
+
+    expect( res.body.traceUrl ).toBe( REMOTE_URL );
+  } );
+} );

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -8,6 +8,7 @@ import { createHttpLoggingMiddleware } from './middleware/http_logger.js';
 import errorHandler from './middleware/error_handler.js';
 import deprecated from './middleware/deprecated.js';
 import { createTraceLogHandler } from './handlers/trace_log.js';
+import { createTraceAttributesHandler } from './handlers/trace_attributes.js';
 import { createStopHandler, createTerminateHandler, createResultHandler } from './handlers/workflow_run.js';
 import { createWorkflowHistoryHandler } from './handlers/workflow_history.js';
 import { readPinnedRunId } from './handlers/utils.js';
@@ -51,6 +52,7 @@ const stopHandler = createStopHandler( client );
 const terminateHandler = createTerminateHandler( client );
 const resultHandler = createResultHandler( client );
 const traceLogHandler = createTraceLogHandler( client );
+const traceAttributesHandler = createTraceAttributesHandler( client );
 
 // Sets payload limit for POST in application/json format. Some workflow have very large payloads
 app.use( express.json( { limit: '2mb' } ) );
@@ -275,6 +277,73 @@ app.use( ( req, res, next ) => {
  *         localPath:
  *           type: string
  *           description: Absolute path to local trace file
+ *     TraceAttributesCostComponent:
+ *       type: object
+ *       required: [name, value]
+ *       properties:
+ *         name:
+ *           type: string
+ *           description: Canonical cost event name (e.g. `cost:llm:request`, `cost:http:request`, `other`).
+ *         value:
+ *           type: number
+ *           description: Summed USD cost for this component bucket.
+ *     TraceAttributesResponse:
+ *       type: object
+ *       description: |
+ *         Aggregated cost, token usage, and runtime computed by walking the trace tree of a completed workflow run.
+ *         Component breakdowns under `attributes.cost.components` are grouped by the canonical event name that
+ *         emitted them (inferred from node kind: llm/http/other). Values sum to `attributes.cost.total`.
+ *       required: [workflowId, runId, startTime, finishTime, runtime, attributes, traceUrl]
+ *       properties:
+ *         workflowId:
+ *           type: string
+ *           description: The workflow execution id
+ *         runId:
+ *           type: string
+ *           description: The specific run id this aggregation belongs to
+ *         startTime:
+ *           type: integer
+ *           nullable: true
+ *           description: ms epoch of the root trace node's start
+ *         finishTime:
+ *           type: integer
+ *           nullable: true
+ *           description: ms epoch of the root trace node's end
+ *         runtime:
+ *           type: integer
+ *           nullable: true
+ *           description: ms between finishTime and startTime, null if either timestamp is missing
+ *         attributes:
+ *           type: object
+ *           required: [cost, tokenUsage]
+ *           properties:
+ *             cost:
+ *               type: object
+ *               required: [total, components]
+ *               properties:
+ *                 total:
+ *                   type: number
+ *                   description: USD; equal to the sum of `components[].value`
+ *                 components:
+ *                   type: array
+ *                   description: Cost contributions bucketed by canonical event name (llm / http / other).
+ *                   items:
+ *                     $ref: '#/components/schemas/TraceAttributesCostComponent'
+ *             tokenUsage:
+ *               type: object
+ *               required: [inputTokens, outputTokens, cachedInputTokens, totalTokens]
+ *               properties:
+ *                 inputTokens:
+ *                   type: integer
+ *                 outputTokens:
+ *                   type: integer
+ *                 cachedInputTokens:
+ *                   type: integer
+ *                 totalTokens:
+ *                   type: integer
+ *         traceUrl:
+ *           type: string
+ *           description: S3 URL of the underlying trace file (same value `/trace-log` returns under `data` for remote traces).
  *     WorkflowRunInfo:
  *       type: object
  *       properties:
@@ -1016,6 +1085,75 @@ app.get( '/workflow/:id/runs/:rid/result', resultHandler );
  */
 app.get( '/workflow/:id/trace-log', traceLogHandler );
 app.get( '/workflow/:id/runs/:rid/trace-log', traceLogHandler );
+
+/**
+ * @swagger
+ * /workflow/{id}/trace-attributes:
+ *   get:
+ *     summary: Get aggregated trace attributes for a completed workflow (latest run)
+ *     description: |
+ *       Returns runtime, cost rolled up by event-name bucket, token-usage totals, and the trace S3 URL
+ *       for the latest run of the given workflow. Completion-only — returns 424 while the workflow is
+ *       still running, mirroring `/result` and `/trace-log`. To pin a specific run, use
+ *       `/workflow/{id}/runs/{rid}/trace-attributes`.
+ *     parameters:
+ *      - in: path
+ *        name: id
+ *        required: true
+ *        schema:
+ *          type: string
+ *        description: The id of the workflow to retrieve trace attributes for
+ *     responses:
+ *       200:
+ *         description: The aggregated trace attributes
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/TraceAttributesResponse'
+ *       404:
+ *         $ref: '#/components/responses/NotFound'
+ *       424:
+ *         $ref: '#/components/responses/FailedDependency'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ *
+ * /workflow/{id}/runs/{rid}/trace-attributes:
+ *   get:
+ *     summary: Get aggregated trace attributes for a specific completed workflow run
+ *     description: |
+ *       Returns runtime, cost rolled up by event-name bucket, token-usage totals, and the trace S3 URL
+ *       for the pinned workflow run. Completion-only — returns 424 while the run is still in progress.
+ *     parameters:
+ *      - in: path
+ *        name: id
+ *        required: true
+ *        schema:
+ *          type: string
+ *      - in: path
+ *        name: rid
+ *        required: true
+ *        schema:
+ *          type: string
+ *          format: uuid
+ *        description: The specific run id to target
+ *     responses:
+ *       200:
+ *         description: The aggregated trace attributes
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/TraceAttributesResponse'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       404:
+ *         $ref: '#/components/responses/NotFound'
+ *       424:
+ *         $ref: '#/components/responses/FailedDependency'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
+app.get( '/workflow/:id/trace-attributes', traceAttributesHandler );
+app.get( '/workflow/:id/runs/:rid/trace-attributes', traceAttributesHandler );
 
 /**
  * @swagger

--- a/docs/guides/openapi.json
+++ b/docs/guides/openapi.json
@@ -242,6 +242,117 @@
           }
         }
       },
+      "TraceAttributesCostComponent": {
+        "type": "object",
+        "required": [
+          "name",
+          "value"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Canonical cost event name (e.g. `cost:llm:request`, `cost:http:request`, `other`)."
+          },
+          "value": {
+            "type": "number",
+            "description": "Summed USD cost for this component bucket."
+          }
+        }
+      },
+      "TraceAttributesResponse": {
+        "type": "object",
+        "description": "Aggregated cost, token usage, and runtime computed by walking the trace tree of a completed workflow run.\nComponent breakdowns under `attributes.cost.components` are grouped by the canonical event name that\nemitted them (inferred from node kind: llm/http/other). Values sum to `attributes.cost.total`.\n",
+        "required": [
+          "workflowId",
+          "runId",
+          "startTime",
+          "finishTime",
+          "runtime",
+          "attributes",
+          "traceUrl"
+        ],
+        "properties": {
+          "workflowId": {
+            "type": "string",
+            "description": "The workflow execution id"
+          },
+          "runId": {
+            "type": "string",
+            "description": "The specific run id this aggregation belongs to"
+          },
+          "startTime": {
+            "type": "integer",
+            "nullable": true,
+            "description": "ms epoch of the root trace node's start"
+          },
+          "finishTime": {
+            "type": "integer",
+            "nullable": true,
+            "description": "ms epoch of the root trace node's end"
+          },
+          "runtime": {
+            "type": "integer",
+            "nullable": true,
+            "description": "ms between finishTime and startTime, null if either timestamp is missing"
+          },
+          "attributes": {
+            "type": "object",
+            "required": [
+              "cost",
+              "tokenUsage"
+            ],
+            "properties": {
+              "cost": {
+                "type": "object",
+                "required": [
+                  "total",
+                  "components"
+                ],
+                "properties": {
+                  "total": {
+                    "type": "number",
+                    "description": "USD; equal to the sum of `components[].value`"
+                  },
+                  "components": {
+                    "type": "array",
+                    "description": "Cost contributions bucketed by canonical event name (llm / http / other).",
+                    "items": {
+                      "$ref": "#/components/schemas/TraceAttributesCostComponent"
+                    }
+                  }
+                }
+              },
+              "tokenUsage": {
+                "type": "object",
+                "required": [
+                  "inputTokens",
+                  "outputTokens",
+                  "cachedInputTokens",
+                  "totalTokens"
+                ],
+                "properties": {
+                  "inputTokens": {
+                    "type": "integer"
+                  },
+                  "outputTokens": {
+                    "type": "integer"
+                  },
+                  "cachedInputTokens": {
+                    "type": "integer"
+                  },
+                  "totalTokens": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          },
+          "traceUrl": {
+            "type": "string",
+            "description": "S3 URL of the underlying trace file (same value `/trace-log` returns under `data` for remote traces)."
+          }
+        }
+      },
       "WorkflowRunInfo": {
         "type": "object",
         "properties": {
@@ -1261,6 +1372,94 @@
                       "$ref": "#/components/schemas/TraceLogLocalResponse"
                     }
                   ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "424": {
+            "$ref": "#/components/responses/FailedDependency"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/workflow/{id}/trace-attributes": {
+      "get": {
+        "summary": "Get aggregated trace attributes for a completed workflow (latest run)",
+        "description": "Returns runtime, cost rolled up by event-name bucket, token-usage totals, and the trace S3 URL\nfor the latest run of the given workflow. Completion-only — returns 424 while the workflow is\nstill running, mirroring `/result` and `/trace-log`. To pin a specific run, use\n`/workflow/{id}/runs/{rid}/trace-attributes`.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The id of the workflow to retrieve trace attributes for"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The aggregated trace attributes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceAttributesResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "424": {
+            "$ref": "#/components/responses/FailedDependency"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/workflow/{id}/runs/{rid}/trace-attributes": {
+      "get": {
+        "summary": "Get aggregated trace attributes for a specific completed workflow run",
+        "description": "Returns runtime, cost rolled up by event-name bucket, token-usage totals, and the trace S3 URL\nfor the pinned workflow run. Completion-only — returns 424 while the run is still in progress.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "rid",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "The specific run id to target"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The aggregated trace attributes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceAttributesResponse"
                 }
               }
             }

--- a/ops/api.Dockerfile
+++ b/ops/api.Dockerfile
@@ -1,25 +1,32 @@
-# Use Node.js slim image for smaller size
-FROM node:24.15.0-slim
+# Build stage: resolve the full workspace then materialize a self-contained
+# api bundle. `pnpm deploy` rewrites workspace symlinks into real copies of
+# every transitive workspace dependency (e.g. @outputai/core), so the runtime
+# image needs nothing from /repo.
+FROM node:24.15.0-slim AS build
 
-# Set working directory
-WORKDIR /app
+WORKDIR /repo
 
-# Enable pnpm via corepack
 RUN corepack enable
 
-# Copy root package files for workspace resolution
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# Workspace metadata first so install layer caches on lockfile changes only
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 
-# Copy API package.json for workspace detection
-COPY ./api/package.json ./api/
-
-# Install only API workspace dependencies
-RUN pnpm install --frozen-lockfile --filter output-api
-
-# Copy the rest of the API code
+# Source for every workspace package output-api depends on (directly or
+# transitively). Keep this list narrow to avoid bloating the build context.
 COPY ./api ./api
+COPY ./sdk ./sdk
 
-WORKDIR /app/api
+# Install everything output-api needs across the workspace, then materialize
+# a self-contained prod bundle at /app.
+RUN pnpm install --frozen-lockfile --filter output-api...
+RUN pnpm deploy --filter output-api --prod --legacy /app
+
+# Runtime stage: just the deployed bundle
+FROM node:24.15.0-slim
+
+WORKDIR /app
+
+COPY --from=build /app /app
 
 ENV NODE_ENV=production
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: 'catalog:'
         version: 3.1038.0
+      '@outputai/core':
+        specifier: 'workspace:'
+        version: link:../sdk/core
       '@temporalio/client':
         specifier: 'catalog:'
         version: 1.17.0
@@ -225,7 +228,7 @@ importers:
         version: 4.1.0
       debug:
         specifier: 4.4.3
-        version: 4.4.3(supports-color@8.1.1)
+        version: 4.4.3(supports-color@5.5.0)
       dotenv:
         specifier: 17.4.2
         version: 17.4.2

--- a/sdk/cli/src/api/generated/api.ts
+++ b/sdk/cli/src/api/generated/api.ts
@@ -160,6 +160,63 @@ export interface TraceLogLocalResponse {
   localPath: string;
 }
 
+export interface TraceAttributesCostComponent {
+  /** Canonical cost event name (e.g. `cost:llm:request`, `cost:http:request`, `other`). */
+  name: string;
+  /** Summed USD cost for this component bucket. */
+  value: number;
+}
+
+export type TraceAttributesResponseAttributesCost = {
+  /** USD; equal to the sum of `components[].value` */
+  total: number;
+  /** Cost contributions bucketed by canonical event name (llm / http / other). */
+  components: TraceAttributesCostComponent[];
+};
+
+export type TraceAttributesResponseAttributesTokenUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens: number;
+  totalTokens: number;
+};
+
+export type TraceAttributesResponseAttributes = {
+  cost: TraceAttributesResponseAttributesCost;
+  tokenUsage: TraceAttributesResponseAttributesTokenUsage;
+};
+
+/**
+ * Aggregated cost, token usage, and runtime computed by walking the trace tree of a completed workflow run.
+Component breakdowns under `attributes.cost.components` are grouped by the canonical event name that
+emitted them (inferred from node kind: llm/http/other). Values sum to `attributes.cost.total`.
+
+ */
+export interface TraceAttributesResponse {
+  /** The workflow execution id */
+  workflowId: string;
+  /** The specific run id this aggregation belongs to */
+  runId: string;
+  /**
+     * ms epoch of the root trace node's start
+     * @nullable
+     */
+  startTime: number | null;
+  /**
+     * ms epoch of the root trace node's end
+     * @nullable
+     */
+  finishTime: number | null;
+  /**
+     * ms between finishTime and startTime, null if either timestamp is missing
+     * @nullable
+     */
+  runtime: number | null;
+  attributes: TraceAttributesResponseAttributes;
+  /** S3 URL of the underlying trace file (same value `/trace-log` returns under `data` for remote traces). */
+  traceUrl: string;
+}
+
 /**
  * Current run status
  */
@@ -1393,6 +1450,127 @@ export const getWorkflowIdRunsRidTraceLog = async (id: string,
     rid: string, options?: ApiRequestOptions): Promise<getWorkflowIdRunsRidTraceLogResponse> => {
 
   return customFetchInstance<getWorkflowIdRunsRidTraceLogResponse>(getGetWorkflowIdRunsRidTraceLogUrl(id,rid),
+  {
+    ...options,
+    method: 'GET'
+
+
+  }
+);}
+
+
+
+/**
+ * Returns runtime, cost rolled up by event-name bucket, token-usage totals, and the trace S3 URL
+for the latest run of the given workflow. Completion-only — returns 424 while the workflow is
+still running, mirroring `/result` and `/trace-log`. To pin a specific run, use
+`/workflow/{id}/runs/{rid}/trace-attributes`.
+
+ * @summary Get aggregated trace attributes for a completed workflow (latest run)
+ */
+export type getWorkflowIdTraceAttributesResponse200 = {
+  data: TraceAttributesResponse
+  status: 200
+}
+
+export type getWorkflowIdTraceAttributesResponse404 = {
+  data: NotFoundResponse
+  status: 404
+}
+
+export type getWorkflowIdTraceAttributesResponse424 = {
+  data: FailedDependencyResponse
+  status: 424
+}
+
+export type getWorkflowIdTraceAttributesResponse500 = {
+  data: InternalServerErrorResponse
+  status: 500
+}
+
+export type getWorkflowIdTraceAttributesResponseSuccess = (getWorkflowIdTraceAttributesResponse200) & {
+  headers: Headers;
+};
+export type getWorkflowIdTraceAttributesResponseError = (getWorkflowIdTraceAttributesResponse404 | getWorkflowIdTraceAttributesResponse424 | getWorkflowIdTraceAttributesResponse500) & {
+  headers: Headers;
+};
+
+export type getWorkflowIdTraceAttributesResponse = (getWorkflowIdTraceAttributesResponseSuccess | getWorkflowIdTraceAttributesResponseError)
+
+export const getGetWorkflowIdTraceAttributesUrl = (id: string,) => {
+
+
+
+
+  return `/workflow/${id}/trace-attributes`
+}
+
+export const getWorkflowIdTraceAttributes = async (id: string, options?: ApiRequestOptions): Promise<getWorkflowIdTraceAttributesResponse> => {
+
+  return customFetchInstance<getWorkflowIdTraceAttributesResponse>(getGetWorkflowIdTraceAttributesUrl(id),
+  {
+    ...options,
+    method: 'GET'
+
+
+  }
+);}
+
+
+
+/**
+ * Returns runtime, cost rolled up by event-name bucket, token-usage totals, and the trace S3 URL
+for the pinned workflow run. Completion-only — returns 424 while the run is still in progress.
+
+ * @summary Get aggregated trace attributes for a specific completed workflow run
+ */
+export type getWorkflowIdRunsRidTraceAttributesResponse200 = {
+  data: TraceAttributesResponse
+  status: 200
+}
+
+export type getWorkflowIdRunsRidTraceAttributesResponse400 = {
+  data: BadRequestResponse
+  status: 400
+}
+
+export type getWorkflowIdRunsRidTraceAttributesResponse404 = {
+  data: NotFoundResponse
+  status: 404
+}
+
+export type getWorkflowIdRunsRidTraceAttributesResponse424 = {
+  data: FailedDependencyResponse
+  status: 424
+}
+
+export type getWorkflowIdRunsRidTraceAttributesResponse500 = {
+  data: InternalServerErrorResponse
+  status: 500
+}
+
+export type getWorkflowIdRunsRidTraceAttributesResponseSuccess = (getWorkflowIdRunsRidTraceAttributesResponse200) & {
+  headers: Headers;
+};
+export type getWorkflowIdRunsRidTraceAttributesResponseError = (getWorkflowIdRunsRidTraceAttributesResponse400 | getWorkflowIdRunsRidTraceAttributesResponse404 | getWorkflowIdRunsRidTraceAttributesResponse424 | getWorkflowIdRunsRidTraceAttributesResponse500) & {
+  headers: Headers;
+};
+
+export type getWorkflowIdRunsRidTraceAttributesResponse = (getWorkflowIdRunsRidTraceAttributesResponseSuccess | getWorkflowIdRunsRidTraceAttributesResponseError)
+
+export const getGetWorkflowIdRunsRidTraceAttributesUrl = (id: string,
+    rid: string,) => {
+
+
+
+
+  return `/workflow/${id}/runs/${rid}/trace-attributes`
+}
+
+export const getWorkflowIdRunsRidTraceAttributes = async (id: string,
+    rid: string, options?: ApiRequestOptions): Promise<getWorkflowIdRunsRidTraceAttributesResponse> => {
+
+  return customFetchInstance<getWorkflowIdRunsRidTraceAttributesResponse>(getGetWorkflowIdRunsRidTraceAttributesUrl(id,rid),
   {
     ...options,
     method: 'GET'

--- a/sdk/cli/src/assets/docker/docker-compose-dev.yml
+++ b/sdk/cli/src/assets/docker/docker-compose-dev.yml
@@ -94,6 +94,12 @@ services:
       - TEMPORAL_ADDRESS=temporal:7233
     ports:
       - '${OUTPUT_API_HOST_PORT:-3001}:3001'
+    # Mount the worker's local trace directory at the same absolute path so
+    # `/workflow/{id}/trace-attributes` can read trace JSON files written by
+    # the worker. The worker stores the host absolute path in the trace
+    # destinations.local field; the API resolves that path on disk.
+    volumes:
+      - ${PWD}/logs:${PWD}/logs:ro
 
   worker:
     depends_on:

--- a/sdk/cli/src/services/cost_calculator.spec.ts
+++ b/sdk/cli/src/services/cost_calculator.spec.ts
@@ -41,7 +41,9 @@ const llmTrace: TraceNode = {
           kind: 'llm',
           name: 'generate_summary',
           input: { loadedPrompt: { config: { model: 'claude-sonnet-4-5' } } },
-          output: { usage: { inputTokens: 1000, outputTokens: 500 } }
+          attributes: {
+            token_usage: { inputTokens: 1000, outputTokens: 500 }
+          }
         }
       ]
     },
@@ -55,7 +57,9 @@ const llmTrace: TraceNode = {
           kind: 'llm',
           name: 'analyze_data',
           input: { loadedPrompt: { config: { model: 'claude-haiku-4-5' } } },
-          output: { usage: { inputTokens: 2000, outputTokens: 1000, cachedInputTokens: 500 } }
+          attributes: {
+            token_usage: { inputTokens: 2000, outputTokens: 1000, cachedInputTokens: 500 }
+          }
         }
       ]
     }
@@ -123,7 +127,9 @@ const duplicateTrace: TraceNode = {
           kind: 'llm',
           name: 'generate',
           input: { loadedPrompt: { config: { model: 'claude-sonnet-4-5' } } },
-          output: { usage: { inputTokens: 1000, outputTokens: 500 } }
+          attributes: {
+            token_usage: { inputTokens: 1000, outputTokens: 500 }
+          }
         }
       ]
     },
@@ -137,7 +143,9 @@ const duplicateTrace: TraceNode = {
           kind: 'llm',
           name: 'generate',
           input: { loadedPrompt: { config: { model: 'claude-sonnet-4-5' } } },
-          output: { usage: { inputTokens: 1000, outputTokens: 500 } }
+          attributes: {
+            token_usage: { inputTokens: 1000, outputTokens: 500 }
+          }
         }
       ]
     }
@@ -206,11 +214,45 @@ describe( 'findLLMCalls', () => {
     expect( calls[1].model ).toBe( 'claude-haiku-4-5' );
   } );
 
-  it( 'extracts token usage', () => {
+  it( 'extracts token usage from attributes.token_usage', () => {
     const calls = findLLMCalls( llmTrace );
     expect( calls[0].usage.inputTokens ).toBe( 1000 );
     expect( calls[0].usage.outputTokens ).toBe( 500 );
     expect( calls[1].usage.cachedInputTokens ).toBe( 500 );
+  } );
+
+  it( 'ignores llm nodes that only have legacy output.usage (no attributes.token_usage)', () => {
+    const legacyOnlyTrace: TraceNode = {
+      kind: 'workflow',
+      name: 'wf',
+      children: [ {
+        id: 'llm-legacy',
+        kind: 'llm',
+        name: 'gen',
+        output: { usage: { inputTokens: 999, outputTokens: 999 } }
+      } ]
+    };
+    expect( findLLMCalls( legacyOnlyTrace ) ).toHaveLength( 0 );
+  } );
+
+  it( 'picks up attributeCost from attributes.cost.total', () => {
+    const trace: TraceNode = {
+      kind: 'workflow',
+      name: 'wf',
+      children: [ {
+        id: 'llm-1',
+        kind: 'llm',
+        name: 'gen',
+        input: { loadedPrompt: { config: { model: 'claude-sonnet-4-5' } } },
+        attributes: {
+          token_usage: { inputTokens: 100, outputTokens: 50 },
+          cost: { total: 0.0042 }
+        }
+      } ]
+    };
+
+    const calls = findLLMCalls( trace );
+    expect( calls[0].attributeCost ).toBeCloseTo( 0.0042, 10 );
   } );
 
   it( 'deduplicates by ID', () => {
@@ -235,6 +277,24 @@ describe( 'findHTTPCalls', () => {
     const calls = findHTTPCalls( httpTrace );
     expect( calls[0].stepName ).toBe( 'fetch_content' );
     expect( calls[1].stepName ).toBe( 'search' );
+  } );
+
+  it( 'reads attributeCost from attributes.cost.total', () => {
+    const trace: TraceNode = {
+      kind: 'workflow',
+      name: 'wf',
+      children: [ {
+        id: 'http-1',
+        kind: 'http',
+        name: 'scrape',
+        input: { url: 'https://api.gx-scraper.test/scrape', method: 'POST' },
+        output: { status: 200 },
+        attributes: { cost: { total: 0.5 } }
+      } ]
+    };
+
+    const calls = findHTTPCalls( trace );
+    expect( calls[0].attributeCost ).toBe( 0.5 );
   } );
 } );
 
@@ -482,7 +542,7 @@ describe( 'calculateCost', () => {
           kind: 'llm',
           name: 'gen',
           input: { loadedPrompt: { config: { model: 'claude-sonnet-4-5-20250514' } } },
-          output: { usage: { inputTokens: 1000, outputTokens: 500 } }
+          attributes: { token_usage: { inputTokens: 1000, outputTokens: 500 } }
         } ]
       } ]
     };
@@ -493,7 +553,7 @@ describe( 'calculateCost', () => {
     expect( report.llmCalls[0].warning ).toBe( 'priced as claude-sonnet-4-5' );
   } );
 
-  it( 'reports unknown model when no prefix match exists', () => {
+  it( 'reports unknown model when no prefix match exists and no attribute cost is present', () => {
     const trace: TraceNode = {
       kind: 'workflow',
       name: 'test',
@@ -506,7 +566,7 @@ describe( 'calculateCost', () => {
           kind: 'llm',
           name: 'gen',
           input: { loadedPrompt: { config: { model: 'totally-unknown-model' } } },
-          output: { usage: { inputTokens: 1000, outputTokens: 500 } }
+          attributes: { token_usage: { inputTokens: 1000, outputTokens: 500 } }
         } ]
       } ]
     };
@@ -530,13 +590,170 @@ describe( 'calculateCost', () => {
           kind: 'llm',
           name: 'gen',
           input: { loadedPrompt: { config: { model: 'claude-sonnet-4-5' } } },
-          output: { usage: { inputTokens: 1000, outputTokens: 500 } }
+          attributes: { token_usage: { inputTokens: 1000, outputTokens: 500 } }
         } ]
       } ]
     };
 
     const report = calculateCost( trace, testConfig, 'test.json' );
     expect( report.llmCalls[0].warning ).toBeUndefined();
+  } );
+
+  it( 'prefers attributes.cost.total over yaml-computed LLM cost when present', () => {
+    const trace: TraceNode = {
+      kind: 'workflow',
+      name: 'test',
+      children: [ {
+        id: 'step-1',
+        kind: 'step',
+        name: 'test#gen',
+        children: [ {
+          id: 'llm-1',
+          kind: 'llm',
+          name: 'gen',
+          input: { loadedPrompt: { config: { model: 'claude-sonnet-4-5' } } },
+          attributes: {
+            token_usage: { inputTokens: 1000, outputTokens: 500 },
+            // Authoritative: this is what the provider reported, not what yaml infers.
+            cost: { total: 0.99 }
+          }
+        } ]
+      } ]
+    };
+
+    const report = calculateCost( trace, testConfig, 'test.json' );
+    expect( report.llmCalls[0].cost ).toBe( 0.99 );
+    expect( report.llmTotalCost ).toBe( 0.99 );
+  } );
+
+  it( 'still surfaces an attribute LLM cost for unknown models without warning', () => {
+    const trace: TraceNode = {
+      kind: 'workflow',
+      name: 'test',
+      children: [ {
+        id: 'step-1',
+        kind: 'step',
+        name: 'test#gen',
+        children: [ {
+          id: 'llm-1',
+          kind: 'llm',
+          name: 'gen',
+          input: { loadedPrompt: { config: { model: 'brand-new-model' } } },
+          attributes: {
+            token_usage: { inputTokens: 100, outputTokens: 20 },
+            cost: { total: 0.0123 }
+          }
+        } ]
+      } ]
+    };
+
+    const report = calculateCost( trace, testConfig, 'test.json' );
+    expect( report.llmTotalCost ).toBeCloseTo( 0.0123, 10 );
+    expect( report.unknownModels ).toEqual( [] );
+  } );
+
+  it( 'includes HTTP request cost from attributes.cost.total for unclassified hosts', () => {
+    // gx-scraper-style: not declared in yaml services, but addRequestCost ran
+    // and put $0.50 on the HTTP node's attributes.cost.total.
+    const trace: TraceNode = {
+      kind: 'workflow',
+      name: 'scraper_workflow',
+      startedAt: 1700000000000,
+      endedAt: 1700000100000,
+      children: [ {
+        id: 'step-1',
+        kind: 'step',
+        name: 'scraper_workflow#scrape',
+        children: [ {
+          id: 'http-1',
+          kind: 'http',
+          name: 'scrape_request',
+          input: { url: 'https://api.gx-scraper.test/v1/scrape', method: 'POST' },
+          output: { status: 200, body: {} },
+          attributes: { cost: { total: 0.5 } }
+        } ]
+      } ]
+    };
+
+    const report = calculateCost( trace, testConfig, 'test.json' );
+    expect( report.serviceTotalCost ).toBe( 0.5 );
+    expect( report.totalCost ).toBe( 0.5 );
+    expect( report.services ).toHaveLength( 1 );
+    expect( report.services[0].calls[0].cost ).toBe( 0.5 );
+  } );
+
+  it( 'prefers attributes.cost.total over yaml service classifier for classified HTTP nodes', () => {
+    // Exa with both a yaml `response_cost` rule AND an attribute cost — the
+    // attribute is authoritative.
+    const trace: TraceNode = {
+      kind: 'workflow',
+      name: 'test_workflow',
+      children: [ {
+        id: 'step-exa',
+        kind: 'step',
+        name: 'test_workflow#search',
+        children: [ {
+          id: 'http-exa',
+          kind: 'http',
+          name: 'exa_request',
+          input: { url: 'https://api.exa.ai/research', method: 'POST' },
+          output: {
+            status: 200,
+            body: { model: 'exa-research', costDollars: { total: 0.15, numSearches: 1, numPages: 5 } }
+          },
+          attributes: { cost: { total: 0.22 } }
+        } ]
+      } ]
+    };
+
+    const report = calculateCost( trace, testConfig, 'test.json' );
+    expect( report.services ).toHaveLength( 1 );
+    expect( report.services[0].serviceName ).toBe( 'exa' );
+    expect( report.services[0].totalCost ).toBe( 0.22 );
+  } );
+
+  it( 'combines LLM and HTTP attribute costs into a single trace total', () => {
+    const trace: TraceNode = {
+      kind: 'workflow',
+      name: 'mixed_workflow',
+      startedAt: 1700000000000,
+      endedAt: 1700000100000,
+      children: [
+        {
+          id: 'step-llm',
+          kind: 'step',
+          name: 'mixed_workflow#draft',
+          children: [ {
+            id: 'llm-1',
+            kind: 'llm',
+            name: 'draft',
+            input: { loadedPrompt: { config: { model: 'claude-sonnet-4-5' } } },
+            attributes: {
+              token_usage: { inputTokens: 100, outputTokens: 50 },
+              cost: { total: 0.01 }
+            }
+          } ]
+        },
+        {
+          id: 'step-http',
+          kind: 'step',
+          name: 'mixed_workflow#scrape',
+          children: [ {
+            id: 'http-1',
+            kind: 'http',
+            name: 'scrape',
+            input: { url: 'https://api.gx-scraper.test/v1/scrape', method: 'POST' },
+            output: { status: 200, body: {} },
+            attributes: { cost: { total: 0.5 } }
+          } ]
+        }
+      ]
+    };
+
+    const report = calculateCost( trace, testConfig, 'test.json' );
+    expect( report.llmTotalCost ).toBeCloseTo( 0.01, 10 );
+    expect( report.serviceTotalCost ).toBeCloseTo( 0.5, 10 );
+    expect( report.totalCost ).toBeCloseTo( 0.51, 10 );
   } );
 } );
 

--- a/sdk/cli/src/services/cost_calculator.ts
+++ b/sdk/cli/src/services/cost_calculator.ts
@@ -22,6 +22,10 @@ function tokenCost( tokens: number, pricePerMillion: number ): number {
   return ( tokens / 1_000_000 ) * pricePerMillion;
 }
 
+function isFiniteNumber( value: unknown ): value is number {
+  return typeof value === 'number' && Number.isFinite( value );
+}
+
 export function extractValue( obj: unknown, path: string ): unknown {
   if ( !path || !obj ) {
     return obj;
@@ -104,6 +108,11 @@ function findCalls<T>(
   return calls;
 }
 
+function readAttributeCost( node: TraceNode ): number | undefined {
+  const total = node.attributes?.cost?.total;
+  return isFiniteNumber( total ) ? total : undefined;
+}
+
 export function findLLMCalls(
   node: TraceNode,
   parentStepName: string | null = null,
@@ -111,24 +120,25 @@ export function findLLMCalls(
 ): LLMCall[] {
   return findCalls<LLMCall>(
     node,
-    n => n.kind === 'llm' && !!n.output?.usage,
+    n => n.kind === 'llm' && !!n.attributes?.token_usage,
     ( n, stepName ) => {
       const loadedPrompt = n.input?.loadedPrompt as
         Record<string, Record<string, unknown>> | undefined;
-      const outputRecord = n.output as Record<string, unknown>;
-      const inputRecord = n.input as Record<string, unknown>;
+      const outputRecord = ( n.output ?? {} ) as Record<string, unknown>;
+      const inputRecord = ( n.input ?? {} ) as Record<string, unknown>;
 
       const model =
         ( loadedPrompt?.config?.model as string ) ||
-        ( outputRecord?.model as string ) ||
-        ( inputRecord?.model as string ) ||
+        ( outputRecord.model as string ) ||
+        ( inputRecord.model as string ) ||
         'unknown';
 
       return {
         stepName: stepName || n.name || 'unknown',
         llmName: n.name || 'llm',
         model,
-        usage: n.output!.usage!
+        usage: n.attributes!.token_usage!,
+        attributeCost: readAttributeCost( n )
       };
     },
     parentStepName,
@@ -150,7 +160,8 @@ export function findHTTPCalls(
       method: ( n.input?.method as string ) || 'GET',
       input: ( n.input as Record<string, unknown> ) || {},
       output: ( n.output as Record<string, unknown> ) || {},
-      status: n.output?.status as number | undefined
+      status: n.output?.status as number | undefined,
+      attributeCost: readAttributeCost( n )
     } ),
     parentStepName,
     seenIds
@@ -414,13 +425,17 @@ function aggregateLLMCosts(
 
   for ( const call of llmCalls ) {
     const { pricing, matchedKey } = findModelPricing( call.model, config.models ?? {} );
-    const { cost, warning } = calculateLLMCallCost( call.usage, pricing );
+    const { cost: yamlCost, warning } = calculateLLMCallCost( call.usage, pricing );
+
+    // Prefer the cost emitted by the LLM provider on the trace node; fall back to
+    // yaml pricing so unknown-model warnings still surface for breakdown display.
+    const cost = call.attributeCost ?? yamlCost;
 
     const prefixWarning = ( pricing && matchedKey !== call.model ) ?
       `priced as ${matchedKey}` :
       undefined;
 
-    if ( !pricing ) {
+    if ( !pricing && call.attributeCost === undefined ) {
       unknownModels.add( call.model );
     }
 
@@ -464,32 +479,56 @@ export function calculateCost( trace: TraceNode, config: PricingConfig, traceFil
     }
 
     const serviceInfo = identifyService( call, config.services );
-    if ( !serviceInfo ) {
+
+    if ( serviceInfo ) {
+      // attributes.cost on the HTTP node is authoritative when present —
+      // addRequestCost() writes the real billed amount there. Fall back to
+      // the yaml service classifier for legacy callers that don't emit it.
+      const result = call.attributeCost !== undefined ?
+        { step: call.stepName, cost: call.attributeCost, usage: '1 request' } :
+        ( () => {
+          if ( serviceInfo.config.type === 'response_cost' ) {
+            const hasCostData = extractValue( call, serviceInfo.config.cost_path! );
+            const isBillableMethod = serviceInfo.config.billable_method &&
+              call.method === serviceInfo.config.billable_method;
+            if ( !hasCostData && !isBillableMethod ) {
+              return null;
+            }
+          }
+          return calculateServiceCost( call, serviceInfo );
+        } )();
+
+      if ( !result ) {
+        continue;
+      }
+
+      if ( !serviceResults[serviceInfo.serviceName] ) {
+        serviceResults[serviceInfo.serviceName] = {
+          serviceName: serviceInfo.serviceName,
+          calls: [],
+          totalCost: 0
+        };
+      }
+
+      serviceResults[serviceInfo.serviceName].calls.push( result );
+      serviceResults[serviceInfo.serviceName].totalCost += result.cost;
       continue;
     }
 
-    if ( serviceInfo.config.type === 'response_cost' ) {
-      const hasCostData = extractValue( call, serviceInfo.config.cost_path! );
-      const isBillableMethod = serviceInfo.config.billable_method &&
-        call.method === serviceInfo.config.billable_method;
-
-      if ( !hasCostData && !isBillableMethod ) {
-        continue;
+    // Unclassified HTTP node — still surface its cost if addRequestCost was called.
+    if ( call.attributeCost !== undefined && call.attributeCost > 0 ) {
+      const bucket = 'http';
+      if ( !serviceResults[bucket] ) {
+        serviceResults[bucket] = { serviceName: bucket, calls: [], totalCost: 0 };
       }
+      serviceResults[bucket].calls.push( {
+        step: call.stepName,
+        cost: call.attributeCost,
+        usage: '1 request',
+        endpoint: call.url
+      } );
+      serviceResults[bucket].totalCost += call.attributeCost;
     }
-
-    const result = calculateServiceCost( call, serviceInfo );
-
-    if ( !serviceResults[serviceInfo.serviceName] ) {
-      serviceResults[serviceInfo.serviceName] = {
-        serviceName: serviceInfo.serviceName,
-        calls: [],
-        totalCost: 0
-      };
-    }
-
-    serviceResults[serviceInfo.serviceName].calls.push( result );
-    serviceResults[serviceInfo.serviceName].totalCost += result.cost;
   }
 
   const {

--- a/sdk/cli/src/types/cost.ts
+++ b/sdk/cli/src/types/cost.ts
@@ -11,6 +11,17 @@ export interface TokenUsage {
   outputTokens?: number;
   cachedInputTokens?: number;
   reasoningTokens?: number;
+  totalTokens?: number;
+}
+
+export interface TraceCostAttribute {
+  total: number;
+  components?: Array<{ name: string; value: number }>;
+}
+
+export interface TraceAttributes {
+  cost?: TraceCostAttribute;
+  token_usage?: TokenUsage;
 }
 
 export interface TraceNode {
@@ -21,7 +32,8 @@ export interface TraceNode {
   endedAt?: number;
   children?: TraceNode[];
   input?: Record<string, unknown>;
-  output?: Record<string, unknown> & { usage?: TokenUsage };
+  output?: Record<string, unknown>;
+  attributes?: TraceAttributes;
 }
 
 export interface LLMCall {
@@ -29,6 +41,7 @@ export interface LLMCall {
   llmName: string;
   model: string;
   usage: TokenUsage;
+  attributeCost?: number;
 }
 
 export interface HTTPCall {
@@ -38,6 +51,7 @@ export interface HTTPCall {
   input: Record<string, unknown>;
   output: Record<string, unknown>;
   status?: number;
+  attributeCost?: number;
 }
 
 // Pricing Configuration Types

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -19,6 +19,9 @@
     "./sdk_utils": {
       "types": "./src/utils/index.d.ts",
       "import": "./src/utils/index.js"
+    },
+    "./sdk_tracing_tools": {
+      "import": "./src/tracing/tools/index.js"
     }
   },
   "files": [

--- a/sdk/core/src/activity_integration/tracing.d.ts
+++ b/sdk/core/src/activity_integration/tracing.d.ts
@@ -42,4 +42,5 @@ export declare function addEventAttribute( args: { eventId: string; name: string
  */
 export declare const Attribute: {
   COST: 'cost';
+  TOKEN_USAGE: 'token_usage';
 };

--- a/sdk/core/src/activity_integration/tracing.js
+++ b/sdk/core/src/activity_integration/tracing.js
@@ -49,5 +49,6 @@ export const addEventAttribute = ( { eventId, name, value } ) =>
  * Known attributes
  */
 export const Attribute = {
-  COST: 'cost'
+  COST: 'cost',
+  TOKEN_USAGE: 'token_usage'
 };

--- a/sdk/core/src/hooks/index.d.ts
+++ b/sdk/core/src/hooks/index.d.ts
@@ -16,8 +16,10 @@ export interface ErrorHookPayload {
  * Payload passed to the onWorkflowStart handler when a workflow run begins.
  */
 export interface WorkflowStartHookPayload {
-  /** Identifier of the workflow run. */
+  /** Workflow id (stable across retries / continue-as-new). */
   id: string;
+  /** Temporal run id for the current execution attempt. */
+  runId: string;
   /** Name of the workflow. */
   name: string;
 }
@@ -26,8 +28,10 @@ export interface WorkflowStartHookPayload {
  * Payload passed to the onWorkflowEnd handler when a workflow run completes successfully.
  */
 export interface WorkflowEndHookPayload {
-  /** Identifier of the workflow run. */
+  /** Workflow id (stable across retries / continue-as-new). */
   id: string;
+  /** Temporal run id for the current execution attempt. */
+  runId: string;
   /** Name of the workflow. */
   name: string;
   /** Duration of the workflow run in milliseconds. */
@@ -38,8 +42,10 @@ export interface WorkflowEndHookPayload {
  * Payload passed to the onWorkflowError handler when a workflow run fails.
  */
 export interface WorkflowErrorHookPayload {
-  /** Identifier of the workflow run. */
+  /** Workflow id (stable across retries / continue-as-new). */
   id: string;
+  /** Temporal run id for the current execution attempt. */
+  runId: string;
   /** Name of the workflow. */
   name: string;
   /** Elapsed time before failure in milliseconds. */

--- a/sdk/core/src/hooks/index.js
+++ b/sdk/core/src/hooks/index.js
@@ -34,16 +34,16 @@ export const onBeforeWorkerStart = handler => messageBus.on( BusEventType.WORKER
   safeInvoke( handler, undefined, 'onBeforeWorkerStart' ) );
 
 /** Listen to workflow start events, excludes catalog workflow */
-export const onWorkflowStart = handler => messageBus.on( BusEventType.WORKFLOW_START, ( { id, name } ) =>
-  WORKFLOW_CATALOG !== name ? safeInvoke( handler, { id, name }, 'onWorkflowStart' ) : null );
+export const onWorkflowStart = handler => messageBus.on( BusEventType.WORKFLOW_START, ( { id, runId, name } ) =>
+  WORKFLOW_CATALOG !== name ? safeInvoke( handler, { id, runId, name }, 'onWorkflowStart' ) : null );
 
 /** Listen to workflow end events, excludes catalog workflow */
-export const onWorkflowEnd = handler => messageBus.on( BusEventType.WORKFLOW_END, ( { id, name, duration } ) =>
-  WORKFLOW_CATALOG !== name ? safeInvoke( handler, { id, name, duration }, 'onWorkflowEnd' ) : null );
+export const onWorkflowEnd = handler => messageBus.on( BusEventType.WORKFLOW_END, ( { id, runId, name, duration } ) =>
+  WORKFLOW_CATALOG !== name ? safeInvoke( handler, { id, runId, name, duration }, 'onWorkflowEnd' ) : null );
 
 /** Listen to workflow error events, excludes catalog workflow */
-export const onWorkflowError = handler => messageBus.on( BusEventType.WORKFLOW_ERROR, ( { id, name, duration, error } ) =>
-  WORKFLOW_CATALOG !== name ? safeInvoke( handler, { id, name, duration, error }, 'onWorkflowError' ) : null );
+export const onWorkflowError = handler => messageBus.on( BusEventType.WORKFLOW_ERROR, ( { id, runId, name, duration, error } ) =>
+  WORKFLOW_CATALOG !== name ? safeInvoke( handler, { id, runId, name, duration, error }, 'onWorkflowError' ) : null );
 
 /** Generic listener for events emitted elsewhere (outside core) */
 export const on = ( eventName, handler ) => messageBus.on( `external:${eventName}`, payload =>

--- a/sdk/core/src/interface/workflow.d.ts
+++ b/sdk/core/src/interface/workflow.d.ts
@@ -63,7 +63,18 @@ export type WorkflowContext<
      *
      * @see {@link https://docs.temporal.io/workflow-execution/workflowid-runid#workflow-id}
      */
-    workflowId: string
+    workflowId: string,
+
+    /**
+     * Internal Temporal run id for the current execution attempt.
+     *
+     * A single `workflowId` can map to multiple `runId`s when a workflow is
+     * retried, reset, or continued-as-new. The current run can be pinned in
+     * downstream `/workflow/{id}/runs/{rid}/...` API calls.
+     *
+     * @see {@link https://docs.temporal.io/workflow-execution/workflowid-runid#run-id}
+     */
+    runId: string
   }
 };
 

--- a/sdk/core/src/interface/workflow.js
+++ b/sdk/core/src/interface/workflow.js
@@ -39,15 +39,20 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
     // this returns a plain function, for example, in unit tests
     if ( !inWorkflowContext() ) {
       validateWithSchema( inputSchema, input, `Workflow ${name} input` );
-      const context = Context.build( { workflowId: 'test-workflow', continueAsNew: async () => {}, isContinueAsNewSuggested: () => false } );
+      const context = Context.build( {
+        workflowId: 'test-workflow',
+        runId: 'test-run',
+        continueAsNew: async () => {},
+        isContinueAsNewSuggested: () => false
+      } );
       const output = await fn( input, deepMerge( context, extra.context ) );
       validateWithSchema( outputSchema, output, `Workflow ${name} output` );
       return output;
     }
 
-    const { workflowId, memo, startTime } = workflowInfo();
+    const { workflowId, runId, memo, startTime } = workflowInfo();
 
-    const context = Context.build( { workflowId, continueAsNew, isContinueAsNewSuggested: () => workflowInfo().continueAsNewSuggested } );
+    const context = Context.build( { workflowId, runId, continueAsNew, isContinueAsNewSuggested: () => workflowInfo().continueAsNewSuggested } );
 
     // Root workflows will not have the execution context yet, since it is set here.
     const isRoot = !memo.executionContext;
@@ -57,6 +62,7 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
        It will be used to as context for tracing (connecting events) */
     const executionContext = memo.executionContext ?? {
       workflowId,
+      runId,
       workflowName: name,
       disableTrace,
       startTime: startTime.getTime()

--- a/sdk/core/src/interface/workflow_context.js
+++ b/sdk/core/src/interface/workflow_context.js
@@ -7,11 +7,12 @@ export class Context {
    * Builds a new context instance
    * @param {object} options - Arguments to build a new context instance
    * @param {string} workflowId
+   * @param {string} runId
    * @param {function} continueAsNew
    * @param {function} isContinueAsNewSuggested
    * @returns {object} context
    */
-  static build( { workflowId, continueAsNew, isContinueAsNewSuggested } ) {
+  static build( { workflowId, runId, continueAsNew, isContinueAsNewSuggested } ) {
     return {
       /**
        * Control namespace: This object adds functions to interact with Temporal flow mechanisms
@@ -24,7 +25,8 @@ export class Context {
        * Info namespace: abstracts workflowInfo()
        */
       info: {
-        workflowId
+        workflowId,
+        runId
       }
     };
   }

--- a/sdk/core/src/tracing/tools/aggregate_trace_attributes.js
+++ b/sdk/core/src/tracing/tools/aggregate_trace_attributes.js
@@ -1,0 +1,118 @@
+/**
+ * Aggregate `attributes.cost` and `attributes.token_usage` across an entire trace tree.
+ *
+ * Walks every node in the tree, sums `attributes.cost.total` grouped by the emitting
+ * event name (inferred from node `kind` — see `eventNameForKind`), and sums
+ * `attributes.token_usage` across LLM nodes. Falls back to `output.usage` on
+ * legacy llm trace nodes that predate the `attributes.token_usage` write
+ * (see overview §1.2).
+ *
+ * @typedef {object} TraceAttributes
+ * @property {{ total: number, components: Array<{ name: string, value: number }> }} cost
+ * @property {{ inputTokens: number, outputTokens: number, cachedInputTokens: number, totalTokens: number }} tokenUsage
+ */
+
+const COST_EVENT_LLM = 'cost:llm:request';
+const COST_EVENT_HTTP = 'cost:http:request';
+const COST_EVENT_OTHER = 'other';
+
+/**
+ * Map a trace node `kind` to the canonical cost event name that would emit it.
+ * Unknown kinds bucket into `other` so future event sources still roll up cleanly.
+ *
+ * @param {string} kind
+ * @returns {string}
+ */
+const eventNameForKind = kind => {
+  if ( kind === 'llm' ) {
+    return COST_EVENT_LLM;
+  }
+  if ( kind === 'http' ) {
+    return COST_EVENT_HTTP;
+  }
+  return COST_EVENT_OTHER;
+};
+
+const isNumber = value => typeof value === 'number' && Number.isFinite( value );
+
+/**
+ * Pull token usage off an llm node, preferring the new attribute over the legacy
+ * `output.usage` fallback. Returns `null` when neither shape is present.
+ */
+const readTokenUsage = node => {
+  const attrUsage = node.attributes?.token_usage;
+  if ( attrUsage && typeof attrUsage === 'object' ) {
+    return attrUsage;
+  }
+  const legacyUsage = node.output?.usage;
+  if ( legacyUsage && typeof legacyUsage === 'object' ) {
+    return legacyUsage;
+  }
+  return null;
+};
+
+/**
+ * Recursively walk a trace tree depth-first, applying `visit` to each node.
+ */
+const walk = ( node, visit ) => {
+  if ( !node ) {
+    return;
+  }
+  visit( node );
+  for ( const child of node.children ?? [] ) {
+    walk( child, visit );
+  }
+};
+
+/**
+ * Build the aggregated `attributes` payload returned by `/trace-attributes`.
+ * Component buckets always appear in a stable order so callers can index them
+ * positionally if they want to.
+ *
+ * @param {object|null} root - The root NodeEntry returned by `buildTraceTree`.
+ * @returns {TraceAttributes}
+ */
+export default function aggregateTraceAttributes( root ) {
+  const costByEvent = new Map( [
+    [ COST_EVENT_LLM, 0 ],
+    [ COST_EVENT_HTTP, 0 ],
+    [ COST_EVENT_OTHER, 0 ]
+  ] );
+  const tokenUsage = { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, totalTokens: 0 };
+
+  walk( root, node => {
+    const cost = node.attributes?.cost;
+    if ( cost && isNumber( cost.total ) ) {
+      const eventName = eventNameForKind( node.kind );
+      costByEvent.set( eventName, ( costByEvent.get( eventName ) ?? 0 ) + cost.total );
+    }
+
+    if ( node.kind === 'llm' ) {
+      const usage = readTokenUsage( node );
+      if ( usage ) {
+        if ( isNumber( usage.inputTokens ) ) {
+          tokenUsage.inputTokens += usage.inputTokens;
+        }
+        if ( isNumber( usage.outputTokens ) ) {
+          tokenUsage.outputTokens += usage.outputTokens;
+        }
+        if ( isNumber( usage.cachedInputTokens ) ) {
+          tokenUsage.cachedInputTokens += usage.cachedInputTokens;
+        }
+        if ( isNumber( usage.totalTokens ) ) {
+          tokenUsage.totalTokens += usage.totalTokens;
+        }
+      }
+    }
+  } );
+
+  const components = Array.from( costByEvent, ( [ name, value ] ) => ( { name, value } ) );
+  const total = components.reduce( ( sum, { value } ) => sum + value, 0 );
+
+  return {
+    cost: { total, components },
+    tokenUsage
+  };
+}
+
+export { COST_EVENT_LLM, COST_EVENT_HTTP, COST_EVENT_OTHER };

--- a/sdk/core/src/tracing/tools/aggregate_trace_attributes.spec.js
+++ b/sdk/core/src/tracing/tools/aggregate_trace_attributes.spec.js
@@ -1,0 +1,231 @@
+import { describe, it, expect } from 'vitest';
+import aggregateTraceAttributes, {
+  COST_EVENT_LLM,
+  COST_EVENT_HTTP,
+  COST_EVENT_OTHER
+} from './aggregate_trace_attributes.js';
+
+const node = ( { id, kind = 'step', attributes = {}, output, children = [] } ) => ( {
+  id,
+  kind,
+  name: id,
+  startedAt: 0,
+  endedAt: 0,
+  input: undefined,
+  output,
+  attributes,
+  children
+} );
+
+describe( 'aggregate_trace_attributes', () => {
+  it( 'returns zeros for a null root', () => {
+    const result = aggregateTraceAttributes( null );
+    expect( result.cost.total ).toBe( 0 );
+    expect( result.cost.components ).toEqual( [
+      { name: COST_EVENT_LLM, value: 0 },
+      { name: COST_EVENT_HTTP, value: 0 },
+      { name: COST_EVENT_OTHER, value: 0 }
+    ] );
+    expect( result.tokenUsage ).toEqual( {
+      inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, totalTokens: 0
+    } );
+  } );
+
+  it( 'returns zeros for a tree with no cost or usage attributes', () => {
+    const root = node( {
+      id: 'wf',
+      kind: 'workflow',
+      children: [ node( { id: 's1' } ), node( { id: 's2' } ) ]
+    } );
+    const result = aggregateTraceAttributes( root );
+    expect( result.cost.total ).toBe( 0 );
+    expect( result.tokenUsage.totalTokens ).toBe( 0 );
+  } );
+
+  it( 'buckets cost by node kind into llm / http / other components', () => {
+    const root = node( {
+      id: 'wf',
+      kind: 'workflow',
+      children: [
+        node( { id: 'llm-1', kind: 'llm', attributes: { cost: { total: 0.20 } } } ),
+        node( { id: 'llm-2', kind: 'llm', attributes: { cost: { total: 0.10 } } } ),
+        node( { id: 'http-1', kind: 'http', attributes: { cost: { total: 0.50 } } } ),
+        // Unknown kind falls into the catch-all bucket
+        node( { id: 'step-1', kind: 'step', attributes: { cost: { total: 0.07 } } } )
+      ]
+    } );
+    const result = aggregateTraceAttributes( root );
+
+    const byName = Object.fromEntries( result.cost.components.map( c => [ c.name, c.value ] ) );
+    expect( byName[COST_EVENT_LLM] ).toBeCloseTo( 0.30, 10 );
+    expect( byName[COST_EVENT_HTTP] ).toBeCloseTo( 0.50, 10 );
+    expect( byName[COST_EVENT_OTHER] ).toBeCloseTo( 0.07, 10 );
+    expect( result.cost.total ).toBeCloseTo( 0.87, 10 );
+  } );
+
+  it( 'total equals the sum of all components', () => {
+    const root = node( {
+      id: 'wf',
+      kind: 'workflow',
+      children: [
+        node( { id: 'llm-1', kind: 'llm', attributes: { cost: { total: 0.1234 } } } ),
+        node( { id: 'http-1', kind: 'http', attributes: { cost: { total: 0.0011 } } } )
+      ]
+    } );
+    const { cost } = aggregateTraceAttributes( root );
+    const sum = cost.components.reduce( ( s, c ) => s + c.value, 0 );
+    expect( cost.total ).toBeCloseTo( sum, 10 );
+  } );
+
+  it( 'sums token_usage across llm nodes from the attribute path', () => {
+    const root = node( {
+      id: 'wf',
+      kind: 'workflow',
+      children: [
+        node( {
+          id: 'llm-1', kind: 'llm', attributes: {
+            token_usage: { inputTokens: 100, outputTokens: 20, cachedInputTokens: 5, totalTokens: 125 }
+          }
+        } ),
+        node( {
+          id: 'llm-2', kind: 'llm', attributes: {
+            token_usage: { inputTokens: 50, outputTokens: 10, cachedInputTokens: 1, totalTokens: 61 }
+          }
+        } )
+      ]
+    } );
+    const { tokenUsage } = aggregateTraceAttributes( root );
+    expect( tokenUsage ).toEqual( {
+      inputTokens: 150,
+      outputTokens: 30,
+      cachedInputTokens: 6,
+      totalTokens: 186
+    } );
+  } );
+
+  it( 'falls back to output.usage on legacy llm nodes that lack attributes.token_usage', () => {
+    const root = node( {
+      id: 'wf',
+      kind: 'workflow',
+      children: [
+        // Legacy shape — usage lives on output.usage, no attributes.token_usage
+        node( {
+          id: 'llm-legacy',
+          kind: 'llm',
+          output: { result: '...', usage: { inputTokens: 200, outputTokens: 40, totalTokens: 240 } }
+        } )
+      ]
+    } );
+    const { tokenUsage } = aggregateTraceAttributes( root );
+    expect( tokenUsage.inputTokens ).toBe( 200 );
+    expect( tokenUsage.outputTokens ).toBe( 40 );
+    expect( tokenUsage.totalTokens ).toBe( 240 );
+    expect( tokenUsage.cachedInputTokens ).toBe( 0 );
+  } );
+
+  it( 'prefers attributes.token_usage over output.usage when both are present', () => {
+    const root = node( {
+      id: 'wf',
+      kind: 'workflow',
+      children: [
+        node( {
+          id: 'llm-1',
+          kind: 'llm',
+          attributes: { token_usage: { inputTokens: 10, outputTokens: 2, totalTokens: 12 } },
+          output: { usage: { inputTokens: 999, outputTokens: 999, totalTokens: 999 } }
+        } )
+      ]
+    } );
+    const { tokenUsage } = aggregateTraceAttributes( root );
+    expect( tokenUsage.inputTokens ).toBe( 10 );
+    expect( tokenUsage.totalTokens ).toBe( 12 );
+  } );
+
+  it( 'ignores token_usage shapes on non-llm nodes', () => {
+    const root = node( {
+      id: 'wf',
+      kind: 'workflow',
+      // attributes.token_usage on a non-llm node is intentionally ignored —
+      // only llm nodes contribute to the token-usage rollup today.
+      children: [
+        node( {
+          id: 'step-1', kind: 'step', attributes: {
+            token_usage: { inputTokens: 999, outputTokens: 999, totalTokens: 999 }
+          }
+        } )
+      ]
+    } );
+    const { tokenUsage } = aggregateTraceAttributes( root );
+    expect( tokenUsage.totalTokens ).toBe( 0 );
+  } );
+
+  it( 'aggregates a mixed tree with cost on http nodes and usage on llm nodes', () => {
+    const root = node( {
+      id: 'wf',
+      kind: 'workflow',
+      children: [
+        node( {
+          id: 'llm-1',
+          kind: 'llm',
+          attributes: {
+            cost: { total: 0.0038 },
+            token_usage: { inputTokens: 2264, outputTokens: 411, cachedInputTokens: 100, totalTokens: 2775 }
+          }
+        } ),
+        node( {
+          id: 'http-1',
+          kind: 'http',
+          attributes: { cost: { total: 0.50 } }
+        } )
+      ]
+    } );
+    const result = aggregateTraceAttributes( root );
+
+    const byName = Object.fromEntries( result.cost.components.map( c => [ c.name, c.value ] ) );
+    expect( byName[COST_EVENT_LLM] ).toBeCloseTo( 0.0038, 10 );
+    expect( byName[COST_EVENT_HTTP] ).toBeCloseTo( 0.50, 10 );
+    expect( byName[COST_EVENT_OTHER] ).toBe( 0 );
+    expect( result.cost.total ).toBeCloseTo( 0.5038, 10 );
+
+    expect( result.tokenUsage ).toEqual( {
+      inputTokens: 2264,
+      outputTokens: 411,
+      cachedInputTokens: 100,
+      totalTokens: 2775
+    } );
+  } );
+
+  it( 'recurses through nested children', () => {
+    const root = node( {
+      id: 'wf',
+      kind: 'workflow',
+      children: [
+        node( {
+          id: 's1',
+          kind: 'step',
+          children: [
+            node( {
+              id: 'llm-1', kind: 'llm', attributes: {
+                cost: { total: 0.01 },
+                token_usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 }
+              }
+            } )
+          ]
+        } )
+      ]
+    } );
+    const result = aggregateTraceAttributes( root );
+    expect( result.cost.total ).toBeCloseTo( 0.01, 10 );
+    expect( result.tokenUsage.totalTokens ).toBe( 15 );
+  } );
+
+  it( 'keeps the canonical component ordering: llm, http, other', () => {
+    const root = node( { id: 'wf', kind: 'workflow' } );
+    const { cost } = aggregateTraceAttributes( root );
+    expect( cost.components.map( c => c.name ) ).toEqual( [
+      COST_EVENT_LLM,
+      COST_EVENT_HTTP,
+      COST_EVENT_OTHER
+    ] );
+  } );
+} );

--- a/sdk/core/src/tracing/tools/index.js
+++ b/sdk/core/src/tracing/tools/index.js
@@ -1,0 +1,7 @@
+export { default as buildTraceTree } from './build_trace_tree.js';
+export {
+  default as aggregateTraceAttributes,
+  COST_EVENT_LLM,
+  COST_EVENT_HTTP,
+  COST_EVENT_OTHER
+} from './aggregate_trace_attributes.js';

--- a/sdk/core/src/worker/sinks.js
+++ b/sdk/core/src/worker/sinks.js
@@ -11,8 +11,8 @@ export const sinks = {
   workflow: {
     start: {
       fn: ( workflowInfo, input ) => {
-        const { workflowId: id, workflowType: name, memo: { parentId, executionContext } } = workflowInfo;
-        messageBus.emit( BusEventType.WORKFLOW_START, { id, name } );
+        const { workflowId: id, runId, workflowType: name, memo: { parentId, executionContext } } = workflowInfo;
+        messageBus.emit( BusEventType.WORKFLOW_START, { id, runId, name } );
         if ( executionContext ) { // filters out internal workflows
           Tracing.addEventStart( { id, kind: ComponentType.WORKFLOW, name, details: input, parentId, executionContext } );
         }
@@ -22,8 +22,8 @@ export const sinks = {
 
     end: {
       fn: ( workflowInfo, output ) => {
-        const { workflowId: id, workflowType: name, startTime, memo: { executionContext } } = workflowInfo;
-        messageBus.emit( BusEventType.WORKFLOW_END, { id, name, duration: Date.now() - startTime.getTime() } );
+        const { workflowId: id, runId, workflowType: name, startTime, memo: { executionContext } } = workflowInfo;
+        messageBus.emit( BusEventType.WORKFLOW_END, { id, runId, name, duration: Date.now() - startTime.getTime() } );
         if ( executionContext ) { // filters out internal workflows
           Tracing.addEventEnd( { id, details: output, executionContext } );
         }
@@ -33,8 +33,8 @@ export const sinks = {
 
     error: {
       fn: ( workflowInfo, error ) => {
-        const { workflowId: id, workflowType: name, startTime, memo: { executionContext } } = workflowInfo;
-        messageBus.emit( BusEventType.WORKFLOW_ERROR, { id, name, error, duration: Date.now() - startTime.getTime() } );
+        const { workflowId: id, runId, workflowType: name, startTime, memo: { executionContext } } = workflowInfo;
+        messageBus.emit( BusEventType.WORKFLOW_ERROR, { id, runId, name, error, duration: Date.now() - startTime.getTime() } );
         if ( executionContext ) { // filters out internal workflows
           Tracing.addEventError( { id, details: error, executionContext } );
         }

--- a/sdk/llm/src/utils/trace.js
+++ b/sdk/llm/src/utils/trace.js
@@ -13,6 +13,8 @@ export const endTraceWithError = ( { traceId, error } ) => {
 export const endTraceWithSuccess = ( { traceId, modelId, response, cost, ...extra } ) => {
   const { totalUsage: usage, text: result, providerMetadata } = response;
   Tracing.addEventAttribute( { eventId: traceId, name: Tracing.Attribute.COST, value: cost } );
-  Tracing.addEventEnd( { id: traceId, details: { result, usage, providerMetadata, ...extra } } );
+  Tracing.addEventAttribute( { eventId: traceId, name: Tracing.Attribute.TOKEN_USAGE, value: usage } );
+  Tracing.addEventEnd( { id: traceId, details: { result, providerMetadata, ...extra } } );
   emitEvent( 'cost:llm:request', { modelId, cost, usage } );
+  emitEvent( 'token_usage:llm:request', { modelId, usage } );
 };

--- a/sdk/llm/src/utils/trace.spec.js
+++ b/sdk/llm/src/utils/trace.spec.js
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import buildTraceTree from '../../../core/src/tracing/tools/build_trace_tree.js';
+import { EventAction } from '../../../core/src/tracing/trace_consts.js';
 
 vi.mock( '@outputai/core/sdk_activity_integration', () => ( {
   Tracing: {
@@ -7,7 +9,8 @@ vi.mock( '@outputai/core/sdk_activity_integration', () => ( {
     addEventAttribute: vi.fn(),
     addEventEnd: vi.fn(),
     Attribute: {
-      COST: 'cost'
+      COST: 'cost',
+      TOKEN_USAGE: 'token_usage'
     }
   },
   emitEvent: vi.fn()
@@ -54,7 +57,7 @@ describe( 'trace utils', () => {
   } );
 
   describe( 'endTraceWithSuccess', () => {
-    it( 'adds cost attribute, ends the trace with response fields and extra details, and emits cost:llm:request', () => {
+    it( 'adds cost + token_usage attributes, ends the trace without usage in output, and emits both cost and token_usage events', () => {
       const cost = { total: 0.01, components: [] };
       const usage = { inputTokens: 2, outputTokens: 3 };
       const response = {
@@ -76,20 +79,63 @@ describe( 'trace utils', () => {
         name: 'cost',
         value: cost
       } );
+      expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
+        eventId: 'trace-a',
+        name: 'token_usage',
+        value: usage
+      } );
       expect( tracing.addEventEnd ).toHaveBeenCalledWith( {
         id: 'trace-a',
         details: {
           result: 'hello',
-          usage,
           providerMetadata: { provider: 'x' },
           sourcesFromTools: [ { url: 'https://u.test', title: '' } ]
         }
       } );
+      expect( tracing.addEventEnd.mock.calls[0][0].details ).not.toHaveProperty( 'usage' );
       expect( emitEvent ).toHaveBeenCalledWith( 'cost:llm:request', {
         modelId: 'my-model',
         cost,
         usage
       } );
+      expect( emitEvent ).toHaveBeenCalledWith( 'token_usage:llm:request', {
+        modelId: 'my-model',
+        usage
+      } );
+    } );
+
+    it( 'produces an llm trace node with attributes.token_usage and no output.usage when fed through buildTraceTree', () => {
+      const usage = { inputTokens: 12, outputTokens: 7, cachedInputTokens: 3, totalTokens: 22 };
+      const cost = { total: 0.0042, components: [ { name: 'input_tokens', value: 0.002 } ] };
+      const response = {
+        text: 'tree result',
+        totalUsage: usage,
+        providerMetadata: { provider: 'p' }
+      };
+
+      // Capture the calls the wrapper makes against Tracing/emit, and translate them into trace
+      // entries — what buildTraceTree consumes server-side to materialize the persisted trace JSON.
+      endTraceWithSuccess( { traceId: 'llm-1', modelId: 'm', response, cost } );
+
+      const entries = [
+        { kind: 'workflow', action: EventAction.START, name: 'wf', id: 'wf', parentId: undefined, details: {}, timestamp: 1 },
+        { kind: 'llm', action: EventAction.START, name: 'generateText', id: 'llm-1', parentId: 'wf', details: { prompt: 'p' }, timestamp: 10 }
+      ];
+      for ( const call of Tracing.addEventAttribute.mock.calls ) {
+        entries.push( { id: call[0].eventId, action: EventAction.ADD_ATTR, details: { name: call[0].name, value: call[0].value }, timestamp: 20 } );
+      }
+      const endDetails = Tracing.addEventEnd.mock.calls[0][0].details;
+      entries.push( { id: 'llm-1', action: EventAction.END, details: endDetails, timestamp: 30 } );
+      entries.push( { id: 'wf', action: EventAction.END, details: {}, timestamp: 40 } );
+
+      const tree = buildTraceTree( entries );
+      const llmNode = tree.children[0];
+
+      expect( llmNode.kind ).toBe( 'llm' );
+      expect( llmNode.attributes.token_usage ).toEqual( usage );
+      expect( llmNode.attributes.cost ).toEqual( cost );
+      expect( llmNode.output ).not.toHaveProperty( 'usage' );
+      expect( llmNode.output ).toMatchObject( { result: 'tree result', providerMetadata: { provider: 'p' } } );
     } );
   } );
 } );


### PR DESCRIPTION
## Summary
- Add `TOKEN_USAGE` attribute constant; emit `token_usage:llm:request` event; drop duplicate `usage` from LLM trace output.
- Add `GET /workflow/{id}/trace-attributes` (and pinned-run variant) returning aggregated cost + token usage + runtime + traceUrl.
- **Add `runId` to `context.info`, `executionContext`, and lifecycle hook payloads** (`onWorkflowStart` / `onWorkflowEnd` / `onWorkflowError`). Every `emitEvent(...)`-broadcast event (`cost:llm:request`, `cost:http:request`, `token_usage:llm:request`) now auto-carries `runId` in addition to `workflowId`.
- Update `output workflow cost` CLI to read from `attributes.cost` / `attributes.token_usage` (drops legacy `output.usage` fallback per cost-feature scope).
- Two framework / packaging fixes discovered during e2e validation:
  - `ops/api.Dockerfile` now uses a two-stage `pnpm deploy --legacy /app` build so `output-api` actually bundles its new `@outputai/core` workspace dep.
  - `sdk/cli/src/assets/docker/docker-compose-dev.yml` bind-mounts the worker's local trace dir into the api container at the same absolute path so the new `/trace-attributes` endpoint can read trace JSON files in local dev mode.

## Dependency rule exception — `output-api` → `@outputai/core`

This PR introduces the **first sanctioned exception** to the convention that `output-api` does not depend on any `@outputai/*` SDK package.

- **Scope:** `output-api` may import from `@outputai/core/sdk_tracing_tools` (the new `aggregateTraceAttributes` walker). New imports from any other `@outputai/core` entrypoint require a fresh discussion + an updated entry here.
- **Why this one is OK:** `sdk_tracing_tools` operates on data structures that core itself owns and persists (the trace tree shape). The api is a thin reader of those structures; moving the walker into the api would duplicate type knowledge core already owns, and putting it in a third package adds versioning/changeset overhead for one function with one external consumer.

## Test plan
- [x] 1878 unit tests pass; trace-attributes endpoint covered (happy / 424 / 404 / legacy / local-fallback).
- [x] OpenAPI spec validates; orval client regenerated.
- [x] Built image smoke-tested: `node -e "import('@outputai/core/sdk_tracing_tools')..."` returns the helper.
- [x] E2E against a real `content_metadata` workflow run via `output dev` — `/trace-attributes` returns the full payload from a local trace file.
- [x] E2E for the new `runId` plumbing — global `onWorkflowEnd` hook in os-workflows POSTs a `workflow_end` ping carrying both `workflowId` and `runId` to atlas; atlas's `WorkflowEndProcessor` enqueues the cost-fetch job with the correct args.
- [x] Lint + build clean.

## Dev release
Already published from this branch:
- npm: `@outputai/*@0.4.1-dev.10cf346.0`
- docker: `outputai/api:0.4.1-dev.10cf346.0`

## Merge order

This PR is one of four shipping together for Linear COS-216 (cost info in Agents HQ). To avoid leaving downstream repos pinned to dev prereleases:

1. **Merge this PR (output#202) first.**
2. Cut a real (non-dev) `@outputai/*` release including these changes — bumps from `0.4.x` to a stable.
3. In **os-workflows#151**, bump `@outputai/*` deps to the stable version and drop the `legacy-peer-deps=true` line in `.npmrc`; merge.
4. **Merge `output_workflows-rails#5`** and cut a real gem release.
5. In **atlas#1918**, update `Gemfile` to reference the released gem version (drop the `branch:` pin), `bundle update output_workflows-rails`, and merge.

## Notes
- Breaking change for the CLI cost calculator: pre-cost-feature traces will report \$0 LLM cost (intentional).
- Cross-PR companions: https://github.com/growthxai/output_workflows-rails/pull/5, https://github.com/growthxai/os-workflows/pull/151, https://github.com/growthxai/atlas/pull/1918