### PR TITLE
chore(core,cli): opt-in attribute signal emission (COS-585)

### DIFF
--- a/.changeset/tasty-doors-like.md
+++ b/.changeset/tasty-doors-like.md
@@ -1,0 +1,5 @@
+---
+"@outputai/core": patch
+---
+
+Attribute signal emission is now opt-in via `OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION=true`. Each LLM call and HTTP request previously fired a Temporal signal back to the workflow, bloating workflow history on runs with many calls. With emission off (the new default), workflow results still expose `attributes` and `aggregations` keys but they are empty/zeroed, and the `cost:llm:request` / `cost:http:request` hooks do not fire. Set the env var on the worker process to opt back in.

--- a/.changeset/tasty-doors-like.md
+++ b/.changeset/tasty-doors-like.md
@@ -1,5 +1,8 @@
 ---
 "@outputai/core": patch
+"@outputai/cli": patch
 ---
 
 Attribute signal emission is now opt-in via `OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION=true`. Each LLM call and HTTP request previously fired a Temporal signal back to the workflow, bloating workflow history on runs with many calls. With emission off (the new default), workflow results still expose `attributes` and `aggregations` keys but they are empty/zeroed, and the `cost:llm:request` / `cost:http:request` hooks do not fire. Set the env var on the worker process to opt back in.
+
+The CLI's dev docker-compose forwards the flag from the host shell, so `OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION=true output dev` opts in without editing compose.

--- a/sdk/cli/src/assets/docker/docker-compose-dev.yml
+++ b/sdk/cli/src/assets/docker/docker-compose-dev.yml
@@ -120,6 +120,7 @@ services:
       - OUTPUT_TRACE_LOCAL_ON=${OUTPUT_TRACE_LOCAL_ON:-true}
       - OUTPUT_TRACE_HOST_PATH=${PWD}/logs
       - OUTPUT_TRACE_HTTP_VERBOSE=${OUTPUT_TRACE_HTTP_VERBOSE:-true}
+      - OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION=${OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION:-false}
       - TEMPORAL_ADDRESS=temporal:7233
       - NODE_OPTIONS=${NODE_OPTIONS:---max-old-space-size=4096}
     command: sh -c "corepack enable && npm run output:worker:install && npm run output:worker:watch"

--- a/sdk/core/src/worker/configs.js
+++ b/sdk/core/src/worker/configs.js
@@ -25,6 +25,11 @@ const envVarSchema = z.object( {
   OUTPUT_ACTIVITY_HEARTBEAT_INTERVAL_MS: z.preprocess( coalesceEmptyString, z.coerce.number().int().positive().default( 2 * 60 * 1000 ) ), // 2min
   // Whether to send activity heartbeats (enabled by default)
   OUTPUT_ACTIVITY_HEARTBEAT_ENABLED: z.transform( v => v === undefined ? true : isStringboolTrue( v ) ),
+  // When true, activities fire Temporal signals carrying attribute/event data (LLM usage,
+  // HTTP request count/cost) back to the workflow for aggregation in the result.
+  // Defaulted OFF: the current emission architecture bloats Temporal history.
+  // Set to "true" to opt in to per-event attribute collection and aggregations.
+  OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION: z.transform( v => v === undefined ? false : isStringboolTrue( v ) ),
   // Time to allow for hooks to flush before shutdown
   OUTPUT_PROCESS_FAILURE_SHUTDOWN_DELAY: z.preprocess( coalesceEmptyString, z.coerce.number().int().positive().default( 3000 ) ),
   // HTTP CONNECT proxy for Temporal gRPC connections (e.g. "proxy-host:8080").
@@ -53,5 +58,6 @@ export const taskQueue = envVars.OUTPUT_CATALOG_ID;
 export const catalogId = envVars.OUTPUT_CATALOG_ID;
 export const activityHeartbeatIntervalMs = envVars.OUTPUT_ACTIVITY_HEARTBEAT_INTERVAL_MS;
 export const activityHeartbeatEnabled = envVars.OUTPUT_ACTIVITY_HEARTBEAT_ENABLED;
+export const enableAttributeSignalEmission = envVars.OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION;
 export const processFailureShutdownDelay = envVars.OUTPUT_PROCESS_FAILURE_SHUTDOWN_DELAY;
 export const grpcProxy = envVars.TEMPORAL_GRPC_PROXY;

--- a/sdk/core/src/worker/configs.spec.js
+++ b/sdk/core/src/worker/configs.spec.js
@@ -11,7 +11,8 @@ const CONFIG_KEYS = [
   'TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS',
   'TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS',
   'OUTPUT_ACTIVITY_HEARTBEAT_INTERVAL_MS',
-  'OUTPUT_ACTIVITY_HEARTBEAT_ENABLED'
+  'OUTPUT_ACTIVITY_HEARTBEAT_ENABLED',
+  'OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION'
 ];
 
 const setEnv = ( overrides = {} ) => {
@@ -63,6 +64,7 @@ describe( 'worker/configs', () => {
     expect( configs.maxConcurrentWorkflowTaskPolls ).toBe( 5 );
     expect( configs.activityHeartbeatIntervalMs ).toBe( 2 * 60 * 1000 );
     expect( configs.activityHeartbeatEnabled ).toBe( true );
+    expect( configs.enableAttributeSignalEmission ).toBe( false );
     expect( configs.taskQueue ).toBe( 'test-catalog' );
     expect( configs.catalogId ).toBe( 'test-catalog' );
   } );
@@ -118,6 +120,30 @@ describe( 'worker/configs', () => {
     setEnv(); // only OUTPUT_CATALOG_ID; OUTPUT_ACTIVITY_HEARTBEAT_ENABLED absent → default true
     const configsDefault = await loadConfigs();
     expect( configsDefault.activityHeartbeatEnabled ).toBe( true );
+  } );
+
+  it( 'OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION: "true"|"1"|"on" → true', async () => {
+    for ( const val of [ 'true', '1', 'on' ] ) {
+      setEnv( { OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION: val } );
+      const configs = await loadConfigs();
+      expect( configs.enableAttributeSignalEmission ).toBe( true );
+      clearEnv();
+    }
+  } );
+
+  it( 'OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION: "false"|other → false, undefined → false (default off)', async () => {
+    setEnv( { OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION: 'false' } );
+    const configsFalse = await loadConfigs();
+    expect( configsFalse.enableAttributeSignalEmission ).toBe( false );
+
+    setEnv( { OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION: '0' } );
+    const configsZero = await loadConfigs();
+    expect( configsZero.enableAttributeSignalEmission ).toBe( false );
+
+    clearEnv();
+    setEnv(); // only OUTPUT_CATALOG_ID; OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION absent → default false
+    const configsDefault = await loadConfigs();
+    expect( configsDefault.enableAttributeSignalEmission ).toBe( false );
   } );
 
   it( 'parses TEMPORAL_ADDRESS and TEMPORAL_NAMESPACE', async () => {

--- a/sdk/core/src/worker/interceptors/activity.js
+++ b/sdk/core/src/worker/interceptors/activity.js
@@ -3,7 +3,7 @@ import { Storage } from '#async_storage';
 import * as Tracing from '#tracing';
 import { headersToObject } from '../sandboxed_utils.js';
 import { BusEventType, METADATA_ACCESS_SYMBOL, Signal } from '#consts';
-import { activityHeartbeatEnabled, activityHeartbeatIntervalMs, namespace } from '../configs.js';
+import { activityHeartbeatEnabled, activityHeartbeatIntervalMs, enableAttributeSignalEmission, namespace } from '../configs.js';
 import { messageBus } from '#bus';
 import { Client } from '@temporalio/client';
 import { createChildLogger } from '#logger';
@@ -81,6 +81,9 @@ export class ActivityExecutionInterceptor {
     };
 
     const sendAttributeSignal = attribute => {
+      if ( !enableAttributeSignalEmission ) {
+        return;
+      }
       attribute.setActivity( id, name );
       state.signals.push(
         workflowHandle

--- a/sdk/core/src/worker/interceptors/activity.spec.js
+++ b/sdk/core/src/worker/interceptors/activity.spec.js
@@ -85,6 +85,9 @@ vi.mock( '../configs.js', () => ( {
   get activityHeartbeatIntervalMs() {
     return parseInt( process.env.OUTPUT_ACTIVITY_HEARTBEAT_INTERVAL_MS || '120000', 10 );
   },
+  get enableAttributeSignalEmission() {
+    return process.env.OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION === 'true';
+  },
   get namespace() {
     return process.env.TEMPORAL_NAMESPACE || 'default';
   }
@@ -111,6 +114,8 @@ describe( 'ActivityExecutionInterceptor', () => {
     // Default: heartbeat enabled with 50ms interval for fast tests
     vi.stubEnv( 'OUTPUT_ACTIVITY_HEARTBEAT_ENABLED', 'true' );
     vi.stubEnv( 'OUTPUT_ACTIVITY_HEARTBEAT_INTERVAL_MS', '50' );
+    // Default: attribute signal emission enabled so existing tests can verify signal-sending behaviour
+    vi.stubEnv( 'OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION', 'true' );
   } );
 
   afterEach( () => {
@@ -217,6 +222,24 @@ describe( 'ActivityExecutionInterceptor', () => {
     expect( attribute.setActivity ).toHaveBeenCalledWith( 'act-1', 'myWorkflow#myStep' );
     expect( workflowHandleMock.signal ).toHaveBeenCalledWith( Signal.ADD_ATTRIBUTE, attribute );
     expect( allSettledWithTimeoutMock ).toHaveBeenCalledWith( [ expect.any( Promise ) ], 30_000 );
+  } );
+
+  it( 'does not signal when OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION is false', async () => {
+    vi.stubEnv( 'OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION', 'false' );
+    const attribute = { setActivity: vi.fn() };
+    runWithContextMock.mockImplementationOnce( async ( fn, ctx ) => {
+      ctx.sendAttributeSignal( attribute );
+      return fn();
+    } );
+    const { ActivityExecutionInterceptor } = await import( './activity.js' );
+    const interceptor = new ActivityExecutionInterceptor( { activities: makeActivities(), workflows: makeWorkflows() } );
+    const next = vi.fn().mockResolvedValue( { result: 'ok' } );
+
+    await expect( interceptor.execute( makeInput(), next ) ).resolves.toEqual( { result: 'ok' } );
+
+    expect( attribute.setActivity ).not.toHaveBeenCalled();
+    expect( workflowHandleMock.signal ).not.toHaveBeenCalled();
+    expect( allSettledWithTimeoutMock ).toHaveBeenCalledWith( [], 30_000 );
   } );
 
   it( 'records trace error event on failed execution', async () => {


### PR DESCRIPTION
## Problem

[#206](https://github.com/growthxai/output/pull/206) introduced per-event Temporal signals (`Signal.ADD_ATTRIBUTE`) so the workflow could collect LLM usage and HTTP request cost data into `attributes`/`aggregations` on the result. Each LLM call and HTTP request fires one signal, and each signal becomes a workflow history event — on workflows with many calls (e.g. the opportunity workflow) this blows up Temporal history and blocks runs from completing end-to-end locally.

## Solution

- New env var `OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION`, **defaulted to `false`**, gates `sendAttributeSignal` in the activity interceptor — `workflowHandle.signal(Signal.ADD_ATTRIBUTE, …)` is never called when off, so no `ADD_ATTRIBUTE` events accumulate in history.
- Workflow result shape preserved — `attributes` is `[]` and `aggregations` is zeroed when the flag is off. No API contract break; `cost:llm:request` / `cost:http:request` hooks simply don't fire.
- Set `OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION=true` on the worker to opt back in.

Temporary escape hatch while the emission architecture is redesigned.

Ref: [COS-585](https://linear.app/growthx/issue/COS-585)

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` — affected suites in `sdk/core/src/worker/configs.spec.js` and `sdk/core/src/worker/interceptors/activity.spec.js` pass (23/23), including new default-off parse coverage and a "signal not fired when disabled" assertion
- [ ] Manual smoke: run the opportunity workflow locally with the default (emission off) and confirm history no longer blows up