### PR TITLE
chore(cli): extend local Temporal namespace retention to 30 days

### DIFF
--- a/.changeset/extend-local-temporal-retention.md
+++ b/.changeset/extend-local-temporal-retention.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Bump default local Temporal namespace retention from 24h to 720h (30 days) so workflow runs aren't garbage-collected within a day during local development.

--- a/docker-compose.temporal.yml
+++ b/docker-compose.temporal.yml
@@ -45,6 +45,7 @@ services:
       - POSTGRES_USER=temporal
       - POSTGRES_PWD=temporal
       - POSTGRES_SEEDS=postgresql
+      - DEFAULT_NAMESPACE_RETENTION=720h
     image: temporalio/auto-setup:latest
     networks:
       - main

--- a/sdk/cli/src/assets/docker/docker-compose-dev.yml
+++ b/sdk/cli/src/assets/docker/docker-compose-dev.yml
@@ -43,6 +43,7 @@ services:
       - POSTGRES_USER=temporal
       - POSTGRES_PWD=temporal
       - POSTGRES_SEEDS=postgresql
+      - DEFAULT_NAMESPACE_RETENTION=720h
     image: temporalio/auto-setup:latest
     networks:
       - main


### PR DESCRIPTION
## Problem

The `temporalio/auto-setup` image used in our local Docker stack defaults the `default` namespace retention to **24h**. Locally-developed workflow runs get garbage-collected within a day, making them disappear before devs can revisit them for debugging or replay. Flagged by Jacob via Slack and tracked as OUT-462.

## Solution

- Set `DEFAULT_NAMESPACE_RETENTION=720h` (30 days) on the `temporal` service in both compose files that drive local dev:
  - `docker-compose.temporal.yml` — the in-repo dev stack (`./run.sh dev`)
  - `sdk/cli/src/assets/docker/docker-compose-dev.yml` — the CLI-shipped template that user projects get out of the box
- Added a patch changeset for `@outputai/cli` since the change ships to consumers via the CLI's bundled assets.

Closes OUT-462

## Notes for reviewers

- **Only applies to fresh namespaces.** `temporalio/auto-setup` honors `DEFAULT_NAMESPACE_RETENTION` only when it first provisions the namespace. Existing local installs (with a populated postgres volume) will keep 24h until they either `docker compose down -v` or run `temporal operator namespace update default --retention 720h` against their running cluster. Acceptable trade-off for a local-dev default — new contributors get the right behavior, existing ones can self-serve.
- **Not exposed as a configurable env var.** The issue asks for a sane default, not a knob. Easy to add later if anyone wants it.

## Test plan

- [ ] `docker compose -f docker-compose.dev.yml down -v && ./run.sh dev`
- [ ] `docker compose exec temporal tctl namespace describe default` shows `Retention: 720h0m0s`
- [ ] `./run.sh validate` still passes