### PR TITLE
feat(core): Adding recursive error serialization to trace files

### DIFF
--- a/.changeset/sour-parks-rule.md
+++ b/.changeset/sour-parks-rule.md
@@ -1,0 +1,21 @@
+---
+"@outputai/core": patch
+---
+
+Improve trace error serialization to preserve nested error causes. Error entries in trace files now include the error `name`, `message`, `stack`, and recursively serialized `cause` values up to 10 levels deep, including JSON-safe non-Error causes where present.
+
+```js
+{
+  name: "from error.constructor.name",
+  message: "from error.message",
+  stack: "from error.stack",
+  cause: { // from .cause
+    name: "from error.constructor.name",
+    message: "from error.message",
+    stack: "from error.stack",
+    cause: {
+      ... // up to 10 levels
+    }
+  }
+}
+```

--- a/sdk/core/src/internal_utils/errors.spec.js
+++ b/sdk/core/src/internal_utils/errors.spec.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { extractErrorDetail } from './errors.js';
+
+describe( 'extractErrorDetail', () => {
+  it( 'returns a matching value from error details', () => {
+    const error = new Error( 'failed' );
+    error.details = [
+      { requestId: 'req-1' },
+      { workflowId: 'workflow-1' }
+    ];
+
+    expect( extractErrorDetail( error, 'workflowId' ) ).toBe( 'workflow-1' );
+  } );
+
+  it( 'walks the cause chain until it finds matching details', () => {
+    const root = new Error( 'root' );
+    root.details = [ { traceId: 'trace-1' } ];
+    const wrapped = new Error( 'wrapped', { cause: root } );
+
+    expect( extractErrorDetail( wrapped, 'traceId' ) ).toBe( 'trace-1' );
+  } );
+
+  it( 'prefers details from the current error over causes', () => {
+    const root = new Error( 'root' );
+    root.details = [ { traceId: 'root-trace' } ];
+    const wrapped = new Error( 'wrapped', { cause: root } );
+    wrapped.details = [ { traceId: 'wrapped-trace' } ];
+
+    expect( extractErrorDetail( wrapped, 'traceId' ) ).toBe( 'wrapped-trace' );
+  } );
+
+  it( 'returns null when the key is not found', () => {
+    const root = new Error( 'root' );
+    root.details = [ { traceId: 'trace-1' } ];
+    const wrapped = new Error( 'wrapped', { cause: root } );
+
+    expect( extractErrorDetail( wrapped, 'missing' ) ).toBeNull();
+  } );
+
+  it( 'returns null for empty errors', () => {
+    expect( extractErrorDetail( null, 'traceId' ) ).toBeNull();
+  } );
+} );

--- a/sdk/core/src/tracing/tools/utils.js
+++ b/sdk/core/src/tracing/tools/utils.js
@@ -1,3 +1,5 @@
+import { inspect } from 'node:util';
+
 /**
  * @typedef {object} SerializedError
  * @property {string} name - The error constructor name
@@ -6,16 +8,35 @@
  */
 
 /**
- * Serialize an error object.
+ * Recursively Serialize an error object. Navigate using "cause" property.
  *
- * If it has ".cause", recursive serialize its cause until finally found an error without it.
+ * Goes up 10 levels deep.
  *
  * @param {Error} error
  * @returns {SerializedError}
  */
-export const serializeError = error =>
-  error.cause ? serializeError( error.cause ) : {
-    name: error.constructor.name,
-    message: error.message,
-    stack: error.stack
+export const serializeError = ( () => {
+
+  const serializeValue = v => {
+    try {
+      return JSON.parse( JSON.stringify( v ) );
+    } catch {
+      return inspect( v, { depth: 5, breakLength: Infinity, colors: false } );
+    }
   };
+
+  return ( error, depth = 0 ) => {
+    if ( depth > 10 ) {
+      return { name: 'Error', message: 'Cause chain too deep' };
+    }
+    if ( error instanceof Error ) {
+      return {
+        name: error.constructor.name,
+        message: error.message,
+        stack: error.stack,
+        ...( error.cause !== undefined ? { cause: serializeError( error.cause, depth + 1 ) } : {} )
+      };
+    }
+    return serializeValue( error );
+  };
+} )();

--- a/sdk/core/src/tracing/tools/utils.spec.js
+++ b/sdk/core/src/tracing/tools/utils.spec.js
@@ -1,14 +1,83 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { serializeError } from './utils.js';
 
-describe( 'tracing/utils', () => {
-  it( 'serializeError unwraps causes and keeps message/stack', () => {
-    const inner = new Error( 'inner' );
-    const outer = new Error( 'outer', { cause: inner } );
+describe( 'serializeError', () => {
+  it( 'serializes basic Error fields', () => {
+    const error = new Error( 'boom' );
 
-    const out = serializeError( outer );
-    expect( out.name ).toBe( 'Error' );
-    expect( out.message ).toBe( 'inner' );
-    expect( typeof out.stack ).toBe( 'string' );
+    const result = serializeError( error );
+
+    expect( result ).toMatchObject( {
+      name: 'Error',
+      message: 'boom'
+    } );
+    expect( typeof result.stack ).toBe( 'string' );
+    expect( result ).not.toHaveProperty( 'cause' );
+  } );
+
+  it( 'preserves custom error constructor names', () => {
+    class CustomError extends Error {}
+    const error = new CustomError( 'custom boom' );
+
+    expect( serializeError( error ) ).toMatchObject( {
+      name: 'CustomError',
+      message: 'custom boom'
+    } );
+  } );
+
+  it( 'recursively serializes Error causes', () => {
+    const root = new TypeError( 'root failure' );
+    const wrapped = new Error( 'wrapped failure', { cause: root } );
+
+    expect( serializeError( wrapped ) ).toMatchObject( {
+      name: 'Error',
+      message: 'wrapped failure',
+      cause: {
+        name: 'TypeError',
+        message: 'root failure'
+      }
+    } );
+  } );
+
+  it( 'preserves JSON-serializable non-Error causes', () => {
+    const cause = {
+      code: 'bad_input',
+      path: [ 'items', 0, 'title' ],
+      message: 'Expected title'
+    };
+    const error = new Error( 'validation failed', { cause } );
+
+    expect( serializeError( error ) ).toMatchObject( {
+      name: 'Error',
+      message: 'validation failed',
+      cause
+    } );
+  } );
+
+  it( 'falls back to inspect for non-JSON-serializable causes', () => {
+    const cause = { name: 'circular' };
+    cause.self = cause;
+    const error = new Error( 'failed', { cause } );
+
+    const result = serializeError( error );
+
+    expect( result.cause ).toContain( 'circular' );
+    expect( result.cause ).toContain( 'Circular' );
+  } );
+
+  it( 'falls back to inspect for primitive values JSON cannot serialize', () => {
+    expect( serializeError( 1n ) ).toBe( '1n' );
+  } );
+
+  it( 'stops serializing cause chains after the depth limit', () => {
+    const makeErrorChain = depth => depth === 0 ?
+      new Error( 'leaf' ) :
+      new Error( `level ${depth}`, { cause: makeErrorChain( depth - 1 ) } );
+    const getCauseAtDepth = ( error, depth ) => depth === 0 ?
+      error :
+      getCauseAtDepth( error.cause, depth - 1 );
+
+    expect( getCauseAtDepth( serializeError( makeErrorChain( 11 ) ), 11 ) )
+      .toEqual( { name: 'Error', message: 'Cause chain too deep' } );
   } );
 } );


### PR DESCRIPTION
## Summary

Error entries on trace files will have an error serialized recursively, navigating up its `.cause` chain, limited to 10 levels. Previously it was printing only the root-most error (the last error in the `.cause` chain)

### New format:
```json
{
  "name": "Error class",
  "message": "Error message",
  "stack": "Error stack trace",
  "cause": {
    "name": "Parent error class",
    "message": "Parent error message",
    "stack": "Parent error stack trace",
    "cause": {
      ... // up until 10 levels
    }
  }
}
```

### Other files in the PR:
- Missing unit tests;


## Test plan

- [x] unit
- [x] manual
