### PR TITLE
feat(llm): Longer HTTP timeout and setting default maxRetries=0 [OUT-447]

### DIFF
--- a/.changeset/petite-pans-count.md
+++ b/.changeset/petite-pans-count.md
@@ -1,0 +1,7 @@
+---
+"@outputai/llm": patch
+---
+
+Increase built-in LLM provider fetch timeouts for long-running responses.
+
+Default AI SDK `maxRetries` to 0 so workflow retries are handled by Temporal.

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -453,7 +453,7 @@ Company size: {{ size }} employees
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `provider` | `string` | `anthropic`, `openai`, `azure`, `vertex`, or `bedrock` |
+| `provider` | `string` | `anthropic`, `openai`, `azure`, `vertex`, `bedrock`, `perplexity`, or a provider registered with `registerProvider` |
 | `model` | `string` | Model identifier |
 | `temperature` | `number` | Sampling temperature (0.0-2.0) |
 | `maxTokens` | `number` | Maximum output tokens |
@@ -590,7 +590,7 @@ All generate functions accept additional [AI SDK options](https://sdk.vercel.ai/
 |--------|------|-------------|
 | `tools` | `ToolSet` | Tools the model can call (generateText and streamText) |
 | `toolChoice` | `'auto' \| 'none' \| 'required'` | Tool selection strategy |
-| `maxRetries` | `number` | Max retry attempts (default: 2) |
+| `maxRetries` | `number` | Max retry attempts (default: 0) |
 | `seed` | `number` | Seed for deterministic output |
 | `abortSignal` | `AbortSignal` | Cancel the request |
 | `topP` | `number` | Nucleus sampling (0-1) |
@@ -601,6 +601,23 @@ All generate functions accept additional [AI SDK options](https://sdk.vercel.ai/
 | `experimental_transform` | `Function` | Stream transform, e.g. `smoothStream()` (streamText only) |
 
 Options set in the prompt file (temperature, maxTokens) can be overridden at call time.
+
+### Retries and Network Timeouts
+
+`generateText` and `streamText` set `maxRetries: 0` by default. In Output workflows, LLM calls usually run inside steps, and steps are Temporal activities. When a provider error is allowed to fail the step, Temporal records the failed activity attempt and retries it according to the workflow's retry policy.
+
+AI SDK retries are still available, but they happen inside one activity attempt. Use them when you want quick provider-level retries before the step fails. Keep the default when you want Temporal to be the single place that controls retries.
+
+Pass `maxRetries` in the function call when you want the AI SDK to retry provider requests:
+
+```typescript
+const result = await generateText({
+  prompt: 'summarize@v1',
+  maxRetries: 2
+});
+```
+
+Built-in providers are initialized with a custom fetch that extends Undici's `headersTimeout` and `bodyTimeout` to 15 minutes. This helps long-running LLM responses where the provider accepts the request but takes longer to return response headers or body chunks, for example reasoning-heavy calls. Active cancellation still works: if you pass `abortSignal`, or the AI SDK/provider aborts the request, that cancellation wins.
 
 ## LLM call cost event
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,12 +18,27 @@ catalogs:
     '@temporalio/common':
       specifier: 1.17.0
       version: 1.17.0
+    '@temporalio/proto':
+      specifier: 1.17.0
+      version: 1.17.0
     '@temporalio/worker':
       specifier: 1.17.0
       version: 1.17.0
     '@temporalio/workflow':
       specifier: 1.17.0
       version: 1.17.0
+    '@types/js-yaml':
+      specifier: 4.0.9
+      version: 4.0.9
+    js-yaml:
+      specifier: 4.1.1
+      version: 4.1.1
+    ky:
+      specifier: 1.14.3
+      version: 1.14.3
+    semver:
+      specifier: 7.7.4
+      version: 7.7.4
     undici:
       specifier: 8.1.0
       version: 8.1.0
@@ -424,6 +439,9 @@ importers:
       liquidjs:
         specifier: 10.25.7
         version: 10.25.7
+      undici:
+        specifier: 'catalog:'
+        version: 8.1.0
 
   test_workflows:
     dependencies:
@@ -13558,7 +13576,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.10.15
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -14928,7 +14946,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 25.6.0
+      '@types/node': 24.10.15
       long: 5.3.2
 
   protobufjs@7.5.6:
@@ -14943,7 +14961,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 25.6.0
+      '@types/node': 24.10.15
       long: 5.3.2
 
   protobufjs@8.0.3:

--- a/sdk/llm/package.json
+++ b/sdk/llm/package.json
@@ -23,7 +23,8 @@
     "decimal.js": "10.6.0",
     "entities": "8.0.0",
     "gray-matter": "4.0.3",
-    "liquidjs": "10.25.7"
+    "liquidjs": "10.25.7",
+    "undici": "catalog:"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/sdk/llm/src/ai_model.js
+++ b/sdk/llm/src/ai_model.js
@@ -1,12 +1,29 @@
-import { bedrock } from '@ai-sdk/amazon-bedrock';
-import { anthropic } from '@ai-sdk/anthropic';
-import { azure } from '@ai-sdk/azure';
-import { vertex } from '@ai-sdk/google-vertex';
-import { openai } from '@ai-sdk/openai';
-import { perplexity } from '@ai-sdk/perplexity';
+import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { createAzure } from '@ai-sdk/azure';
+import { createVertex } from '@ai-sdk/google-vertex';
+import { createOpenAI } from '@ai-sdk/openai';
+import { createPerplexity } from '@ai-sdk/perplexity';
 import { ValidationError, z } from '@outputai/core';
+import { Agent, fetch } from 'undici';
 
-export const builtInProviders = { azure, anthropic, openai, vertex, bedrock, perplexity };
+const dispatcher = new Agent( {
+  headersTimeout: 15 * 60 * 1000, // 15 min
+  bodyTimeout: 15 * 60 * 1000
+} );
+
+const customFetch = ( input, init ) => fetch( input, { dispatcher, ...init } );
+const initProvider = factory => factory( { fetch: customFetch } );
+
+export const builtInProviders = {
+  azure: initProvider( createAzure ),
+  anthropic: initProvider( createAnthropic ),
+  openai: initProvider( createOpenAI ),
+  vertex: initProvider( createVertex ),
+  bedrock: initProvider( createAmazonBedrock ),
+  perplexity: initProvider( createPerplexity )
+};
+
 export const providers = { ...builtInProviders };
 
 const registerProviderSchema = z.object( {
@@ -14,20 +31,17 @@ const registerProviderSchema = z.object( {
   providerFn: z.function()
 } );
 
+const toolConfigSchema = z.record( z.string(), z.unknown() );
+
 export function registerProvider( name, providerFn ) {
   const result = registerProviderSchema.safeParse( { name, providerFn } );
   if ( !result.success ) {
-    throw new ValidationError(
-      `Invalid provider registration: ${z.prettifyError( result.error )}`,
-      { cause: result.error }
-    );
+    throw new ValidationError( `Invalid provider registration: ${z.prettifyError( result.error )}` );
   }
   providers[name] = providerFn;
 }
 
-export function getRegisteredProviders() {
-  return Object.keys( providers );
-}
+export const getRegisteredProviders = () => Object.keys( providers );
 
 export function loadModel( prompt ) {
   const config = prompt?.config;
@@ -49,10 +63,8 @@ export function loadModel( prompt ) {
   const provider = providers[providerName];
 
   if ( !provider ) {
-    const validProviders = Object.keys( providers ).join( ', ' );
-    throw new Error(
-      `Invalid provider "${providerName}". Valid providers: ${validProviders}`
-    );
+    const availableProviders = Object.keys( providers ).join( ', ' );
+    throw new Error( `Invalid provider "${providerName}". Valid providers: ${availableProviders}` );
   }
 
   return provider( modelName );
@@ -60,7 +72,12 @@ export function loadModel( prompt ) {
 
 export function loadTools( prompt ) {
   const config = prompt?.config;
-  const toolsConfig = config?.tools;
+
+  if ( !config ) {
+    throw new Error( 'Prompt is missing config object' );
+  }
+
+  const { tools: toolsConfig, provider: providerName } = config;
 
   if ( !toolsConfig ) {
     return null;
@@ -84,20 +101,15 @@ export function loadTools( prompt ) {
     return null;
   }
 
-  const providerName = config.provider;
   const provider = providers[providerName];
 
   if ( !provider ) {
-    const validProviders = Object.keys( providers ).join( ', ' );
-    throw new Error(
-      `Invalid provider "${providerName}". Valid providers: ${validProviders}`
-    );
+    const availableProviders = Object.keys( providers ).join( ', ' );
+    throw new Error( `Invalid provider "${providerName}". Valid providers: ${availableProviders}` );
   }
 
   if ( !provider.tools || typeof provider.tools !== 'object' ) {
-    throw new Error(
-      `Provider "${providerName}" does not support provider-specific tools.`
-    );
+    throw new Error( `Provider "${providerName}" does not support provider-specific tools.` );
   }
 
   const tools = {};
@@ -109,18 +121,14 @@ export function loadTools( prompt ) {
       const availableTools = Object.keys( provider.tools )
         .filter( key => typeof provider.tools[key] === 'function' )
         .join( ', ' );
+      const toolsMessage = availableTools ? `Available tools: ${availableTools}` : 'No tools are available';
 
-      throw new Error(
-        `Unknown tool "${toolName}" for provider "${providerName}".` +
-        ( availableTools ? ` Available tools: ${availableTools}` : '' )
-      );
+      throw new Error( `Unknown tool "${toolName}" for provider "${providerName}". ${toolsMessage}` );
     }
 
-    if ( typeof toolConfig !== 'object' || toolConfig === null ) {
-      throw new Error(
-        `Configuration for tool "${toolName}" must be an object. ` +
-        `Use "${toolName}: {}" for tools without configuration.`
-      );
+    const result = toolConfigSchema.safeParse( toolConfig );
+    if ( !result.success ) {
+      throw new ValidationError( `Invalid config for tool "${toolName}": ${z.prettifyError( result.error )}` );
     }
 
     tools[toolName] = toolFactory( toolConfig );

--- a/sdk/llm/src/ai_model.spec.js
+++ b/sdk/llm/src/ai_model.spec.js
@@ -1,10 +1,12 @@
 import { it, expect, vi, afterEach, describe } from 'vitest';
 
-const openaiImpl = vi.fn( model => `openai:${model}` );
-const azureImpl = vi.fn( model => `azure:${model}` );
-const anthropicImpl = vi.fn( model => `anthropic:${model}` );
-const bedrockImpl = vi.fn( model => `bedrock:${model}` );
-const perplexityImpl = vi.fn( model => `perplexity:${model}` );
+const providerFactoryOptions = vi.hoisted( () => ( {} ) );
+const openaiImpl = vi.hoisted( () => vi.fn( model => `openai:${model}` ) );
+const azureImpl = vi.hoisted( () => vi.fn( model => `azure:${model}` ) );
+const anthropicImpl = vi.hoisted( () => vi.fn( model => `anthropic:${model}` ) );
+const bedrockImpl = vi.hoisted( () => vi.fn( model => `bedrock:${model}` ) );
+const perplexityImpl = vi.hoisted( () => vi.fn( model => `perplexity:${model}` ) );
+const vertexImpl = vi.hoisted( () => vi.fn( model => `vertex:${model}` ) );
 
 // OpenAI mock with tools support
 vi.mock( '@ai-sdk/openai', () => {
@@ -12,12 +14,20 @@ vi.mock( '@ai-sdk/openai', () => {
   openaiMock.tools = {
     webSearch: ( config = {} ) => ( { type: 'webSearch', config } )
   };
-  return { openai: openaiMock };
+  return {
+    createOpenAI: options => {
+      providerFactoryOptions.openai = options;
+      return openaiMock;
+    }
+  };
 } );
 
 // Azure mock without tools support
 vi.mock( '@ai-sdk/azure', () => ( {
-  azure: ( ...values ) => azureImpl( ...values )
+  createAzure: options => {
+    providerFactoryOptions.azure = options;
+    return ( ...values ) => azureImpl( ...values );
+  }
 } ) );
 
 // Anthropic mock with tools support
@@ -30,7 +40,12 @@ vi.mock( '@ai-sdk/anthropic', () => {
     codeExecution_20250522: ( config = {} ) => ( { type: 'codeExecution_20250522', config } ),
     codeExecution_20250825: ( config = {} ) => ( { type: 'codeExecution_20250825', config } )
   };
-  return { anthropic: anthropicMock };
+  return {
+    createAnthropic: options => {
+      providerFactoryOptions.anthropic = options;
+      return anthropicMock;
+    }
+  };
 } );
 
 // Bedrock mock with tools support
@@ -42,17 +57,25 @@ vi.mock( '@ai-sdk/amazon-bedrock', () => {
     textEditor_20250429: ( config = {} ) => ( { type: 'textEditor_20250429', config } ),
     computer_20241022: ( config = {} ) => ( { type: 'computer_20241022', config } )
   };
-  return { bedrock: bedrockMock };
+  return {
+    createAmazonBedrock: options => {
+      providerFactoryOptions.bedrock = options;
+      return bedrockMock;
+    }
+  };
 } );
 
 // Perplexity mock
 vi.mock( '@ai-sdk/perplexity', () => ( {
-  perplexity: ( ...values ) => perplexityImpl( ...values )
+  createPerplexity: options => {
+    providerFactoryOptions.perplexity = options;
+    return ( ...values ) => perplexityImpl( ...values );
+  }
 } ) );
 
 // Vertex mock with tools support
 vi.mock( '@ai-sdk/google-vertex', () => {
-  const vertexFn = model => `vertex:${model}`;
+  const vertexFn = ( ...values ) => vertexImpl( ...values );
   vertexFn.tools = {
     googleSearch: ( config = {} ) => ( { type: 'googleSearch', config } ),
     fileSearch: ( config = {} ) => ( { type: 'fileSearch', config } ),
@@ -62,7 +85,12 @@ vi.mock( '@ai-sdk/google-vertex', () => {
     codeExecution: ( config = {} ) => ( { type: 'codeExecution', config } ),
     vertexRagStore: ( config = {} ) => ( { type: 'vertexRagStore', config } )
   };
-  return { vertex: vertexFn };
+  return {
+    createVertex: options => {
+      providerFactoryOptions.vertex = options;
+      return vertexFn;
+    }
+  };
 } );
 
 import { loadModel, loadTools, registerProvider, getRegisteredProviders, providers, builtInProviders } from './ai_model.js';
@@ -73,6 +101,17 @@ afterEach( async () => {
 } );
 
 describe( 'loadModel', () => {
+  it( 'initializes built-in providers with custom fetch', () => {
+    expect( providerFactoryOptions ).toMatchObject( {
+      azure: { fetch: expect.any( Function ) },
+      anthropic: { fetch: expect.any( Function ) },
+      openai: { fetch: expect.any( Function ) },
+      vertex: { fetch: expect.any( Function ) },
+      bedrock: { fetch: expect.any( Function ) },
+      perplexity: { fetch: expect.any( Function ) }
+    } );
+  } );
+
   it( 'loads model using selected provider', () => {
     const result = loadModel( { config: { provider: 'openai', model: 'gpt-4o-mini' } } );
 
@@ -617,7 +656,7 @@ describe( 'loadTools', () => {
           provider: 'vertex',
           tools: { googleSearch: null }
         }
-      } ) ).toThrow( 'Configuration for tool "googleSearch" must be an object' );
+      } ) ).toThrow( /Invalid config for tool "googleSearch".*expected record, received null/s );
     } );
 
     it( 'throws error when tool config is a string', () => {
@@ -626,7 +665,7 @@ describe( 'loadTools', () => {
           provider: 'vertex',
           tools: { googleSearch: 'MODE_DYNAMIC' }
         }
-      } ) ).toThrow( 'Configuration for tool "googleSearch" must be an object' );
+      } ) ).toThrow( /Invalid config for tool "googleSearch".*expected record, received string/s );
     } );
 
     it( 'throws error for unknown tool on Bedrock with dynamic tool listing', () => {

--- a/sdk/llm/src/ai_sdk.js
+++ b/sdk/llm/src/ai_sdk.js
@@ -64,10 +64,10 @@ export const hydratePromptTemplate = ( prompt, variables, promptDir, callerSkill
   return { loadedPrompt: meta, allVariables: variables, tools };
 };
 
-export async function generateText( { prompt, variables, promptDir, skills = [], maxSteps = 10, ...extraAiSdkOptions } ) {
+export async function generateText( { prompt, variables, promptDir, skills = [], maxSteps = 10, ...aiSdkArgs } ) {
   const callerSkills = typeof skills === 'function' ? await skills( variables ) : skills;
   const { loadedPrompt, allVariables, tools } =
-    hydratePromptTemplate( prompt, variables, promptDir, callerSkills, extraAiSdkOptions.tools );
+    hydratePromptTemplate( prompt, variables, promptDir, callerSkills, aiSdkArgs.tools );
   const hasTools = Object.keys( tools ).length > 0;
 
   validateGenerateTextArgs( { prompt, variables: allVariables } );
@@ -78,9 +78,10 @@ export async function generateText( { prompt, variables, promptDir, skills = [],
   try {
     const response = await AI.generateText( {
       ...loadAiSdkOptionsFromPrompt( loadedPrompt ),
-      ...extraAiSdkOptions,
+      maxRetries: 0,
+      ...aiSdkArgs,
       ...( hasTools ? { tools } : {} ),
-      ...( hasTools && !extraAiSdkOptions.stopWhen ? { stopWhen: stepCountIs( maxSteps ) } : {} )
+      ...( hasTools && !aiSdkArgs.stopWhen ? { stopWhen: stepCountIs( maxSteps ) } : {} )
     } );
     return wrapTextResponse( { traceId, modelId, response } );
   } catch ( error ) {
@@ -89,7 +90,7 @@ export async function generateText( { prompt, variables, promptDir, skills = [],
   }
 }
 
-export function streamText( { prompt, variables, onFinish, onError, ...restOptions } ) {
+export function streamText( { prompt, variables, onFinish, onError, ...aiSdkArgs } ) {
   validateStreamTextArgs( { prompt, variables } );
   const loadedPrompt = loadPrompt( prompt, variables );
   const traceId = startTrace( { name: 'streamText', prompt, variables, loadedPrompt } );
@@ -98,7 +99,8 @@ export function streamText( { prompt, variables, onFinish, onError, ...restOptio
   try {
     return AI.streamText( {
       ...loadAiSdkOptionsFromPrompt( loadedPrompt ),
-      ...restOptions,
+      maxRetries: 0,
+      ...aiSdkArgs,
       ...wrapStreamOnFinishResponse( { traceId, modelId, onFinish } ),
       onError( event ) {
         endTraceWithError( { traceId, error: event.error } );

--- a/sdk/llm/src/ai_sdk.spec.js
+++ b/sdk/llm/src/ai_sdk.spec.js
@@ -149,6 +149,7 @@ describe( 'ai_sdk', () => {
       model: 'MODEL',
       messages: basePrompt.messages,
       temperature: 0.3,
+      maxRetries: 0,
       providerOptions: basePrompt.config.providerOptions
     } );
     expect( result ).toBe( generateTextAiFixture.response );
@@ -182,6 +183,7 @@ describe( 'ai_sdk', () => {
     expect( aiFns.generateText ).toHaveBeenCalledWith( {
       model: 'MODEL',
       messages: promptWithProviderOptions.messages,
+      maxRetries: 0,
       providerOptions: {
         thinking: {
           type: 'enabled',
@@ -362,6 +364,7 @@ describe( 'ai_sdk', () => {
         model: 'MODEL',
         messages: basePrompt.messages,
         temperature: 0.3,
+        maxRetries: 0,
         providerOptions: basePrompt.config.providerOptions,
         onFinish: expect.any( Function ),
         onError: expect.any( Function )


### PR DESCRIPTION
## Summary

- Using a custom fetch to increase header and body timeouts to 15min when making LLM requests;
- Setting AI SDK's maxRetries to `0` as default, thus delegating retry in LLM calls to temporal;

## Test plan

[x] Manual workflow test
[x] Unit test
[x] e2e tests
