### PR TITLE
fix(core): honor FatalError/ValidationError as non-retryable from steps

### DIFF
--- a/sdk/core/src/errors.js
+++ b/sdk/core/src/errors.js
@@ -6,9 +6,26 @@
 /**
  * Any generic fatal errors
  */
-export class FatalError extends Error { }
+export class FatalError extends Error {
+  // Set the instance `.name` to the class name. Temporal's default failure
+  // converter types an activity's ApplicationFailure from the thrown error's
+  // `.name`, and that type is what `nonRetryableErrorTypes` matches against.
+  // Without this, `name` inherits "Error", so a FatalError thrown from a STEP
+  // never matches `nonRetryableErrorTypes: ["FatalError"]` and gets retried.
+  constructor( ...args ) {
+    super( ...args );
+    this.name = 'FatalError';
+  }
+}
 
 /**
  * Any validation error
  */
-export class ValidationError extends Error { }
+export class ValidationError extends Error {
+  // See FatalError above — the instance `.name` must equal the class name so
+  // the activity failure converter tags it as non-retryable.
+  constructor( ...args ) {
+    super( ...args );
+    this.name = 'ValidationError';
+  }
+}

--- a/sdk/core/src/errors.spec.js
+++ b/sdk/core/src/errors.spec.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { FatalError, ValidationError } from './errors.js';
+
+// Regression: the instance `.name` must equal the class name. Temporal's
+// default activity failure converter types the ApplicationFailure from the
+// thrown error's `.name`, and that type is matched against
+// `nonRetryableErrorTypes`. If `.name` falls back to the inherited "Error",
+// a FatalError/ValidationError thrown from a step is retried instead of
+// failing fast.
+describe( 'errors', () => {
+  describe( 'FatalError', () => {
+    it( 'sets name to the class name so it matches nonRetryableErrorTypes', () => {
+      expect( new FatalError( 'boom' ).name ).toBe( 'FatalError' );
+    } );
+
+    it( 'preserves the message and is an Error', () => {
+      const error = new FatalError( 'boom' );
+      expect( error ).toBeInstanceOf( Error );
+      expect( error.message ).toBe( 'boom' );
+    } );
+  } );
+
+  describe( 'ValidationError', () => {
+    it( 'sets name to the class name so it matches nonRetryableErrorTypes', () => {
+      expect( new ValidationError( 'bad input' ).name ).toBe( 'ValidationError' );
+    } );
+
+    it( 'preserves the message and is an Error', () => {
+      const error = new ValidationError( 'bad input' );
+      expect( error ).toBeInstanceOf( Error );
+      expect( error.message ).toBe( 'bad input' );
+    } );
+  } );
+} );


### PR DESCRIPTION
**TL;DR:** A `FatalError` (or `ValidationError`) thrown from a **step** was being retried through the full retry budget instead of failing fast. Root cause: the error's instance `.name` inherited `"Error"`, so it never matched `nonRetryableErrorTypes: ["FatalError"]`. Fix sets `this.name` in both error constructors.

<details><summary>Why</summary>

Temporal's default activity failure converter types an `ApplicationFailure` from the thrown error's **instance** `.name`, and that `type` is what `nonRetryableErrorTypes` is matched against.

- `FatalError`/`ValidationError` were `class extends Error {}` with no `this.name` — so an *instance* had `.name === "Error"` (the static class `.name` is `"FatalError"`, but the converter reads the instance).
- The activity interceptor (`worker/interceptors/activity.js`) re-throws the raw error, so it reaches the default converter as type `"Error"` → no match → **retried**.
- The **workflow** interceptor (`worker/interceptors/workflow.js`) was unaffected — it wraps with `new ApplicationFailure(msg, error.constructor.name, …)` (`"FatalError"`). So only **step-thrown** fatals (where all I/O lives) hit the bug.

Since nearly all `FatalError`s are thrown from steps, "fatal" errors were effectively retryable everywhere.

</details>

<details><summary>Prod evidence</summary>

`gsc_sync` step `fetchAndWriteGscDailyTotals` threw `FatalError` ("Google access token expired or invalid…") and retried through **attempt 6 over ~45 min** (09:10 → 09:55) before failing, instead of failing on attempt 1.

</details>

<details><summary>Fix</summary>

Set `this.name` to the class name in both error constructors. Chosen over wrapping in the activity interceptor because it's one line per class and also fixes any client-side `instanceof`/name checks. Adds `errors.spec.js`.

</details>

<details><summary>Testing</summary>

`errors.spec.js` (4 tests) passes. The rest of the `sdk/core` suite has pre-existing failures from missing workspace deps (`decimal.js`, `folder-hash`, `json-stream-stringify` not installed locally) — unrelated to this change; CI installs them.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)