### PR TITLE
feat(llm): Wrap NoObjectGenerateError in Error with better messages [OUT-263]

### DIFF
--- a/.changeset/tiny-toys-unite.md
+++ b/.changeset/tiny-toys-unite.md
@@ -1,0 +1,9 @@
+---
+"@outputai/llm": patch
+---
+
+Wrap AI SDK `NoObjectGeneratedError` caused by schema validation failures in a new error. This error adds the first validation issue to its `.message`. Example:
+
+```txt
+No object generated: response did not match schema. First issue is "Invalid input: expected string, received number" at path [name].
+```

--- a/sdk/llm/src/utils/error_handler.js
+++ b/sdk/llm/src/utils/error_handler.js
@@ -6,11 +6,36 @@ import {
   LoadAPIKeyError,
   LoadSettingError,
   NoImageGeneratedError,
+  NoObjectGeneratedError,
   NoSuchModelError,
   NoSuchProviderError,
   UnsupportedFunctionalityError
 } from 'ai';
 import { FatalError } from '@outputai/core';
+
+/**
+ * Recursively search an error cause chain until finds an error which is instance of given prototype.
+ *
+ * @param {object} error - Error instance.
+ * @param {Function|string} _class - Target constructor or constructor name.
+ * @param {number} depth - Current depth, search up to 10 causes deep.
+ * @returns {object|null} - Error or null if not found.
+ */
+export const findInstanceInCauseChain = ( error, _class, depth = 0 ) => {
+  if ( !error || typeof error !== 'object' ) {
+    return null;
+  }
+  if ( typeof _class === 'string' && error.constructor.name === _class ) {
+    return error;
+  }
+  if ( typeof _class === 'function' && error instanceof _class ) {
+    return error;
+  }
+  if ( depth >= 10 ) {
+    return null;
+  }
+  return error.cause ? findInstanceInCauseChain( error.cause, _class, depth + 1 ) : null;
+};
 
 const toFatalError = ( error, extraMessage = '' ) => new FatalError(
   `AI-SDK fatal error${extraMessage ? ` (${extraMessage})` : ''}: ${error.message}`,
@@ -21,6 +46,20 @@ export const mapAiError = error => {
   if ( error instanceof FatalError ) {
     return error;
   }
+
+  // NoObjectGeneratedError can be thrown when the response doesn't match the schema
+  // This adds a wrapper to that error serializing the first zod validation in the message, to make it easier to debug.
+  if ( NoObjectGeneratedError.isInstance( error ) && error.message.includes( 'No object generated: response did not match schema.' ) ) {
+    const zodError = findInstanceInCauseChain( error, 'ZodError' );
+    if ( zodError && zodError.issues?.length > 0 ) {
+      const { path, message } = zodError.issues[0];
+      const wrapper = new Error( `${error.message} First issue is "${message}" at path [${path.join( ', ' )}].`, { cause: error } );
+      wrapper.name = 'NoObjectGeneratedError';
+      return wrapper;
+    }
+    return error;
+  }
+
   if ( APICallError.isInstance( error ) && !error.isRetryable ) {
     // Non-retryable API failures are already classified by AI SDK as permanent provider failures.
     return toFatalError( error, error.statusCode ? `HTTP ${error.statusCode}` : '' );

--- a/sdk/llm/src/utils/error_handler.spec.js
+++ b/sdk/llm/src/utils/error_handler.spec.js
@@ -20,7 +20,7 @@ import {
   UnsupportedFunctionalityError
 } from 'ai';
 import { FatalError } from '@outputai/core';
-import { mapAiError } from './error_handler.js';
+import { findInstanceInCauseChain, mapAiError } from './error_handler.js';
 
 const makeApiCallError = ( input = {} ) => new APICallError( {
   message: 'Provider rejected the request',
@@ -130,9 +130,99 @@ const preservedAiSdkErrors = [
   ]
 ];
 
+describe( 'findInstanceInCauseChain', () => {
+  class FirstCustomError extends Error {}
+  class SecondCustomError extends Error {}
+
+  it( 'returns the input error when it matches the target constructor', () => {
+    const error = new FirstCustomError( 'first' );
+
+    expect( findInstanceInCauseChain( error, FirstCustomError ) ).toBe( error );
+  } );
+
+  it( 'returns the input error when it matches the target constructor name', () => {
+    const error = new FirstCustomError( 'first' );
+
+    expect( findInstanceInCauseChain( error, 'FirstCustomError' ) ).toBe( error );
+  } );
+
+  it( 'walks the cause chain to find an error by constructor', () => {
+    const target = new SecondCustomError( 'second' );
+    const wrapper = new FirstCustomError( 'first', { cause: target } );
+
+    expect( findInstanceInCauseChain( wrapper, SecondCustomError ) ).toBe( target );
+  } );
+
+  it( 'walks the cause chain to find an error by constructor name', () => {
+    const target = new SecondCustomError( 'second' );
+    const wrapper = new FirstCustomError( 'first', { cause: target } );
+
+    expect( findInstanceInCauseChain( wrapper, 'SecondCustomError' ) ).toBe( target );
+  } );
+
+  it( 'returns null when the target is not found', () => {
+    const error = new FirstCustomError( 'first', { cause: new Error( 'root' ) } );
+
+    expect( findInstanceInCauseChain( error, SecondCustomError ) ).toBeNull();
+  } );
+
+  it( 'returns null for empty or non-object inputs', () => {
+    expect( findInstanceInCauseChain( null, Error ) ).toBeNull();
+    expect( findInstanceInCauseChain( 'not an error', Error ) ).toBeNull();
+  } );
+
+  it( 'stops searching after the depth limit', () => {
+    const makeErrorChain = depth => depth === 0 ?
+      new SecondCustomError( 'target' ) :
+      new FirstCustomError( `level ${depth}`, { cause: makeErrorChain( depth - 1 ) } );
+
+    expect( findInstanceInCauseChain( makeErrorChain( 11 ), SecondCustomError ) ).toBeNull();
+  } );
+} );
+
 describe( 'mapAiError', () => {
   it( 'preserves existing FatalError instances', () => {
     const error = new FatalError( 'Already fatal' );
+
+    expect( mapAiError( error ) ).toBe( error );
+  } );
+
+  it( 'adds first schema issue details to NoObjectGeneratedError schema mismatches', () => {
+    class ZodError extends Error {
+      constructor( issues ) {
+        super( 'schema failed' );
+        this.issues = issues;
+      }
+    }
+    const zodError = new ZodError( [
+      {
+        path: [ 'items', 0, 'title' ],
+        message: 'Expected string'
+      }
+    ] );
+    const validationError = new Error( 'validation failed', { cause: zodError } );
+    const error = new NoObjectGeneratedError( {
+      message: 'No object generated: response did not match schema.',
+      text: '{"items":[{}]}',
+      cause: validationError
+    } );
+
+    const result = mapAiError( error );
+
+    expect( result ).not.toBe( error );
+    expect( result.name ).toBe( 'NoObjectGeneratedError' );
+    expect( result.message ).toBe(
+      'No object generated: response did not match schema. First issue is "Expected string" at path [items, 0, title].'
+    );
+    expect( result.cause ).toBe( error );
+  } );
+
+  it( 'preserves NoObjectGeneratedError schema mismatches when no schema issue is available', () => {
+    const error = new NoObjectGeneratedError( {
+      message: 'No object generated: response did not match schema.',
+      text: '{"items":[{}]}',
+      cause: new Error( 'validation failed' )
+    } );
 
     expect( mapAiError( error ) ).toBe( error );
   } );

--- a/test_workflows/src/workflows/invalid_schema/invalid_schema@v1.prompt
+++ b/test_workflows/src/workflows/invalid_schema/invalid_schema@v1.prompt
@@ -1,0 +1,14 @@
+---
+provider: anthropic
+model: claude-haiku-4-5
+temperature: 0
+maxTokens: 1000
+---
+
+<assistant>
+Return a concise structured response.
+</assistant>
+
+<user>
+Return an object with the answer field set to any short string.
+</user>

--- a/test_workflows/src/workflows/invalid_schema/steps.ts
+++ b/test_workflows/src/workflows/invalid_schema/steps.ts
@@ -1,0 +1,20 @@
+import { step, z } from '@outputai/core';
+import { generateText, Output } from '@outputai/llm';
+
+const impossibleOutputSchema = z.object( {
+  answer: z.string().refine( () => false, 'This schema is intentionally impossible to satisfy.' )
+} );
+
+export const generateInvalidSchemaOutput = step( {
+  name: 'generateInvalidSchemaOutput',
+  description: 'Forces an AI SDK structured output validation failure',
+  outputSchema: impossibleOutputSchema,
+  fn: async () => {
+    const { output } = await generateText( {
+      prompt: 'invalid_schema@v1',
+      output: Output.object( { schema: impossibleOutputSchema } )
+    } );
+
+    return output;
+  }
+} );

--- a/test_workflows/src/workflows/invalid_schema/workflow.ts
+++ b/test_workflows/src/workflows/invalid_schema/workflow.ts
@@ -1,0 +1,13 @@
+import { workflow, z } from '@outputai/core';
+import { generateInvalidSchemaOutput } from './steps.js';
+
+const outputSchema = z.object( {
+  answer: z.string()
+} );
+
+export default workflow( {
+  name: 'invalid_schema',
+  description: 'A workflow that intentionally triggers AI SDK output schema validation failure',
+  outputSchema,
+  fn: async () => generateInvalidSchemaOutput()
+} );


### PR DESCRIPTION
## Summary

Wrap AI SDK `NoObjectGeneratedError` caused by schema validation failures in a new error. This error adds the first validation issue to its `.message`. Example:

```txt
No object generated: response did not match schema. First issue is "Invalid input: expected string, received number" at path [name].
```

### Temporal Workflow failure:
<img width="854" height="340" alt="image" src="https://github.com/user-attachments/assets/d1d9496b-4ff4-4e79-9f0b-e17791018e72" />


## Test plan

- [x] Manual
- [x] unit
