### PR TITLE
fix(core): Fix worker activity Temporal client config

### DIFF
--- a/.changeset/every-queens-return.md
+++ b/.changeset/every-queens-return.md
@@ -1,0 +1,5 @@
+---
+"@outputai/core": patch
+---
+
+Fix worker activity Temporal client to use the configured namespace when signaling workflows. This resolves unauthorized signal errors in Temporal Cloud production namespaces.

--- a/sdk/core/src/worker/interceptors/activity.js
+++ b/sdk/core/src/worker/interceptors/activity.js
@@ -3,7 +3,7 @@ import { Storage } from '#async_storage';
 import * as Tracing from '#tracing';
 import { headersToObject } from '../sandboxed_utils.js';
 import { BusEventType, METADATA_ACCESS_SYMBOL } from '#consts';
-import { activityHeartbeatEnabled, activityHeartbeatIntervalMs } from '../configs.js';
+import { activityHeartbeatEnabled, activityHeartbeatIntervalMs, namespace } from '../configs.js';
 import { messageBus } from '#bus';
 import { Client } from '@temporalio/client';
 
@@ -38,7 +38,7 @@ export class ActivityExecutionInterceptor {
 
   async execute( input, next ) {
     const startDate = Date.now();
-    const client = new Client( { connection: this.connection } );
+    const client = new Client( { connection: this.connection, namespace } );
 
     const { workflowExecution: { workflowId }, activityId: id, activityType: name, workflowType: workflowName } = Context.current().info;
     const { executionContext } = headersToObject( input.headers );

--- a/sdk/core/src/worker/interceptors/activity.spec.js
+++ b/sdk/core/src/worker/interceptors/activity.spec.js
@@ -4,6 +4,7 @@ import { BusEventType } from '#consts';
 const METADATA_ACCESS_SYMBOL = vi.hoisted( () => Symbol( '__metadata' ) );
 const workflowHandleMock = vi.hoisted( () => ( { signal: vi.fn() } ) );
 const getHandleMock = vi.hoisted( () => vi.fn( () => workflowHandleMock ) );
+const clientConstructorMock = vi.hoisted( () => vi.fn() );
 
 const heartbeatMock = vi.fn();
 const runWithContextMock = vi.hoisted( () => vi.fn().mockImplementation( async fn => fn() ) );
@@ -25,6 +26,10 @@ vi.mock( '@temporalio/activity', () => ( {
 
 vi.mock( '@temporalio/client', () => ( {
   Client: class Client {
+    constructor( options ) {
+      clientConstructorMock( options );
+    }
+
     workflow = {
       getHandle: getHandleMock
     };
@@ -68,6 +73,9 @@ vi.mock( '../configs.js', () => ( {
   },
   get activityHeartbeatIntervalMs() {
     return parseInt( process.env.OUTPUT_ACTIVITY_HEARTBEAT_INTERVAL_MS || '120000', 10 );
+  },
+  get namespace() {
+    return process.env.TEMPORAL_NAMESPACE || 'default';
   }
 } ) );
 
@@ -116,6 +124,7 @@ describe( 'ActivityExecutionInterceptor', () => {
     expect( addEventStartMock ).toHaveBeenCalledOnce();
     expect( addEventEndMock ).toHaveBeenCalledOnce();
     expect( addEventErrorMock ).not.toHaveBeenCalled();
+    expect( clientConstructorMock ).toHaveBeenCalledWith( { connection: undefined, namespace: 'default' } );
     expect( runWithContextMock ).toHaveBeenCalledWith(
       expect.any( Function ),
       expect.objectContaining( {


### PR DESCRIPTION
## Summary

Fix worker activity Temporal client to use the configured namespace when signaling workflows.

## Test plan

[x] manual
[x] unit
[x] e2e
