### PR TITLE
update workflowIdConflictPolicy fix possible catalog startup crash when multiple worker instances start simultaneously

### DIFF
--- a/.changeset/lovely-nights-kneel.md
+++ b/.changeset/lovely-nights-kneel.md
@@ -1,0 +1,5 @@
+---
+"@outputai/core": patch
+---
+
+update workflowIdConflictPolicy fix possible catalog startup crash when multiple worker instances start simultaneously

--- a/sdk/core/src/worker/start_catalog.js
+++ b/sdk/core/src/worker/start_catalog.js
@@ -30,7 +30,7 @@ export const startCatalog = async ( { connection, namespace, catalog } ) => {
   await client.workflow.start( WORKFLOW_CATALOG, {
     taskQueue,
     workflowId: catalogId, // use the name of the task queue as the catalog name, ensuring uniqueness
-    workflowIdConflictPolicy: WorkflowIdConflictPolicy.FAIL,
+    workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
     args: [ catalog ]
   } );
 };

--- a/sdk/core/src/worker/start_catalog.spec.js
+++ b/sdk/core/src/worker/start_catalog.spec.js
@@ -28,7 +28,7 @@ vi.mock( '@temporalio/client', async importOriginal => {
   };
 } );
 
-vi.mock( '@temporalio/common', () => ( { WorkflowIdConflictPolicy: { FAIL: 'FAIL' } } ) );
+vi.mock( '@temporalio/common', () => ( { WorkflowIdConflictPolicy: { USE_EXISTING: 'USE_EXISTING' } } ) );
 
 describe( 'worker/start_catalog', () => {
   const mockConnection = {};
@@ -54,7 +54,7 @@ describe( 'worker/start_catalog', () => {
     expect( workflowStartMock ).toHaveBeenCalledWith( 'catalog', {
       taskQueue,
       workflowId: catalogId,
-      workflowIdConflictPolicy: 'FAIL',
+      workflowIdConflictPolicy: 'USE_EXISTING',
       args: [ catalog ]
     } );
   } );
@@ -72,7 +72,7 @@ describe( 'worker/start_catalog', () => {
     expect( workflowStartMock ).toHaveBeenCalledWith( 'catalog', {
       taskQueue,
       workflowId: catalogId,
-      workflowIdConflictPolicy: 'FAIL',
+      workflowIdConflictPolicy: 'USE_EXISTING',
       args: [ catalog ]
     } );
   } );
@@ -90,7 +90,7 @@ describe( 'worker/start_catalog', () => {
     expect( workflowStartMock ).toHaveBeenCalledWith( 'catalog', {
       taskQueue,
       workflowId: catalogId,
-      workflowIdConflictPolicy: 'FAIL',
+      workflowIdConflictPolicy: 'USE_EXISTING',
       args: [ catalog ]
     } );
   } );
@@ -111,7 +111,7 @@ describe( 'worker/start_catalog', () => {
     expect( workflowStartMock ).toHaveBeenCalledWith( 'catalog', {
       taskQueue,
       workflowId: catalogId,
-      workflowIdConflictPolicy: 'FAIL',
+      workflowIdConflictPolicy: 'USE_EXISTING',
       args: [ catalog ]
     } );
   } );


### PR DESCRIPTION
In certain auto scaling scenarios, or a deploy of many instances at once, there can be a race condition where multiple workers simultaneously try to shut down the previous catalog and replace it with their own, instead of 1 by 1 replacing the one before it. When that happens, instances fail and exit, which looks bad. At least in Render, the auto scaler keeps trying though, and eventually we get to the number we want, because eventually multiple worker instances aren't trying to complete the same `catalogId` workflow and then start their own, only to have 1 winner and a bunch of losers hit this `FAIL`:

https://github.com/growthxai/output/blob/0eeffece25b6f471c48b705a214471164b8c5946/sdk/core/src/worker/start_catalog.js#L33

Replace that `FAIL` with `USE_EXISTING` to gracefully handle the rare(-ish) race condition. 

Claude's explanation below: 
<details>

# Catalog startup with USE_EXISTING

## Serial startup (instances staggered)

Each instance: describe() → existing catalog running → executeUpdate('complete') → closes it (COMPLETED) → start() with USE_EXISTING → starts fresh
catalog.

The next instance finds the fresh catalog, completes it, starts another. Each instance hands off cleanly. Same behavior as before.

---
## Simultaneous startup (N instances race)

All N instances call describe() at the same time, all see the same running catalog. All call executeUpdate('complete') — first one closes it, rest get an
error caught silently. All call start() with USE_EXISTING — first one starts a fresh catalog, the rest attach to it.

This is the fix. Previously FAIL crashed the rest. USE_EXISTING lets them attach instead.

---
## Rolling deploy (Deploy A running, Deploy B rolls out)

Deploy B instances complete Deploy A's catalog via describe/complete, then start a fresh catalog among themselves using USE_EXISTING. When Deploy A
instances shut down (worker.shutdown(), no catalog interaction), Deploy A's catalog is already gone — Deploy B owns a fresh one and continues handling its
tasks.

---
## Scale down

The catalog is a Temporal workflow, not a process running inside a worker. When instances shut down they stop polling the task queue — they don't touch
the catalog. Remaining instances continue handling it.

---
## Why USE_EXISTING is safe

The describe/complete block always runs first. By the time any instance calls start(), the old catalog is already closed and the slot is empty (or another
instance just filled it). USE_EXISTING only matters when two instances reach start() simultaneously against that empty slot — first one starts fresh, the
rest attach. All racing instances run the same code and would produce identical catalog content, so attaching to the winner's catalog is correct.


</details>

See prior PRs at https://github.com/growthxai/output/pull/125 and https://github.com/growthxai/output/pull/138 which both were not merged but probably described similar if not the same troubles.