### PR TITLE
fix(http): propagate requestId across Response.clone() (COS-489)

### DIFF
--- a/.changeset/cost-survives-clone.md
+++ b/.changeset/cost-survives-clone.md
@@ -3,3 +3,5 @@
 ---
 
 Propagate the per-request id across `Response.clone()` so cost emission works from inside ky `afterResponse` hooks. ky clones the response before invoking the hook, which stripped the symbol property `addRequestCost` reads to correlate the request — every hook calling `addRequestCost(response, value)` silently dropped its cost. Patches `clone()` on the original response so each clone re-runs `addRequestIdToResponse`, propagating the tag through any depth of clones. Header-based fallback isn't viable — undici responses are immutable on the received side.
+
+Also tightens the `addRequestIdToResponse` signature to `: void` (was `: Response`). The function mutates in place; the return-the-input pattern was misleading. The one external call site already discarded the return, so no consumer code needs to change.

--- a/.changeset/cost-survives-clone.md
+++ b/.changeset/cost-survives-clone.md
@@ -1,0 +1,5 @@
+---
+"@outputai/http": patch
+---
+
+Propagate the per-request id across `Response.clone()` so cost emission works from inside ky `afterResponse` hooks. ky clones the response before invoking the hook, which stripped the symbol property `addRequestCost` reads to correlate the request — every hook calling `addRequestCost(response, value)` silently dropped its cost. Patches `clone()` on the original response so each clone re-runs `addRequestIdToResponse`, propagating the tag through any depth of clones. Header-based fallback isn't viable — undici responses are immutable on the received side.

--- a/sdk/http/src/cost.spec.ts
+++ b/sdk/http/src/cost.spec.ts
@@ -29,6 +29,7 @@ vi.mock( '@outputai/core/sdk_activity_integration', () => {
 
 import { Tracing, emitEvent } from '@outputai/core/sdk_activity_integration';
 import { addRequestCost } from './cost.js';
+import { addRequestIdToResponse } from './fetch/utils.js';
 
 const tracing = vi.mocked( Tracing, true );
 const emit = vi.mocked( emitEvent, true );
@@ -92,6 +93,30 @@ describe( 'addRequestCost', () => {
         url: response.url,
         requestId: 'evt-cost-2',
         total: cost
+      } )
+    } );
+    const attribute = tracing.addEventAttribute.mock.calls[0][0].attribute;
+    expect( emit ).toHaveBeenCalledWith( 'cost:http:request', attribute );
+  } );
+
+  // ky clones the response before passing it to afterResponse hooks. Without
+  // the clone-propagation patch in addRequestIdToResponse, this path silently
+  // dropped cost (warned "did not originate from @outputai/http") for every
+  // service client that emits cost from inside a ky hook.
+  it( 'records cost on a cloned response (regression: ky afterResponse hooks)', () => {
+    const response = new Response( undefined, { status: 200 } );
+    addRequestIdToResponse( response, 'evt-clone-1' );
+
+    const cloned = response.clone();
+    addRequestCost( cloned, 4.2 );
+
+    expect( console.warn ).not.toHaveBeenCalled();
+    expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
+      eventId: 'evt-clone-1',
+      attribute: expect.objectContaining( {
+        type: Tracing.Attribute.HTTPRequestCost.TYPE,
+        requestId: 'evt-clone-1',
+        total: 4.2
       } )
     } );
     const attribute = tracing.addEventAttribute.mock.calls[0][0].attribute;

--- a/sdk/http/src/cost.spec.ts
+++ b/sdk/http/src/cost.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Response } from 'undici';
 import { requestIdSymbol } from './consts.js';
 
 vi.mock( '@outputai/core/sdk_activity_integration', () => {

--- a/sdk/http/src/fetch/utils.spec.ts
+++ b/sdk/http/src/fetch/utils.spec.ts
@@ -315,5 +315,17 @@ describe( 'fetch/utils', () => {
         value: 'req-456'
       } );
     } );
+
+    it( 'propagates the request id to clones (ky afterResponse passes the clone)', () => {
+      const response = new Response( 'ok' );
+      addRequestIdToResponse( response, 'req-789' );
+
+      const cloned = response.clone();
+      expect( ( cloned as unknown as Record<symbol, unknown> )[requestIdSymbol] ).toBe( 'req-789' );
+
+      // recursion: clones of clones inherit too
+      const grandchild = cloned.clone();
+      expect( ( grandchild as unknown as Record<symbol, unknown> )[requestIdSymbol] ).toBe( 'req-789' );
+    } );
   } );
 } );

--- a/sdk/http/src/fetch/utils.spec.ts
+++ b/sdk/http/src/fetch/utils.spec.ts
@@ -293,12 +293,11 @@ describe( 'fetch/utils', () => {
   } );
 
   describe( 'addRequestIdToResponse', () => {
-    it( 'stores request id under requestIdSymbol and returns the same response', () => {
+    it( 'stores request id under requestIdSymbol on the response', () => {
       const response = new Response( 'ok' );
 
-      const enriched = addRequestIdToResponse( response, 'req-123' );
+      addRequestIdToResponse( response, 'req-123' );
 
-      expect( enriched ).toBe( response );
       expect( ( response as unknown as Record<symbol, unknown> )[requestIdSymbol] ).toBe( 'req-123' );
     } );
 

--- a/sdk/http/src/fetch/utils.ts
+++ b/sdk/http/src/fetch/utils.ts
@@ -100,23 +100,24 @@ export const parseBody = async ( r : Request | Response ) : Promise<string | obj
 };
 
 /**
- * Tag a response with its request id so downstream code (e.g. addRequestCost)
- * can correlate. Stores the id under a private symbol AND patches `clone()` so
- * the tag propagates to clones — ky clones the response before invoking
- * `afterResponse` hooks, and undici headers are immutable on received
- * responses, so a symbol re-attached inside `clone()` is the only path that
- * survives.
+ * Tag a response in place with its request id so downstream code (e.g.
+ * `addRequestCost`) can correlate. Stores the id under a private symbol AND
+ * patches `clone()` so the tag propagates to clones — ky clones the response
+ * before invoking `afterResponse` hooks, and undici headers are immutable on
+ * received responses, so a symbol re-attached inside `clone()` is the only
+ * path that survives.
  */
-export const addRequestIdToResponse = ( response: Response, requestId: string ) : Response => {
+export const addRequestIdToResponse = ( response: Response, requestId: string ) : void => {
   Object.defineProperty( response, requestIdSymbol, { value: requestId, enumerable: false, configurable: false, writable: false } );
   const originalClone = response.clone.bind( response );
   Object.defineProperty( response, 'clone', {
     value: function clone() {
-      return addRequestIdToResponse( originalClone(), requestId );
+      const cloned = originalClone();
+      addRequestIdToResponse( cloned, requestId );
+      return cloned;
     },
     enumerable: false,
     configurable: true,
     writable: true
   } );
-  return response;
 };

--- a/sdk/http/src/fetch/utils.ts
+++ b/sdk/http/src/fetch/utils.ts
@@ -104,19 +104,19 @@ export const parseBody = async ( r : Request | Response ) : Promise<string | obj
  * can correlate. Stores the id under a private symbol AND patches `clone()` so
  * the tag propagates to clones — ky clones the response before invoking
  * `afterResponse` hooks, and undici headers are immutable on received
- * responses, so the symbol on the clone is the only path that survives.
+ * responses, so a symbol re-attached inside `clone()` is the only path that
+ * survives.
  */
-export const addRequestIdToResponse = ( response: Response, requestId: string ) : void => {
-  Object.defineProperty( response, requestIdSymbol, { value: requestId, enumerable: false, configurable: true, writable: false } );
+export const addRequestIdToResponse = ( response: Response, requestId: string ) : Response => {
+  Object.defineProperty( response, requestIdSymbol, { value: requestId, enumerable: false, configurable: false, writable: false } );
   const originalClone = response.clone.bind( response );
   Object.defineProperty( response, 'clone', {
     value: function clone() {
-      const cloned = originalClone();
-      addRequestIdToResponse( cloned, requestId );
-      return cloned;
+      return addRequestIdToResponse( originalClone(), requestId );
     },
     enumerable: false,
     configurable: true,
     writable: true
   } );
+  return response;
 };

--- a/sdk/http/src/fetch/utils.ts
+++ b/sdk/http/src/fetch/utils.ts
@@ -100,12 +100,23 @@ export const parseBody = async ( r : Request | Response ) : Promise<string | obj
 };
 
 /**
- * Adds a non-enumerable, non-configurable and non-writable property to a response.
- *
- * This property is identified by a unique symbol and contains the id of the request.
- *
- * @param response
- * @param requestId
+ * Tag a response with its request id so downstream code (e.g. addRequestCost)
+ * can correlate. Stores the id under a private symbol AND patches `clone()` so
+ * the tag propagates to clones — ky clones the response before invoking
+ * `afterResponse` hooks, and undici headers are immutable on received
+ * responses, so the symbol on the clone is the only path that survives.
  */
-export const addRequestIdToResponse = ( response: Response, requestId: string ) =>
-  Object.defineProperty( response, requestIdSymbol, { value: requestId, enumerable: false, configurable: false, writable: false } );
+export const addRequestIdToResponse = ( response: Response, requestId: string ) : void => {
+  Object.defineProperty( response, requestIdSymbol, { value: requestId, enumerable: false, configurable: true, writable: false } );
+  const originalClone = response.clone.bind( response );
+  Object.defineProperty( response, 'clone', {
+    value: function clone() {
+      const cloned = originalClone();
+      addRequestIdToResponse( cloned, requestId );
+      return cloned;
+    },
+    enumerable: false,
+    configurable: true,
+    writable: true
+  } );
+};


### PR DESCRIPTION
## Overview
Make the `requestId` tag attached by `@outputai/http`'s custom fetch survive `Response.clone()`. Unblocks every service client that wants to emit cost from inside a `ky` `afterResponse` hook — required by all 7 client PRs in the COS-489 wave (Jina, Semrush, DataForSEO, Exa, Tavily, SerpAPI, Firecrawl).

## Problem / Solution
`ky` clones the response before passing it to `afterResponse` hooks (see `ky/distribution/core/Ky.js`: `const clonedResponse = ky.#decorateResponse(response.clone());`). The clone is a fresh `Response` object that doesn't carry the `requestIdSymbol` property `addRequestCost` reads to correlate the request — so any hook calling `addRequestCost(response, value)` warns "did not originate from @outputai/http" and silently drops the cost.

Tried a header fallback first (`response.headers.set('x-output-request-id', requestId)`), but undici Responses are immutable on the received side — `headers.set()` throws.

Patches `clone()` on the original response so each clone re-runs `addRequestIdToResponse`, propagating the tag through any depth of clones. Recursive — clones of clones inherit too.

## Notes for reviewers
- `configurable: true` on the symbol property (was `false`) — needed because the recursion calls `defineProperty` on already-tagged clones in pathological cases. No external API depends on it being locked.
- Verified E2E with the Jina hook on `os-workflows#222` against `context_brand_research`: workflow result includes `http:request:cost { total: 0.00006662 }` and `aggregations.cost.total` correctly sums Jina + LLM.