### PR TITLE
refactor(llm): Better NoGeneratedObjectError handling

### DIFF
--- a/.changeset/tiny-toys-unite.md
+++ b/.changeset/tiny-toys-unite.md
@@ -2,7 +2,7 @@
 "@outputai/llm": patch
 ---
 
-Wrap AI SDK `NoObjectGeneratedError` caused by schema validation failures in a new error. This error adds the first validation issue to its `.message`. Example:
+Recreate AI SDK `NoObjectGeneratedError` schema validation failures as new `NoObjectGeneratedError` instances with a clearer message:
 
 ```txt
 No object generated: response did not match schema. First issue is "Invalid input: expected string, received number" at path [name].

--- a/sdk/llm/src/utils/error_handler.js
+++ b/sdk/llm/src/utils/error_handler.js
@@ -48,10 +48,9 @@ const toFatalError = ( error, extraMessage = '' ) => new FatalError(
 /**
  * Map an AI SDK error to a framework specific error:
  *
- * Unrecoverable errors become FatalErrors.
- *
- * NoObjectGeneratedError from invalid schema are reinitialized with a better message.
- *
+ * - AI SDK Unrecoverable errors become FatalErrors, check code to see options.
+ * - NoObjectGeneratedError from invalid schema are reinitialized with a better message.
+ * - Other errors are preserved.
  * @param {object} error - Original Error
  * @returns {object} A new Error
  */

--- a/sdk/llm/src/utils/error_handler.js
+++ b/sdk/llm/src/utils/error_handler.js
@@ -13,6 +13,9 @@ import {
 } from 'ai';
 import { FatalError } from '@outputai/core';
 
+// AI SDK does not expose a dedicated schema-mismatch discriminator for NoObjectGeneratedError.
+const NO_OBJECT_SCHEMA_MISMATCH_MESSAGE = 'No object generated: response did not match schema.';
+
 /**
  * Recursively search an error cause chain until finds an error which is instance of given prototype.
  *
@@ -25,7 +28,7 @@ export const findInstanceInCauseChain = ( error, _class, depth = 0 ) => {
   if ( !error || typeof error !== 'object' ) {
     return null;
   }
-  if ( typeof _class === 'string' && error.constructor.name === _class ) {
+  if ( typeof _class === 'string' && error.constructor?.name === _class ) {
     return error;
   }
   if ( typeof _class === 'function' && error instanceof _class ) {
@@ -42,20 +45,35 @@ const toFatalError = ( error, extraMessage = '' ) => new FatalError(
   { cause: error }
 );
 
+/**
+ * Map an AI SDK error to a framework specific error:
+ *
+ * Unrecoverable errors become FatalErrors.
+ *
+ * NoObjectGeneratedError from invalid schema are reinitialized with a better message.
+ *
+ * @param {object} error - Original Error
+ * @returns {object} A new Error
+ */
 export const mapAiError = error => {
   if ( error instanceof FatalError ) {
     return error;
   }
 
-  // NoObjectGeneratedError can be thrown when the response doesn't match the schema
-  // This adds a wrapper to that error serializing the first zod validation in the message, to make it easier to debug.
-  if ( NoObjectGeneratedError.isInstance( error ) && error.message.includes( 'No object generated: response did not match schema.' ) ) {
+  // NoObjectGeneratedError can be thrown when the response doesn't match the schema.
+  // This re-creates the error with a better message, making it easier to debug.
+  if ( NoObjectGeneratedError.isInstance( error ) && error.message.includes( NO_OBJECT_SCHEMA_MISMATCH_MESSAGE ) ) {
     const zodError = findInstanceInCauseChain( error, 'ZodError' );
     if ( zodError && zodError.issues?.length > 0 ) {
-      const { path, message } = zodError.issues[0];
-      const wrapper = new Error( `${error.message} First issue is "${message}" at path [${path.join( ', ' )}].`, { cause: error } );
-      wrapper.name = 'NoObjectGeneratedError';
-      return wrapper;
+      const [ { path, message } ] = zodError.issues;
+      return new NoObjectGeneratedError( {
+        message: `${error.message} First issue is "${message}" at path [${path.join( ', ' )}].`,
+        cause: error.cause,
+        text: error.text,
+        response: error.response,
+        usage: error.usage,
+        finishReason: error.finishReason
+      } );
     }
     return error;
   }

--- a/sdk/llm/src/utils/error_handler.spec.js
+++ b/sdk/llm/src/utils/error_handler.spec.js
@@ -171,6 +171,13 @@ describe( 'findInstanceInCauseChain', () => {
     expect( findInstanceInCauseChain( 'not an error', Error ) ).toBeNull();
   } );
 
+  it( 'returns null for object causes without constructors', () => {
+    const cause = Object.create( null );
+    const error = new FirstCustomError( 'first', { cause } );
+
+    expect( findInstanceInCauseChain( error, 'SecondCustomError' ) ).toBeNull();
+  } );
+
   it( 'stops searching after the depth limit', () => {
     const makeErrorChain = depth => depth === 0 ?
       new SecondCustomError( 'target' ) :
@@ -204,17 +211,25 @@ describe( 'mapAiError', () => {
     const error = new NoObjectGeneratedError( {
       message: 'No object generated: response did not match schema.',
       text: '{"items":[{}]}',
+      response: { id: 'response-1' },
+      usage: { totalTokens: 10 },
+      finishReason: 'stop',
       cause: validationError
     } );
 
     const result = mapAiError( error );
 
     expect( result ).not.toBe( error );
-    expect( result.name ).toBe( 'NoObjectGeneratedError' );
+    expect( NoObjectGeneratedError.isInstance( result ) ).toBe( true );
+    expect( result.name ).toBe( 'AI_NoObjectGeneratedError' );
     expect( result.message ).toBe(
       'No object generated: response did not match schema. First issue is "Expected string" at path [items, 0, title].'
     );
-    expect( result.cause ).toBe( error );
+    expect( result.cause ).toBe( validationError );
+    expect( result.text ).toBe( error.text );
+    expect( result.response ).toBe( error.response );
+    expect( result.usage ).toBe( error.usage );
+    expect( result.finishReason ).toBe( error.finishReason );
   } );
 
   it( 'preserves NoObjectGeneratedError schema mismatches when no schema issue is available', () => {


### PR DESCRIPTION
## Summary

Follow up to https://github.com/growthxai/output/pull/245. This keeps the same idea but creates a copy of AI SDK's. `NoGeneratedObjectError` with the better message, so to keep all other properties and support to `.isInstance()`.

## Test plan

- [x] unit
- [x] manual
