### PR TITLE
update docs with notes on credentials for deploying with docker

### DIFF
--- a/docs/guides/operations/credentials.mdx
+++ b/docs/guides/operations/credentials.mdx
@@ -199,7 +199,15 @@ The resolution order is: environment variable first, then key file. Workflow key
 
 ### Docker
 
-Pass the key as an environment variable in your Docker Compose or container config:
+The encrypted credentials file must be present in the image — the key alone isn't enough. Make sure your Dockerfile includes:
+
+```dockerfile
+COPY config/ ./config/
+```
+
+The `config/` directory is not cleaned up after the build because the encrypted file is read at runtime, not build time.
+
+Pass the decryption key as an environment variable in your Docker Compose or container config:
 
 ```yaml
 # docker-compose.yml

--- a/docs/guides/operations/deployment/railway.mdx
+++ b/docs/guides/operations/deployment/railway.mdx
@@ -105,10 +105,11 @@ RUN npm run output:worker:install
 
 # Build the worker
 COPY src/ ./src/
+COPY config/ ./config/
 COPY tsconfig.json ./
 RUN npm run output:worker:build
 
-# Clean up source files after build
+# Clean up source files after build (config stays — credentials are needed at runtime)
 RUN rm -rf ./src tsconfig.json
 
 # Create non-root user for security
@@ -324,6 +325,12 @@ Workers scale independently from the API. If workflows are queuing up in Tempora
 1. Increase `NODE_OPTIONS` memory allocation
 2. Upgrade Railway plan for more resources
 3. Check for memory leaks in workflow code (large payloads, unbounded arrays)
+
+### Credentials not found
+
+1. Verify `config/credentials.yml.enc` (or the environment-scoped equivalent) exists in your repo and is committed
+2. Verify `OUTPUT_CREDENTIALS_KEY` (or the environment-scoped variant) is set in Railway with the correct master key
+3. Verify the Dockerfile includes `COPY config/ ./config/` — without it, the encrypted file never reaches the container
 
 ### Build failures
 


### PR DESCRIPTION
## Summary

Update docs with notes on copying the `config/` directory for Docker based deploys. 

No changeset here because it's just user facing docs