### PR TITLE
feat: Adding costs/llm_usage breakdown and total to workflow results [OUT-449]

### DIFF
--- a/.changeset/crisp-ants-divide.md
+++ b/.changeset/crisp-ants-divide.md
@@ -1,0 +1,8 @@
+---
+"@outputai/core": minor
+"@outputai/http": minor
+"@outputai/llm": minor
+"output-api": minor
+---
+
+Adding emitted attributes to the workflow result together with aggregated costs, token usage and http cals

--- a/.changeset/crisp-ants-divide.md
+++ b/.changeset/crisp-ants-divide.md
@@ -5,4 +5,24 @@
 "output-api": minor
 ---
 
-Adding emitted attributes to the workflow result together with aggregated costs, token usage and http cals
+Workflow runs now return durable usage and cost metadata alongside the workflow output. Each completed or failed run can include raw `attributes` plus convenient `aggregations` for total cost, token usage, and HTTP request counts.
+
+For example, API and CLI JSON results can now include:
+
+```json
+{
+  "attributes": [
+    { "type": "llm:usage", "modelId": "gpt-4o", "total": 0.00122, "tokensUsed": 226 },
+    { "type": "http:request:cost", "url": "https://api.vendor.com/search", "total": 0.42 }
+  ],
+  "aggregations": {
+    "cost": { "total": 0.42122 },
+    "tokens": { "total": 226 },
+    "httpRequests": { "total": 1 }
+  }
+}
+```
+
+Cost events now emit the same attribute-shaped payloads used in workflow results, making hook handlers and saved run metadata easier to reconcile. This also updates `@outputai/http` request cost tracking and `@outputai/llm` response cost data to use the new attribute format.
+
+Learn more in the [workflow result docs](https://docs.output.ai/api), [CLI result format](https://docs.output.ai/packages/cli#workflow-result-json-format), [cost events guide](https://docs.output.ai/costs/cost-events), and [v0.4.0 to v0.5.0 migration guide](https://docs.output.ai/migrations/v0.4.0-to-v0.5.0).

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -353,6 +353,21 @@
           "trace": {
             "$ref": "#/components/schemas/TraceInfo"
           },
+          "attributes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "nullable": true,
+            "description": "Durable workflow attributes collected during execution"
+          },
+          "aggregations": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true,
+            "description": "Convenience totals derived from attributes"
+          },
           "status": {
             "type": "string",
             "enum": [
@@ -569,32 +584,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "workflowId": {
-                      "type": "string",
-                      "description": "The workflow execution id"
-                    },
-                    "output": {
-                      "description": "The output of the workflow, null if workflow failed"
-                    },
-                    "trace": {
-                      "$ref": "#/components/schemas/TraceInfo"
-                    },
-                    "status": {
-                      "type": "string",
-                      "enum": [
-                        "completed",
-                        "failed"
-                      ],
-                      "description": "The workflow execution status"
-                    },
-                    "error": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "Error message if workflow failed, null otherwise"
-                    }
-                  }
+                  "$ref": "#/components/schemas/WorkflowResultResponse"
                 }
               }
             }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -355,12 +355,12 @@
           },
           "attributes": {
             "type": "array",
+            "nullable": true,
+            "description": "Durable workflow attributes collected during execution",
             "items": {
               "type": "object",
               "additionalProperties": true
-            },
-            "nullable": true,
-            "description": "Durable workflow attributes collected during execution"
+            }
           },
           "aggregations": {
             "type": "object",

--- a/api/src/clients/temporal_client.js
+++ b/api/src/clients/temporal_client.js
@@ -169,13 +169,32 @@ export const extractWorkflowInput = history => {
  * @param {WorkflowExecutionStatus} args.status - The workflow status
  * @param {string} args.runId - The specific run id for this execution
  * @param {string|number|boolean|object|array|undefined|null} args.input - The original workflow input
- * @param {string|number|boolean|object|array|undefined|null} args.output - The workflow output
- * @param {object|undefined} args.trace - Trace information
- * @param {string|undefined} args.error - Error message if failed
+ * @param {object} args.result - The workflow result from @outputai/core
+ * @param {Error} args.error - Error
  * @returns {WorkflowResult}
  */
-const buildWorkflowResult = ( { workflowId, status, runId, input, output, trace, error } ) =>
-  ( { workflowId, runId, status, input, output: output ?? null, trace: trace ?? null, error: error ?? null } );
+const buildWorkflowResult = ( { workflowId, status, runId, input, result, error } ) =>
+  ( {
+    workflowId,
+    runId,
+    status,
+    input,
+    ...( result ? {
+      output: result.output,
+      trace: result.trace,
+      cost: result.cost
+    } : {
+      output: null,
+      trace: null,
+      cost: null
+    } ),
+    ...( error ? {
+      trace: extractTraceInfo( error ),
+      error: extractErrorMessage( error )
+    } : {
+      error: null
+    } )
+  } );
 
 export default {
   async init() {
@@ -240,7 +259,7 @@ export default {
             handle.result(),
             new Promise( ( _, rj ) => setTimeout( () => rj( new WorkflowExecutionTimedOutError() ), executionTimeout ) )
           ] );
-          return buildWorkflowResult( { workflowId, status: 'completed', runId, input, output: result.output, trace: result.trace } );
+          return buildWorkflowResult( { workflowId, status: 'completed', runId, input, result } );
         } catch ( error ) {
           // Workflow failures are returned as data, not thrown
           if ( error instanceof WorkflowFailedError ) {
@@ -249,11 +268,7 @@ export default {
               errorMessage: error.message,
               hasTrace: Boolean( extractTraceInfo( error ) )
             } );
-            return buildWorkflowResult( {
-              workflowId, status: 'failed', runId, input,
-              trace: extractTraceInfo( error ),
-              error: extractErrorMessage( error )
-            } );
+            return buildWorkflowResult( { workflowId, status: 'failed', runId, input, error } );
           }
           // Other errors (timeout, not found, etc.) are still thrown
           error.workflowId = workflowId;
@@ -395,7 +410,7 @@ export default {
         // For completed workflows, return the full result
         if ( description.status.code === TemporalStatus.COMPLETED ) {
           const result = await pinnedHandle.result();
-          return buildWorkflowResult( { workflowId, status, runId: resolvedRunId, input, output: result.output, trace: result.trace } );
+          return buildWorkflowResult( { workflowId, status, runId: resolvedRunId, input, result } );
         }
 
         // CONTINUED_AS_NEW is not an error - it means the workflow continued in a new execution
@@ -421,13 +436,7 @@ export default {
             throw e;
           } );
 
-        return buildWorkflowResult( {
-          workflowId, status, runId: resolvedRunId, input,
-          ...( workflowError && {
-            trace: extractTraceInfo( workflowError ),
-            error: extractErrorMessage( workflowError )
-          } )
-        } );
+        return buildWorkflowResult( { workflowId, status, runId: resolvedRunId, input, error: workflowError } );
       },
 
       /**

--- a/api/src/clients/temporal_client.js
+++ b/api/src/clients/temporal_client.js
@@ -1,6 +1,6 @@
 import { Client, Connection, defaultPayloadConverter } from '@temporalio/client';
 import { temporal as temporalConfig } from '#configs';
-import { buildWorkflowId, extractTraceInfo, extractErrorMessage, takeFromAsyncIterable } from '#utils';
+import { buildWorkflowId, extractErrorDetail, extractErrorMessage, takeFromAsyncIterable } from '#utils';
 import { logger } from '#logger';
 import {
   WorkflowNotFoundError,
@@ -182,14 +182,18 @@ const buildWorkflowResult = ( { workflowId, status, runId, input, result, error 
     ...( result ? {
       output: result.output,
       trace: result.trace,
-      cost: result.cost
+      attributes: result.attributes,
+      aggregations: result.aggregations
     } : {
       output: null,
       trace: null,
-      cost: null
+      attributes: null,
+      aggregations: null
     } ),
     ...( error ? {
-      trace: extractTraceInfo( error ),
+      trace: extractErrorDetail( error, 'trace' ),
+      attributes: extractErrorDetail( error, 'attributes' ),
+      aggregations: extractErrorDetail( error, 'aggregations' ),
       error: extractErrorMessage( error )
     } : {
       error: null
@@ -266,7 +270,7 @@ export default {
             logger.warn( 'Workflow execution failed', {
               workflowId,
               errorMessage: error.message,
-              hasTrace: Boolean( extractTraceInfo( error ) )
+              hasTrace: Boolean( extractErrorDetail( error, 'trace' ) )
             } );
             return buildWorkflowResult( { workflowId, status: 'failed', runId, input, error } );
           }

--- a/api/src/clients/temporal_client.spec.js
+++ b/api/src/clients/temporal_client.spec.js
@@ -121,7 +121,7 @@ const walkCause = e => e?.cause ? walkCause( e.cause ) : ( e?.message ?? null );
 
 vi.mock( '#utils', () => ( {
   buildWorkflowId: vi.fn( () => 'test-uuid' ),
-  extractTraceInfo: vi.fn( e => e?.details?.find?.( d => d.trace )?.trace ),
+  extractErrorDetail: vi.fn( ( e, key ) => e?.details?.find?.( d => Object.prototype.hasOwnProperty.call( d, key ) )?.[key] ?? null ),
   extractErrorMessage: vi.fn( e => walkCause( e ) ),
   takeFromAsyncIterable: async ( iterable, count ) => {
     const items = [];
@@ -175,8 +175,10 @@ describe( 'temporal_client', () => {
   describe( 'runWorkflow', () => {
     it( 'should return failed status with trace and deepest error message from cause chain', async () => {
       const tracePayload = { destinations: { local: '/tmp/trace.json' } };
+      const attributes = [ { type: 'llm:usage', total: 0.4, tokensUsed: 20 } ];
+      const aggregations = { cost: { total: 0.4 }, tokens: { total: 20 }, httpRequests: { total: 0 } };
       const workflowError = new MockWorkflowFailedError( 'Workflow execution failed', {
-        details: [ { trace: tracePayload } ],
+        details: [ { trace: tracePayload, attributes, aggregations } ],
         cause: { message: 'Activity task failed', cause: { message: 'step error message' } }
       } );
 
@@ -199,8 +201,9 @@ describe( 'temporal_client', () => {
         status: 'failed',
         input: { input: 'data' },
         output: null,
-        cost: null,
         trace: tracePayload,
+        attributes,
+        aggregations,
         error: 'step error message'
       } );
       expect( mockLoggerWarn ).toHaveBeenCalledWith( 'Workflow execution failed', expect.objectContaining( {
@@ -210,7 +213,12 @@ describe( 'temporal_client', () => {
     } );
 
     it( 'should return completed status with output on success', async () => {
-      const successResult = { output: { data: 'result' }, trace: { local: '/tmp/trace.json' }, cost: 'some-cost' };
+      const successResult = {
+        output: { data: 'result' },
+        trace: { local: '/tmp/trace.json' },
+        attributes: [ { type: 'llm:usage' } ],
+        aggregations: { cost: { total: 1 }, tokens: { total: 10 }, httpRequests: { total: 0 } }
+      };
 
       mockQuery.mockResolvedValue( { workflows: [ { name: 'test-workflow' } ] } );
       mockStart.mockResolvedValue( {
@@ -231,8 +239,9 @@ describe( 'temporal_client', () => {
         status: 'completed',
         input: { input: 'data' },
         output: { data: 'result' },
-        cost: 'some-cost',
         trace: { local: '/tmp/trace.json' },
+        attributes: [ { type: 'llm:usage' } ],
+        aggregations: { cost: { total: 1 }, tokens: { total: 10 }, httpRequests: { total: 0 } },
         error: null
       } );
     } );
@@ -348,7 +357,12 @@ describe( 'temporal_client', () => {
     } );
 
     it( 'should return completed workflow with output and trace', async () => {
-      const workflowOutput = { output: { data: 'result' }, trace: { local: '/tmp/trace.json' }, cost: 'some-cost' };
+      const workflowOutput = {
+        output: { data: 'result' },
+        trace: { local: '/tmp/trace.json' },
+        attributes: [ { type: 'http:request:count' } ],
+        aggregations: { cost: { total: 0 }, tokens: { total: 0 }, httpRequests: { total: 1 } }
+      };
 
       mockDescribe.mockResolvedValue( {
         status: { code: 2, name: 'COMPLETED' },
@@ -366,8 +380,9 @@ describe( 'temporal_client', () => {
         status: 'completed',
         input: null,
         output: { data: 'result' },
-        cost: 'some-cost',
         trace: { local: '/tmp/trace.json' },
+        attributes: [ { type: 'http:request:count' } ],
+        aggregations: { cost: { total: 0 }, tokens: { total: 0 }, httpRequests: { total: 1 } },
         error: null
       } );
     } );
@@ -431,8 +446,10 @@ describe( 'temporal_client', () => {
 
     it( 'should return failed workflow with deepest error message and trace from WorkflowFailedError', async () => {
       const tracePayload = { destinations: { local: '/tmp/trace.json' } };
+      const attributes = [ { type: 'http:request:cost', total: 1.5 } ];
+      const aggregations = { cost: { total: 1.5 }, tokens: { total: 0 }, httpRequests: { total: 0 } };
       const workflowError = new MockWorkflowFailedError( 'Workflow execution failed', {
-        details: [ { trace: tracePayload } ],
+        details: [ { trace: tracePayload, attributes, aggregations } ],
         cause: { message: 'Activity task failed', cause: { message: 'step error message' } }
       } );
 
@@ -452,8 +469,9 @@ describe( 'temporal_client', () => {
         status: 'failed',
         input: null,
         output: null,
-        cost: null,
         trace: tracePayload,
+        attributes,
+        aggregations,
         error: 'step error message'
       } );
     } );
@@ -500,8 +518,9 @@ describe( 'temporal_client', () => {
         status: 'continued',
         input: null,
         output: null,
-        cost: null,
         trace: null,
+        attributes: null,
+        aggregations: null,
         error: null
       } );
     } );

--- a/api/src/clients/temporal_client.spec.js
+++ b/api/src/clients/temporal_client.spec.js
@@ -199,6 +199,7 @@ describe( 'temporal_client', () => {
         status: 'failed',
         input: { input: 'data' },
         output: null,
+        cost: null,
         trace: tracePayload,
         error: 'step error message'
       } );
@@ -209,7 +210,7 @@ describe( 'temporal_client', () => {
     } );
 
     it( 'should return completed status with output on success', async () => {
-      const successResult = { output: { data: 'result' }, trace: { local: '/tmp/trace.json' } };
+      const successResult = { output: { data: 'result' }, trace: { local: '/tmp/trace.json' }, cost: 'some-cost' };
 
       mockQuery.mockResolvedValue( { workflows: [ { name: 'test-workflow' } ] } );
       mockStart.mockResolvedValue( {
@@ -230,6 +231,7 @@ describe( 'temporal_client', () => {
         status: 'completed',
         input: { input: 'data' },
         output: { data: 'result' },
+        cost: 'some-cost',
         trace: { local: '/tmp/trace.json' },
         error: null
       } );
@@ -346,7 +348,7 @@ describe( 'temporal_client', () => {
     } );
 
     it( 'should return completed workflow with output and trace', async () => {
-      const workflowOutput = { output: { data: 'result' }, trace: { local: '/tmp/trace.json' } };
+      const workflowOutput = { output: { data: 'result' }, trace: { local: '/tmp/trace.json' }, cost: 'some-cost' };
 
       mockDescribe.mockResolvedValue( {
         status: { code: 2, name: 'COMPLETED' },
@@ -364,6 +366,7 @@ describe( 'temporal_client', () => {
         status: 'completed',
         input: null,
         output: { data: 'result' },
+        cost: 'some-cost',
         trace: { local: '/tmp/trace.json' },
         error: null
       } );
@@ -449,6 +452,7 @@ describe( 'temporal_client', () => {
         status: 'failed',
         input: null,
         output: null,
+        cost: null,
         trace: tracePayload,
         error: 'step error message'
       } );
@@ -496,6 +500,7 @@ describe( 'temporal_client', () => {
         status: 'continued',
         input: null,
         output: null,
+        cost: null,
         trace: null,
         error: null
       } );

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -344,6 +344,18 @@ app.use( ( req, res, next ) => {
  *           description: The result of workflow, null if workflow failed
  *         trace:
  *           $ref: '#/components/schemas/TraceInfo'
+ *         attributes:
+ *           type: array
+ *           nullable: true
+ *           description: Durable workflow attributes collected during execution
+ *           items:
+ *             type: object
+ *             additionalProperties: true
+ *         aggregations:
+ *           type: object
+ *           nullable: true
+ *           additionalProperties: true
+ *           description: Convenience totals derived from attributes
  *         status:
  *           type: string
  *           enum: [completed, failed, canceled, terminated, timed_out, continued]
@@ -474,23 +486,7 @@ app.use( ( req, res, next ) => {
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 workflowId:
- *                   type: string
- *                   description: The workflow execution id
- *                 output:
- *                   description: The output of the workflow, null if workflow failed
- *                 trace:
- *                   $ref: '#/components/schemas/TraceInfo'
- *                 status:
- *                   type: string
- *                   enum: [completed, failed]
- *                   description: The workflow execution status
- *                 error:
- *                   type: string
- *                   nullable: true
- *                   description: Error message if workflow failed, null otherwise
+ *               $ref: '#/components/schemas/WorkflowResultResponse'
  *       400:
  *         $ref: '#/components/responses/BadRequest'
  *       404:

--- a/api/src/utils.js
+++ b/api/src/utils.js
@@ -49,14 +49,14 @@ export function parseS3Url( url ) {
 }
 
 /**
- * Walks the error chain (via error.cause) and returns the first error whose details contain a "trace" object.
- * Returns undefined when the argument is falsy; otherwise the first trace found or the result of recursing on cause.
- * "trace" is added to Temporal workflow errors by Core.
+ * Walks the error chain and returns the first matching detail value.
  *
  * @param {Error} e
+ * @param {string} key
  * @returns {unknown}
  */
-export const extractTraceInfo = e => e ? ( e.details?.find?.( d => d.trace )?.trace ?? extractTraceInfo( e.cause ) ) : undefined;
+export const extractErrorDetail = ( e, key ) =>
+  e ? ( e.details?.find?.( d => d[key] )?.[key] ?? extractErrorDetail( e.cause, key ) ) : null;
 
 /**
  * Walks the error chain (via error.cause) and returns the message from the deepest error.

--- a/api/src/utils.spec.js
+++ b/api/src/utils.spec.js
@@ -3,7 +3,7 @@ import { InvalidTraceFileUrl } from './clients/errors.js';
 import {
   buildWorkflowId,
   parseS3Url,
-  extractTraceInfo,
+  extractErrorDetail,
   extractErrorMessage,
   takeFromAsyncIterable
 } from './utils.js';
@@ -101,12 +101,12 @@ describe( 'utils spec', () => {
     } );
   } );
 
-  describe( 'extractTraceInfo', () => {
+  describe( 'extractErrorDetail', () => {
     it( 'returns trace from error.details when present', () => {
       const tracePayload = { destinations: { local: 'xxx', remote: 'yyy' } };
       const error = { details: [ { trace: tracePayload } ] };
 
-      expect( extractTraceInfo( error ) ).toEqual( tracePayload );
+      expect( extractErrorDetail( error, 'trace' ) ).toEqual( tracePayload );
     } );
 
     it( 'returns trace from nested cause chain', () => {
@@ -114,7 +114,7 @@ describe( 'utils spec', () => {
       const inner = { details: [ { trace: tracePayload } ] };
       const outer = { cause: inner };
 
-      expect( extractTraceInfo( outer ) ).toEqual( tracePayload );
+      expect( extractErrorDetail( outer, 'trace' ) ).toEqual( tracePayload );
     } );
 
     it( 'returns trace from deeply nested cause chain', () => {
@@ -123,27 +123,27 @@ describe( 'utils spec', () => {
       const middle = { cause: deepest };
       const outer = { cause: middle };
 
-      expect( extractTraceInfo( outer ) ).toEqual( tracePayload );
+      expect( extractErrorDetail( outer, 'trace' ) ).toEqual( tracePayload );
     } );
 
-    it( 'returns undefined for null input', () => {
-      expect( extractTraceInfo( null ) ).toBeUndefined();
+    it( 'returns null for null input', () => {
+      expect( extractErrorDetail( null, 'trace' ) ).toBeNull();
     } );
 
-    it( 'returns undefined for undefined input', () => {
-      expect( extractTraceInfo( undefined ) ).toBeUndefined();
+    it( 'returns null for undefined input', () => {
+      expect( extractErrorDetail( undefined, 'trace' ) ).toBeNull();
     } );
 
-    it( 'returns undefined when no trace exists in chain', () => {
+    it( 'returns null when no trace exists in chain', () => {
       const error = { details: [ { other: 'data' } ], cause: { details: [] } };
 
-      expect( extractTraceInfo( error ) ).toBeUndefined();
+      expect( extractErrorDetail( error, 'trace' ) ).toBeNull();
     } );
 
     it( 'handles errors without details array', () => {
       const error = { message: 'error without details' };
 
-      expect( extractTraceInfo( error ) ).toBeUndefined();
+      expect( extractErrorDetail( error, 'trace' ) ).toBeNull();
     } );
 
     it( 'returns first trace found when multiple exist in chain', () => {
@@ -152,26 +152,46 @@ describe( 'utils spec', () => {
       const inner = { details: [ { trace: innerTrace } ] };
       const outer = { details: [ { trace: outerTrace } ], cause: inner };
 
-      expect( extractTraceInfo( outer ) ).toEqual( outerTrace );
+      expect( extractErrorDetail( outer, 'trace' ) ).toEqual( outerTrace );
     } );
 
     it( 'handles error with empty details array', () => {
       const error = { details: [] };
 
-      expect( extractTraceInfo( error ) ).toBeUndefined();
+      expect( extractErrorDetail( error, 'trace' ) ).toBeNull();
     } );
 
     it( 'handles details without trace property', () => {
       const error = { details: [ { foo: 'bar' }, { baz: 'qux' } ] };
 
-      expect( extractTraceInfo( error ) ).toBeUndefined();
+      expect( extractErrorDetail( error, 'trace' ) ).toBeNull();
     } );
 
     it( 'uses details.find when details is array-like with find', () => {
       const tracePayload = { id: 't1' };
       const error = { details: [ { trace: tracePayload } ] };
 
-      expect( extractTraceInfo( error ) ).toEqual( tracePayload );
+      expect( extractErrorDetail( error, 'trace' ) ).toEqual( tracePayload );
+    } );
+
+    it( 'returns the requested detail from error.details', () => {
+      const attributes = [ { type: 'llm:usage' } ];
+      const error = { details: [ { attributes } ] };
+
+      expect( extractErrorDetail( error, 'attributes' ) ).toBe( attributes );
+    } );
+
+    it( 'returns the requested detail from a nested cause chain', () => {
+      const aggregations = { cost: { total: 1 } };
+      const error = { cause: { details: [ { aggregations } ] } };
+
+      expect( extractErrorDetail( error, 'aggregations' ) ).toBe( aggregations );
+    } );
+
+    it( 'returns null when the requested detail is missing', () => {
+      const error = { details: [ { trace: {} } ], cause: { details: [] } };
+
+      expect( extractErrorDetail( error, 'attributes' ) ).toBeNull();
     } );
   } );
 

--- a/docs/guides/api/errors.mdx
+++ b/docs/guides/api/errors.mdx
@@ -12,6 +12,8 @@ Error responses are JSON. The body includes:
 
 For `503`, the server may send a `Retry-After` header suggesting when to retry.
 
+Workflow execution failures are different from API request errors. `POST /workflow/run` and `GET /workflow/:id/result` return the standard workflow result payload with `status: "failed"`, `output: null`, and an `error` message. When available, that failed result also includes `trace`, `attributes`, and `aggregations` collected before the failure.
+
 | Code | Error | Cause |
 |------|-------|-------|
 | 400 | ValidationError | Invalid request body or query. |

--- a/docs/guides/api/index.mdx
+++ b/docs/guides/api/index.mdx
@@ -38,6 +38,58 @@ curl http://localhost:3001/workflow/<workflow-id>/status
 curl http://localhost:3001/workflow/<workflow-id>/result
 ```
 
+## Workflow Result Payload
+
+`POST /workflow/run` and `GET /workflow/:id/result` return the same structured workflow result:
+
+```json
+{
+  "workflowId": "lead_enrichment-a1b2c3d4-5678-90ab-cdef-1234567890ab",
+  "runId": "b5c6d7e8-9012-3456-7890-abcdef123456",
+  "status": "completed",
+  "input": { "companyDomain": "acme.com" },
+  "output": {
+    "company": "Acme Corp",
+    "summary": "Enterprise software company focused on..."
+  },
+  "trace": { "destinations": {} },
+  "attributes": [
+    {
+      "type": "llm:usage",
+      "modelId": "anthropic/claude-3-5-sonnet",
+      "total": 0.0084,
+      "tokensUsed": 1200,
+      "usage": [
+        { "type": "input", "ppm": 3, "amount": 800, "total": 0.0024 },
+        { "type": "output", "ppm": 15, "amount": 400, "total": 0.006 }
+      ]
+    }
+  ],
+  "aggregations": {
+    "cost": { "total": 0.0084 },
+    "tokens": { "total": 1200, "input": 800, "output": 400 },
+    "httpRequests": { "total": 0 }
+  },
+  "error": null
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `workflowId` | Workflow execution ID. |
+| `runId` | Specific Temporal run ID. |
+| `status` | Current or final execution status. |
+| `input` | Original workflow input. |
+| `output` | Value returned by the workflow on success, or `null` on failure. |
+| `trace` | Trace metadata for the run, or `null` when unavailable. |
+| `attributes` | Durable workflow attributes collected during execution, such as LLM usage and HTTP cost/count attributes. |
+| `aggregations` | Convenience totals derived from `attributes`, including `cost.total`, `tokens.total`, and `httpRequests.total`. |
+| `error` | Error message on failure, otherwise `null`. |
+
+`attributes` are the primary data source for usage and cost details. Use `aggregations` when you only need high-level totals for billing, reporting, or dashboards.
+
+When a workflow fails after collecting attributes, the result still includes the available `trace`, `attributes`, and `aggregations` fields alongside the error message.
+
 ## Interacting with Running Workflows
 
 Output supports sending data to running workflows and reading their state via signals, queries, and updates. The workflow must define handlers for these — see [External Integration](/workflows/external-integration) for how to set them up.

--- a/docs/guides/costs/cost-events.mdx
+++ b/docs/guides/costs/cost-events.mdx
@@ -5,8 +5,8 @@ description: "Monitor LLM and HTTP request costs in real time — cost:llm:reque
 
 The [cost estimation CLI](/costs) shows you costs after a workflow finishes. **Cost events** expose similar data while a workflow runs:
 
-- **`cost:llm:request`** — emitted when an LLM call finishes (`generateText` / `streamText`), with model id, token usage, and estimated dollar cost.
-- **`cost:http:request`** — emitted when you attach a dollar cost to an HTTP response with [`addRequestCost`](/packages/http#attaching-request-cost) from `@outputai/http`, with the request id, URL, and cost you supplied.
+- **`cost:llm:request`** — emitted when an LLM call finishes (`generateText` / `streamText`), with an LLM usage attribute.
+- **`cost:http:request`** — emitted when you attach a dollar cost to an HTTP response with [`addRequestCost`](/packages/http#attaching-request-cost) from `@outputai/http`, with an HTTP request cost attribute.
 
 Use either or both to log spend to your observability stack, trigger alerts, or aggregate cost per workflow over time.
 
@@ -23,13 +23,15 @@ See [Error Hooks — Setup](/operations/error-hooks#setup) for the hook file reg
 ```javascript src/llm_cost_hooks.js
 import { on } from '@outputai/core/hooks';
 
-on( 'cost:llm:request', async ( { workflowId, activityId, modelId, usage, cost } ) => {
+on( 'cost:llm:request', async ( { workflowId, activityId, activityName, modelId, total, tokensUsed, usage } ) => {
   console.log( 'LLM call', {
     workflowId,
     activityId,
+    activityName,
     modelId,
-    tokens: usage?.totalTokens,
-    cost: cost?.total
+    tokens: tokensUsed,
+    cost: total,
+    usage
   } );
 } );
 ```
@@ -37,8 +39,8 @@ on( 'cost:llm:request', async ( { workflowId, activityId, modelId, usage, cost }
 ```javascript src/http_cost_hooks.js
 import { on } from '@outputai/core/hooks';
 
-on( 'cost:http:request', async ( { workflowId, activityId, requestId, url, cost } ) => {
-  console.log( 'HTTP request', { workflowId, activityId, requestId, url, total: cost?.total } );
+on( 'cost:http:request', async ( { workflowId, activityId, activityName, requestId, url, total } ) => {
+  console.log( 'HTTP request', { workflowId, activityId, activityName, requestId, url, total } );
 } );
 ```
 
@@ -52,106 +54,83 @@ An `cost:llm:request` event is emitted after every `generateText` and `streamTex
 
 ### Payload
 
-The handler receives a single object:
+The handler receives a single LLM usage attribute object:
+
+```json
+{
+  "workflowId": "workflow-123",
+  "type": "llm:usage",
+  "activityId": "activity-1",
+  "activityName": "generateSummary",
+  "modelId": "gpt-4o",
+  "usage": [
+    { "type": "input", "ppm": 5, "amount": 217, "total": 0.001085 },
+    { "type": "output", "ppm": 15, "amount": 9, "total": 0.000135 }
+  ],
+  "total": 0.00122,
+  "tokensUsed": 226
+}
+```
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `workflowId` | `string \| undefined` | Temporal workflow execution ID. Present when the call runs inside a workflow. |
+| `type` | `"llm:usage"` | Attribute type. |
 | `activityId` | `string \| undefined` | Temporal activity ID of the step that made the LLM call. Present when the call runs inside a workflow activity. |
+| `activityName` | `string \| undefined` | Temporal activity name of the step that made the LLM call. Present when the call runs inside a workflow activity. |
 | `modelId` | `string` | Model identifier (e.g. `claude-sonnet-4-20250514`, `gpt-4o`). From the prompt file config. |
-| `usage` | `object` | Token usage for this call. See [Usage shape](#usage-shape). |
-| `cost` | `object` | Computed dollar cost for this call. See [Cost structure](#cost-structure). |
+| `usage` | `array` | Priced usage entries for this call. See [Usage entries](#usage-entries). |
+| `total` | `number` | Total estimated cost in dollars. |
+| `tokensUsed` | `number` | Total number of tokens represented by `usage`. |
 
-### Usage shape
-
-`usage` follows the AI SDK's [totalUsage](https://ai-sdk.dev/docs/reference/ai-sdk-core/generate-text#total-usage) shape, aggregated across all steps for that call:
-
-```json
-{
-  "inputTokens": 217,
-  "inputTokenDetails": { "noCacheTokens": 217, "cacheReadTokens": 0, "cacheWriteTokens": 0 },
-  "outputTokens": 9,
-  "outputTokenDetails": { "textTokens": null, "reasoningTokens": null },
-  "totalTokens": 226,
-  "reasoningTokens": null,
-  "cachedInputTokens": 0
-}
-```
-
-When the model uses extended thinking, `reasoningTokens` and `outputTokenDetails.reasoningTokens` are set. Cached prompt tokens are reported in `cachedInputTokens` and `inputTokenDetails.cacheReadTokens`.
-
-### Cost structure
+### Usage entries
 
 Cost is computed from the model's per-million-token pricing, fetched from a built-in pricing source and cached for 24 hours. For each priced dimension, the dollar amount is `(tokens / 1_000_000) * pricePerMillion`. Non-cached input tokens use `inputTokens - (cachedInputTokens ?? 0)`.
 
-The payload matches `LLMCallCost` from `@outputai/llm`: on success you get a numeric **`total`** plus a **`components`** array; on failure **`total`** is `null` and **`message`** explains why.
-
 | Field | Type | Description |
 |-------|------|-------------|
-| `total` | `number \| null` | Total estimated cost in dollars. `null` if pricing could not be computed. |
-| `message` | `string` | Present when `total` is `null` (e.g. unknown model, pricing fetch failed, or unexpected error). |
-| `components` | `array` | Present when `total` is a number. Each entry is `{ name: string, value: number }`. Only dimensions that have pricing for the model are included. |
+| `type` | `string` | Usage dimension. |
+| `ppm` | `number` | Price per million tokens for this dimension. |
+| `amount` | `number` | Token count for this dimension. |
+| `total` | `number` | Cost for this dimension. |
 
-**`components[].name` values**
+`usage[].type` values:
 
-| `name` | Description |
+| `type` | Description |
 |--------|-------------|
-| `input_tokens` | Non-cached prompt tokens. |
-| `input_cached_tokens` | Cached prompt read tokens (`cachedInputTokens`). |
-| `output_tokens` | Completion tokens. |
-| `reasoning_tokens` | Reasoning tokens, only when the model defines separate reasoning pricing; omitted otherwise. |
+| `input` | Non-cached prompt tokens. |
+| `input_cached` | Cached prompt read tokens (`cachedInputTokens`). |
+| `output` | Completion tokens. |
+| `reasoning` | Reasoning tokens, only when the model defines separate reasoning pricing. |
 
-**Successful calculation:**
-
-```json
-{
-  "total": 0.002341,
-  "components": [
-    { "name": "input_tokens", "value": 0.001302 },
-    { "name": "input_cached_tokens", "value": 0 },
-    { "name": "output_tokens", "value": 0.001039 },
-    { "name": "reasoning_tokens", "value": 0.00027 }
-  ]
-}
-```
-
-A given response may list only a subset of these — for example no `reasoning_tokens` row if that price is not configured for the model.
-
-**Unknown model or pricing unavailable:**
-
-```json
-{
-  "total": null,
-  "message": "Missing cost reference for model"
-}
-```
+Only available, finite usage dimensions are included. For example, `reasoning` is omitted when the model does not define separate reasoning pricing, and `input_cached` is omitted when there are no cached input tokens.
 
 ## HTTP request cost
 
-Events fire only when your code calls [`addRequestCost( response, cost )`](/packages/http#attaching-request-cost) with a **response object created by `@outputai/http`** (or its exported `fetch`). The SDK attaches the cost to the existing HTTP trace event and emits `cost:http:request`. If the response did not originate from this package, `addRequestCost` no-ops (with a console warning) and **no** hook event is emitted.
+Events fire only when your code calls [`addRequestCost( response, total )`](/packages/http#attaching-request-cost) with a **response object created by `@outputai/http`** (or its exported `fetch`). The SDK attaches the cost to the existing HTTP trace event and emits `cost:http:request`. If the response did not originate from this package, `addRequestCost` no-ops (with a console warning) and **no** hook event is emitted.
 
 ### Payload
 
-The handler receives a single object. As with `cost:llm:request`, `workflowId` and `activityId` are filled when the hook runs inside a Temporal workflow activity.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `workflowId` | `string \| undefined` | Temporal workflow execution ID. Present when the handler runs inside a workflow. |
-| `activityId` | `string \| undefined` | Temporal activity ID. Present when the handler runs inside a workflow activity. |
-| `requestId` | `string` | Internal id linking this payload to the HTTP trace event for that request. |
-| `url` | `string` | Final response URL (same as `response.url`). |
-| `cost` | `object` | Dollar cost you passed to `addRequestCost`. See [HTTP cost shape](#http-cost-shape). |
-
-### HTTP cost shape
-
-Same top-level shape as LLM costs: a numeric **`total`** and an optional **`components`** array of `{ name, value }`. For HTTP, **`name` and `value` are entirely yours** — they mirror what you pass to `addRequestCost` (for example labels derived from vendor billing headers).
+The handler receives a single HTTP request cost attribute object:
 
 ```json
 {
-  "total": 0.42,
-  "components": [
-    { "name": "input", "value": 0.12 },
-    { "name": "output", "value": 0.3 }
-  ]
+  "workflowId": "workflow-123",
+  "type": "http:request:cost",
+  "activityId": "activity-1",
+  "activityName": "searchVendors",
+  "requestId": "req-123",
+  "url": "https://api.vendor.com/search",
+  "total": 0.42
 }
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workflowId` | `string \| undefined` | Temporal workflow execution ID. Present when the request runs inside a workflow. |
+| `type` | `"http:request:cost"` | Attribute type. |
+| `activityId` | `string \| undefined` | Temporal activity ID of the step that made the HTTP request. Present when the request runs inside a workflow activity. |
+| `activityName` | `string \| undefined` | Temporal activity name of the step that made the HTTP request. Present when the request runs inside a workflow activity. |
+| `requestId` | `string` | Internal id linking this payload to the HTTP trace event for that request. |
+| `url` | `string` | Final response URL (same as `response.url`). |
+| `total` | `number` | Dollar cost passed to `addRequestCost`. |

--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -151,7 +151,10 @@
                 "group": "Migration Guides",
                 "pages": [
                   "migrations/index",
-                  "migrations/v0.1.12-to-v0.2.0"
+                  "migrations/v0.1.12-to-v0.2.0",
+                  "migrations/v0.2.0-to-v0.3.0",
+                  "migrations/v0.3.0-to-v0.4.0",
+                  "migrations/v0.4.0-to-v0.5.0"
                 ]
               }
             ]

--- a/docs/guides/migrations/index.mdx
+++ b/docs/guides/migrations/index.mdx
@@ -27,4 +27,7 @@ It reads the `@outputai/*` version in your `package.json`, finds the matching gu
   <Card title="v0.3.0 → v0.4.0" href="/migrations/v0.3.0-to-v0.4.0">
     Package.json Output.ai config section rename.
   </Card>
+  <Card title="v0.4.0 → v0.5.0" href="/migrations/v0.4.0-to-v0.5.0">
+    HTTP request cost API and cost event payload changes.
+  </Card>
 </CardGroup>

--- a/docs/guides/migrations/v0.4.0-to-v0.5.0.mdx
+++ b/docs/guides/migrations/v0.4.0-to-v0.5.0.mdx
@@ -1,0 +1,240 @@
+---
+title: "v0.4.0 → v0.5.0"
+description: "Upgrading Output.ai projects from v0.4.0 to v0.5.0: HTTP and LLM cost API and cost event payload changes."
+---
+
+This guide covers the `@outputai/http` and `@outputai/llm` cost tracking changes in v0.5.0.
+
+## What changed
+
+- `addRequestCost` now accepts a numeric total instead of a `RequestCost` object.
+- The `RequestCost` type is removed.
+- The `cost:http:request` event now receives an HTTP request cost attribute instead of `{ requestId, url, cost }`.
+- LLM response `.cost` is now an LLM usage attribute instead of `{ total, components }`.
+- LLM usage entries only include available, finite dimensions; missing dimensions are omitted.
+- The `cost:llm:request` event now receives the LLM usage attribute instead of `{ modelId, cost, usage }`.
+
+## Migration steps
+
+### Update `addRequestCost`
+
+Pass the total request cost directly.
+
+#### Before
+
+```ts
+import { addRequestCost } from '@outputai/http';
+
+addRequestCost( response, {
+  total: inputCost + outputCost,
+  components: [
+    { name: 'input', value: inputCost },
+    { name: 'output', value: outputCost }
+  ]
+} );
+```
+
+#### After
+
+```ts
+import { addRequestCost } from '@outputai/http';
+
+addRequestCost( response, inputCost + outputCost );
+```
+
+### Remove `RequestCost` imports
+
+The `RequestCost` object shape is no longer part of the public API.
+
+#### Before
+
+```ts
+import { addRequestCost, type RequestCost } from '@outputai/http';
+
+const cost: RequestCost = {
+  total: 0.42
+};
+
+addRequestCost( response, cost );
+```
+
+#### After
+
+```ts
+import { addRequestCost } from '@outputai/http';
+
+const cost = 0.42;
+
+addRequestCost( response, cost );
+```
+
+### Update `cost:http:request` hooks
+
+The event payload is now the HTTP request cost attribute.
+
+#### Before
+
+```js
+import { on } from '@outputai/core/hooks';
+
+on( 'cost:http:request', async ( { requestId, url, cost } ) => {
+  console.log( requestId, url, cost.total );
+} );
+```
+
+#### After
+
+```js
+import { on } from '@outputai/core/hooks';
+
+on( 'cost:http:request', async ( { workflowId, requestId, url, total, activityId, activityName } ) => {
+  console.log( workflowId, requestId, url, total, activityId, activityName );
+} );
+```
+
+### Update LLM response cost handling
+
+The `.cost` property on `generateText()` responses and `streamText()` `onFinish` responses is now an LLM usage attribute.
+
+#### Before
+
+```js
+const response = await generateText( { prompt: 'summarize@v1' } );
+
+console.log( response.cost.total );
+for ( const component of response.cost.components ) {
+  console.log( component.name, component.value );
+}
+```
+
+#### After
+
+```js
+const response = await generateText( { prompt: 'summarize@v1' } );
+
+console.log( response.cost?.total );
+console.log( response.cost?.tokensUsed );
+for ( const usage of response.cost?.usage ?? [] ) {
+  console.log( usage.type, usage.amount, usage.total );
+}
+```
+
+### Handle omitted LLM usage fields
+
+Cost usage entries now include only the dimensions that are available and priced.
+
+#### Before
+
+```js
+const cached = response.cost.components.find( c => c.name === 'input_cached_tokens' );
+console.log( cached?.value ?? 0 );
+```
+
+#### After
+
+```js
+const cached = response.cost?.usage.find( u => u.type === 'input_cached' );
+console.log( cached?.total ?? 0 );
+```
+
+Use these `usage[].type` values:
+
+| `type` | Description |
+|--------|-------------|
+| `input` | Non-cached prompt tokens. |
+| `input_cached` | Cached prompt read tokens. |
+| `output` | Completion tokens. |
+| `reasoning` | Reasoning tokens, when separately priced. |
+
+### Update `cost:llm:request` hooks
+
+The event payload is now the LLM usage attribute.
+
+#### Before
+
+```js
+import { on } from '@outputai/core/hooks';
+
+on( 'cost:llm:request', async ( { modelId, cost, usage } ) => {
+  console.log( modelId, usage.totalTokens, cost.total );
+} );
+```
+
+#### After
+
+```js
+import { on } from '@outputai/core/hooks';
+
+on( 'cost:llm:request', async ( { workflowId, modelId, tokensUsed, total, usage, activityId, activityName } ) => {
+  console.log( workflowId, modelId, tokensUsed, total, usage, activityId, activityName );
+} );
+```
+
+## Cost attribute reference
+
+HTTP and LLM cost payloads are now trace attributes. Hook payloads include `workflowId`; workflow result attributes are nested under a result that already has `workflowId` and `runId`, so they do not repeat the workflow ID.
+
+### HTTP request cost hook payload
+
+```json
+{
+  "type": "http:request:cost",
+  "workflowId": "workflow-123",
+  "activityId": "activity-456",
+  "activityName": "lookupCompany",
+  "requestId": "request-789",
+  "url": "https://api.example.com/companies",
+  "total": 0.42
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `type` | Always `"http:request:cost"`. |
+| `workflowId` | Workflow execution ID. Present on hook payloads. |
+| `activityId` | Activity ID of the step that made the request, when available. |
+| `activityName` | Activity name of the step that made the request, when available. |
+| `requestId` | Internal ID linking the cost to the traced HTTP request. |
+| `url` | Final response URL. |
+| `total` | Dollar cost passed to `addRequestCost`. |
+
+### LLM usage cost hook payload
+
+```json
+{
+  "type": "llm:usage",
+  "workflowId": "workflow-123",
+  "activityId": "activity-456",
+  "activityName": "generateSummary",
+  "modelId": "anthropic/claude-3-5-sonnet",
+  "total": 0.0084,
+  "tokensUsed": 1200,
+  "usage": [
+    { "type": "input", "ppm": 3, "amount": 800, "total": 0.0024 },
+    { "type": "output", "ppm": 15, "amount": 400, "total": 0.006 }
+  ]
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `type` | Always `"llm:usage"`. |
+| `workflowId` | Workflow execution ID. Present on hook payloads. |
+| `activityId` | Activity ID of the step that made the LLM request, when available. |
+| `activityName` | Activity name of the step that made the LLM request, when available. |
+| `modelId` | Model identifier used for the request. |
+| `total` | Total computed dollar cost. |
+| `tokensUsed` | Sum of token amounts included in `usage`. |
+| `usage` | Per-dimension token usage and cost entries. |
+
+Each `usage` entry includes `type`, `ppm`, `amount`, and `total`. Only available, finite usage dimensions are included.
+
+## Checklist
+
+- Replace every `addRequestCost(response, { total, components })` call with `addRequestCost(response, total)`.
+- Remove `RequestCost` imports and annotations.
+- Update `cost:http:request` hook handlers to read `total` directly from the payload.
+- Remove any logic that expected HTTP cost `components`; HTTP request costs are now a single total value.
+- Replace LLM `response.cost.components` reads with `response.cost?.usage`.
+- Handle `response.cost === null` when pricing cannot be computed.
+- Update `cost:llm:request` hook handlers to read the LLM usage attribute payload directly.

--- a/docs/guides/migrations/v0.4.0-to-v0.5.0.mdx
+++ b/docs/guides/migrations/v0.4.0-to-v0.5.0.mdx
@@ -12,6 +12,7 @@ This guide covers the `@outputai/http` and `@outputai/llm` cost tracking changes
 - The `cost:http:request` event now receives an HTTP request cost attribute instead of `{ requestId, url, cost }`.
 - LLM response `.cost` is now an LLM usage attribute instead of `{ total, components }`.
 - LLM usage entries only include available, finite dimensions; missing dimensions are omitted.
+- Missing LLM costs are returned as `null`, not as cost objects with `total: null` and `message`.
 - The `cost:llm:request` event now receives the LLM usage attribute instead of `{ modelId, cost, usage }`.
 
 ## Migration steps
@@ -118,6 +119,34 @@ for ( const usage of response.cost?.usage ?? [] ) {
   console.log( usage.type, usage.amount, usage.total );
 }
 ```
+
+When pricing cannot be computed, `response.cost` is `null`.
+
+### Handle missing LLM costs
+
+When LLM pricing cannot be loaded or the model is missing from the pricing table, Output no longer returns a cost object with `total: null` and `message`.
+
+#### Before
+
+```js
+const response = await generateText( { prompt: 'summarize@v1' } );
+
+if ( response.cost.total === null ) {
+  console.warn( response.cost.message );
+}
+```
+
+#### After
+
+```js
+const response = await generateText( { prompt: 'summarize@v1' } );
+
+if ( response.cost === null ) {
+  console.warn( 'LLM cost was not available for this response.' );
+}
+```
+
+No `cost:llm:request` event or LLM usage trace attribute is emitted when cost is missing.
 
 ### Handle omitted LLM usage fields
 
@@ -236,5 +265,5 @@ Each `usage` entry includes `type`, `ppm`, `amount`, and `total`. Only available
 - Update `cost:http:request` hook handlers to read `total` directly from the payload.
 - Remove any logic that expected HTTP cost `components`; HTTP request costs are now a single total value.
 - Replace LLM `response.cost.components` reads with `response.cost?.usage`.
-- Handle `response.cost === null` when pricing cannot be computed.
+- Handle `response.cost === null` when pricing cannot be computed; do not expect a cost object with `total: null` and `message`.
 - Update `cost:llm:request` hook handlers to read the LLM usage attribute payload directly.

--- a/docs/guides/openapi.json
+++ b/docs/guides/openapi.json
@@ -353,6 +353,21 @@
           "trace": {
             "$ref": "#/components/schemas/TraceInfo"
           },
+          "attributes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": true
+            },
+            "nullable": true,
+            "description": "Durable workflow attributes collected during execution"
+          },
+          "aggregations": {
+            "type": "object",
+            "nullable": true,
+            "additionalProperties": true,
+            "description": "Convenience totals derived from attributes"
+          },
           "status": {
             "type": "string",
             "enum": [
@@ -569,32 +584,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "workflowId": {
-                      "type": "string",
-                      "description": "The workflow execution id"
-                    },
-                    "output": {
-                      "description": "The output of the workflow, null if workflow failed"
-                    },
-                    "trace": {
-                      "$ref": "#/components/schemas/TraceInfo"
-                    },
-                    "status": {
-                      "type": "string",
-                      "enum": [
-                        "completed",
-                        "failed"
-                      ],
-                      "description": "The workflow execution status"
-                    },
-                    "error": {
-                      "type": "string",
-                      "nullable": true,
-                      "description": "Error message if workflow failed, null otherwise"
-                    }
-                  }
+                  "$ref": "#/components/schemas/WorkflowResultResponse"
                 }
               }
             }

--- a/docs/guides/openapi.json
+++ b/docs/guides/openapi.json
@@ -355,12 +355,12 @@
           },
           "attributes": {
             "type": "array",
+            "nullable": true,
+            "description": "Durable workflow attributes collected during execution",
             "items": {
               "type": "object",
               "additionalProperties": true
-            },
-            "nullable": true,
-            "description": "Durable workflow attributes collected during execution"
+            }
           },
           "aggregations": {
             "type": "object",

--- a/docs/guides/operations/error-handling.mdx
+++ b/docs/guides/operations/error-handling.mdx
@@ -65,6 +65,40 @@ export default workflow({
 
 If you don't catch the error, the workflow fails.
 
+### Error metadata
+
+When a root workflow fails, Output attaches execution metadata to the Temporal error returned by the runtime. This metadata includes:
+
+- `trace` — Trace metadata for the run, when available.
+- `attributes` — Durable attributes collected before the failure, such as LLM usage and HTTP cost/count attributes.
+- `aggregations` — Convenience totals derived from those attributes.
+
+The CLI and API expose these attachments on failed workflow results alongside the error message. This lets you inspect partial cost, token, and HTTP request data for failed runs without changing your workflow code.
+
+If you inspect raw errors directly, remember that workflow failures are native Temporal errors such as `ApplicationFailure` or `ChildWorkflowFailure`. The metadata is stored in a Temporal failure's `details`, which may be on a nested error in the `.cause` chain rather than on the top-level error object. Walk the `.cause` chain and look for `details` containing `trace`, `attributes`, or `aggregations`.
+
+```typescript
+function getWorkflowErrorMetadata(error: unknown) {
+  let current = error as { cause?: unknown; details?: unknown[] } | null;
+
+  while (current) {
+    const metadata = current.details?.find((detail) =>
+      detail &&
+      typeof detail === 'object' &&
+      ('trace' in detail || 'attributes' in detail || 'aggregations' in detail)
+    );
+
+    if (metadata) {
+      return metadata;
+    }
+
+    current = current.cause as typeof current;
+  }
+
+  return null;
+}
+```
+
 ## FatalError and ValidationError
 
 Sometimes retrying won't help — the API key is invalid, the resource doesn't exist, or the data is fundamentally wrong. For these cases, throw `FatalError` or `ValidationError` to fail immediately without retries.

--- a/docs/guides/packages/cli.mdx
+++ b/docs/guides/packages/cli.mdx
@@ -297,6 +297,56 @@ output workflow result <workflowId>
 |------|---------|-------------|
 | `--format, -f` | text | Output format: json, text |
 
+#### Workflow result JSON format
+
+Use `--format json` with `output workflow run` or `output workflow result` to print the full structured workflow result:
+
+```json
+{
+  "workflowId": "lead_enrichment-a1b2c3d4-5678-90ab-cdef-1234567890ab",
+  "runId": "b5c6d7e8-9012-3456-7890-abcdef123456",
+  "status": "completed",
+  "input": { "companyDomain": "acme.com" },
+  "output": {
+    "company": "Acme Corp",
+    "summary": "Enterprise software company focused on..."
+  },
+  "trace": { "destinations": {} },
+  "attributes": [
+    {
+      "type": "llm:usage",
+      "modelId": "anthropic/claude-3-5-sonnet",
+      "total": 0.0084,
+      "tokensUsed": 1200,
+      "usage": [
+        { "type": "input", "ppm": 3, "amount": 800, "total": 0.0024 },
+        { "type": "output", "ppm": 15, "amount": 400, "total": 0.006 }
+      ]
+    }
+  ],
+  "aggregations": {
+    "cost": { "total": 0.0084 },
+    "tokens": { "total": 1200, "input": 800, "output": 400 },
+    "httpRequests": { "total": 0 }
+  },
+  "error": null
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `workflowId` | Workflow execution ID. |
+| `runId` | Specific Temporal run ID. |
+| `status` | Current or final execution status. |
+| `input` | Original workflow input. |
+| `output` | Value returned by the workflow on success, or `null` on failure. |
+| `trace` | Trace metadata for the run, or `null` when unavailable. |
+| `attributes` | Durable workflow attributes collected during execution, such as LLM usage and HTTP cost/count attributes. |
+| `aggregations` | Convenience totals derived from `attributes`, including `cost.total`, `tokens.total`, and `httpRequests.total`. |
+| `error` | Error message on failure, otherwise `null`. |
+
+`attributes` are the primary data source for usage and cost details. Use `aggregations` when you only need high-level totals.
+
 ### output workflow stop
 
 Stop a running workflow gracefully:

--- a/docs/guides/packages/http.mdx
+++ b/docs/guides/packages/http.mdx
@@ -123,14 +123,10 @@ const response = await client.post( 'search', {
 const inputCost = Number( response.headers.get( 'x-cost-input-usd' ) ?? 0 );
 const outputCost = Number( response.headers.get( 'x-cost-output-usd' ) ?? 0 );
 
-addRequestCost( response, {
-  total: inputCost + outputCost,
-  components: [
-    { name: 'input', value: inputCost },
-    { name: 'output', value: outputCost }
-  ]
-} );
+addRequestCost( response, inputCost + outputCost );
 ```
+
+`addRequestCost` accepts the total request cost as a number.
 
 `addRequestCost` only works with responses created by `@outputai/http` (or its exported `fetch`). If the response did not come from this package, the function safely no-ops and logs a warning.
 

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -412,6 +412,24 @@ Start with `generateText`. Move to `Agent` when you need conversation state or a
 | `response` | Raw provider response metadata |
 | `warnings` | Any warnings from the provider |
 | `toolCalls` | Tool calls made by the model (when using tools) |
+| `cost` | LLM usage attribute with `modelId`, `usage`, `total`, and `tokensUsed`; `null` when pricing could not be computed |
+
+The `cost` property is an LLM usage attribute:
+
+```json
+{
+  "type": "llm:usage",
+  "modelId": "gpt-4o",
+  "usage": [
+    { "type": "input", "ppm": 5, "amount": 217, "total": 0.001085 },
+    { "type": "output", "ppm": 15, "amount": 9, "total": 0.000135 }
+  ],
+  "total": 0.00122,
+  "tokensUsed": 226
+}
+```
+
+Only available, finite usage dimensions are included in `usage`. For example, `reasoning` is omitted when the model does not define separate reasoning pricing.
 
 **Streaming response shape.** `streamText` returns a different result type. Stream iterables (`textStream`, `fullStream`) provide real-time chunks, while scalar properties (`text`, `usage`, `finishReason`, etc.) are promises that resolve when the stream completes:
 
@@ -646,7 +664,7 @@ Built-in providers are initialized with a custom fetch that extends Undici's `he
 
 ## LLM call cost event
 
-Each `generateText` and `streamText` call emits a `cost:llm:request` event after the LLM responds. You can observe it with the same [hooks mechanism](/packages/core#error-hooks) as error hooks: register a handler with `on('cost:llm:request', handler)` from `@outputai/core/hooks` in a hook file listed under `outputai.hookFiles`. The payload includes token usage, computed cost, workflow/activity context, and model id. For payload details, setup, and cost structure, see [Cost Events](/costs/cost-events).
+Each `generateText` and `streamText` call emits a `cost:llm:request` event after the LLM responds and cost can be computed. You can observe it with the same [hooks mechanism](/packages/core#error-hooks) as error hooks: register a handler with `on('cost:llm:request', handler)` from `@outputai/core/hooks` in a hook file listed under `outputai.hookFiles`. The payload is the same LLM usage attribute exposed on `response.cost`. For payload details, see [Cost Events](/costs/cost-events).
 
 ## loadPrompt
 

--- a/docs/guides/workflows/running.mdx
+++ b/docs/guides/workflows/running.mdx
@@ -133,7 +133,7 @@ Status: failed
 Error: Step 'lookup_company' failed: 404 Not Found
 ```
 
-Use `--format json` for the full structured response including status, output, and error fields.
+Use `--format json` for the full structured response including status, output, error, and execution metadata fields. See the [CLI package docs](/packages/cli#workflow-result-json-format) for the JSON format.
 
 ## Debugging Execution
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,51 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-catalogs:
-  default:
-    '@aws-sdk/client-s3':
-      specifier: 3.1038.0
-      version: 3.1038.0
-    '@temporalio/activity':
-      specifier: 1.17.0
-      version: 1.17.0
-    '@temporalio/client':
-      specifier: 1.17.0
-      version: 1.17.0
-    '@temporalio/common':
-      specifier: 1.17.0
-      version: 1.17.0
-    '@temporalio/proto':
-      specifier: 1.17.0
-      version: 1.17.0
-    '@temporalio/worker':
-      specifier: 1.17.0
-      version: 1.17.0
-    '@temporalio/workflow':
-      specifier: 1.17.0
-      version: 1.17.0
-    '@types/js-yaml':
-      specifier: 4.0.9
-      version: 4.0.9
-    js-yaml:
-      specifier: 4.1.1
-      version: 4.1.1
-    ky:
-      specifier: 1.14.3
-      version: 1.14.3
-    semver:
-      specifier: 7.7.4
-      version: 7.7.4
-    undici:
-      specifier: 8.1.0
-      version: 8.1.0
-    winston:
-      specifier: 3.19.0
-      version: 3.19.0
-    zod:
-      specifier: 4.3.6
-      version: 4.3.6
-
 overrides:
   tar@<6.2.1: '>=6.2.1'
   zod@<=3.22.2: '>=3.22.3'
@@ -430,9 +385,6 @@ importers:
       ai:
         specifier: 6.0.168
         version: 6.0.168(zod@4.3.6)
-      decimal.js:
-        specifier: 10.6.0
-        version: 10.6.0
       entities:
         specifier: 8.0.0
         version: 8.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,9 @@ importers:
       '@temporalio/workflow':
         specifier: 'catalog:'
         version: 1.17.0
+      decimal.js:
+        specifier: 10.6.0
+        version: 10.6.0
       json-stream-stringify:
         specifier: 3.1.6
         version: 3.1.6
@@ -11037,6 +11040,7 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+    optional: true
 
   '@types/react@19.2.14':
     dependencies:
@@ -14966,7 +14970,7 @@ snapshots:
 
   protobufjs@8.0.3:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.10.15
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -16299,7 +16303,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.19.2: {}
+  undici-types@7.19.2:
+    optional: true
 
   undici@8.1.0: {}
 

--- a/sdk/cli/src/api/generated/api.ts
+++ b/sdk/cli/src/api/generated/api.ts
@@ -230,6 +230,14 @@ export interface WorkflowStatusResponse {
   completedAt?: number;
 }
 
+export type WorkflowResultResponseAttributesItem = { [key: string]: unknown };
+
+/**
+ * Convenience totals derived from attributes
+ * @nullable
+ */
+export type WorkflowResultResponseAggregations = { [key: string]: unknown } | null;
+
 /**
  * The workflow execution status
  */
@@ -255,10 +263,16 @@ export interface WorkflowResultResponse {
   /** The result of workflow, null if workflow failed */
   output?: unknown;
   trace?: TraceInfo;
-  /** Durable workflow attributes collected during execution */
-  attributes?: { [key: string]: unknown }[] | null;
-  /** Convenience totals derived from attributes */
-  aggregations?: { [key: string]: unknown } | null;
+  /**
+     * Durable workflow attributes collected during execution
+     * @nullable
+     */
+  attributes?: WorkflowResultResponseAttributesItem[] | null;
+  /**
+     * Convenience totals derived from attributes
+     * @nullable
+     */
+  aggregations?: WorkflowResultResponseAggregations;
   /** The workflow execution status */
   status?: WorkflowResultResponseStatus;
   /**
@@ -344,40 +358,6 @@ export type PostWorkflowRunBody = {
   taskQueue?: string;
   /** (Optional) The max time to wait for the execution, defaults to 30s */
   timeout?: number;
-};
-
-/**
- * The workflow execution status
- */
-export type PostWorkflowRun200Status = typeof PostWorkflowRun200Status[keyof typeof PostWorkflowRun200Status];
-
-
-export const PostWorkflowRun200Status = {
-  completed: 'completed',
-  failed: 'failed',
-} as const;
-
-export type PostWorkflowRun200 = {
-  /** The workflow execution id */
-  workflowId?: string;
-  /** The specific run id for this execution */
-  runId?: string;
-  /** The original input passed to the workflow, null if unavailable */
-  input?: unknown;
-  /** The output of the workflow, null if workflow failed */
-  output?: unknown;
-  trace?: TraceInfo;
-  /** Durable workflow attributes collected during execution */
-  attributes?: { [key: string]: unknown }[] | null;
-  /** Convenience totals derived from attributes */
-  aggregations?: { [key: string]: unknown } | null;
-  /** The workflow execution status */
-  status?: PostWorkflowRun200Status;
-  /**
-     * Error message if workflow failed, null otherwise
-     * @nullable
-     */
-  error?: string | null;
 };
 
 export type PostWorkflowStartBody = {
@@ -603,7 +583,7 @@ export const getHealth = async ( options?: ApiRequestOptions): Promise<getHealth
  * @summary Execute a workflow synchronously
  */
 export type postWorkflowRunResponse200 = {
-  data: PostWorkflowRun200
+  data: WorkflowResultResponse
   status: 200
 }
 

--- a/sdk/cli/src/api/generated/api.ts
+++ b/sdk/cli/src/api/generated/api.ts
@@ -255,6 +255,10 @@ export interface WorkflowResultResponse {
   /** The result of workflow, null if workflow failed */
   output?: unknown;
   trace?: TraceInfo;
+  /** Durable workflow attributes collected during execution */
+  attributes?: { [key: string]: unknown }[] | null;
+  /** Convenience totals derived from attributes */
+  aggregations?: { [key: string]: unknown } | null;
   /** The workflow execution status */
   status?: WorkflowResultResponseStatus;
   /**
@@ -356,9 +360,17 @@ export const PostWorkflowRun200Status = {
 export type PostWorkflowRun200 = {
   /** The workflow execution id */
   workflowId?: string;
+  /** The specific run id for this execution */
+  runId?: string;
+  /** The original input passed to the workflow, null if unavailable */
+  input?: unknown;
   /** The output of the workflow, null if workflow failed */
   output?: unknown;
   trace?: TraceInfo;
+  /** Durable workflow attributes collected during execution */
+  attributes?: { [key: string]: unknown }[] | null;
+  /** Convenience totals derived from attributes */
+  aggregations?: { [key: string]: unknown } | null;
   /** The workflow execution status */
   status?: PostWorkflowRun200Status;
   /**

--- a/sdk/cli/src/commands/workflow/dataset/generate.ts
+++ b/sdk/cli/src/commands/workflow/dataset/generate.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { Args, Command, Flags, ux } from '@oclif/core';
 import { postWorkflowRun } from '#api/generated/api.js';
-import type { PostWorkflowRun200 } from '#api/generated/api.js';
+import type { WorkflowResultResponse } from '#api/generated/api.js';
 import {
   writeDataset,
   resolveDefaultDatasetsDir,
@@ -115,7 +115,7 @@ export default class DatasetGenerate extends Command {
       this.error( 'API returned invalid response', { exit: 1 } );
     }
 
-    const { workflowId, output } = response.data as PostWorkflowRun200;
+    const { workflowId, output } = response.data as WorkflowResultResponse;
     const executionTimeMs = await getExecutionTime( workflowId );
 
     const dataset = buildDataset(

--- a/sdk/cli/src/commands/workflow/run.ts
+++ b/sdk/cli/src/commands/workflow/run.ts
@@ -1,5 +1,5 @@
 import { Args, Command, Flags } from '@oclif/core';
-import { postWorkflowRun, type PostWorkflowRun200 } from '#api/generated/api.js';
+import { postWorkflowRun, type WorkflowResultResponse } from '#api/generated/api.js';
 import { OUTPUT_FORMAT, OutputFormat } from '#utils/constants.js';
 import { formatOutput } from '#utils/output_formatter.js';
 import { formatWorkflowResult, ERROR_STATUSES } from '#utils/format_workflow_result.js';
@@ -105,7 +105,7 @@ export default class WorkflowRun extends Command {
       this.error( 'API returned invalid response', { exit: 1 } );
     }
 
-    const data = response.data as PostWorkflowRun200;
+    const data = response.data as WorkflowResultResponse;
     const output = formatOutput(
       data,
       flags.format as OutputFormat,

--- a/sdk/cli/src/commands/workflow/test_eval.ts
+++ b/sdk/cli/src/commands/workflow/test_eval.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path';
 import { Args, Command, Flags } from '@oclif/core';
 import { postWorkflowRun } from '#api/generated/api.js';
-import type { PostWorkflowRun200 } from '#api/generated/api.js';
+import type { WorkflowResultResponse } from '#api/generated/api.js';
 import { readAllDatasets, writeDataset } from '#services/datasets.js';
 import { handleApiError } from '#utils/error_handler.js';
 import {
@@ -83,7 +83,7 @@ export default class WorkflowTest extends Command {
       config: { timeout: 600000 }
     } );
 
-    const evalData = response?.data as PostWorkflowRun200 | undefined;
+    const evalData = response?.data as WorkflowResultResponse | undefined;
     if ( !evalData?.output ) {
       this.error( 'Eval workflow returned no output', { exit: 1 } );
     }
@@ -148,7 +148,7 @@ export default class WorkflowTest extends Command {
       const updated: Dataset = {
         ...dataset,
         last_output: {
-          output: ( response.data as PostWorkflowRun200 ).output,
+          output: ( response.data as WorkflowResultResponse ).output,
           executionTimeMs,
           date: new Date().toISOString()
         }

--- a/sdk/cli/src/utils/format_workflow_result.spec.ts
+++ b/sdk/cli/src/utils/format_workflow_result.spec.ts
@@ -84,12 +84,16 @@ describe( 'formatWorkflowResult', () => {
       workflowId: 'wf-456',
       status: 'failed' as const,
       output: null,
+      attributes: [ { type: 'llm:usage', total: 0.4 } ],
+      aggregations: { cost: { total: 0.4 }, tokens: { total: 20 }, httpRequests: { total: 0 } },
       error: 'Activity task failed'
     };
 
     const output = formatOutput( data, 'json', formatWorkflowResult );
     const parsed = JSON.parse( output );
     expect( parsed.status ).toBe( 'failed' );
+    expect( parsed.attributes ).toEqual( [ { type: 'llm:usage', total: 0.4 } ] );
+    expect( parsed.aggregations ).toEqual( { cost: { total: 0.4 }, tokens: { total: 20 }, httpRequests: { total: 0 } } );
     expect( parsed.error ).toBe( 'Activity task failed' );
   } );
 } );

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -70,6 +70,7 @@
     "#logger": "./src/logger.js",
     "#utils": "./src/utils/index.js",
     "#tracing": "./src/tracing/internal_interface.js",
+    "#trace_attribute": "./src/tracing/trace_attribute.js",
     "#async_storage": "./src/async_storage.js",
     "#internal_activities": "./src/internal_activities/index.js"
   }

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -46,6 +46,7 @@
     "@temporalio/common": "catalog:",
     "@temporalio/worker": "catalog:",
     "@temporalio/workflow": "catalog:",
+    "decimal.js": "10.6.0",
     "json-stream-stringify": "3.1.6",
     "redis": "5.12.1",
     "stacktrace-parser": "0.1.11",

--- a/sdk/core/src/activity_integration/tracing.d.ts
+++ b/sdk/core/src/activity_integration/tracing.d.ts
@@ -1,3 +1,6 @@
+import type { Attribute } from '#trace_attribute';
+
+export { Attribute } from '#trace_attribute';
 /**
  * Creates a new event.
  *
@@ -32,14 +35,6 @@ export declare function addEventError( args: { id: string; details: unknown } ):
  *
  * @param args
  * @param args.eventId - The id of the event to attach the attribute to.
- * @param args.name - The attribute name
- * @param args.value - The attribute value
+ * @param args.attribute - The attribute to attach to the event.
  */
-export declare function addEventAttribute( args: { eventId: string; name: string, value: unknown } ): void;
-
-/**
- * Known attributes.
- */
-export declare const Attribute: {
-  COST: 'cost';
-};
+export declare function addEventAttribute( args: { eventId: string; attribute: Attribute.Instance } ): void;

--- a/sdk/core/src/activity_integration/tracing.js
+++ b/sdk/core/src/activity_integration/tracing.js
@@ -1,6 +1,6 @@
-import { addEventActionWithContext, EventAction, Attribute } from '#tracing';
+import { addEventActionWithContext, EventAction } from '#tracing';
 
-export { Attribute };
+export { Attribute } from '#trace_attribute';
 
 /**
  * Creates a new event.
@@ -44,5 +44,5 @@ export const addEventError = ( { id, details } ) => addEventActionWithContext( E
  * @param {unknown} args.value - The attribute value
  * @returns {void}
  */
-export const addEventAttribute = ( { eventId, name, value } ) =>
-  addEventActionWithContext( EventAction.ADD_ATTR, { id: eventId, details: { name, value } } );
+export const addEventAttribute = ( { eventId, attribute } ) =>
+  addEventActionWithContext( EventAction.ADD_ATTR, { id: eventId, details: attribute } );

--- a/sdk/core/src/activity_integration/tracing.js
+++ b/sdk/core/src/activity_integration/tracing.js
@@ -1,4 +1,6 @@
-import { addEventActionWithContext, EventAction } from '#tracing';
+import { addEventActionWithContext, EventAction, Attribute } from '#tracing';
+
+export { Attribute };
 
 /**
  * Creates a new event.
@@ -44,10 +46,3 @@ export const addEventError = ( { id, details } ) => addEventActionWithContext( E
  */
 export const addEventAttribute = ( { eventId, name, value } ) =>
   addEventActionWithContext( EventAction.ADD_ATTR, { id: eventId, details: { name, value } } );
-
-/**
- * Known attributes
- */
-export const Attribute = {
-  COST: 'cost'
-};

--- a/sdk/core/src/consts.js
+++ b/sdk/core/src/consts.js
@@ -33,6 +33,10 @@ export const BusEventType = {
   RUNTIME_ERROR: 'runtime_error'
 };
 
+export const Signal = {
+  ADD_ATTRIBUTE: 'add_attribute'
+};
+
 export const WorkflowSpecialOutput = {
   CONTINUED_AS_NEW: '<<continued_as_new>>'
 };

--- a/sdk/core/src/interface/aggregations.js
+++ b/sdk/core/src/interface/aggregations.js
@@ -5,16 +5,17 @@ export const aggregateAttributes = attributes => ( {
   cost: {
     total: attributes
       .filter( a => [ Attribute.HTTPRequestCost.TYPE, Attribute.LLMUsage.TYPE ].includes( a.type ) )
-      .reduce( ( sum, a ) => Decimal( a.total ).add( sum ).toNumber(), 0 )
+      .reduce( ( sum, a ) => sum.add( a.total ), Decimal( 0 ) ).toNumber()
   },
   tokens: {
     total: attributes
       .filter( a => Attribute.LLMUsage.TYPE === a.type )
-      .reduce( ( sum, a ) => Decimal( a.tokensUsed ).add( sum ).toNumber(), 0 ),
-    ...attributes
+      .reduce( ( sum, a ) => sum.add( a.tokensUsed ), Decimal( 0 ) ).toNumber(),
+    ...Object.entries( attributes
       .filter( a => Attribute.LLMUsage.TYPE === a.type )
       .flatMap( a => a.usage )
-      .reduce( ( obj, a ) => Object.assign( obj, { [a.type]: Decimal( obj[a.type] ?? 0 ).add( a.amount ).toNumber() } ), {} )
+      .reduce( ( obj, a ) => Object.assign( obj, { [a.type]: ( obj[a.type] ?? Decimal( 0 ) ).add( a.amount ) } ), {} ) )
+      .reduce( ( obj, [ k, v ] ) => Object.assign( obj, { [k]: v.toNumber() } ), {} ) // convert all values to number
 
   },
   httpRequests: {

--- a/sdk/core/src/interface/aggregations.js
+++ b/sdk/core/src/interface/aggregations.js
@@ -1,0 +1,23 @@
+import { Attribute } from '#trace_attribute';
+import Decimal from 'decimal.js';
+
+export const aggregateAttributes = attributes => ( {
+  cost: {
+    total: attributes
+      .filter( a => [ Attribute.HTTPRequestCost.TYPE, Attribute.LLMUsage.TYPE ].includes( a.type ) )
+      .reduce( ( sum, a ) => Decimal( a.total ).add( sum ).toNumber(), 0 )
+  },
+  tokens: {
+    total: attributes
+      .filter( a => Attribute.LLMUsage.TYPE === a.type )
+      .reduce( ( sum, a ) => Decimal( a.tokensUsed ).add( sum ).toNumber(), 0 ),
+    ...attributes
+      .filter( a => Attribute.LLMUsage.TYPE === a.type )
+      .flatMap( a => a.usage )
+      .reduce( ( obj, a ) => Object.assign( obj, { [a.type]: Decimal( obj[a.type] ?? 0 ).add( a.amount ).toNumber() } ), {} )
+
+  },
+  httpRequests: {
+    total: attributes.filter( a => Attribute.HTTPRequestCount.TYPE === a.type ).length
+  }
+} );

--- a/sdk/core/src/interface/aggregations.spec.js
+++ b/sdk/core/src/interface/aggregations.spec.js
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { Attribute } from '#trace_attribute';
+import { aggregateAttributes } from './aggregations.js';
+
+describe( 'aggregateAttributes', () => {
+  it( 'returns zeroed aggregations when there are no attributes', () => {
+    expect( aggregateAttributes( [] ) ).toEqual( {
+      cost: { total: 0 },
+      tokens: { total: 0 },
+      httpRequests: { total: 0 }
+    } );
+  } );
+
+  it( 'aggregates costs, token usage, and HTTP request count by attribute type', () => {
+    const attributes = [
+      {
+        type: Attribute.HTTPRequestCount.TYPE,
+        url: 'https://api.example.test/a',
+        requestId: 'req-1'
+      },
+      {
+        type: Attribute.HTTPRequestCount.TYPE,
+        url: 'https://api.example.test/b',
+        requestId: 'req-2'
+      },
+      {
+        type: Attribute.HTTPRequestCost.TYPE,
+        url: 'https://api.example.test/a',
+        requestId: 'req-1',
+        total: 0.2
+      },
+      {
+        type: Attribute.LLMUsage.TYPE,
+        modelId: 'gpt-4o',
+        total: 0.3,
+        tokensUsed: 120,
+        usage: [
+          { type: 'input', ppm: 1, amount: 100, total: 0.1 },
+          { type: 'output', ppm: 2, amount: 20, total: 0.2 }
+        ]
+      },
+      {
+        type: Attribute.LLMUsage.TYPE,
+        modelId: 'gpt-4o-mini',
+        total: 0.05,
+        tokensUsed: 30,
+        usage: [
+          { type: 'input', ppm: 1, amount: 25, total: 0.025 },
+          { type: 'reasoning', ppm: 5, amount: 5, total: 0.025 }
+        ]
+      },
+      {
+        type: 'unrelated',
+        total: 100,
+        tokensUsed: 100
+      }
+    ];
+
+    expect( aggregateAttributes( attributes ) ).toEqual( {
+      cost: { total: 0.55 },
+      tokens: {
+        total: 150,
+        input: 125,
+        output: 20,
+        reasoning: 5
+      },
+      httpRequests: { total: 2 }
+    } );
+  } );
+
+  it( 'uses LLMUsage.tokensUsed for total tokens instead of summing usage amounts', () => {
+    const attributes = [
+      {
+        type: Attribute.LLMUsage.TYPE,
+        modelId: 'provider-model',
+        total: 0.1,
+        tokensUsed: 42,
+        usage: [
+          { type: 'input', ppm: 1, amount: 10, total: 0.01 },
+          { type: 'output', ppm: 1, amount: 5, total: 0.005 }
+        ]
+      }
+    ];
+
+    expect( aggregateAttributes( attributes ).tokens ).toEqual( {
+      total: 42,
+      input: 10,
+      output: 5
+    } );
+  } );
+} );

--- a/sdk/core/src/interface/events.js
+++ b/sdk/core/src/interface/events.js
@@ -1,0 +1,6 @@
+import Decimal from 'decimal.js';
+
+export const formatCost = events => ( {
+  events,
+  total: Decimal( events.reduce( ( sum, c ) => c.total + sum, 0 ) ).toNumber()
+} );

--- a/sdk/core/src/interface/events.js
+++ b/sdk/core/src/interface/events.js
@@ -1,6 +1,0 @@
-import Decimal from 'decimal.js';
-
-export const formatCost = events => ( {
-  events,
-  total: Decimal( events.reduce( ( sum, c ) => c.total + sum, 0 ) ).toNumber()
-} );

--- a/sdk/core/src/interface/workflow.js
+++ b/sdk/core/src/interface/workflow.js
@@ -3,7 +3,7 @@ import { proxyActivities, inWorkflowContext, executeChild, workflowInfo, uuid4, 
 import { defineSignal, setHandler } from '@temporalio/workflow';
 import { validateWorkflow } from './validations/static.js';
 import { validateWithSchema } from './validations/runtime.js';
-import { SHARED_STEP_PREFIX, ACTIVITY_GET_TRACE_DESTINATIONS, METADATA_ACCESS_SYMBOL } from '#consts';
+import { SHARED_STEP_PREFIX, ACTIVITY_GET_TRACE_DESTINATIONS, METADATA_ACCESS_SYMBOL, Signal } from '#consts';
 import { deepMerge, setMetadata, toUrlSafeBase64 } from '#utils';
 import { FatalError, ValidationError } from '#errors';
 import { Context } from './workflow_context.js';
@@ -76,7 +76,7 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
     const traceDestinations = isRoot ? ( await steps[ACTIVITY_GET_TRACE_DESTINATIONS]( executionContext ) ) : null;
 
     const attributes = [];
-    setHandler( defineSignal( 'add_attribute' ), e => attributes.push( e ) );
+    setHandler( defineSignal( Signal.ADD_ATTRIBUTE ), e => attributes.push( e ) );
 
     try {
       // validation comes after setting memo to have that info already set for interceptor even if validations fail

--- a/sdk/core/src/interface/workflow.js
+++ b/sdk/core/src/interface/workflow.js
@@ -7,7 +7,7 @@ import { SHARED_STEP_PREFIX, ACTIVITY_GET_TRACE_DESTINATIONS, METADATA_ACCESS_SY
 import { deepMerge, setMetadata, toUrlSafeBase64 } from '#utils';
 import { FatalError, ValidationError } from '#errors';
 import { Context } from './workflow_context.js';
-import { formatCost } from './events.js';
+import { aggregateAttributes } from './aggregations.js';
 
 const defaultOptions = {
   activityOptions: {
@@ -23,6 +23,9 @@ const defaultOptions = {
   },
   disableTrace: false
 };
+
+export const extractErrorDetail = ( e, key ) =>
+  e ? ( e.details?.find?.( d => d[key] )?.[key] ?? extractErrorDetail( e.cause, key ) ) : null;
 
 export function workflow( { name, description, inputSchema, outputSchema, fn, options = {}, aliases = [] } ) {
   validateWorkflow( { name, description, inputSchema, outputSchema, fn, options, aliases } );
@@ -71,10 +74,9 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
 
     // Run the internal activity to retrieve the workflow trace destinations (only for root workflows, not nested)
     const traceDestinations = isRoot ? ( await steps[ACTIVITY_GET_TRACE_DESTINATIONS]( executionContext ) ) : null;
-    const traceObject = { trace: { destinations: traceDestinations } };
 
-    const costEvents = [];
-    setHandler( defineSignal( 'add_event:cost' ), e => costEvents.push( e ) );
+    const attributes = [];
+    setHandler( defineSignal( 'add_attribute' ), e => attributes.push( e ) );
 
     try {
       // validation comes after setting memo to have that info already set for interceptor even if validations fail
@@ -96,17 +98,25 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
          * @param {import('@temporalio/workflow').ActivityOptions} extra.options
          * @returns {Promise<unknown>}
          */
-        startWorkflow: async ( childName, input, extra = {} ) =>
-          executeChild( childName, {
-            args: input ? [ input ] : [],
-            workflowId: `${workflowId}-${toUrlSafeBase64( uuid4() )}`,
-            parentClosePolicy: ParentClosePolicy[extra?.detached ? 'ABANDON' : 'TERMINATE'],
-            memo: {
-              executionContext,
-              parentId: workflowId,
-              ...( extra?.options?.activityOptions && { activityOptions: deepMerge( activityOptions, extra.options.activityOptions ) } )
-            }
-          } )
+        startWorkflow: async ( childName, input, extra = {} ) => {
+          try {
+            const result = await executeChild( childName, {
+              args: input ? [ input ] : [],
+              workflowId: `${workflowId}-${toUrlSafeBase64( uuid4() )}`,
+              parentClosePolicy: ParentClosePolicy[extra?.detached ? 'ABANDON' : 'TERMINATE'],
+              memo: {
+                executionContext,
+                parentId: workflowId,
+                ...( extra?.options?.activityOptions && { activityOptions: deepMerge( activityOptions, extra.options.activityOptions ) } )
+              }
+            } );
+            attributes.push( ...( result.attributes ?? [] ) );
+            return result.output;
+          } catch ( error ) {
+            attributes.push( ...( extractErrorDetail( error, 'attributes' ) ?? [] ) );
+            throw error;
+          }
+        }
       };
 
       const output = await fn.call( dispatchers, input, context );
@@ -115,14 +125,17 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
 
       if ( isRoot ) {
         // Append the trace info to the result of the workflow
-        return { output, ...traceObject, cost: formatCost( costEvents ) };
+        return { output, trace: { destinations: traceDestinations }, attributes, aggregations: aggregateAttributes( attributes ) };
       }
 
-      return output;
+      return { output, attributes };
     } catch ( e ) {
-      // Append the trace info as metadata of the error, so it can be read by the interceptor.
+      // Append the extra info as metadata of the error, so it can be read by the interceptor.
+      e[METADATA_ACCESS_SYMBOL] = { ...( e[METADATA_ACCESS_SYMBOL] ?? {} ), attributes };
+      // if it is roo also add trace/aggregations
       if ( isRoot ) {
-        e[METADATA_ACCESS_SYMBOL] = { ...( e[METADATA_ACCESS_SYMBOL] ?? {} ), ...traceObject, cost: formatCost( costEvents ) };
+        e[METADATA_ACCESS_SYMBOL].trace = { destinations: traceDestinations };
+        e[METADATA_ACCESS_SYMBOL].aggregations = aggregateAttributes( attributes );
       }
       throw e;
     }

--- a/sdk/core/src/interface/workflow.js
+++ b/sdk/core/src/interface/workflow.js
@@ -1,11 +1,13 @@
 // THIS RUNS IN THE TEMPORAL'S SANDBOX ENVIRONMENT
 import { proxyActivities, inWorkflowContext, executeChild, workflowInfo, uuid4, ParentClosePolicy, continueAsNew } from '@temporalio/workflow';
+import { defineSignal, setHandler } from '@temporalio/workflow';
 import { validateWorkflow } from './validations/static.js';
 import { validateWithSchema } from './validations/runtime.js';
 import { SHARED_STEP_PREFIX, ACTIVITY_GET_TRACE_DESTINATIONS, METADATA_ACCESS_SYMBOL } from '#consts';
 import { deepMerge, setMetadata, toUrlSafeBase64 } from '#utils';
 import { FatalError, ValidationError } from '#errors';
 import { Context } from './workflow_context.js';
+import { formatCost } from './events.js';
 
 const defaultOptions = {
   activityOptions: {
@@ -71,6 +73,9 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
     const traceDestinations = isRoot ? ( await steps[ACTIVITY_GET_TRACE_DESTINATIONS]( executionContext ) ) : null;
     const traceObject = { trace: { destinations: traceDestinations } };
 
+    const costEvents = [];
+    setHandler( defineSignal( 'add_event:cost' ), e => costEvents.push( e ) );
+
     try {
       // validation comes after setting memo to have that info already set for interceptor even if validations fail
       validateWithSchema( inputSchema, input, `Workflow ${name} input` );
@@ -110,14 +115,14 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
 
       if ( isRoot ) {
         // Append the trace info to the result of the workflow
-        return { output, ...traceObject };
+        return { output, ...traceObject, cost: formatCost( costEvents ) };
       }
 
       return output;
     } catch ( e ) {
       // Append the trace info as metadata of the error, so it can be read by the interceptor.
       if ( isRoot ) {
-        e[METADATA_ACCESS_SYMBOL] = { ...( e[METADATA_ACCESS_SYMBOL] ?? {} ), ...traceObject };
+        e[METADATA_ACCESS_SYMBOL] = { ...( e[METADATA_ACCESS_SYMBOL] ?? {} ), ...traceObject, cost: formatCost( costEvents ) };
       }
       throw e;
     }

--- a/sdk/core/src/interface/workflow.spec.js
+++ b/sdk/core/src/interface/workflow.spec.js
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { z } from 'zod';
 
 const inWorkflowContextMock = vi.hoisted( () => vi.fn( () => true ) );
+const defineSignalMock = vi.hoisted( () => vi.fn( name => name ) );
+const setHandlerMock = vi.hoisted( () => vi.fn() );
 const traceDestinationsStepMock = vi.fn().mockResolvedValue( { local: '/tmp/trace' } );
 const executeChildMock = vi.fn().mockResolvedValue( undefined );
 const continueAsNewMock = vi.fn().mockResolvedValue( undefined );
@@ -41,7 +43,9 @@ vi.mock( '@temporalio/workflow', () => ( {
   workflowInfo: workflowInfoMock,
   uuid4: () => '550e8400e29b41d4a716446655440000',
   ParentClosePolicy: { TERMINATE: 'TERMINATE', ABANDON: 'ABANDON' },
-  continueAsNew: continueAsNewMock
+  continueAsNew: continueAsNewMock,
+  defineSignal: ( ...args ) => defineSignalMock( ...args ),
+  setHandler: ( ...args ) => setHandlerMock( ...args )
 } ) );
 
 vi.mock( '#consts', async importOriginal => {
@@ -57,6 +61,7 @@ describe( 'workflow()', () => {
   beforeEach( () => {
     vi.clearAllMocks();
     inWorkflowContextMock.mockReturnValue( true );
+    defineSignalMock.mockImplementation( name => name );
     workflowInfoMock.mockReturnValue( { ...workflowInfoReturn } );
     workflowInfoReturn.memo = {};
     proxyActivitiesMock.mockImplementation( () => {
@@ -217,7 +222,7 @@ describe( 'workflow()', () => {
   } );
 
   describe( 'root workflow (in workflow context)', () => {
-    it( 'calls getTraceDestinations, returns { output, trace } and assigns executionContext to memo', async () => {
+    it( 'calls getTraceDestinations, returns { output, trace, cost } and assigns executionContext to memo', async () => {
       const { workflow } = await import( './workflow.js' );
 
       const wf = workflow( {
@@ -232,7 +237,8 @@ describe( 'workflow()', () => {
       expect( traceDestinationsStepMock ).toHaveBeenCalledTimes( 1 );
       expect( result ).toEqual( {
         output: { v: 42 },
-        trace: { destinations: { local: '/tmp/trace' } }
+        trace: { destinations: { local: '/tmp/trace' } },
+        cost: { events: [], total: 0 }
       } );
       const memo = workflowInfoMock().memo;
       expect( memo.executionContext ).toEqual( {
@@ -448,8 +454,10 @@ describe( 'workflow()', () => {
   } );
 
   describe( 'error handling (root workflow)', () => {
-    it( 'rethrows error from fn and rejects with same message', async () => {
+    it( 'rethrows error from fn with trace and cost metadata', async () => {
       const { workflow } = await import( './workflow.js' );
+      const { METADATA_ACCESS_SYMBOL } = await import( '#consts' );
+      const error = new Error( 'workflow failed' );
 
       const wf = workflow( {
         name: 'err_wf',
@@ -457,11 +465,15 @@ describe( 'workflow()', () => {
         inputSchema: z.object( {} ),
         outputSchema: z.object( {} ),
         fn: async () => {
-          throw new Error( 'workflow failed' );
+          throw error;
         }
       } );
 
       await expect( wf( {} ) ).rejects.toThrow( 'workflow failed' );
+      expect( error[METADATA_ACCESS_SYMBOL] ).toEqual( {
+        trace: { destinations: { local: '/tmp/trace' } },
+        cost: { events: [], total: 0 }
+      } );
     } );
   } );
 } );

--- a/sdk/core/src/interface/workflow.spec.js
+++ b/sdk/core/src/interface/workflow.spec.js
@@ -1,3 +1,4 @@
+import { Signal } from '#consts';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { z } from 'zod';
 
@@ -268,7 +269,7 @@ describe( 'workflow()', () => {
       const { Attribute } = await import( '#trace_attribute' );
       const handlers = { addAttribute: () => {} };
       setHandlerMock.mockImplementation( ( signalName, handler ) => {
-        if ( signalName === 'add_attribute' ) {
+        if ( signalName === Signal.ADD_ATTRIBUTE ) {
           handlers.addAttribute = handler;
         }
       } );

--- a/sdk/core/src/interface/workflow.spec.js
+++ b/sdk/core/src/interface/workflow.spec.js
@@ -43,6 +43,13 @@ vi.mock( '@temporalio/workflow', () => ( {
   workflowInfo: workflowInfoMock,
   uuid4: () => '550e8400e29b41d4a716446655440000',
   ParentClosePolicy: { TERMINATE: 'TERMINATE', ABANDON: 'ABANDON' },
+  ChildWorkflowFailure: class ChildWorkflowFailure extends Error {
+    constructor( message, cause ) {
+      super( message );
+      this.name = 'ChildWorkflowFailure';
+      this.cause = cause;
+    }
+  },
   continueAsNew: continueAsNewMock,
   defineSignal: ( ...args ) => defineSignalMock( ...args ),
   setHandler: ( ...args ) => setHandlerMock( ...args )
@@ -56,6 +63,12 @@ vi.mock( '#consts', async importOriginal => {
     ACTIVITY_GET_TRACE_DESTINATIONS: '__internal#getTraceDestinations'
   };
 } );
+
+const emptyAggregations = {
+  cost: { total: 0 },
+  tokens: { total: 0 },
+  httpRequests: { total: 0 }
+};
 
 describe( 'workflow()', () => {
   beforeEach( () => {
@@ -222,7 +235,7 @@ describe( 'workflow()', () => {
   } );
 
   describe( 'root workflow (in workflow context)', () => {
-    it( 'calls getTraceDestinations, returns { output, trace, cost } and assigns executionContext to memo', async () => {
+    it( 'calls getTraceDestinations, returns root trace data and assigns executionContext to memo', async () => {
       const { workflow } = await import( './workflow.js' );
 
       const wf = workflow( {
@@ -238,7 +251,8 @@ describe( 'workflow()', () => {
       expect( result ).toEqual( {
         output: { v: 42 },
         trace: { destinations: { local: '/tmp/trace' } },
-        cost: { events: [], total: 0 }
+        attributes: [],
+        aggregations: emptyAggregations
       } );
       const memo = workflowInfoMock().memo;
       expect( memo.executionContext ).toEqual( {
@@ -246,6 +260,68 @@ describe( 'workflow()', () => {
         workflowName: 'root_wf',
         disableTrace: false,
         startTime: new Date( '2025-01-01T00:00:00Z' ).getTime()
+      } );
+    } );
+
+    it( 'collects attribute signals and returns aggregated attributes', async () => {
+      const { workflow } = await import( './workflow.js' );
+      const { Attribute } = await import( '#trace_attribute' );
+      const handlers = { addAttribute: () => {} };
+      setHandlerMock.mockImplementation( ( signalName, handler ) => {
+        if ( signalName === 'add_attribute' ) {
+          handlers.addAttribute = handler;
+        }
+      } );
+
+      const httpRequest = {
+        type: Attribute.HTTPRequestCount.TYPE,
+        url: 'https://api.example.test/items',
+        requestId: 'req-1'
+      };
+      const httpCost = {
+        type: Attribute.HTTPRequestCost.TYPE,
+        url: 'https://api.example.test/items',
+        requestId: 'req-1',
+        total: 2.5
+      };
+      const llmUsage = {
+        type: Attribute.LLMUsage.TYPE,
+        modelId: 'gpt-4o',
+        total: 0.25,
+        usage: [
+          { type: 'input', ppm: 5, amount: 20_000, total: 0.1 },
+          { type: 'output', ppm: 30, amount: 5_000, total: 0.15 }
+        ],
+        tokensUsed: 25_000
+      };
+
+      const wf = workflow( {
+        name: 'attr_wf',
+        description: 'Attributes',
+        inputSchema: z.object( {} ),
+        outputSchema: z.object( { ok: z.boolean() } ),
+        fn: async () => {
+          handlers.addAttribute( httpRequest );
+          handlers.addAttribute( httpCost );
+          handlers.addAttribute( llmUsage );
+          return { ok: true };
+        }
+      } );
+
+      const result = await wf( {} );
+      expect( result ).toEqual( {
+        output: { ok: true },
+        trace: { destinations: { local: '/tmp/trace' } },
+        attributes: [ httpRequest, httpCost, llmUsage ],
+        aggregations: {
+          cost: { total: 2.75 },
+          tokens: {
+            total: 25_000,
+            input: 20_000,
+            output: 5_000
+          },
+          httpRequests: { total: 1 }
+        }
       } );
     } );
 
@@ -267,7 +343,7 @@ describe( 'workflow()', () => {
   } );
 
   describe( 'child workflow (memo.executionContext already set)', () => {
-    it( 'does not call getTraceDestinations and returns plain output', async () => {
+    it( 'does not call getTraceDestinations and returns an internal output envelope', async () => {
       workflowInfoMock.mockReturnValue( {
         ...workflowInfoReturn,
         memo: { executionContext: { workflowId: 'parent-1', workflowName: 'parent_wf' } }
@@ -284,7 +360,7 @@ describe( 'workflow()', () => {
 
       const result = await wf( {} );
       expect( traceDestinationsStepMock ).not.toHaveBeenCalled();
-      expect( result ).toEqual( { x: 'child' } );
+      expect( result ).toEqual( { output: { x: 'child' }, attributes: [] } );
     } );
   } );
 
@@ -387,6 +463,7 @@ describe( 'workflow()', () => {
     it( 'calls executeChild with correct args and TERMINATE when not detached', async () => {
       const { workflow } = await import( './workflow.js' );
       const { ParentClosePolicy } = await import( '@temporalio/workflow' );
+      executeChildMock.mockResolvedValueOnce( { output: {}, attributes: [] } );
 
       const wf = workflow( {
         name: 'parent_wf',
@@ -414,6 +491,7 @@ describe( 'workflow()', () => {
     it( 'uses ABANDON when extra.detached is true', async () => {
       const { workflow } = await import( './workflow.js' );
       const { ParentClosePolicy } = await import( '@temporalio/workflow' );
+      executeChildMock.mockResolvedValueOnce( { output: {}, attributes: [] } );
 
       const wf = workflow( {
         name: 'detach_wf',
@@ -434,6 +512,7 @@ describe( 'workflow()', () => {
 
     it( 'passes empty args when input is null/omitted', async () => {
       const { workflow } = await import( './workflow.js' );
+      executeChildMock.mockResolvedValueOnce( { output: {}, attributes: [] } );
 
       const wf = workflow( {
         name: 'no_input_wf',
@@ -451,10 +530,93 @@ describe( 'workflow()', () => {
         args: []
       } ) );
     } );
+
+    it( 'returns child output and merges child attributes into the root result', async () => {
+      const { workflow } = await import( './workflow.js' );
+      const { Attribute } = await import( '#trace_attribute' );
+      const childAttribute = {
+        type: Attribute.LLMUsage.TYPE,
+        modelId: 'gpt-4o',
+        total: 0.4,
+        tokensUsed: 20,
+        usage: [
+          { type: 'input', ppm: 10, amount: 20, total: 0.4 }
+        ]
+      };
+      executeChildMock.mockResolvedValueOnce( {
+        output: { child: 'ok' },
+        attributes: [ childAttribute ]
+      } );
+
+      const wf = workflow( {
+        name: 'merge_child_wf',
+        description: 'Merge child attributes',
+        inputSchema: z.object( {} ),
+        outputSchema: z.object( { child: z.string() } ),
+        async fn() {
+          return this.startWorkflow( 'child_wf', { id: 1 } );
+        }
+      } );
+
+      const result = await wf( {} );
+      expect( result ).toEqual( {
+        output: { child: 'ok' },
+        trace: { destinations: { local: '/tmp/trace' } },
+        attributes: [ childAttribute ],
+        aggregations: {
+          cost: { total: 0.4 },
+          tokens: {
+            total: 20,
+            input: 20
+          },
+          httpRequests: { total: 0 }
+        }
+      } );
+    } );
+
+    it( 'merges child error attributes before rethrowing to root metadata', async () => {
+      const { workflow } = await import( './workflow.js' );
+      const { ChildWorkflowFailure } = await import( '@temporalio/workflow' );
+      const { METADATA_ACCESS_SYMBOL } = await import( '#consts' );
+      const { Attribute } = await import( '#trace_attribute' );
+      const childAttribute = {
+        type: Attribute.HTTPRequestCost.TYPE,
+        url: 'https://api.example.test',
+        requestId: 'req-child',
+        total: 2
+      };
+      const childError = new ChildWorkflowFailure( 'child failed', {
+        message: 'Child workflow execution failed',
+        details: [ { attributes: [ childAttribute ] } ]
+      } );
+      executeChildMock.mockRejectedValueOnce( childError );
+
+      const wf = workflow( {
+        name: 'child_error_wf',
+        description: 'Child error attributes',
+        inputSchema: z.object( {} ),
+        outputSchema: z.object( {} ),
+        async fn() {
+          await this.startWorkflow( 'child_wf', { id: 1 } );
+          return {};
+        }
+      } );
+
+      await expect( wf( {} ) ).rejects.toThrow( 'child failed' );
+      expect( childError[METADATA_ACCESS_SYMBOL] ).toEqual( {
+        attributes: [ childAttribute ],
+        trace: { destinations: { local: '/tmp/trace' } },
+        aggregations: {
+          cost: { total: 2 },
+          tokens: { total: 0 },
+          httpRequests: { total: 0 }
+        }
+      } );
+    } );
   } );
 
   describe( 'error handling (root workflow)', () => {
-    it( 'rethrows error from fn with trace and cost metadata', async () => {
+    it( 'rethrows error from fn with trace attributes and aggregation metadata', async () => {
       const { workflow } = await import( './workflow.js' );
       const { METADATA_ACCESS_SYMBOL } = await import( '#consts' );
       const error = new Error( 'workflow failed' );
@@ -472,7 +634,8 @@ describe( 'workflow()', () => {
       await expect( wf( {} ) ).rejects.toThrow( 'workflow failed' );
       expect( error[METADATA_ACCESS_SYMBOL] ).toEqual( {
         trace: { destinations: { local: '/tmp/trace' } },
-        cost: { events: [], total: 0 }
+        attributes: [],
+        aggregations: emptyAggregations
       } );
     } );
   } );

--- a/sdk/core/src/tracing/internal_interface.js
+++ b/sdk/core/src/tracing/internal_interface.js
@@ -1,5 +1,5 @@
 import { addEventAction, addEventActionWithContext, init, getDestinations } from './trace_engine.js';
-import { EventAction, Attribute } from './trace_consts.js';
+import { EventAction } from './trace_consts.js';
 
 /**
  * Init method, if not called, no processors are attached and trace functions are dummy
@@ -11,7 +11,7 @@ export { init, getDestinations };
  */
 export { addEventActionWithContext };
 
-export { EventAction, Attribute };
+export { EventAction };
 
 /**
  * Trace nomenclature

--- a/sdk/core/src/tracing/internal_interface.js
+++ b/sdk/core/src/tracing/internal_interface.js
@@ -1,5 +1,5 @@
 import { addEventAction, addEventActionWithContext, init, getDestinations } from './trace_engine.js';
-import { EventAction } from './trace_consts.js';
+import { EventAction, Attribute } from './trace_consts.js';
 
 /**
  * Init method, if not called, no processors are attached and trace functions are dummy
@@ -11,7 +11,7 @@ export { init, getDestinations };
  */
 export { addEventActionWithContext };
 
-export { EventAction };
+export { EventAction, Attribute };
 
 /**
  * Trace nomenclature

--- a/sdk/core/src/tracing/tools/build_trace_tree.js
+++ b/sdk/core/src/tracing/tools/build_trace_tree.js
@@ -62,7 +62,7 @@ export default entries => {
     if ( action === EventAction.START ) {
       Object.assign( node, { input: details, startedAt: timestamp, kind, name } );
     } else if ( action === EventAction.ADD_ATTR ) {
-      node.attributes[details.name] = details.value;
+      node.attributes[details.type] = details;
     } else if ( action === EventAction.END ) {
       Object.assign( node, { output: details, endedAt: timestamp } );
     } else if ( action === EventAction.ERROR ) {

--- a/sdk/core/src/tracing/tools/build_trace_tree.spec.js
+++ b/sdk/core/src/tracing/tools/build_trace_tree.spec.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { EventAction } from '../trace_consts.js';
+import { Attribute } from '#trace_attribute';
 import buildTraceTree from './build_trace_tree.js';
 
 describe( 'build_trace_tree', () => {
@@ -26,34 +27,66 @@ this can indicate it timed out or was interrupted.>>' );
     expect( buildTraceTree( entries ) ).toBeNull();
   } );
 
-  it( 'add_attr action merges details.name and details.value into node.attributes', () => {
+  it( 'add_attr action stores attribute details by type on node.attributes', () => {
+    const requestCount = {
+      type: Attribute.HTTPRequestCount.TYPE,
+      url: 'https://api.example.test',
+      requestId: 'req-1'
+    };
+    const requestCost = {
+      type: Attribute.HTTPRequestCost.TYPE,
+      url: 'https://api.example.test',
+      requestId: 'req-1',
+      total: 0.2
+    };
     const entries = [
       { kind: 'workflow', id: 'wf', parentId: undefined, action: EventAction.START, name: 'wf', details: {}, timestamp: 100 },
       { kind: 'step', id: 's', parentId: 'wf', action: EventAction.START, name: 'step', details: {}, timestamp: 200 },
-      { id: 's', action: EventAction.ADD_ATTR, details: { name: 'latency_ms', value: 42 }, timestamp: 250 },
-      { id: 's', action: EventAction.ADD_ATTR, details: { name: 'retries', value: 1 }, timestamp: 260 },
+      { id: 's', action: EventAction.ADD_ATTR, details: requestCount, timestamp: 250 },
+      { id: 's', action: EventAction.ADD_ATTR, details: requestCost, timestamp: 260 },
       { id: 'wf', action: EventAction.END, details: {}, timestamp: 300 }
     ];
     const result = buildTraceTree( entries );
     expect( result ).not.toBeNull();
-    expect( result.children[0].attributes ).toEqual( { latency_ms: 42, retries: 1 } );
+    expect( result.children[0].attributes ).toEqual( {
+      [Attribute.HTTPRequestCount.TYPE]: requestCount,
+      [Attribute.HTTPRequestCost.TYPE]: requestCost
+    } );
   } );
 
-  it( 'add_attr action overwrites prior value for the same attribute name', () => {
+  it( 'add_attr action overwrites prior value for the same attribute type', () => {
+    const firstCost = {
+      type: Attribute.HTTPRequestCost.TYPE,
+      url: 'https://api.example.test',
+      requestId: 'req-1',
+      total: 1
+    };
+    const secondCost = {
+      type: Attribute.HTTPRequestCost.TYPE,
+      url: 'https://api.example.test',
+      requestId: 'req-1',
+      total: 2
+    };
     const entries = [
       { kind: 'workflow', id: 'wf', parentId: undefined, action: EventAction.START, name: 'wf', details: {}, timestamp: 1 },
-      { id: 'wf', action: EventAction.ADD_ATTR, details: { name: 'x', value: 1 }, timestamp: 2 },
-      { id: 'wf', action: EventAction.ADD_ATTR, details: { name: 'x', value: 2 }, timestamp: 3 },
+      { id: 'wf', action: EventAction.ADD_ATTR, details: firstCost, timestamp: 2 },
+      { id: 'wf', action: EventAction.ADD_ATTR, details: secondCost, timestamp: 3 },
       { id: 'wf', action: EventAction.END, details: {}, timestamp: 4 }
     ];
     const result = buildTraceTree( entries );
-    expect( result.attributes ).toEqual( { x: 2 } );
+    expect( result.attributes ).toEqual( { [Attribute.HTTPRequestCost.TYPE]: secondCost } );
   } );
 
   it( 'add_attr does not attach nodes as children (only start does)', () => {
     const entries = [
       { kind: 'workflow', id: 'wf', parentId: undefined, action: EventAction.START, name: 'wf', details: {}, timestamp: 1 },
-      { id: 'orphan', parentId: 'wf', action: EventAction.ADD_ATTR, details: { name: 'k', value: 'v' }, timestamp: 2 },
+      {
+        id: 'orphan',
+        parentId: 'wf',
+        action: EventAction.ADD_ATTR,
+        details: { type: Attribute.HTTPRequestCount.TYPE, url: 'https://api.example.test', requestId: 'req-1' },
+        timestamp: 2
+      },
       { id: 'wf', action: EventAction.END, details: {}, timestamp: 3 }
     ];
     const result = buildTraceTree( entries );
@@ -75,6 +108,11 @@ this can indicate it timed out or was interrupted.>>' );
   } );
 
   it( 'builds a tree from workflow/step/IO entries with grouping and sorting', () => {
+    const stepAttribute = {
+      type: Attribute.HTTPRequestCount.TYPE,
+      url: 'https://api.example.test/step-1',
+      requestId: 'req-step-1'
+    };
     const entries = [
       // workflow start
       { kind: 'workflow', action: EventAction.START, name: 'wf', id: 'wf', parentId: undefined, details: { a: 1 }, timestamp: 1000 },
@@ -83,7 +121,7 @@ this can indicate it timed out or was interrupted.>>' );
       { id: 'eval', action: EventAction.END, details: { z: 1 }, timestamp: 1600 },
       // step1 start
       { kind: 'step', action: EventAction.START, name: 'step-1', id: 's1', parentId: 'wf', details: { x: 1 }, timestamp: 2000 },
-      { id: 's1', action: EventAction.ADD_ATTR, details: { name: 'step_tag', value: 'alpha' }, timestamp: 2050 },
+      { id: 's1', action: EventAction.ADD_ATTR, details: stepAttribute, timestamp: 2050 },
       // IO under step1
       { kind: 'IO', action: EventAction.START, name: 'test-1', id: 'io1', parentId: 's1', details: { y: 2 }, timestamp: 2300 },
       // step2 start
@@ -132,7 +170,7 @@ this can indicate it timed out or was interrupted.>>' );
           endedAt: 2800,
           input: { x: 1 },
           output: { done: true },
-          attributes: { step_tag: 'alpha' },
+          attributes: { [Attribute.HTTPRequestCount.TYPE]: stepAttribute },
           children: [
             {
               id: 'io1',

--- a/sdk/core/src/tracing/trace_attribute.d.ts
+++ b/sdk/core/src/tracing/trace_attribute.d.ts
@@ -1,0 +1,38 @@
+export declare namespace Attribute {
+  export interface Usage {
+    type: string;
+    ppm: number;
+    amount: number;
+    total: number;
+  }
+
+  export class HTTPRequestCount {
+    static TYPE: 'http:request:count';
+    type: typeof HTTPRequestCount.TYPE;
+    url: string;
+    requestId: string;
+    constructor( url: string, requestId: string );
+  }
+
+  export class HTTPRequestCost {
+    static TYPE: 'http:request:cost';
+    type: typeof HTTPRequestCost.TYPE;
+    url: string;
+    requestId: string;
+    total: number;
+    constructor( url: string, requestId: string, total: number );
+  }
+
+  export class LLMUsage {
+    static TYPE: 'llm:usage';
+    type: typeof LLMUsage.TYPE;
+    modelId: string;
+    usage: Usage[];
+    constructor( modelId: string );
+    addUsage( usage: { type: string; ppm: number; amount: number } ): void;
+    readonly total: number;
+    readonly tokensUsed: number;
+  }
+
+  export type Instance = HTTPRequestCount | HTTPRequestCost | LLMUsage;
+}

--- a/sdk/core/src/tracing/trace_attribute.js
+++ b/sdk/core/src/tracing/trace_attribute.js
@@ -1,0 +1,80 @@
+import Decimal from 'decimal.js';
+
+/**
+ * All attributes inherit from this
+ */
+export class BaseAttribute {
+  activityId;
+  activityName;
+  date = Date.now();
+  type;
+
+  constructor( type ) {
+    this.type = type;
+  }
+
+  setActivity( id, name ) {
+    this.activityId = id;
+    this.activityName = name;
+  }
+}
+
+class HTTPRequestCount extends BaseAttribute {
+  static TYPE = 'http:request:count';
+  url;
+  requestId;
+
+  constructor( url, requestId ) {
+    super( HTTPRequestCount.TYPE );
+    this.url = url;
+    this.requestId = requestId;
+  }
+}
+
+class HTTPRequestCost extends BaseAttribute {
+  static TYPE = 'http:request:cost';
+  url;
+  requestId;
+  total = 0;
+
+  constructor( url, requestId, total ) {
+    super( HTTPRequestCost.TYPE );
+    this.url = url;
+    this.requestId = requestId;
+    this.total = total;
+  }
+}
+
+class LLMUsage extends BaseAttribute {
+  static TYPE = 'llm:usage';
+  modelId;
+  usage = [];
+  total = 0;
+  tokensUsed = 0;
+
+  constructor( modelId ) {
+    super( LLMUsage.TYPE );
+    this.modelId = modelId;
+  }
+
+  addUsage( { type, ppm, amount } ) {
+    const total = Decimal( amount ).div( 1_000_000 ).mul( ppm ).toNumber();
+    this.usage.push( {
+      type,
+      ppm,
+      amount,
+      total
+    } );
+    this.total = Decimal( this.total ).add( total ).toNumber();
+    this.tokensUsed = Decimal( this.tokensUsed ).add( amount ).toNumber();
+  }
+}
+
+/**
+ * Types of ADD_ATTR attributes
+ */
+export const Attribute = {
+  LLMUsage,
+  HTTPRequestCost,
+  HTTPRequestCount
+};

--- a/sdk/core/src/tracing/trace_consts.js
+++ b/sdk/core/src/tracing/trace_consts.js
@@ -7,10 +7,3 @@ export const EventAction = {
   ERROR: 'error',
   ADD_ATTR: 'add_attr'
 };
-
-/**
- * Types of ADD_ATTR attributes
- */
-export const Attribute = {
-  COST: 'cost'
-};

--- a/sdk/core/src/tracing/trace_consts.js
+++ b/sdk/core/src/tracing/trace_consts.js
@@ -7,3 +7,10 @@ export const EventAction = {
   ERROR: 'error',
   ADD_ATTR: 'add_attr'
 };
+
+/**
+ * Types of ADD_ATTR attributes
+ */
+export const Attribute = {
+  COST: 'cost'
+};

--- a/sdk/core/src/tracing/trace_engine.js
+++ b/sdk/core/src/tracing/trace_engine.js
@@ -6,7 +6,8 @@ import * as localProcessor from './processors/local/index.js';
 import * as s3Processor from './processors/s3/index.js';
 import { ComponentType } from '#consts';
 import { createChildLogger } from '#logger';
-import { EventAction, Attribute } from './trace_consts.js';
+import { EventAction } from './trace_consts.js';
+import { BaseAttribute } from './trace_attribute.js';
 
 const log = createChildLogger( 'Tracing' );
 
@@ -94,11 +95,12 @@ export function addEventActionWithContext( action, options ) {
   if ( storeContent ) { // If there is no storageContext this was not called from a Temporal environment
     const { parentId, parentName, executionContext, workflowHandle } = storeContent;
     if ( action === EventAction.ADD_ATTR ) {
-      const { name, value } = options.details;
-      const date = Date.now();
-      if ( name === Attribute.COST ) {
-        workflowHandle.signal( 'add_event:cost', { activityId: parentId, activityName: parentName, ...value, date } );
+      const attribute = options.details;
+      if ( !( attribute instanceof BaseAttribute ) ) {
+        throw new Error( `${EventAction.ADD_ATTR} called argument that is not a BaseAttribute instance` );
       }
+      attribute.setActivity( parentId, parentName );
+      workflowHandle.signal( 'add_attribute', attribute );
     }
     addEventAction( action, { ...options, parentId, executionContext } );
   }

--- a/sdk/core/src/tracing/trace_engine.js
+++ b/sdk/core/src/tracing/trace_engine.js
@@ -4,7 +4,7 @@ import { serializeError } from './tools/utils.js';
 import { isStringboolTrue } from '#utils';
 import * as localProcessor from './processors/local/index.js';
 import * as s3Processor from './processors/s3/index.js';
-import { ComponentType } from '#consts';
+import { ComponentType, Signal } from '#consts';
 import { createChildLogger } from '#logger';
 import { EventAction } from './trace_consts.js';
 import { BaseAttribute } from './trace_attribute.js';
@@ -100,7 +100,7 @@ export function addEventActionWithContext( action, options ) {
         throw new Error( `${EventAction.ADD_ATTR} called argument that is not a BaseAttribute instance` );
       }
       attribute.setActivity( parentId, parentName );
-      workflowHandle.signal( 'add_attribute', attribute );
+      workflowHandle.signal( Signal.ADD_ATTRIBUTE, attribute );
     }
     addEventAction( action, { ...options, parentId, executionContext } );
   }

--- a/sdk/core/src/tracing/trace_engine.js
+++ b/sdk/core/src/tracing/trace_engine.js
@@ -6,6 +6,7 @@ import * as localProcessor from './processors/local/index.js';
 import * as s3Processor from './processors/s3/index.js';
 import { ComponentType } from '#consts';
 import { createChildLogger } from '#logger';
+import { EventAction, Attribute } from './trace_consts.js';
 
 const log = createChildLogger( 'Tracing' );
 
@@ -91,7 +92,14 @@ export const addEventAction = ( action, { kind, name, id, parentId, details, exe
 export function addEventActionWithContext( action, options ) {
   const storeContent = Storage.load();
   if ( storeContent ) { // If there is no storageContext this was not called from a Temporal environment
-    const { parentId, executionContext } = storeContent;
+    const { parentId, parentName, executionContext, workflowHandle } = storeContent;
+    if ( action === EventAction.ADD_ATTR ) {
+      const { name, value } = options.details;
+      const date = Date.now();
+      if ( name === Attribute.COST ) {
+        workflowHandle.signal( 'add_event:cost', { activityId: parentId, activityName: parentName, ...value, date } );
+      }
+    }
     addEventAction( action, { ...options, parentId, executionContext } );
   }
 };

--- a/sdk/core/src/worker/index.js
+++ b/sdk/core/src/worker/index.js
@@ -69,7 +69,7 @@ const callerDir = process.argv[2];
     workflowsPath,
     activities,
     sinks,
-    interceptors: initInterceptors( { activities, workflows } ),
+    interceptors: initInterceptors( { activities, workflows, connection } ),
     maxConcurrentWorkflowTaskExecutions,
     maxConcurrentActivityTaskExecutions,
     maxCachedWorkflows,

--- a/sdk/core/src/worker/index.spec.js
+++ b/sdk/core/src/worker/index.spec.js
@@ -123,7 +123,7 @@ describe( 'worker/index', () => {
       maxConcurrentActivityTaskPolls: configValues.maxConcurrentActivityTaskPolls,
       maxConcurrentWorkflowTaskPolls: configValues.maxConcurrentWorkflowTaskPolls
     } ) );
-    expect( initInterceptorsMock ).toHaveBeenCalledWith( { activities: {}, workflows: [] } );
+    expect( initInterceptorsMock ).toHaveBeenCalledWith( { activities: {}, workflows: [], connection: mockConnection } );
     expect( registerShutdownMock ).toHaveBeenCalledWith( { worker: mockWorker, log: mockLog } );
     expect( startCatalogMock ).toHaveBeenCalledWith( {
       connection: mockConnection,

--- a/sdk/core/src/worker/interceptors.js
+++ b/sdk/core/src/worker/interceptors.js
@@ -4,7 +4,7 @@ import { ActivityExecutionInterceptor } from './interceptors/activity.js';
 
 const __dirname = dirname( fileURLToPath( import.meta.url ) );
 
-export const initInterceptors = ( { activities, workflows } ) => ( {
+export const initInterceptors = ( { activities, workflows, connection } ) => ( {
   workflowModules: [ join( __dirname, './interceptors/workflow.js' ) ],
-  activityInbound: [ () => new ActivityExecutionInterceptor( { activities, workflows } ) ]
+  activityInbound: [ () => new ActivityExecutionInterceptor( { activities, workflows, connection } ) ]
 } );

--- a/sdk/core/src/worker/interceptors/activity.js
+++ b/sdk/core/src/worker/interceptors/activity.js
@@ -5,6 +5,7 @@ import { headersToObject } from '../sandboxed_utils.js';
 import { BusEventType, METADATA_ACCESS_SYMBOL } from '#consts';
 import { activityHeartbeatEnabled, activityHeartbeatIntervalMs } from '../configs.js';
 import { messageBus } from '#bus';
+import { Client } from '@temporalio/client';
 
 /*
   This interceptor wraps every activity execution with cross-cutting concerns:
@@ -23,7 +24,7 @@ import { messageBus } from '#bus';
   - Headers injected by the workflow interceptor (executionContext)
 */
 export class ActivityExecutionInterceptor {
-  constructor( { activities, workflows } ) {
+  constructor( { activities, workflows, connection } ) {
     this.activities = activities;
     this.workflowsMap = workflows.reduce( ( map, w ) => {
       map.set( w.name, w );
@@ -32,13 +33,18 @@ export class ActivityExecutionInterceptor {
       }
       return map;
     }, new Map() );
+    this.connection = connection;
   };
 
   async execute( input, next ) {
     const startDate = Date.now();
+    const client = new Client( { connection: this.connection } );
+
     const { workflowExecution: { workflowId }, activityId: id, activityType: name, workflowType: workflowName } = Context.current().info;
     const { executionContext } = headersToObject( input.headers );
     const { type: kind } = this.activities?.[name]?.[METADATA_ACCESS_SYMBOL];
+
+    const workflowHandle = client.workflow.getHandle( workflowId );
 
     messageBus.emit( BusEventType.ACTIVITY_START, { id, name, kind, workflowId, workflowName } );
     Tracing.addEventStart( { id, name, kind, parentId: workflowId, details: input.args[0], executionContext } );
@@ -56,7 +62,8 @@ export class ActivityExecutionInterceptor {
       intervals.heartbeat = activityHeartbeatEnabled && setInterval( () => Context.current().heartbeat(), activityHeartbeatIntervalMs );
 
       // Wraps the execution with accessible metadata for the activity
-      const output = await Storage.runWithContext( async _ => next( input ), { parentId: id, executionContext, workflowFilename } );
+      const ctx = { parentId: id, parentName: name, executionContext, workflowFilename, workflowHandle };
+      const output = await Storage.runWithContext( async _ => next( input ), ctx );
 
       messageBus.emit( BusEventType.ACTIVITY_END, { id, name, kind, workflowId, workflowName, duration: Date.now() - startDate } );
       Tracing.addEventEnd( { id, details: output, executionContext } );

--- a/sdk/core/src/worker/interceptors/activity.spec.js
+++ b/sdk/core/src/worker/interceptors/activity.spec.js
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BusEventType } from '#consts';
 
 const METADATA_ACCESS_SYMBOL = vi.hoisted( () => Symbol( '__metadata' ) );
+const workflowHandleMock = vi.hoisted( () => ( { signal: vi.fn() } ) );
+const getHandleMock = vi.hoisted( () => vi.fn( () => workflowHandleMock ) );
 
 const heartbeatMock = vi.fn();
 const runWithContextMock = vi.hoisted( () => vi.fn().mockImplementation( async fn => fn() ) );
@@ -18,6 +20,14 @@ vi.mock( '@temporalio/activity', () => ( {
       info: contextInfoMock,
       heartbeat: heartbeatMock
     } )
+  }
+} ) );
+
+vi.mock( '@temporalio/client', () => ( {
+  Client: class Client {
+    workflow = {
+      getHandle: getHandleMock
+    };
   }
 } ) );
 
@@ -108,12 +118,15 @@ describe( 'ActivityExecutionInterceptor', () => {
     expect( addEventErrorMock ).not.toHaveBeenCalled();
     expect( runWithContextMock ).toHaveBeenCalledWith(
       expect.any( Function ),
-      {
+      expect.objectContaining( {
         parentId: 'act-1',
+        parentName: 'myWorkflow#myStep',
         executionContext: { workflowId: 'wf-1' },
-        workflowFilename: '/workflows/myWorkflow.js'
-      }
+        workflowFilename: '/workflows/myWorkflow.js',
+        workflowHandle: workflowHandleMock
+      } )
     );
+    expect( getHandleMock ).toHaveBeenCalledWith( 'wf-1' );
   } );
 
   it( 'records trace error event on failed execution', async () => {

--- a/sdk/http/src/cost.spec.ts
+++ b/sdk/http/src/cost.spec.ts
@@ -17,6 +17,13 @@ import { addRequestCost } from './cost.js';
 const tracing = vi.mocked( Tracing, true );
 const emit = vi.mocked( emitEvent, true );
 
+const costWithInfo = ( response: Response, cost: object ) => ( {
+  ...cost,
+  info: {
+    url: response.url
+  }
+} );
+
 describe( 'addRequestCost', () => {
   beforeEach( () => {
     tracing.addEventAttribute.mockClear();
@@ -52,7 +59,7 @@ describe( 'addRequestCost', () => {
     expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
       eventId: 'evt-cost-1',
       name: Tracing.Attribute.COST,
-      value: cost
+      value: costWithInfo( response, cost )
     } );
     expect( emit ).toHaveBeenCalledWith( 'cost:http:request', {
       requestId: 'evt-cost-1',
@@ -77,7 +84,7 @@ describe( 'addRequestCost', () => {
     expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
       eventId: 'evt-cost-2',
       name: Tracing.Attribute.COST,
-      value: cost
+      value: costWithInfo( response, cost )
     } );
     expect( emit ).toHaveBeenCalledWith( 'cost:http:request', {
       requestId: 'evt-cost-2',
@@ -96,7 +103,7 @@ describe( 'addRequestCost', () => {
     expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
       eventId: 'evt-cost-3',
       name: Tracing.Attribute.COST,
-      value: cost
+      value: costWithInfo( response, cost )
     } );
     expect( emit ).toHaveBeenCalledWith( 'cost:http:request', {
       requestId: 'evt-cost-3',

--- a/sdk/http/src/cost.spec.ts
+++ b/sdk/http/src/cost.spec.ts
@@ -1,28 +1,37 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { requestIdSymbol } from './consts.js';
 
-vi.mock( '@outputai/core/sdk_activity_integration', () => ( {
-  Tracing: {
-    addEventAttribute: vi.fn(),
-    Attribute: {
-      COST: 'cost'
+vi.mock( '@outputai/core/sdk_activity_integration', () => {
+  class HTTPRequestCost {
+    static TYPE = 'http:request:cost';
+    type = HTTPRequestCost.TYPE;
+    url: string;
+    requestId: string;
+    total: number;
+
+    constructor( url: string, requestId: string, total: number ) {
+      this.url = url;
+      this.requestId = requestId;
+      this.total = total;
     }
-  },
-  emitEvent: vi.fn()
-} ) );
+  }
+
+  return {
+    Tracing: {
+      addEventAttribute: vi.fn(),
+      Attribute: {
+        HTTPRequestCost
+      }
+    },
+    emitEvent: vi.fn()
+  };
+} );
 
 import { Tracing, emitEvent } from '@outputai/core/sdk_activity_integration';
 import { addRequestCost } from './cost.js';
 
 const tracing = vi.mocked( Tracing, true );
 const emit = vi.mocked( emitEvent, true );
-
-const costWithInfo = ( response: Response, cost: object ) => ( {
-  ...cost,
-  info: {
-    url: response.url
-  }
-} );
 
 describe( 'addRequestCost', () => {
   beforeEach( () => {
@@ -37,7 +46,7 @@ describe( 'addRequestCost', () => {
 
   it( 'shortcircuits when the response has no http request id', () => {
     const response = new Response();
-    const cost = { total: 1 };
+    const cost = 1;
 
     addRequestCost( response, cost );
 
@@ -51,64 +60,41 @@ describe( 'addRequestCost', () => {
   it( 'records cost on the trace event when the response carries the request id', () => {
     const response = new Response( undefined, { status: 200 } );
     Reflect.set( response, requestIdSymbol, 'evt-cost-1' );
-    const cost = { total: 2.5 };
+    const cost = 2.5;
 
     addRequestCost( response, cost );
 
     expect( console.warn ).not.toHaveBeenCalled();
     expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
       eventId: 'evt-cost-1',
-      name: Tracing.Attribute.COST,
-      value: costWithInfo( response, cost )
+      attribute: expect.objectContaining( {
+        type: Tracing.Attribute.HTTPRequestCost.TYPE,
+        url: response.url,
+        requestId: 'evt-cost-1',
+        total: cost
+      } )
     } );
-    expect( emit ).toHaveBeenCalledWith( 'cost:http:request', {
-      requestId: 'evt-cost-1',
-      url: response.url,
-      cost
-    } );
+    const attribute = tracing.addEventAttribute.mock.calls[0][0].attribute;
+    expect( emit ).toHaveBeenCalledWith( 'cost:http:request', attribute );
   } );
 
-  it( 'forwards multiple components to tracing', () => {
+  it( 'records zero cost on the trace event', () => {
     const response = new Response();
     Reflect.set( response, requestIdSymbol, 'evt-cost-2' );
-    const cost = {
-      total: 10,
-      components: [
-        { name: 'input', value: 3 },
-        { name: 'output', value: 7 }
-      ]
-    };
+    const cost = 0;
 
     addRequestCost( response, cost );
 
     expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
       eventId: 'evt-cost-2',
-      name: Tracing.Attribute.COST,
-      value: costWithInfo( response, cost )
+      attribute: expect.objectContaining( {
+        type: Tracing.Attribute.HTTPRequestCost.TYPE,
+        url: response.url,
+        requestId: 'evt-cost-2',
+        total: cost
+      } )
     } );
-    expect( emit ).toHaveBeenCalledWith( 'cost:http:request', {
-      requestId: 'evt-cost-2',
-      url: response.url,
-      cost
-    } );
-  } );
-
-  it( 'forwards an empty components array to tracing', () => {
-    const response = new Response();
-    Reflect.set( response, requestIdSymbol, 'evt-cost-3' );
-    const cost = { total: 1, components: [] };
-
-    addRequestCost( response, cost );
-
-    expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
-      eventId: 'evt-cost-3',
-      name: Tracing.Attribute.COST,
-      value: costWithInfo( response, cost )
-    } );
-    expect( emit ).toHaveBeenCalledWith( 'cost:http:request', {
-      requestId: 'evt-cost-3',
-      url: response.url,
-      cost
-    } );
+    const attribute = tracing.addEventAttribute.mock.calls[0][0].attribute;
+    expect( emit ).toHaveBeenCalledWith( 'cost:http:request', attribute );
   } );
 } );

--- a/sdk/http/src/cost.ts
+++ b/sdk/http/src/cost.ts
@@ -2,33 +2,21 @@ import { KyResponse } from 'ky';
 import { Tracing, emitEvent } from '@outputai/core/sdk_activity_integration';
 import { requestIdSymbol } from './consts.js';
 
-export type RequestCost = {
-  total: number,
-  components?: Array<{
-    name: string,
-    value: number
-  }>
-};
-
 /**
  * Attach cost information to the trace of an HTTP Request using the response
  *
  * @param response - The response of the HTTP Request to attach the information
- * @param cost - The cost information
+ * @param value - The price of the HTTP request
  * @returns
  */
-export const addRequestCost = ( response: KyResponse | Response, cost: RequestCost ) : void => {
+export const addRequestCost = ( response: KyResponse | Response, value: number ) : void => {
   const eventId = Reflect.get( response, requestIdSymbol ) as string;
   if ( !eventId ) {
     console.warn( 'addRequestCost(): The "response" argument did not originate from @outputai/http, no costs were added.' );
     return;
   }
-  const costWithDescription = {
-    ...cost,
-    info: {
-      url: response.url
-    }
-  };
-  Tracing.addEventAttribute( { eventId, name: Tracing.Attribute.COST, value: costWithDescription } );
-  emitEvent( 'cost:http:request', { requestId: eventId, url: response.url, cost } );
+
+  const attribute = new Tracing.Attribute.HTTPRequestCost( response.url, eventId, value );
+  Tracing.addEventAttribute( { eventId, attribute } );
+  emitEvent( 'cost:http:request', attribute );
 };

--- a/sdk/http/src/cost.ts
+++ b/sdk/http/src/cost.ts
@@ -23,6 +23,12 @@ export const addRequestCost = ( response: KyResponse | Response, cost: RequestCo
     console.warn( 'addRequestCost(): The "response" argument did not originate from @outputai/http, no costs were added.' );
     return;
   }
-  Tracing.addEventAttribute( { eventId, name: Tracing.Attribute.COST, value: cost } );
+  const costWithDescription = {
+    ...cost,
+    info: {
+      url: response.url
+    }
+  };
+  Tracing.addEventAttribute( { eventId, name: Tracing.Attribute.COST, value: costWithDescription } );
   emitEvent( 'cost:http:request', { requestId: eventId, url: response.url, cost } );
 };

--- a/sdk/http/src/fetch/logger.spec.ts
+++ b/sdk/http/src/fetch/logger.spec.ts
@@ -1,14 +1,31 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Response, Request } from 'undici';
 
-vi.mock( '@outputai/core/sdk_activity_integration', () => ( {
-  Tracing: {
-    addEventStart: vi.fn(),
-    addEventEnd: vi.fn(),
-    addEventError: vi.fn(),
-    addEventAttribute: vi.fn()
+vi.mock( '@outputai/core/sdk_activity_integration', () => {
+  class HTTPRequestCount {
+    static TYPE = 'http:request:count';
+    type = HTTPRequestCount.TYPE;
+    url: string;
+    requestId: string;
+
+    constructor( url: string, requestId: string ) {
+      this.url = url;
+      this.requestId = requestId;
+    }
   }
-} ) );
+
+  return {
+    Tracing: {
+      addEventStart: vi.fn(),
+      addEventEnd: vi.fn(),
+      addEventError: vi.fn(),
+      addEventAttribute: vi.fn(),
+      Attribute: {
+        HTTPRequestCount
+      }
+    }
+  };
+} );
 
 import { Tracing } from '@outputai/core/sdk_activity_integration';
 
@@ -34,11 +51,14 @@ beforeEach( () => {
 
 describe( 'fetch/logger', () => {
   describe( 'logRequest', () => {
-    const expectRequestIdAttribute = ( requestId: string ) => {
+    const expectRequestCountAttribute = ( requestId: string, url: string ) => {
       expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
         eventId: requestId,
-        name: 'requestId',
-        value: requestId
+        attribute: expect.objectContaining( {
+          type: Tracing.Attribute.HTTPRequestCount.TYPE,
+          url,
+          requestId
+        } )
       } );
     };
 
@@ -57,7 +77,7 @@ describe( 'fetch/logger', () => {
           url: 'https://api.example.com/r'
         }
       } );
-      expectRequestIdAttribute( 'req-1' );
+      expectRequestCountAttribute( 'req-1', 'https://api.example.com/r' );
     } );
 
     it( 'defaults method to GET', async () => {
@@ -67,7 +87,7 @@ describe( 'fetch/logger', () => {
       await logRequest( { requestId: 'r2', request } );
 
       expect( ( tracing.addEventStart.mock.calls[0][0].details as { method: string } ).method ).toBe( 'GET' );
-      expectRequestIdAttribute( 'r2' );
+      expectRequestCountAttribute( 'r2', 'https://x.test/' );
     } );
 
     it( 'includes redacted headers and parsed body when verbose is on', async () => {
@@ -95,7 +115,7 @@ describe( 'fetch/logger', () => {
           body: { x: 1 }
         }
       } );
-      expectRequestIdAttribute( 'req-v' );
+      expectRequestCountAttribute( 'req-v', 'https://api.example.com/p' );
     } );
   } );
 

--- a/sdk/http/src/fetch/logger.ts
+++ b/sdk/http/src/fetch/logger.ts
@@ -18,7 +18,7 @@ export const logRequest = async ( { requestId, request } : { requestId: string, 
       ...( config.logVerbose && { headers: redactHeaders( request.headers ), body: await parseBody( request ) } )
     }
   } );
-  Tracing.addEventAttribute( { eventId: requestId, name: 'requestId', value: requestId } );
+  Tracing.addEventAttribute( { eventId: requestId, attribute: new Tracing.Attribute.HTTPRequestCount( request.url, requestId ) } );
 };
 
 /**

--- a/sdk/llm/package.json
+++ b/sdk/llm/package.json
@@ -20,7 +20,6 @@
     "@perplexity-ai/ai-sdk": "0.1.3",
     "@tavily/ai-sdk": "0.4.1",
     "ai": "6.0.168",
-    "decimal.js": "10.6.0",
     "entities": "8.0.0",
     "gray-matter": "4.0.3",
     "liquidjs": "10.25.7",

--- a/sdk/llm/src/cost/index.js
+++ b/sdk/llm/src/cost/index.js
@@ -23,18 +23,27 @@ export const calculateLLMCallCost = async ( { modelId, usage } ) => {
       return { total: null, message: 'Missing cost reference for model' };
     }
 
-    const { inputTokens, cachedInputTokens, outputTokens, reasoningTokens } = usage;
+    const { inputTokens, cachedInputTokens, outputTokens, reasoningTokens, totalTokens } = usage;
 
     const nonCachedTokens = inputTokens - ( cachedInputTokens ?? 0 );
 
-    const components = [
-      Number.isFinite( cost.input ) ? { name: 'input_tokens', value: calcCost( nonCachedTokens, cost.input ) } : false,
-      Number.isFinite( cost.cache_read ) ? { name: 'input_cached_tokens', value: calcCost( cachedInputTokens, cost.cache_read ) } : false,
-      Number.isFinite( cost.output ) ? { name: 'output_tokens', value: calcCost( outputTokens, cost.output ) } : false,
-      /* When there aren't reasoning costs, the providers doesn't differentiate reasoning vs output, so the price is included in the output */
-      Number.isFinite( cost.reasoning ) ? { name: 'reasoning_tokens', value: calcCost( reasoningTokens, cost.reasoning ) } : false
-    ].filter( v => !!v );
-    return { total: components.reduce( ( v, e ) => v.plus( e.value ), Decimal( 0 ) ).toNumber(), components };
+    const components = [];
+    if ( Number.isFinite( cost.input ) ) {
+      components.push( { name: 'input_tokens', value: calcCost( nonCachedTokens, cost.input ), tokens: nonCachedTokens } );
+    }
+    if ( Number.isFinite( cost.cache_read ) ) {
+      components.push( { name: 'input_cached_tokens', value: calcCost( cachedInputTokens, cost.cache_read ), tokens: cachedInputTokens } );
+    }
+    if ( Number.isFinite( cost.output ) ) {
+      components.push( { name: 'output_tokens', value: calcCost( outputTokens, cost.output ), tokens: outputTokens } );
+    }
+    // When there aren't reasoning costs, the providers doesn't differentiate reasoning vs output, so the price is included in the output
+    if ( Number.isFinite( cost.reasoning ) ) {
+      components.push( { name: 'reasoning_tokens', value: calcCost( reasoningTokens, cost.reasoning ), tokens: reasoningTokens } );
+    }
+
+    const total = components.reduce( ( v, e ) => v.plus( e.value ), Decimal( 0 ) ).toNumber();
+    return { total, components, info: { modelId, tokens: totalTokens } };
   } catch ( error ) {
     console.error( 'Error calculating LLM call costs', error );
     return { total: null, message: `Error calculating LLM call costs: ${error.constructor.name} - ${error.message}` };

--- a/sdk/llm/src/cost/index.js
+++ b/sdk/llm/src/cost/index.js
@@ -1,8 +1,5 @@
 import { fetchModelsPricing } from './fetch_models_pricing.js';
-import Decimal from 'decimal.js';
-
-const M = 1_000_000;
-const calcCost = ( tokens, ppm ) => Decimal( tokens ?? 0 ).div( M ).mul( ppm ).toNumber();
+import { Tracing } from '@outputai/core/sdk_activity_integration';
 
 /**
  * Calculates the cost of an llm call based on the model and usage.
@@ -14,38 +11,41 @@ const calcCost = ( tokens, ppm ) => Decimal( tokens ?? 0 ).div( M ).mul( ppm ).t
 export const calculateLLMCallCost = async ( { modelId, usage } ) => {
   try {
     const models = await fetchModelsPricing();
+
     if ( !models ) {
-      return { total: null, message: 'Failed to fetch models pricing' };
+      console.warn( 'Failed to fetch models pricing' );
+      return null;
     }
 
-    const cost = models.get( modelId );
-    if ( !cost ) {
-      return { total: null, message: 'Missing cost reference for model' };
+    const pricing = models.get( modelId );
+    if ( !pricing ) {
+      console.warn( 'Missing cost reference for model' );
+      return null;
     }
 
-    const { inputTokens, cachedInputTokens, outputTokens, reasoningTokens, totalTokens } = usage;
+    const { inputTokens, cachedInputTokens, outputTokens, reasoningTokens } = usage;
 
     const nonCachedTokens = inputTokens - ( cachedInputTokens ?? 0 );
 
-    const components = [];
-    if ( Number.isFinite( cost.input ) ) {
-      components.push( { name: 'input_tokens', value: calcCost( nonCachedTokens, cost.input ), tokens: nonCachedTokens } );
+    const llmUsage = new Tracing.Attribute.LLMUsage( modelId );
+
+    if ( Number.isFinite( pricing.input ) && Number.isFinite( nonCachedTokens ) ) {
+      llmUsage.addUsage( { type: 'input', ppm: pricing.input, amount: nonCachedTokens } );
     }
-    if ( Number.isFinite( cost.cache_read ) ) {
-      components.push( { name: 'input_cached_tokens', value: calcCost( cachedInputTokens, cost.cache_read ), tokens: cachedInputTokens } );
+    if ( Number.isFinite( pricing.cache_read ) && Number.isFinite( cachedInputTokens ) ) {
+      llmUsage.addUsage( { type: 'input_cached', ppm: pricing.cache_read, amount: cachedInputTokens } );
     }
-    if ( Number.isFinite( cost.output ) ) {
-      components.push( { name: 'output_tokens', value: calcCost( outputTokens, cost.output ), tokens: outputTokens } );
+    if ( Number.isFinite( pricing.output ) && Number.isFinite( outputTokens ) ) {
+      llmUsage.addUsage( { type: 'output', ppm: pricing.output, amount: outputTokens } );
     }
     // When there aren't reasoning costs, the providers doesn't differentiate reasoning vs output, so the price is included in the output
-    if ( Number.isFinite( cost.reasoning ) ) {
-      components.push( { name: 'reasoning_tokens', value: calcCost( reasoningTokens, cost.reasoning ), tokens: reasoningTokens } );
+    if ( Number.isFinite( pricing.reasoning ) && Number.isFinite( reasoningTokens ) ) {
+      llmUsage.addUsage( { type: 'reasoning', ppm: pricing.reasoning, amount: reasoningTokens } );
     }
 
-    const total = components.reduce( ( v, e ) => v.plus( e.value ), Decimal( 0 ) ).toNumber();
-    return { total, components, info: { modelId, tokens: totalTokens } };
+    return llmUsage;
   } catch ( error ) {
     console.error( 'Error calculating LLM call costs', error );
-    return { total: null, message: `Error calculating LLM call costs: ${error.constructor.name} - ${error.message}` };
+    return null;
   }
 };

--- a/sdk/llm/src/cost/index.spec.js
+++ b/sdk/llm/src/cost/index.spec.js
@@ -1,22 +1,75 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const mockFetchModelsPricing = vi.fn();
+const mockFetchModelsPricing = vi.hoisted( () => vi.fn() );
+
 vi.mock( './fetch_models_pricing.js', () => ( {
   fetchModelsPricing: ( ...args ) => mockFetchModelsPricing( ...args )
 } ) );
 
+vi.mock( '@outputai/core/sdk_activity_integration', () => {
+  class LLMUsage {
+    static TYPE = 'llm:usage';
+    type = LLMUsage.TYPE;
+    modelId;
+    usage = [];
+
+    constructor( modelId ) {
+      this.modelId = modelId;
+    }
+
+    addUsage( { type, ppm, amount } ) {
+      this.usage.push( {
+        type,
+        ppm,
+        amount,
+        total: ( amount / 1_000_000 ) * ppm
+      } );
+    }
+
+    get total() {
+      return this.usage.reduce( ( total, current ) => total + current.total, 0 );
+    }
+
+    get tokensUsed() {
+      return this.usage.reduce( ( total, current ) => total + current.amount, 0 );
+    }
+  }
+
+  return {
+    Tracing: {
+      Attribute: {
+        LLMUsage
+      }
+    }
+  };
+} );
+
+import { Tracing } from '@outputai/core/sdk_activity_integration';
 import { calculateLLMCallCost } from './index.js';
 
-const expectCostInfo = ( result, modelId, tokens = undefined ) => {
-  expect( result.info ).toEqual( { modelId, tokens } );
+const expectLLMUsage = ( result, { modelId, usage, total, tokensUsed } ) => {
+  expect( result ).toBeInstanceOf( Tracing.Attribute.LLMUsage );
+  expect( result ).toEqual( expect.objectContaining( {
+    type: Tracing.Attribute.LLMUsage.TYPE,
+    modelId,
+    usage
+  } ) );
+  expect( result.total ).toBeCloseTo( total );
+  expect( result.tokensUsed ).toBe( tokensUsed );
 };
 
 describe( 'calculateLLMCallCost', () => {
   beforeEach( () => {
     vi.clearAllMocks();
+    vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
+    vi.spyOn( console, 'error' ).mockImplementation( () => {} );
   } );
 
-  it( 'returns total null and message when fetchModelsPricing returns null', async () => {
+  afterEach( () => {
+    vi.restoreAllMocks();
+  } );
+
+  it( 'returns null when fetchModelsPricing returns null', async () => {
     mockFetchModelsPricing.mockResolvedValue( null );
 
     const result = await calculateLLMCallCost( {
@@ -24,10 +77,11 @@ describe( 'calculateLLMCallCost', () => {
       usage: { inputTokens: 100, outputTokens: 50 }
     } );
 
-    expect( result ).toEqual( { total: null, message: 'Failed to fetch models pricing' } );
+    expect( result ).toBeNull();
+    expect( console.warn ).toHaveBeenCalledWith( 'Failed to fetch models pricing' );
   } );
 
-  it( 'returns total null and message when model is missing from cost table', async () => {
+  it( 'returns null when model is missing from cost table', async () => {
     mockFetchModelsPricing.mockResolvedValue( new Map() );
 
     const result = await calculateLLMCallCost( {
@@ -35,49 +89,50 @@ describe( 'calculateLLMCallCost', () => {
       usage: { inputTokens: 100, outputTokens: 50 }
     } );
 
-    expect( result ).toEqual( {
-      total: null,
-      message: 'Missing cost reference for model'
-    } );
+    expect( result ).toBeNull();
+    expect( console.warn ).toHaveBeenCalledWith( 'Missing cost reference for model' );
   } );
 
-  it( 'calculates input and output cost from mock model', async () => {
-    const cost = { input: 2, output: 10, cache_read: 1 };
-    mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'gpt-4o', cost ] ] ) );
+  it( 'calculates input and output usage from model pricing', async () => {
+    mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'gpt-4o', { input: 2, output: 10, cache_read: 1 } ] ] ) );
 
     const result = await calculateLLMCallCost( {
       modelId: 'gpt-4o',
       usage: { inputTokens: 1_000_000, outputTokens: 500_000 }
     } );
 
-    expect( result.total ).toBe( 7 );
-    expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 2, tokens: 1_000_000 },
-      { name: 'input_cached_tokens', value: 0, tokens: undefined },
-      { name: 'output_tokens', value: 5, tokens: 500_000 }
-    ] );
-    expectCostInfo( result, 'gpt-4o' );
+    expectLLMUsage( result, {
+      modelId: 'gpt-4o',
+      usage: [
+        { type: 'input', ppm: 2, amount: 1_000_000, total: 2 },
+        { type: 'output', ppm: 10, amount: 500_000, total: 5 }
+      ],
+      total: 7,
+      tokensUsed: 1_500_000
+    } );
   } );
 
-  it( 'splits input into non-cached and cached at respective rates', async () => {
-    const cost = { input: 4, cache_read: 1, output: 10 };
-    mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'cached-model', cost ] ] ) );
+  it( 'splits input into non-cached and cached usage at respective rates', async () => {
+    mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'cached-model', { input: 4, cache_read: 1, output: 10 } ] ] ) );
 
     const result = await calculateLLMCallCost( {
       modelId: 'cached-model',
       usage: { inputTokens: 1_000_000, cachedInputTokens: 500_000, outputTokens: 100_000 }
     } );
 
-    expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 2, tokens: 500_000 },
-      { name: 'input_cached_tokens', value: 0.5, tokens: 500_000 },
-      { name: 'output_tokens', value: 1, tokens: 100_000 }
-    ] );
-    expect( result.total ).toBeCloseTo( 3.5 );
-    expectCostInfo( result, 'cached-model' );
+    expectLLMUsage( result, {
+      modelId: 'cached-model',
+      usage: [
+        { type: 'input', ppm: 4, amount: 500_000, total: 2 },
+        { type: 'input_cached', ppm: 1, amount: 500_000, total: 0.5 },
+        { type: 'output', ppm: 10, amount: 100_000, total: 1 }
+      ],
+      total: 3.5,
+      tokensUsed: 1_100_000
+    } );
   } );
 
-  it( 'omits cached component when model has no cache_read (non-cached rate applies to full input minus cached)', async () => {
+  it( 'omits cached usage when model has no cache_read rate', async () => {
     mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'no-cache', { input: 2, output: 10 } ] ] ) );
 
     const result = await calculateLLMCallCost( {
@@ -85,15 +140,18 @@ describe( 'calculateLLMCallCost', () => {
       usage: { inputTokens: 1_000_000, cachedInputTokens: 200_000, outputTokens: 0 }
     } );
 
-    expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 1.6, tokens: 800_000 },
-      { name: 'output_tokens', value: 0, tokens: 0 }
-    ] );
-    expect( result.total ).toBe( 1.6 );
-    expectCostInfo( result, 'no-cache' );
+    expectLLMUsage( result, {
+      modelId: 'no-cache',
+      usage: [
+        { type: 'input', ppm: 2, amount: 800_000, total: 1.6 },
+        { type: 'output', ppm: 10, amount: 0, total: 0 }
+      ],
+      total: 1.6,
+      tokensUsed: 800_000
+    } );
   } );
 
-  it( 'omits input component when pricing has no input rate', async () => {
+  it( 'omits input usage when pricing has no input rate', async () => {
     mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'out-only', { output: 10 } ] ] ) );
 
     const result = await calculateLLMCallCost( {
@@ -101,14 +159,17 @@ describe( 'calculateLLMCallCost', () => {
       usage: { inputTokens: 100, outputTokens: 50 }
     } );
 
-    expect( result.total ).toBe( 0.0005 );
-    expect( result.components ).toEqual( [
-      { name: 'output_tokens', value: 0.0005, tokens: 50 }
-    ] );
-    expectCostInfo( result, 'out-only' );
+    expectLLMUsage( result, {
+      modelId: 'out-only',
+      usage: [
+        { type: 'output', ppm: 10, amount: 50, total: 0.0005 }
+      ],
+      total: 0.0005,
+      tokensUsed: 50
+    } );
   } );
 
-  it( 'omits output component when pricing has no output rate', async () => {
+  it( 'omits output usage when pricing has no output rate', async () => {
     mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'in-only', { input: 1 } ] ] ) );
 
     const result = await calculateLLMCallCost( {
@@ -116,14 +177,17 @@ describe( 'calculateLLMCallCost', () => {
       usage: { inputTokens: 100, outputTokens: 50 }
     } );
 
-    expect( result.total ).toBe( 0.0001 );
-    expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 0.0001, tokens: 100 }
-    ] );
-    expectCostInfo( result, 'in-only' );
+    expectLLMUsage( result, {
+      modelId: 'in-only',
+      usage: [
+        { type: 'input', ppm: 1, amount: 100, total: 0.0001 }
+      ],
+      total: 0.0001,
+      tokensUsed: 100
+    } );
   } );
 
-  it( 'uses reasoning cost when present', async () => {
+  it( 'includes reasoning usage when present', async () => {
     mockFetchModelsPricing.mockResolvedValue( new Map( [ [
       'with-reasoning',
       { input: 1, output: 10, reasoning: 60 }
@@ -134,16 +198,19 @@ describe( 'calculateLLMCallCost', () => {
       usage: { inputTokens: 100, outputTokens: 20, reasoningTokens: 50 }
     } );
 
-    expect( result.total ).toBeCloseTo( 0.0033 );
-    expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 0.0001, tokens: 100 },
-      { name: 'output_tokens', value: 0.0002, tokens: 20 },
-      { name: 'reasoning_tokens', value: 0.003, tokens: 50 }
-    ] );
-    expectCostInfo( result, 'with-reasoning' );
+    expectLLMUsage( result, {
+      modelId: 'with-reasoning',
+      usage: [
+        { type: 'input', ppm: 1, amount: 100, total: 0.0001 },
+        { type: 'output', ppm: 10, amount: 20, total: 0.0002 },
+        { type: 'reasoning', ppm: 60, amount: 50, total: 0.003 }
+      ],
+      total: 0.0033,
+      tokensUsed: 170
+    } );
   } );
 
-  it( 'omits reasoning component when reasoning cost missing (included in output)', async () => {
+  it( 'omits reasoning usage when reasoning cost is missing', async () => {
     mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'no-reasoning', { input: 1, output: 10 } ] ] ) );
 
     const result = await calculateLLMCallCost( {
@@ -151,15 +218,18 @@ describe( 'calculateLLMCallCost', () => {
       usage: { inputTokens: 100, outputTokens: 20, reasoningTokens: 50 }
     } );
 
-    expect( result.total ).toBeCloseTo( 0.0003 );
-    expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 0.0001, tokens: 100 },
-      { name: 'output_tokens', value: 0.0002, tokens: 20 }
-    ] );
-    expectCostInfo( result, 'no-reasoning' );
+    expectLLMUsage( result, {
+      modelId: 'no-reasoning',
+      usage: [
+        { type: 'input', ppm: 1, amount: 100, total: 0.0001 },
+        { type: 'output', ppm: 10, amount: 20, total: 0.0002 }
+      ],
+      total: 0.0003,
+      tokensUsed: 120
+    } );
   } );
 
-  it( 'includes reasoning component with zero when reasoningTokens is zero', async () => {
+  it( 'includes reasoning usage with zero amount when reasoningTokens is zero', async () => {
     mockFetchModelsPricing.mockResolvedValue( new Map( [ [
       'full',
       { input: 2, output: 8, reasoning: 60 }
@@ -170,16 +240,19 @@ describe( 'calculateLLMCallCost', () => {
       usage: { inputTokens: 100, outputTokens: 50, reasoningTokens: 0 }
     } );
 
-    expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 0.0002, tokens: 100 },
-      { name: 'output_tokens', value: 0.0004, tokens: 50 },
-      { name: 'reasoning_tokens', value: 0, tokens: 0 }
-    ] );
-    expect( result.total ).toBeCloseTo( 0.0006 );
-    expectCostInfo( result, 'full' );
+    expectLLMUsage( result, {
+      modelId: 'full',
+      usage: [
+        { type: 'input', ppm: 2, amount: 100, total: 0.0002 },
+        { type: 'output', ppm: 8, amount: 50, total: 0.0004 },
+        { type: 'reasoning', ppm: 60, amount: 0, total: 0 }
+      ],
+      total: 0.0006,
+      tokensUsed: 150
+    } );
   } );
 
-  it( 'treats null/undefined token counts as 0', async () => {
+  it( 'omits usage entries for non-finite token counts', async () => {
     mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'm', { input: 1, output: 2 } ] ] ) );
 
     const result = await calculateLLMCallCost( {
@@ -187,11 +260,26 @@ describe( 'calculateLLMCallCost', () => {
       usage: { inputTokens: null, outputTokens: undefined }
     } );
 
-    expect( result.total ).toBe( 0 );
-    expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 0, tokens: 0 },
-      { name: 'output_tokens', value: 0, tokens: undefined }
-    ] );
-    expectCostInfo( result, 'm' );
+    expectLLMUsage( result, {
+      modelId: 'm',
+      usage: [
+        { type: 'input', ppm: 1, amount: 0, total: 0 }
+      ],
+      total: 0,
+      tokensUsed: 0
+    } );
+  } );
+
+  it( 'returns null when pricing lookup throws', async () => {
+    const error = new Error( 'boom' );
+    mockFetchModelsPricing.mockRejectedValue( error );
+
+    const result = await calculateLLMCallCost( {
+      modelId: 'gpt-4o',
+      usage: { inputTokens: 100, outputTokens: 50 }
+    } );
+
+    expect( result ).toBeNull();
+    expect( console.error ).toHaveBeenCalledWith( 'Error calculating LLM call costs', error );
   } );
 } );

--- a/sdk/llm/src/cost/index.spec.js
+++ b/sdk/llm/src/cost/index.spec.js
@@ -7,6 +7,10 @@ vi.mock( './fetch_models_pricing.js', () => ( {
 
 import { calculateLLMCallCost } from './index.js';
 
+const expectCostInfo = ( result, modelId, tokens = undefined ) => {
+  expect( result.info ).toEqual( { modelId, tokens } );
+};
+
 describe( 'calculateLLMCallCost', () => {
   beforeEach( () => {
     vi.clearAllMocks();
@@ -48,10 +52,11 @@ describe( 'calculateLLMCallCost', () => {
 
     expect( result.total ).toBe( 7 );
     expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 2 },
-      { name: 'input_cached_tokens', value: 0 },
-      { name: 'output_tokens', value: 5 }
+      { name: 'input_tokens', value: 2, tokens: 1_000_000 },
+      { name: 'input_cached_tokens', value: 0, tokens: undefined },
+      { name: 'output_tokens', value: 5, tokens: 500_000 }
     ] );
+    expectCostInfo( result, 'gpt-4o' );
   } );
 
   it( 'splits input into non-cached and cached at respective rates', async () => {
@@ -64,11 +69,12 @@ describe( 'calculateLLMCallCost', () => {
     } );
 
     expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 2 },
-      { name: 'input_cached_tokens', value: 0.5 },
-      { name: 'output_tokens', value: 1 }
+      { name: 'input_tokens', value: 2, tokens: 500_000 },
+      { name: 'input_cached_tokens', value: 0.5, tokens: 500_000 },
+      { name: 'output_tokens', value: 1, tokens: 100_000 }
     ] );
     expect( result.total ).toBeCloseTo( 3.5 );
+    expectCostInfo( result, 'cached-model' );
   } );
 
   it( 'omits cached component when model has no cache_read (non-cached rate applies to full input minus cached)', async () => {
@@ -80,10 +86,11 @@ describe( 'calculateLLMCallCost', () => {
     } );
 
     expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 1.6 },
-      { name: 'output_tokens', value: 0 }
+      { name: 'input_tokens', value: 1.6, tokens: 800_000 },
+      { name: 'output_tokens', value: 0, tokens: 0 }
     ] );
     expect( result.total ).toBe( 1.6 );
+    expectCostInfo( result, 'no-cache' );
   } );
 
   it( 'omits input component when pricing has no input rate', async () => {
@@ -96,8 +103,9 @@ describe( 'calculateLLMCallCost', () => {
 
     expect( result.total ).toBe( 0.0005 );
     expect( result.components ).toEqual( [
-      { name: 'output_tokens', value: 0.0005 }
+      { name: 'output_tokens', value: 0.0005, tokens: 50 }
     ] );
+    expectCostInfo( result, 'out-only' );
   } );
 
   it( 'omits output component when pricing has no output rate', async () => {
@@ -110,8 +118,9 @@ describe( 'calculateLLMCallCost', () => {
 
     expect( result.total ).toBe( 0.0001 );
     expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 0.0001 }
+      { name: 'input_tokens', value: 0.0001, tokens: 100 }
     ] );
+    expectCostInfo( result, 'in-only' );
   } );
 
   it( 'uses reasoning cost when present', async () => {
@@ -127,10 +136,11 @@ describe( 'calculateLLMCallCost', () => {
 
     expect( result.total ).toBeCloseTo( 0.0033 );
     expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 0.0001 },
-      { name: 'output_tokens', value: 0.0002 },
-      { name: 'reasoning_tokens', value: 0.003 }
+      { name: 'input_tokens', value: 0.0001, tokens: 100 },
+      { name: 'output_tokens', value: 0.0002, tokens: 20 },
+      { name: 'reasoning_tokens', value: 0.003, tokens: 50 }
     ] );
+    expectCostInfo( result, 'with-reasoning' );
   } );
 
   it( 'omits reasoning component when reasoning cost missing (included in output)', async () => {
@@ -143,9 +153,10 @@ describe( 'calculateLLMCallCost', () => {
 
     expect( result.total ).toBeCloseTo( 0.0003 );
     expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 0.0001 },
-      { name: 'output_tokens', value: 0.0002 }
+      { name: 'input_tokens', value: 0.0001, tokens: 100 },
+      { name: 'output_tokens', value: 0.0002, tokens: 20 }
     ] );
+    expectCostInfo( result, 'no-reasoning' );
   } );
 
   it( 'includes reasoning component with zero when reasoningTokens is zero', async () => {
@@ -160,11 +171,12 @@ describe( 'calculateLLMCallCost', () => {
     } );
 
     expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 0.0002 },
-      { name: 'output_tokens', value: 0.0004 },
-      { name: 'reasoning_tokens', value: 0 }
+      { name: 'input_tokens', value: 0.0002, tokens: 100 },
+      { name: 'output_tokens', value: 0.0004, tokens: 50 },
+      { name: 'reasoning_tokens', value: 0, tokens: 0 }
     ] );
     expect( result.total ).toBeCloseTo( 0.0006 );
+    expectCostInfo( result, 'full' );
   } );
 
   it( 'treats null/undefined token counts as 0', async () => {
@@ -177,8 +189,9 @@ describe( 'calculateLLMCallCost', () => {
 
     expect( result.total ).toBe( 0 );
     expect( result.components ).toEqual( [
-      { name: 'input_tokens', value: 0 },
-      { name: 'output_tokens', value: 0 }
+      { name: 'input_tokens', value: 0, tokens: 0 },
+      { name: 'output_tokens', value: 0, tokens: undefined }
     ] );
+    expectCostInfo( result, 'm' );
   } );
 } );

--- a/sdk/llm/src/utils/trace.js
+++ b/sdk/llm/src/utils/trace.js
@@ -12,7 +12,9 @@ export const endTraceWithError = ( { traceId, error } ) => {
 
 export const endTraceWithSuccess = ( { traceId, modelId, response, cost, ...extra } ) => {
   const { totalUsage: usage, text: result, providerMetadata } = response;
-  Tracing.addEventAttribute( { eventId: traceId, name: Tracing.Attribute.COST, value: cost } );
+  if ( cost ) {
+    Tracing.addEventAttribute( { eventId: traceId, attribute: cost } );
+    emitEvent( 'cost:llm:request', cost );
+  }
   Tracing.addEventEnd( { id: traceId, details: { result, usage, providerMetadata, ...extra } } );
-  emitEvent( 'cost:llm:request', { modelId, cost, usage } );
 };

--- a/sdk/llm/src/utils/trace.spec.js
+++ b/sdk/llm/src/utils/trace.spec.js
@@ -5,10 +5,7 @@ vi.mock( '@outputai/core/sdk_activity_integration', () => ( {
     addEventStart: vi.fn(),
     addEventError: vi.fn(),
     addEventAttribute: vi.fn(),
-    addEventEnd: vi.fn(),
-    Attribute: {
-      COST: 'cost'
-    }
+    addEventEnd: vi.fn()
   },
   emitEvent: vi.fn()
 } ) );
@@ -54,8 +51,8 @@ describe( 'trace utils', () => {
   } );
 
   describe( 'endTraceWithSuccess', () => {
-    it( 'adds cost attribute, ends the trace with response fields and extra details, and emits cost:llm:request', () => {
-      const cost = { total: 0.01, components: [] };
+    it( 'adds cost attribute, emits cost attribute, and ends the trace with response fields and extra details', () => {
+      const cost = { type: 'llm:usage', modelId: 'my-model', total: 0.01, usage: [] };
       const usage = { inputTokens: 2, outputTokens: 3 };
       const response = {
         text: 'hello',
@@ -73,9 +70,9 @@ describe( 'trace utils', () => {
 
       expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
         eventId: 'trace-a',
-        name: 'cost',
-        value: cost
+        attribute: cost
       } );
+      expect( emitEvent ).toHaveBeenCalledWith( 'cost:llm:request', cost );
       expect( tracing.addEventEnd ).toHaveBeenCalledWith( {
         id: 'trace-a',
         details: {
@@ -85,10 +82,31 @@ describe( 'trace utils', () => {
           sourcesFromTools: [ { url: 'https://u.test', title: '' } ]
         }
       } );
-      expect( emitEvent ).toHaveBeenCalledWith( 'cost:llm:request', {
+    } );
+
+    it( 'does not emit or add an attribute when cost is missing', () => {
+      const usage = { inputTokens: 2, outputTokens: 3 };
+      const response = {
+        text: 'hello',
+        totalUsage: usage,
+        providerMetadata: { provider: 'x' }
+      };
+
+      endTraceWithSuccess( {
+        traceId: 'trace-no-cost',
         modelId: 'my-model',
-        cost,
-        usage
+        response
+      } );
+
+      expect( tracing.addEventAttribute ).not.toHaveBeenCalled();
+      expect( emitEvent ).not.toHaveBeenCalled();
+      expect( tracing.addEventEnd ).toHaveBeenCalledWith( {
+        id: 'trace-no-cost',
+        details: {
+          result: 'hello',
+          usage,
+          providerMetadata: { provider: 'x' }
+        }
       } );
     } );
   } );

--- a/test_workflows/src/hooks.js
+++ b/test_workflows/src/hooks.js
@@ -5,6 +5,7 @@ const colorize = message => `\x1b[45;30m[HOOK]\x1b[0;35;1m ${message}\x1b[0m`;
 // custom + sub modules
 on( 'custom_event', async payload => console.log( colorize( 'on(custom_event)' ), payload ) );
 on( 'cost:llm:request', payload => console.log( colorize( 'on(cost:llm:request)' ), payload ) );
+on( 'cost:http:request', payload => console.log( colorize( 'on(cost:llm:request)' ), payload ) );
 
 // Generic on error
 onError( payload => console.log( colorize( 'onError()' ), payload ) );

--- a/test_workflows/src/workflows/http/api_client.ts
+++ b/test_workflows/src/workflows/http/api_client.ts
@@ -57,9 +57,7 @@ export async function exportClients(): Promise<HttpBinResponse> {
  */
 export async function getContracts(): Promise<HttpBinResponse> {
   const response = await contractsClient.get( '' );
-  await addRequestCost( response, {
-    total: 120
-  } );
+  await addRequestCost( response, 120 );
   return response.json() as Promise<HttpBinResponse>;
 }
 

--- a/test_workflows/src/workflows/http_error/steps.ts
+++ b/test_workflows/src/workflows/http_error/steps.ts
@@ -1,0 +1,10 @@
+import { step } from '@outputai/core';
+import { fetch } from '@outputai/http';
+
+export const call = step( {
+  name: 'call',
+  description: 'Make a broken http call',
+  fn: async () => {
+    await fetch( 'https://coolbeans.sofax' );
+  }
+} );

--- a/test_workflows/src/workflows/http_error/workflow.ts
+++ b/test_workflows/src/workflows/http_error/workflow.ts
@@ -1,0 +1,17 @@
+import { workflow } from '@outputai/core';
+import { call } from './steps.js';
+
+export default workflow( {
+  name: 'http_error',
+  description: 'Demonstrates a failed HTTP call',
+  fn: async () => {
+    await call();
+  },
+  options: {
+    activityOptions: {
+      retry: {
+        maximumAttempts: 1
+      }
+    }
+  }
+} );

--- a/test_workflows/src/workflows/nested_http/workflow.ts
+++ b/test_workflows/src/workflows/nested_http/workflow.ts
@@ -1,0 +1,10 @@
+import { workflow } from '@outputai/core';
+import httpWorkflow from '../http/workflow.js';
+
+export default workflow( {
+  name: 'nested_http',
+  description: 'A workflow to test nested http workflows',
+  fn: async () => {
+    await httpWorkflow();
+  }
+} );

--- a/test_workflows/src/workflows/nested_http_error/workflow.ts
+++ b/test_workflows/src/workflows/nested_http_error/workflow.ts
@@ -1,0 +1,10 @@
+import { workflow } from '@outputai/core';
+import httpErrorWorkflow from '../http_error/workflow.js';
+
+export default workflow( {
+  name: 'nested_http_error',
+  description: 'A workflow to test nested http error workflows',
+  fn: async () => {
+    await httpErrorWorkflow();
+  }
+} );


### PR DESCRIPTION
## Summary

Add a new properties `attributes: []` and `aggregations: {}` to the workflow execution result from `@outputai/core` and in the API.

The object contains the value of each attribute added via `Trace.addEventAttribute()`, plus aggregate cost/usage information based on the attributes:

### Attributes shapes

#### LLMUsage
```js
{
  type: 'llm:usage',
  modelId: string,
  usage: [
    {
      type: string,
      ppm: number,
      amount: number,
      total: number
    }
  ],
  total: number,
  tokensUsed: number
}
```

#### HTTPRequestCount
```js
{
  type: 'http:request:count',
  url: string,
  requestId: string
}
```

#### HTTPRequestCost
```js
{
  type: 'http:request:cost',
  url: string,
  requestId: string,
  total: number
}
```

### Aggregations shape

```js
{
  "cost": {
    "total": number
  },
  "tokens": {
    "total": number,
    "<type>": number // where <type> is each type added to LLMUsage.usage[]
  },
  "httpRequests": {
    "total": 5
  }
}
```

### Examples
<details>

<summary>Workflow result with costs from LLM calls in activities</summary>

```json
{
  "workflowId": "qFDWmuY3D2ZBJzxse6U-0",
  "runId": "019e289e-4e23-7615-8998-027b8aad0e6f",
  "status": "completed",
  "input": "<<omitted>>",
  "output": "<<omitted>>",
  "trace": "<<omitted>>",
  "attributes": [
    {
      "activityId": "2",
      "activityName": "prompt#explainTopic",
      "date": 1778797927462,
      "type": "llm:usage",
      "modelId": "claude-haiku-4-5",
      "usage": [
        {
          "type": "input",
          "ppm": 1,
          "amount": 38,
          "total": 0.000038
        },
        {
          "type": "input_cached",
          "ppm": 0.1,
          "amount": 0,
          "total": 0
        },
        {
          "type": "output",
          "ppm": 5,
          "amount": 231,
          "total": 0.001155
        }
      ],
      "total": 0.001193,
      "tokensUsed": 269
    },
    {
      "activityId": "3",
      "activityName": "prompt#generateCookingInstruction",
      "date": 1778797930387,
      "type": "llm:usage",
      "modelId": "claude-haiku-4-5",
      "usage": [
        {
          "type": "input",
          "ppm": 1,
          "amount": 321,
          "total": 0.000321
        },
        {
          "type": "input_cached",
          "ppm": 0.1,
          "amount": 0,
          "total": 0
        },
        {
          "type": "output",
          "ppm": 5,
          "amount": 186,
          "total": 0.00093
        }
      ],
      "total": 0.001251,
      "tokensUsed": 507
    },
    {
      "activityId": "4",
      "activityName": "prompt#generateDrawingInstructions",
      "date": 1778797935482,
      "type": "llm:usage",
      "modelId": "claude-haiku-4-5",
      "usage": [
        {
          "type": "input",
          "ppm": 1,
          "amount": 311,
          "total": 0.000311
        },
        {
          "type": "input_cached",
          "ppm": 0.1,
          "amount": 0,
          "total": 0
        },
        {
          "type": "output",
          "ppm": 5,
          "amount": 453,
          "total": 0.002265
        }
      ],
      "total": 0.002576,
      "tokensUsed": 764
    },
    {
      "activityId": "5",
      "activityName": "prompt#generateChoice",
      "date": 1778797936661,
      "type": "llm:usage",
      "modelId": "claude-haiku-4-5",
      "usage": [
        {
          "type": "input",
          "ppm": 1,
          "amount": 217,
          "total": 0.000217
        },
        {
          "type": "input_cached",
          "ppm": 0.1,
          "amount": 0,
          "total": 0
        },
        {
          "type": "output",
          "ppm": 5,
          "amount": 9,
          "total": 0.000045
        }
      ],
      "total": 0.000262,
      "tokensUsed": 226
    }
  ],
  "aggregations": {
    "cost": {
      "total": 0.005282
    },
    "tokens": {
      "total": 1766,
      "input": 887,
      "input_cached": 0,
      "output": 879
    },
    "httpRequests": {
      "total": 0
    }
  },
  "error": null
}
```

</details>

<details>

<summary>Workflow result with calls and costs from HTTP requests</summary>

```json
{
  "workflowId": "0X2122Xo4zIhtMzfFKPdy",
  "runId": "019e2897-ae7a-7333-b364-214164ad6b3a",
  "status": "completed",
  "input": "<<omitted>>",
  "output": "<<omitted>>",
  "trace": "<<omitted>>",
  "attributes": [
    {
      "activityId": "2",
      "activityName": "http#listClientsStep",
      "date": 1778797489839,
      "type": "http:request:count",
      "url": "https://httpbin.io/anything/clients/",
      "requestId": "e3630b1f-27ce-47f6-a6d1-ab97ed743e02"
    },
    {
      "activityId": "3",
      "activityName": "http#createClientStep",
      "date": 1778797490395,
      "type": "http:request:count",
      "url": "https://httpbin.io/anything/clients/",
      "requestId": "4a87b754-42bd-4fe5-908f-6ec3429f4c1c"
    },
    {
      "activityId": "4",
      "activityName": "http#exportClientsStep",
      "date": 1778797490522,
      "type": "http:request:count",
      "url": "https://httpbin.io/anything/clients/export",
      "requestId": "ac4f6e90-c9d3-4609-bcb4-5ea74732955e"
    },
    {
      "activityId": "5",
      "activityName": "http#listContractsStep",
      "date": 1778797490641,
      "type": "http:request:count",
      "url": "https://httpbin.io/anything/contracts/",
      "requestId": "5ca2abe5-947c-426e-9890-deb1c408cbc0"
    },
    {
      "activityId": "5",
      "activityName": "http#listContractsStep",
      "date": 1778797490747,
      "type": "http:request:cost",
      "url": "https://httpbin.io/anything/contracts/",
      "requestId": "5ca2abe5-947c-426e-9890-deb1c408cbc0",
      "total": 120
    },
    {
      "activityId": "6",
      "activityName": "http#createContractStep",
      "date": 1778797490764,
      "type": "http:request:count",
      "url": "https://httpbin.io/anything/contracts/",
      "requestId": "566ec19e-53a7-440c-82ff-a53dbd45225e"
    }
  ],
  "aggregations": {
    "cost": {
      "total": 120
    },
    "tokens": {
      "total": 0
    },
    "httpRequests": {
      "total": 5
    }
  },
  "error": null
}
```

</details>

### Important
- On activity failures, attributes are preserved;
- On activity retry, attributes from previous attempts are preserved;
- Child workflow attributes are concatenated to the parent attributes;
- Failed child workflow attributes are also concatenated to the parent attributes;
- Failed workflows still have attributes/aggregations (attached to error, like trace information);
- The final aggregation is calculate at the end of the workflow;
 
## Test plan

[x] unit
[x] e2e
[x] manual
