### PR TITLE
chore(llm): bump @ai-sdk/anthropic to 3.0.78 for advisor tool

### DIFF
--- a/.changeset/advisor-tool-support.md
+++ b/.changeset/advisor-tool-support.md
@@ -1,0 +1,13 @@
+---
+"@outputai/llm": minor
+---
+
+Bump `@ai-sdk/anthropic` from `3.0.71` to `3.0.78` to expose Anthropic's new server-side `advisor_20260301` tool factory. Prompts can now configure it directly:
+
+```yaml
+provider: anthropic
+tools:
+  advisor_20260301: {}
+```
+
+No code changes were required in `@outputai/llm` — `loadTools()` resolves tool factories dynamically off the provider, so the new factory wires up automatically. Advisor support is Anthropic-direct only (not Vertex or Bedrock).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,8 +385,8 @@ importers:
         specifier: 4.0.96
         version: 4.0.96(zod@4.4.3)
       '@ai-sdk/anthropic':
-        specifier: 3.0.71
-        version: 3.0.71(zod@4.4.3)
+        specifier: 3.0.78
+        version: 3.0.78(zod@4.4.3)
       '@ai-sdk/azure':
         specifier: 3.0.54
         version: 3.0.54(zod@4.4.3)
@@ -471,6 +471,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/anthropic@3.0.78':
+    resolution: {integrity: sha512-0OY12G20cUt6iU6htpEA1491Oz++NVxZxlmWGX4B7rSbeZ5pnDmOu6YtW9BKzdZlNx5Gn23i6WMxyZFoMKNcgA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/azure@3.0.54':
     resolution: {integrity: sha512-lnW7V+Kl3OKKvNXHaZSf/D35vo4bchfMm7WzxILZMPJ5N7W6i1oDeSXVurSKlR685Kvpi8ZA76LBJKSbzff3yw==}
     engines: {node: '>=18'}
@@ -518,6 +524,16 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
@@ -7659,6 +7675,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.23(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/anthropic@3.0.78(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/azure@3.0.54(zod@4.4.3)':
     dependencies:
       '@ai-sdk/openai': 3.0.53(zod@4.4.3)
@@ -7715,6 +7737,17 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.8
       zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
+
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.8':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,7 @@ catalog:
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - "@growthxlabs/gx-workflows"
+  - "@ai-sdk/anthropic"
 
 trustPolicy: no-downgrade
 blockExoticSubdeps: true

--- a/sdk/llm/package.json
+++ b/sdk/llm/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "@ai-sdk/amazon-bedrock": "4.0.96",
-    "@ai-sdk/anthropic": "3.0.71",
+    "@ai-sdk/anthropic": "3.0.78",
     "@ai-sdk/azure": "3.0.54",
     "@ai-sdk/google-vertex": "4.0.112",
     "@ai-sdk/openai": "3.0.53",


### PR DESCRIPTION
## Overview

- Bumps `@ai-sdk/anthropic` from `3.0.71` to `3.0.78` in `sdk/llm/package.json` so Anthropic's `advisor_20260301` server-side tool factory is exposed. Prompts can now configure `tools: { advisor_20260301: {} }`.
- `loadTools()` already resolves tool factories dynamically off `provider.tools`, so no source changes were needed in `@outputai/llm`.
- Adds `@ai-sdk/anthropic` to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` — the 7-day release-age floor from #213 blocks the 5-day-old `3.0.78` release.
- Adds a minor changeset for `@outputai/llm`.

Advisor support is Anthropic-direct only — Vertex and Bedrock paths still bundle `3.0.71` transitively and are unaffected, which matches the upstream support matrix.

Closes OUT-453

## Test plan

- [x] `pnpm install` — clean install, lockfile updates `sdk/llm` direct pin to `3.0.78(zod@4.4.3)`
- [x] `npm run lint` passes
- [x] `npm run build:packages` passes
- [x] `npm test` — 1877 tests pass across 153 files
- [x] Smoke: from `sdk/llm`, `createAnthropic().tools` now includes `advisor_20260301` (alongside the existing `bash_*`, `codeExecution_*`, `webSearch_*` factories)

## Notes for reviewers

- **Added `@ai-sdk/anthropic` to `minimumReleaseAgeExclude`** — #213 set a 7-day floor on new releases and `3.0.78` is 5 days old. The Linear ask is explicitly `>=3.0.77`, so waiting it out wasn't an option. The exclude entry is the documented escape hatch; `@ai-sdk/anthropic` is a first-party Anthropic SDK published to npm, so the risk profile matches the existing `@growthxlabs/gx-workflows` exclusion.

## Follow-up (out of scope)

- `pnpm-workspace.yaml` has a stray `- "@growthxlabs/workflows_catalog"` array entry dangling under `auditLevel: moderate` (looks like an unintended displacement from `minimumReleaseAgeExclude`). It triggers `npm warn invalid config audit-level=...` warnings during builds. Pre-existing from #213 — worth a separate ticket.