### PR TITLE
feat(credentials): asymmetric (sealed) credentials mode

### DIFF
--- a/.changeset/sealed-credentials.md
+++ b/.changeset/sealed-credentials.md
@@ -1,0 +1,44 @@
+---
+"@outputai/credentials": minor
+"@outputai/cli": minor
+---
+
+## Asymmetric (sealed) credentials
+
+Adds an opt-in **sealed** credentials mode alongside the existing symmetric scheme.
+Sealed credentials are encrypted to a **committed public key** and decrypted with a
+**private key that only the runtime needs** — so contributors can add credentials
+without any secret on their machine, and there is no secret encryption key to
+misconfigure.
+
+Each value is sealed individually (libsodium `crypto_box_seal`-style: ephemeral X25519
+ECDH → HKDF-SHA256 → AES-256-GCM), so the credential file is plain YAML with visible
+keys and `sealed:` values plus a `__format__`/`__recipient__` header.
+
+**`@outputai/credentials`**
+- New crypto/format API: `generateKeypair`, `publicKeyFromPrivate`, `seal`, `open`,
+  `sealTree`, `openTree`, `resealTree`, `detectFormat`, `parseSealedDocument`,
+  `serializeSealedDocument`, `openSealedDocument`, `isSealedValue`, `isValidKeyHex`, and
+  `resolvePublicKeyPath` / `resolveWorkflowPublicKeyPath`.
+- The provider auto-detects sealed files and opens them with the configured private key.
+  The recipient header is mandatory and must match the key, so a wrong or missing key
+  fails fast with `SealedRecipientMismatchError` (never opens blindly). `seal` validates
+  the recipient public key and `open` rejects malformed tokens. Legacy symmetric files
+  keep working unchanged.
+
+**`@outputai/cli`**
+- `output credentials init --sealed` — generate a keypair, write the gitignored private
+  key and the committed public key, and create a sealed file.
+- `output credentials set` — seals the value with the public key; no private key needed.
+- `output credentials verify` — verifies a file was sealed for the committed public key.
+  This check needs **no secret**, so it is safe to run in CI.
+- `output credentials migrate --to-sealed` — convert a legacy symmetric file to sealed
+  form and emit the new private key to configure in the runtime. Writes are atomic with
+  rollback so a failed migration is non-destructive, and key files are written `0600`.
+- `edit` / `show` / `get` transparently support sealed files (private key required).
+  `edit` preserves the ciphertext of unchanged values so a single edit only diffs what
+  actually changed.
+
+Because the public key is committed, anyone with repo write access can add a credential
+value (but not read existing ones). Guard the credential files with CODEOWNERS + branch
+protection; see the operations guide. The key-free `verify` command is safe to run in CI.

--- a/docs/guides/operations/credentials.mdx
+++ b/docs/guides/operations/credentials.mdx
@@ -183,6 +183,92 @@ stripe:
 `--environment` and `--workflow` are mutually exclusive flags. Environment scoping applies at the global level; workflow scoping applies per-workflow.
 </Note>
 
+## Sealed (Asymmetric) Credentials
+
+The default scheme is **symmetric**: one key both encrypts and decrypts, so everyone who edits credentials needs that secret, and a file encrypted with the wrong key only fails — silently — at runtime in production.
+
+**Sealed credentials** are an opt-in asymmetric alternative. A keypair splits the two roles:
+
+- The **public key** encrypts and is **committed** to the repo. There is no secret encryption key to misconfigure, and anyone can add a credential without holding a secret.
+- The **private key** only decrypts and lives **only in the runtime** (and your secret manager). It never needs to be on a contributor's machine.
+
+Each value is sealed individually (an ephemeral-key `crypto_box_seal`-style construction over X25519 + AES-256-GCM), so the file is plain YAML with visible keys and `sealed:` values:
+
+```yaml
+# config/credentials/production.yml.enc (sealed)
+__format__: sealed-v1
+__recipient__: 29964e49...        # the committed public key
+anthropic:
+  api_key: "sealed:BcqmP+jqI2N2..."
+openai:
+  api_key: "sealed:fCkZn2jgrRSW..."
+```
+
+Credential **names** are visible (they aren't secret); only **values** are encrypted.
+
+### Initialize
+
+```bash
+output credentials init --sealed --environment production
+```
+
+This writes three files:
+- `config/credentials/production.key` — the **private** key (gitignore this)
+- `config/credentials/production.pub` — the **public** key (**commit** this)
+- `config/credentials/production.yml.enc` — the sealed credentials (commit this)
+
+### Add credentials without a secret
+
+`set` seals the value with the committed public key — no private key required:
+
+```bash
+output credentials set anthropic.api_key sk-ant-xxxxx --environment production
+```
+
+`edit`, `show`, and `get` work the same as before, but require the private key (they decrypt).
+
+### Controlling who can change credentials
+
+Sealing is deliberately a public operation: because the encryption key is committed, **anyone who can write to the repo can add or change a credential value** (they can't read existing values — that still needs the private key). This is the trade-off for letting contributors add secrets without holding one. With the symmetric scheme, only key-holders could write.
+
+Move that write-control to the repo, where it belongs. Protect the credentials files with branch protection and ownership:
+
+```text
+# .github/CODEOWNERS
+config/credentials/**  @your-org/secrets-admins
+config/credentials.yml.enc  @your-org/secrets-admins
+config/credentials.pub  @your-org/secrets-admins
+```
+
+Then on the default branch, require pull-request review (so a CODEOWNERS approval is mandatory for any credential change), and require signed commits so a change is attributable. Pair this with the key-free `verify` check below in CI to catch a wrong-key commit. The private key stays out of the repo entirely, so even a malicious write can only *add* a value sealed to the canonical key — never exfiltrate an existing one.
+
+### Verify — a key-free CI check
+
+Because the encryption identity is public, you can confirm a file was sealed for the canonical key **without any secret**, which makes it safe for CI:
+
+```bash
+output credentials verify --environment production
+```
+
+It checks the file's `__recipient__` against the committed `.pub`. If a private key is also available (e.g. in the runtime), it additionally confirms every value opens. Add it to CI to catch a wrong-key commit before it ever deploys:
+
+```yaml
+# GitHub Actions — no secret needed
+- run: output credentials verify --environment production
+```
+
+At runtime, the wrong private key fails fast with a `SealedRecipientMismatchError` at load, instead of a generic decrypt error surfaced lazily on first use.
+
+### Migrate an existing file
+
+Convert a legacy symmetric file in place. This decrypts with the current key, generates a keypair, seals every value, and prints the new private key to configure in your runtime:
+
+```bash
+output credentials migrate --to-sealed --environment production
+```
+
+The runtime private key uses the **same** env var as before (`OUTPUT_CREDENTIALS_KEY_PRODUCTION`) — it now holds the X25519 private key. Legacy symmetric files keep working unchanged, so migration is per-environment and optional.
+
 ## Deploying to Production
 
 In local development, the `.key` files on disk handle decryption. In production, CI/CD, and Docker — where you don't have key files — set the decryption key as an environment variable.

--- a/docs/guides/packages/credentials.mdx
+++ b/docs/guides/packages/credentials.mdx
@@ -14,8 +14,13 @@ import {
   // Credential access
   credentials,
 
-  // Encryption utilities
+  // Encryption utilities (symmetric)
   encrypt, decrypt, generateKey,
+
+  // Sealed (asymmetric) credentials
+  generateKeypair, publicKeyFromPrivate, seal, open,
+  sealTree, openTree, detectFormat,
+  parseSealedDocument, serializeSealedDocument,
 
   // Provider system
   setProvider, getProvider,
@@ -23,9 +28,10 @@ import {
 
   // Error types
   MissingCredentialError, MissingKeyError,
+  SealedRecipientMismatchError, SealedValueError,
 
   // Path resolution
-  resolveCredentialsPath, resolveKeyPath, resolveKeyEnvVar,
+  resolveCredentialsPath, resolveKeyPath, resolveKeyEnvVar, resolvePublicKeyPath,
   resolveWorkflowCredentialsPath, resolveWorkflowKeyPath, resolveWorkflowKeyEnvVar,
   getNestedValue
 } from '@outputai/credentials';
@@ -34,12 +40,15 @@ import {
 | Export | Description |
 |--------|-------------|
 | `credentials` | Read credentials via dot-notation paths (`get`, `require`) |
-| `encrypt` / `decrypt` / `generateKey` | Low-level AES-256-GCM encryption utilities |
+| `encrypt` / `decrypt` / `generateKey` | Low-level AES-256-GCM encryption utilities (symmetric) |
+| `generateKeypair` / `seal` / `open` | Asymmetric (sealed) credentials: a public key seals values, a private key opens them |
+| `sealTree` / `openTree` / `detectFormat` | Seal or open a whole credential tree; detect sealed vs legacy files |
 | `setProvider` / `getProvider` | Swap the credential storage backend |
-| `encryptedYamlProvider` | Default provider: encrypted YAML files on disk |
+| `encryptedYamlProvider` | Default provider: encrypted YAML files on disk (symmetric and sealed) |
 | `MissingCredentialError` | Thrown by `credentials.require()` when a path has no value |
 | `MissingKeyError` | Thrown when no decryption key can be found |
-| `resolveCredentialsPath` / `resolveKeyPath` / ... | Path resolution helpers for credentials and key files |
+| `SealedRecipientMismatchError` | Thrown when the private key does not match a sealed file's recipient |
+| `resolveCredentialsPath` / `resolveKeyPath` / `resolvePublicKeyPath` / ... | Path resolution helpers for credentials, key, and public-key files |
 
 ## Quick Start
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,6 +331,12 @@ importers:
       '@noble/ciphers':
         specifier: 2.2.0
         version: 2.2.0
+      '@noble/curves':
+        specifier: 2.2.0
+        version: 2.2.0
+      '@noble/hashes':
+        specifier: 2.2.0
+        version: 2.2.0
       '@outputai/core':
         specifier: 'workspace:'
         version: link:../core
@@ -1870,9 +1876,17 @@ packages:
     resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
     engines: {node: '>= 20.19.0'}
 
+  '@noble/curves@2.2.0':
+    resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
+    engines: {node: '>= 20.19.0'}
+
   '@noble/hashes@1.8.0':
     resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
@@ -2172,7 +2186,7 @@ packages:
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react: 19.2.4
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -9762,7 +9776,13 @@ snapshots:
 
   '@noble/ciphers@2.2.0': {}
 
+  '@noble/curves@2.2.0':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
   '@noble/hashes@1.8.0': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@nodable/entities@2.1.0': {}
 

--- a/sdk/cli/src/commands/credentials/init.spec.ts
+++ b/sdk/cli/src/commands/credentials/init.spec.ts
@@ -14,6 +14,12 @@ describe( 'credentials init command', () => {
       credPath: '/project/config/credentials.yml.enc'
     } );
     vi.mocked( credentialsService.resolveKeyPath ).mockReturnValue( '/project/config/credentials.key' );
+    vi.mocked( credentialsService.initSealed ).mockReturnValue( {
+      keyPath: '/project/config/credentials.key',
+      credPath: '/project/config/credentials.yml.enc',
+      pubPath: '/project/config/credentials.pub',
+      publicKey: 'a'.repeat( 64 )
+    } );
   } );
 
   afterEach( () => {
@@ -79,6 +85,15 @@ describe( 'credentials init command', () => {
       await cmd.run();
 
       expect( credentialsService.initCredentials ).toHaveBeenCalled();
+    } );
+
+    it( 'should call initSealed and log public-key guidance with --sealed', async () => {
+      const cmd = createTestCommand( { sealed: true } );
+      await cmd.run();
+
+      expect( credentialsService.initSealed ).toHaveBeenCalledWith( undefined, undefined );
+      expect( credentialsService.initCredentials ).not.toHaveBeenCalled();
+      expect( cmd.log ).toHaveBeenCalledWith( expect.stringContaining( 'COMMIT the public key' ) );
     } );
   } );
 } );

--- a/sdk/cli/src/commands/credentials/init.ts
+++ b/sdk/cli/src/commands/credentials/init.ts
@@ -1,6 +1,7 @@
 import { Command, Flags } from '@oclif/core';
 import {
   initCredentials,
+  initSealed,
   resolveCredentialsPath,
   resolveKeyPath,
   credentialsExist
@@ -12,6 +13,7 @@ export default class CredentialsInit extends Command {
   static override examples = [
     '<%= config.bin %> <%= command.id %>',
     '<%= config.bin %> <%= command.id %> --environment production',
+    '<%= config.bin %> <%= command.id %> --sealed --environment production',
     '<%= config.bin %> <%= command.id %> --workflow my_workflow'
   ];
 
@@ -23,6 +25,11 @@ export default class CredentialsInit extends Command {
     workflow: Flags.string( {
       char: 'w',
       description: 'Target a specific workflow directory'
+    } ),
+    sealed: Flags.boolean( {
+      char: 's',
+      description: 'Use asymmetric (sealed) credentials: a committed public key encrypts, a private key decrypts',
+      default: false
     } ),
     force: Flags.boolean( {
       char: 'f',
@@ -44,6 +51,23 @@ export default class CredentialsInit extends Command {
       this.error(
         `Credentials already exist at ${resolveCredentialsPath( environment, workflow )}. Use --force to overwrite.`
       );
+    }
+
+    if ( flags.sealed ) {
+      const { keyPath, credPath, pubPath, publicKey } = initSealed( environment, workflow );
+
+      this.log( '' );
+      this.log( `Created private key: ${keyPath}` );
+      this.log( `Created public key:  ${pubPath}` );
+      this.log( `Created credentials: ${credPath}` );
+      this.log( `Recipient public key: ${publicKey}` );
+      this.log( '' );
+      this.log( 'IMPORTANT: Add the PRIVATE key file to .gitignore (keep it only in your runtime):' );
+      this.log( `  ${keyPath}` );
+      this.log( 'COMMIT the public key and the credentials file — they are safe to share.' );
+      this.log( '' );
+      this.log( 'Add credentials with: output credentials set <path> <value>  (no private key needed)' );
+      return;
     }
 
     const { keyPath, credPath } = initCredentials( environment, workflow );

--- a/sdk/cli/src/commands/credentials/migrate.ts
+++ b/sdk/cli/src/commands/credentials/migrate.ts
@@ -1,0 +1,98 @@
+import { Command, Flags } from '@oclif/core';
+import { confirm } from '@inquirer/prompts';
+import { resolveKeyEnvVar, resolveWorkflowKeyEnvVar } from '@outputai/credentials';
+import { getErrorMessage } from '#utils/error_utils.js';
+import {
+  credentialsExist,
+  isSealedCredentials,
+  migrateToSealed,
+  resolveCredentialsPath
+} from '#services/credentials_service.js';
+
+export default class CredentialsMigrate extends Command {
+  static override description =
+    'Migrate a legacy (symmetric) credentials file to asymmetric (sealed) form. Decrypts with the ' +
+    'current key, generates a new keypair, seals every value to it, and writes a new private key.';
+
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> --to-sealed --environment production',
+    '<%= config.bin %> <%= command.id %> --to-sealed --workflow my_workflow'
+  ];
+
+  static override flags = {
+    'to-sealed': Flags.boolean( {
+      description: 'Convert the credentials file to sealed (asymmetric) form',
+      default: false
+    } ),
+    environment: Flags.string( {
+      char: 'e',
+      description: 'Target environment (e.g. production, development)'
+    } ),
+    workflow: Flags.string( {
+      char: 'w',
+      description: 'Target a specific workflow directory'
+    } ),
+    yes: Flags.boolean( {
+      char: 'y',
+      description: 'Skip the confirmation prompt',
+      default: false
+    } )
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse( CredentialsMigrate );
+    const environment = flags.environment;
+    const workflow = flags.workflow;
+
+    if ( environment && workflow ) {
+      this.error( 'Cannot specify both --environment and --workflow.' );
+    }
+
+    if ( !flags['to-sealed'] ) {
+      this.error( 'Specify a migration direction. Currently supported: --to-sealed.' );
+    }
+
+    if ( !credentialsExist( environment, workflow ) ) {
+      this.error(
+        `No credentials file found at ${resolveCredentialsPath( environment, workflow )}. Run "output credentials init" first.`
+      );
+    }
+
+    if ( isSealedCredentials( environment, workflow ) ) {
+      this.error( `Credentials at ${resolveCredentialsPath( environment, workflow )} are already sealed.` );
+    }
+
+    if ( !flags.yes ) {
+      this.warn(
+        'This rewrites the credentials file and REPLACES the key file with a new private key. ' +
+        'The old symmetric key will no longer decrypt this file.'
+      );
+      const shouldContinue = await confirm( { message: 'Continue?', default: false } ).catch( () => false );
+      if ( !shouldContinue ) {
+        this.log( 'Aborted.' );
+        return;
+      }
+    }
+
+    try {
+      const { keyPath, pubPath, credPath, privateKey } = migrateToSealed( environment, workflow );
+      const envVar = workflow ? resolveWorkflowKeyEnvVar( workflow ) : resolveKeyEnvVar( environment );
+
+      this.log( '' );
+      this.log( `Sealed credentials: ${credPath}` );
+      this.log( `Wrote public key:   ${pubPath}  (COMMIT this)` );
+      this.log( `Wrote private key:  ${keyPath}  (gitignored — keep secret)` );
+      this.log( '' );
+      this.log( 'Next steps:' );
+      this.log( `  1. Commit ${pubPath} and the credentials file.` );
+      this.log( `  2. Set the new private key in your runtime as ${envVar}:` );
+      this.log( '' );
+      this.log( `     ${privateKey}` );
+      this.log( '' );
+      this.log( '  3. Store the private key in your secret manager (e.g. 1Password).' );
+      this.log( '  4. Verify with: output credentials verify' );
+    } catch ( error ) {
+      this.error( `Migration failed: ${getErrorMessage( error )}` );
+    }
+  }
+}

--- a/sdk/cli/src/commands/credentials/set.ts
+++ b/sdk/cli/src/commands/credentials/set.ts
@@ -1,12 +1,17 @@
 import { Args, Command, Flags } from '@oclif/core';
 import { confirm } from '@inquirer/prompts';
 import { load as parseYaml, dump as stringifyYaml } from 'js-yaml';
+import { seal } from '@outputai/credentials';
 import { getErrorMessage } from '#utils/error_utils.js';
 import {
   decryptCredentials,
   credentialsExist,
   writeEncrypted,
-  resolveCredentialsPath
+  resolveCredentialsPath,
+  isSealedCredentials,
+  readSealedDocument,
+  writeSealedDocument,
+  resolveRecipientPublicKey
 } from '#services/credentials_service.js';
 
 type CredentialsObject = Record<string, unknown>;
@@ -138,6 +143,39 @@ export default class CredentialsSet extends Command {
     }
 
     try {
+      // Sealed credentials: seal the single new value with the committed public key.
+      // The other values stay sealed and the private key is never needed.
+      if ( isSealedCredentials( environment, workflow ) ) {
+        const recipient = resolveRecipientPublicKey( environment, workflow );
+        const { recipient: fileRecipient, data } = readSealedDocument( environment, workflow );
+
+        // If the committed public key was rotated away from the recipient the existing
+        // values were sealed to, "set" cannot re-seal those values (no private key, no
+        // plaintext) — writing here would leave a file with two recipients. Refuse.
+        if ( fileRecipient && fileRecipient !== recipient ) {
+          this.error(
+            `The committed public key (${recipient}) does not match the recipient the existing ` +
+            `credentials were sealed to (${fileRecipient}). "set" cannot re-seal existing values. ` +
+            'Re-seal with "output credentials edit" (which decrypts and re-seals everything), ' +
+            'or restore the matching public key, before adding new values.'
+          );
+        }
+
+        const conflict = detectPathConflict( data, args.path );
+        if ( conflict && !flags.yes ) {
+          const shouldContinue = await this.confirmOverwrite( conflict, args.path );
+          if ( !shouldContinue ) {
+            this.log( 'Aborted.' );
+            return;
+          }
+        }
+
+        setNestedValue( data, args.path, seal( args.value, recipient ) );
+        writeSealedDocument( environment, recipient, data, workflow );
+        this.log( `Set ${args.path}` );
+        return;
+      }
+
       const plaintext = decryptCredentials( environment, workflow );
       const data = ( parseYaml( plaintext ) || {} ) as CredentialsObject;
 

--- a/sdk/cli/src/commands/credentials/verify.ts
+++ b/sdk/cli/src/commands/credentials/verify.ts
@@ -1,0 +1,139 @@
+import fs from 'node:fs';
+import { Command, Flags } from '@oclif/core';
+import {
+  decrypt,
+  detectFormat,
+  parseSealedDocument,
+  openSealedDocument,
+  SEALED_FORMAT
+} from '@outputai/credentials';
+import { getErrorMessage } from '#utils/error_utils.js';
+import {
+  credentialsExist,
+  resolveCredentialsPath,
+  resolvePublicKeyPath,
+  resolveKeyOptional
+} from '#services/credentials_service.js';
+
+export default class CredentialsVerify extends Command {
+  static override description =
+    'Verify a credentials file. For sealed credentials this confirms the file was sealed for the ' +
+    'committed public key — a check that needs NO secret, so it is safe to run in CI.';
+
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> --environment production',
+    '<%= config.bin %> <%= command.id %> --workflow my_workflow'
+  ];
+
+  static override flags = {
+    environment: Flags.string( {
+      char: 'e',
+      description: 'Target environment (e.g. production, development)'
+    } ),
+    workflow: Flags.string( {
+      char: 'w',
+      description: 'Target a specific workflow directory'
+    } )
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse( CredentialsVerify );
+    const environment = flags.environment;
+    const workflow = flags.workflow;
+
+    if ( environment && workflow ) {
+      this.error( 'Cannot specify both --environment and --workflow.' );
+    }
+
+    if ( !credentialsExist( environment, workflow ) ) {
+      this.error(
+        `No credentials file found at ${resolveCredentialsPath( environment, workflow )}. Run "output credentials init" first.`
+      );
+    }
+
+    const credPath = resolveCredentialsPath( environment, workflow );
+    const content = fs.readFileSync( credPath, 'utf8' ).trim();
+
+    if ( detectFormat( content ) === SEALED_FORMAT ) {
+      this.verifySealed( environment, workflow, credPath, content );
+      return;
+    }
+
+    this.verifyLegacy( environment, workflow, credPath );
+  }
+
+  private verifySealed(
+    environment: string | undefined,
+    workflow: string | undefined,
+    credPath: string,
+    content: string
+  ): void {
+    const { recipient } = parseSealedDocument( content );
+
+    if ( !recipient ) {
+      this.error( `Sealed credentials at ${credPath} have no __recipient__ public key.` );
+    }
+
+    this.log( 'Format:    sealed-v1' );
+    this.log( `Recipient: ${recipient}` );
+
+    // Key-free check: the file's recipient must match the committed public key.
+    const pubPath = resolvePublicKeyPath( environment, workflow );
+    if ( fs.existsSync( pubPath ) ) {
+      const committedPub = fs.readFileSync( pubPath, 'utf8' ).trim();
+
+      if ( committedPub !== recipient ) {
+        this.error(
+          `Recipient mismatch: the credentials file was sealed for ${recipient}, but the committed ` +
+          `public key (${pubPath}) is ${committedPub}. The file was sealed with the wrong key.`
+        );
+      }
+
+      this.log( `✓ Recipient matches committed public key (${pubPath}).` );
+    } else {
+      this.warn( `No committed public key at ${pubPath} to check the recipient against.` );
+    }
+
+    // Optional deeper check when a private key is available (e.g. locally or in prod).
+    // openSealedDocument runs the same key/recipient/value checks the runtime uses, so
+    // WITH a key, verify and the runtime agree on whether the file opens. The key-free
+    // path above only checks the recipient identity — it cannot detect a corrupt value.
+    const key = resolveKeyOptional( environment, workflow );
+    if ( key ) {
+      try {
+        openSealedDocument( content, key, credPath );
+      } catch ( error ) {
+        this.error( getErrorMessage( error ) );
+      }
+
+      this.log( '✓ Private key opens every sealed value.' );
+    } else {
+      this.log( '(no private key available — recipient check only)' );
+    }
+
+    this.log( 'Verification passed.' );
+  }
+
+  private verifyLegacy( environment: string | undefined, workflow: string | undefined, credPath: string ): void {
+    this.log( 'Format: legacy (symmetric)' );
+
+    const key = resolveKeyOptional( environment, workflow );
+    if ( !key ) {
+      this.warn(
+        'Legacy credentials cannot be verified without the symmetric key — there is no public ' +
+        'identity to check. Consider "output credentials migrate --to-sealed" for key-free verification.'
+      );
+      return;
+    }
+
+    // The decrypt path throws InvalidCredentialsKeyError on a wrong key.
+    try {
+      decrypt( fs.readFileSync( credPath, 'utf8' ).trim(), key );
+    } catch ( error ) {
+      this.error( `Failed to decrypt ${credPath}: ${getErrorMessage( error )}` );
+    }
+
+    this.log( '✓ The configured key decrypts the file.' );
+    this.log( 'Verification passed.' );
+  }
+}

--- a/sdk/cli/src/services/credentials_service.integration.test.ts
+++ b/sdk/cli/src/services/credentials_service.integration.test.ts
@@ -3,11 +3,17 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { load as parseYaml } from 'js-yaml';
-import { encrypt, decrypt, generateKey } from '@outputai/credentials';
+import { encrypt, decrypt, generateKey, generateKeypair, seal, SealedRecipientMismatchError } from '@outputai/credentials';
 import {
   initCredentials,
+  initSealed,
+  migrateToSealed,
   decryptCredentials,
-  writeEncrypted
+  writeEncrypted,
+  writeSealedDocument,
+  readSealedDocument,
+  resolveRecipientPublicKey,
+  isSealedCredentials
 } from './credentials_service.js';
 
 describe( 'credentials service integration', () => {
@@ -167,6 +173,153 @@ describe( 'credentials service integration', () => {
 
       expect( fs.readFileSync( prod.keyPath ).equals( prodKeyBytes ) ).toBe( true );
       expect( fs.readFileSync( prod.credPath ).equals( prodCredBytes ) ).toBe( true );
+    } ) );
+  } );
+
+  describe( 'sealed (asymmetric) credentials', () => {
+    const withIsolatedProject = ( body: () => void ): void => {
+      const originalCwd = process.cwd();
+      const projectDir = fs.mkdtempSync( path.join( os.tmpdir(), 'output-creds-sealed-' ) );
+      process.chdir( projectDir );
+      try {
+        body();
+      } finally {
+        process.chdir( originalCwd );
+        fs.rmSync( projectDir, { recursive: true, force: true } );
+      }
+    };
+
+    it( 'initSealed creates a private key, a committed public key, and a sealed file', () => withIsolatedProject( () => {
+      const { keyPath, pubPath, credPath, publicKey } = initSealed( 'production' );
+
+      expect( fs.existsSync( keyPath ) ).toBe( true );
+      expect( fs.readFileSync( pubPath, 'utf8' ).trim() ).toBe( publicKey );
+      expect( fs.readFileSync( credPath, 'utf8' ) ).toContain( '__format__: sealed-v1' );
+      expect( isSealedCredentials( 'production' ) ).toBe( true );
+    } ) );
+
+    it( 'a value can be added without the private key, then read back with it', () => withIsolatedProject( () => {
+      const { keyPath } = initSealed( 'production' );
+      const privateKey = fs.readFileSync( keyPath, 'utf8' ).trim();
+
+      // Seal a value using only the committed public key, with the private key absent.
+      const recipient = resolveRecipientPublicKey( 'production' );
+      fs.rmSync( keyPath );
+
+      const { data } = readSealedDocument( 'production' );
+      ( data.anthropic as Record<string, unknown> ).api_key = seal( 'sk-ant-REAL', recipient );
+      writeSealedDocument( 'production', recipient, data );
+
+      // Restore the private key; the value added without it now decrypts.
+      fs.writeFileSync( keyPath, privateKey, { mode: 0o600 } );
+      expect( decryptCredentials( 'production' ) ).toContain( 'sk-ant-REAL' );
+    } ) );
+
+    it( 'decryptCredentials opens sealed values and rejects the wrong private key', () => withIsolatedProject( () => {
+      const { keyPath, publicKey } = initSealed( 'production' );
+      const recipient = resolveRecipientPublicKey( 'production' );
+      expect( recipient ).toBe( publicKey );
+
+      const { data } = readSealedDocument( 'production' );
+      ( data.anthropic as Record<string, unknown> ).api_key = seal( 'sk-ant-REAL', recipient );
+      writeSealedDocument( 'production', recipient, data );
+
+      // Correct key (written by initSealed) opens the value.
+      expect( decryptCredentials( 'production' ) ).toContain( 'sk-ant-REAL' );
+
+      // A different private key is rejected with a precise error.
+      fs.writeFileSync( keyPath, generateKeypair().privateKey, { mode: 0o600 } );
+      expect( () => decryptCredentials( 'production' ) ).toThrow( SealedRecipientMismatchError );
+    } ) );
+
+    it( 'migrateToSealed converts a legacy file and the old symmetric key stops working', () => withIsolatedProject( () => {
+      const legacyKey = generateKey();
+      fs.mkdirSync( 'config/credentials', { recursive: true } );
+      fs.writeFileSync( 'config/credentials/production.key', legacyKey, { mode: 0o600 } );
+      fs.writeFileSync(
+        'config/credentials/production.yml.enc',
+        encrypt( 'anthropic:\n  api_key: sk-legacy\n', legacyKey ),
+        'utf8'
+      );
+
+      const { privateKey, publicKey, pubPath } = migrateToSealed( 'production' );
+
+      expect( isSealedCredentials( 'production' ) ).toBe( true );
+      expect( fs.readFileSync( pubPath, 'utf8' ).trim() ).toBe( publicKey );
+      // The new private key (written to the key file) opens the migrated value.
+      expect( decryptCredentials( 'production' ) ).toContain( 'sk-legacy' );
+      expect( fs.readFileSync( 'config/credentials/production.key', 'utf8' ).trim() ).toBe( privateKey );
+
+      // The old symmetric key can no longer decrypt the now-sealed file.
+      expect( () => decrypt( fs.readFileSync( 'config/credentials/production.yml.enc', 'utf8' ).trim(), legacyKey ) )
+        .toThrow();
+    } ) );
+
+    it( 'migrateToSealed tightens the private key file to 0600 even over a broad-perm legacy key', () => withIsolatedProject( () => {
+      const legacyKey = generateKey();
+      fs.mkdirSync( 'config/credentials', { recursive: true } );
+      // Legacy key created out-of-band with world-readable perms.
+      fs.writeFileSync( 'config/credentials/production.key', legacyKey, { mode: 0o644 } );
+      fs.chmodSync( 'config/credentials/production.key', 0o644 );
+      fs.writeFileSync(
+        'config/credentials/production.yml.enc',
+        encrypt( 'anthropic:\n  api_key: sk-legacy\n', legacyKey ),
+        'utf8'
+      );
+
+      const { keyPath } = migrateToSealed( 'production' );
+
+      // Low 3 octal digits of the mode must be 600 (owner read/write only).
+      expect( fs.statSync( keyPath ).mode.toString( 8 ).slice( -3 ) ).toBe( '600' );
+    } ) );
+
+    it( 'writeEncrypted preserves the sealed token of an unchanged value when editing', () => withIsolatedProject( () => {
+      initSealed( 'production' );
+      const recipient = resolveRecipientPublicKey( 'production' );
+
+      const { data } = readSealedDocument( 'production' );
+      ( data.anthropic as Record<string, unknown> ).api_key = seal( 'KEEP', recipient );
+      ( data.openai as Record<string, unknown> ).api_key = seal( 'OLD', recipient );
+      writeSealedDocument( 'production', recipient, data );
+
+      const before = readSealedDocument( 'production' ).data;
+      const keptToken = ( before.anthropic as Record<string, unknown> ).api_key;
+
+      // Edit flow: decrypt, change only openai, re-save.
+      writeEncrypted( 'production', 'anthropic:\n  api_key: KEEP\nopenai:\n  api_key: NEW\n' );
+
+      const after = readSealedDocument( 'production' ).data;
+      // Unchanged value keeps its exact ciphertext (no diff churn); changed value is re-sealed.
+      expect( ( after.anthropic as Record<string, unknown> ).api_key ).toBe( keptToken );
+      expect( ( after.openai as Record<string, unknown> ).api_key )
+        .not.toBe( ( before.openai as Record<string, unknown> ).api_key );
+      expect( decryptCredentials( 'production' ) ).toContain( 'NEW' );
+    } ) );
+
+    it( 'writeEncrypted re-seals the whole tree to the rotated recipient (never a mixed-recipient file)', () => withIsolatedProject( () => {
+      initSealed( 'production' );
+      const original = resolveRecipientPublicKey( 'production' );
+
+      const { data } = readSealedDocument( 'production' );
+      ( data.anthropic as Record<string, unknown> ).api_key = seal( 'A1', original );
+      ( data.openai as Record<string, unknown> ).api_key = seal( 'A2', original );
+      writeSealedDocument( 'production', original, data );
+
+      // Rotate the committed public key WITHOUT re-sealing the file: the file's values
+      // are still sealed to `original`, but the .pub now advertises a new recipient.
+      const rotated = generateKeypair();
+      fs.writeFileSync( 'config/credentials/production.pub', rotated.publicKey, 'utf8' );
+
+      // An edit (one value changed) must seal EVERY value to the rotated recipient.
+      writeEncrypted( 'production', 'anthropic:\n  api_key: A1\nopenai:\n  api_key: CHANGED\n' );
+
+      expect( readSealedDocument( 'production' ).recipient ).toBe( rotated.publicKey );
+
+      // The rotated private key opens the entire file — no value was left sealed to `original`.
+      fs.writeFileSync( 'config/credentials/production.key', rotated.privateKey, { mode: 0o600 } );
+      const plain = decryptCredentials( 'production' );
+      expect( plain ).toContain( 'A1' );
+      expect( plain ).toContain( 'CHANGED' );
     } ) );
   } );
 } );

--- a/sdk/cli/src/services/credentials_service.ts
+++ b/sdk/cli/src/services/credentials_service.ts
@@ -1,14 +1,26 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { dump as stringifyYaml } from 'js-yaml';
+import { load as parseYaml, dump as stringifyYaml } from 'js-yaml';
 import {
   encrypt, decrypt, generateKey,
+  generateKeypair,
+  isValidKeyHex,
+  detectFormat,
+  parseSealedDocument,
+  serializeSealedDocument,
+  sealTree,
+  resealTree,
+  openSealedDocument,
+  SEALED_FORMAT,
   resolveCredentialsPath as resolveCredPath,
   resolveKeyPath as resolveKPath,
+  resolvePublicKeyPath as resolvePubPath,
   resolveKeyEnvVar,
   resolveWorkflowCredentialsPath,
   resolveWorkflowKeyPath,
-  resolveWorkflowKeyEnvVar
+  resolveWorkflowPublicKeyPath,
+  resolveWorkflowKeyEnvVar,
+  type SealedDocument
 } from '@outputai/credentials';
 
 export type CredentialsEnvironment = string | undefined;
@@ -28,6 +40,11 @@ export const resolveKeyPath = ( environment: CredentialsEnvironment, workflow?: 
   workflow ?
     resolveWorkflowKeyPath( resolveWorkflowDir( workflow ) ) :
     resolveKPath( process.cwd(), environment );
+
+export const resolvePublicKeyPath = ( environment: CredentialsEnvironment, workflow?: WorkflowTarget ): string =>
+  workflow ?
+    resolveWorkflowPublicKeyPath( resolveWorkflowDir( workflow ) ) :
+    resolvePubPath( process.cwd(), environment );
 
 export const resolveKey = ( environment: CredentialsEnvironment, workflow?: WorkflowTarget ): string => {
   if ( workflow ) {
@@ -61,27 +78,155 @@ export const resolveKey = ( environment: CredentialsEnvironment, workflow?: Work
   throw new Error( `No key found. Set ${envVar} env var or create ${keyPath}.` );
 };
 
+/** Like resolveKey but returns null instead of throwing when no key is available. */
+export const resolveKeyOptional = ( environment: CredentialsEnvironment, workflow?: WorkflowTarget ): string | null => {
+  try {
+    return resolveKey( environment, workflow );
+  } catch {
+    return null;
+  }
+};
+
 export const credentialsExist = ( environment: CredentialsEnvironment, workflow?: WorkflowTarget ): boolean =>
   fs.existsSync( resolveCredentialsPath( environment, workflow ) );
 
-export const decryptCredentials = ( environment: CredentialsEnvironment, workflow?: WorkflowTarget ): string => {
-  const key = resolveKey( environment, workflow );
+/**
+ * Write a file durably: stage to a temp file in the same directory, fsync, set the
+ * requested mode explicitly (so it applies even when overwriting an existing file —
+ * `writeFileSync`'s `mode` option is ignored for files that already exist), then rename
+ * into place. The rename is atomic, so a reader never sees a half-written file.
+ */
+const writeFileAtomic = ( filePath: string, data: string | Uint8Array, mode?: number ): void => {
+  const dir = path.dirname( filePath );
+  fs.mkdirSync( dir, { recursive: true } );
+
+  const tmp = path.join( dir, `.${path.basename( filePath )}.${process.pid}.tmp` );
+  try {
+    const bytes = typeof data === 'string' ? Buffer.from( data, 'utf8' ) : Buffer.from( data );
+    const fd = fs.openSync( tmp, 'w', mode ?? 0o644 );
+    try {
+      fs.writeSync( fd, bytes );
+      fs.fsyncSync( fd );
+    } finally {
+      fs.closeSync( fd );
+    }
+
+    if ( mode !== undefined ) {
+      fs.chmodSync( tmp, mode );
+    }
+
+    fs.renameSync( tmp, filePath );
+  } catch ( error ) {
+    fs.rmSync( tmp, { force: true } );
+    throw error;
+  }
+};
+
+const readCredentialsFile = ( environment: CredentialsEnvironment, workflow?: WorkflowTarget ): { credPath: string; content: string } => {
   const credPath = resolveCredentialsPath( environment, workflow );
 
   if ( !fs.existsSync( credPath ) ) {
     throw new Error( `Credentials file not found: ${credPath}` );
   }
 
-  const ciphertext = fs.readFileSync( credPath, 'utf8' ).trim();
-  return decrypt( ciphertext, key );
+  return { credPath, content: fs.readFileSync( credPath, 'utf8' ).trim() };
+};
+
+export const isSealedCredentials = ( environment: CredentialsEnvironment, workflow?: WorkflowTarget ): boolean => {
+  if ( !credentialsExist( environment, workflow ) ) {
+    return false;
+  }
+
+  const { content } = readCredentialsFile( environment, workflow );
+  return detectFormat( content ) === SEALED_FORMAT;
+};
+
+/** Read a sealed document (recipient + still-sealed tree) without needing the private key. */
+export const readSealedDocument = ( environment: CredentialsEnvironment, workflow?: WorkflowTarget ): SealedDocument => {
+  const { content } = readCredentialsFile( environment, workflow );
+  return parseSealedDocument( content );
+};
+
+/** Write a sealed document. Needs only the recipient public key, not the private key. */
+export const writeSealedDocument = (
+  environment: CredentialsEnvironment,
+  recipient: string,
+  data: Record<string, unknown>,
+  workflow?: WorkflowTarget
+): void => {
+  const credPath = resolveCredentialsPath( environment, workflow );
+  writeFileAtomic( credPath, serializeSealedDocument( recipient, data ) );
+};
+
+/**
+ * Resolve the recipient public key for sealing a write: the committed `.pub` file if
+ * present, otherwise the `__recipient__` recorded in the existing sealed file.
+ */
+export const resolveRecipientPublicKey = ( environment: CredentialsEnvironment, workflow?: WorkflowTarget ): string => {
+  const pubPath = resolvePublicKeyPath( environment, workflow );
+
+  const validate = ( recipient: string, source: string ): string => {
+    if ( !isValidKeyHex( recipient ) ) {
+      throw new Error( `Recipient public key in ${source} is malformed (expected 64 hex characters): "${recipient}".` );
+    }
+    return recipient;
+  };
+
+  if ( fs.existsSync( pubPath ) ) {
+    return validate( fs.readFileSync( pubPath, 'utf8' ).trim(), pubPath );
+  }
+
+  if ( isSealedCredentials( environment, workflow ) ) {
+    const { recipient } = readSealedDocument( environment, workflow );
+
+    if ( recipient ) {
+      return validate( recipient, 'the credentials file __recipient__ header' );
+    }
+  }
+
+  throw new Error(
+    `No recipient public key found at ${pubPath} and the credentials file has no recipient. ` +
+    'Run "output credentials init --sealed" or "output credentials migrate --to-sealed" first.'
+  );
+};
+
+export const decryptCredentials = ( environment: CredentialsEnvironment, workflow?: WorkflowTarget ): string => {
+  const key = resolveKey( environment, workflow );
+  const { credPath, content } = readCredentialsFile( environment, workflow );
+
+  if ( detectFormat( content ) === SEALED_FORMAT ) {
+    return stringifyYaml( openSealedDocument( content, key, credPath ) );
+  }
+
+  return decrypt( content, key );
 };
 
 export const writeEncrypted = ( environment: CredentialsEnvironment, plaintext: string, workflow?: WorkflowTarget ): void => {
-  const key = resolveKey( environment, workflow );
   const credPath = resolveCredentialsPath( environment, workflow );
 
-  fs.mkdirSync( path.dirname( credPath ), { recursive: true } );
-  fs.writeFileSync( credPath, encrypt( plaintext, key ), 'utf8' );
+  // Re-seal in place when the existing file is sealed: needs only the public key.
+  if ( isSealedCredentials( environment, workflow ) ) {
+    const recipient = resolveRecipientPublicKey( environment, workflow );
+    const tree = ( parseYaml( plaintext ) || {} ) as Record<string, unknown>;
+
+    // Preserve the existing sealed token for any unchanged value, so a single edit only
+    // rewrites the values that actually changed (each seal uses a fresh ephemeral key, so
+    // a blind re-seal would churn every line). Only safe when the recipient is unchanged
+    // AND a private key can open the previous values — otherwise (e.g. the committed .pub
+    // was rotated) seal the whole tree to the current recipient so the file is never left
+    // with values sealed to two different recipients.
+    const key = resolveKeyOptional( environment, workflow );
+    const { recipient: previousRecipient, data: previous } = readSealedDocument( environment, workflow );
+    const sealed = ( key && previousRecipient === recipient ) ?
+      resealTree( tree, previous, recipient, key ) :
+      sealTree( tree, recipient );
+
+    writeSealedDocument( environment, recipient, sealed, workflow );
+    return;
+  }
+
+  const key = resolveKey( environment, workflow );
+  writeFileAtomic( credPath, encrypt( plaintext, key ) );
 };
 
 export const initCredentials = ( environment: CredentialsEnvironment, workflow?: WorkflowTarget ): { keyPath: string; credPath: string } => {
@@ -102,6 +247,99 @@ export const initCredentials = ( environment: CredentialsEnvironment, workflow?:
   fs.writeFileSync( credPath, encrypt( template, key ), 'utf8' );
 
   return { keyPath, credPath };
+};
+
+export const initSealed = (
+  environment: CredentialsEnvironment,
+  workflow?: WorkflowTarget
+): { keyPath: string; credPath: string; pubPath: string; publicKey: string } => {
+  const credPath = resolveCredentialsPath( environment, workflow );
+  const keyPath = resolveKeyPath( environment, workflow );
+  const pubPath = resolvePublicKeyPath( environment, workflow );
+
+  const { privateKey, publicKey } = generateKeypair();
+
+  const template = sealTree( {
+    anthropic: { api_key: '' },
+    openai: { api_key: '' }
+  }, publicKey );
+
+  writeFileAtomic( keyPath, privateKey, 0o600 );
+  writeFileAtomic( pubPath, publicKey );
+  writeFileAtomic( credPath, serializeSealedDocument( publicKey, template ) );
+
+  return { keyPath, credPath, pubPath, publicKey };
+};
+
+/**
+ * Convert a legacy (symmetric) credentials file to sealed form. Decrypts with the
+ * current symmetric key, generates a fresh X25519 keypair, seals every value to it,
+ * and overwrites the key file with the new private key. The caller must distribute the
+ * returned private key to the runtime and commit the public key.
+ *
+ * Writes are atomic (temp file + rename) and, if any write throws, the original
+ * credentials and key file are restored so a failed migration is not destructive.
+ */
+export const migrateToSealed = (
+  environment: CredentialsEnvironment,
+  workflow?: WorkflowTarget
+): { keyPath: string; pubPath: string; credPath: string; privateKey: string; publicKey: string } => {
+  const credPath = resolveCredentialsPath( environment, workflow );
+
+  if ( !fs.existsSync( credPath ) ) {
+    throw new Error( `No credentials file found at ${credPath}. Run "output credentials init" first.` );
+  }
+
+  if ( isSealedCredentials( environment, workflow ) ) {
+    throw new Error( `Credentials at ${credPath} are already sealed.` );
+  }
+
+  const keyPath = resolveKeyPath( environment, workflow );
+  const pubPath = resolvePublicKeyPath( environment, workflow );
+
+  // Snapshot the originals (raw bytes) so a mid-migration failure can be rolled back to
+  // the pre-migration content of all three files. (The key file is always restored 0600,
+  // tightening it if it happened to be broader.)
+  const originalCred = fs.readFileSync( credPath );
+  const originalKey = fs.existsSync( keyPath ) ? fs.readFileSync( keyPath ) : null;
+  const originalPub = fs.existsSync( pubPath ) ? fs.readFileSync( pubPath ) : null;
+
+  // Do all fallible work (decrypt + seal) before touching any file on disk.
+  const plaintext = decryptCredentials( environment, workflow );
+  const tree = ( parseYaml( plaintext ) || {} ) as Record<string, unknown>;
+  const { privateKey, publicKey } = generateKeypair();
+  const sealedContent = serializeSealedDocument( publicKey, sealTree( tree, publicKey ) );
+
+  const restore = ( filePath: string, original: Buffer | null, mode?: number ): void => {
+    if ( original ) {
+      writeFileAtomic( filePath, original, mode );
+    } else {
+      fs.rmSync( filePath, { force: true } );
+    }
+  };
+
+  try {
+    writeFileAtomic( keyPath, privateKey, 0o600 );
+    writeFileAtomic( pubPath, publicKey );
+    writeFileAtomic( credPath, sealedContent );
+  } catch ( error ) {
+    // Best-effort: attempt every restore even if one fails, and surface the ORIGINAL
+    // error rather than a rollback failure, so none of the three files is left half-migrated.
+    for ( const undo of [
+      (): void => restore( credPath, originalCred ),
+      (): void => restore( keyPath, originalKey, 0o600 ),
+      (): void => restore( pubPath, originalPub )
+    ] ) {
+      try {
+        undo();
+      } catch {
+        // keep attempting the remaining restores
+      }
+    }
+    throw error;
+  }
+
+  return { keyPath, pubPath, credPath, privateKey, publicKey };
 };
 
 export const initCredentialsAtPath = ( projectPath: string ): { keyPath: string; credPath: string } => {

--- a/sdk/credentials/package.json
+++ b/sdk/credentials/package.json
@@ -21,6 +21,8 @@
   },
   "dependencies": {
     "@noble/ciphers": "2.2.0",
+    "@noble/curves": "2.2.0",
+    "@noble/hashes": "2.2.0",
     "@outputai/core": "workspace:",
     "js-yaml": "catalog:"
   },

--- a/sdk/credentials/src/encrypted_yaml_provider.spec.ts
+++ b/sdk/credentials/src/encrypted_yaml_provider.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { dump as stringifyYaml } from 'js-yaml';
 import { encrypt, generateKey } from './encryption.js';
+import { generateKeypair, sealTree, serializeSealedDocument } from './sealedbox.js';
 
 const YAML_CONTENT = stringifyYaml( {
   db: { host: 'localhost', password: 'secret' }
@@ -239,6 +240,60 @@ describe( 'encrypted YAML provider', () => {
       } );
 
       expect( result ).toEqual( { db: { host: 'localhost', password: 'secret' } } );
+    } );
+  } );
+
+  describe( 'sealed credentials', () => {
+    const recipient = generateKeypair();
+    const sealedDoc = serializeSealedDocument(
+      recipient.publicKey,
+      sealTree( { db: { host: 'localhost', password: 'secret' } }, recipient.publicKey )
+    );
+
+    it( 'should open sealed values with the matching private key', async () => {
+      process.env.OUTPUT_CREDENTIALS_KEY = recipient.privateKey;
+
+      vi.doMock( 'node:fs', () => ( {
+        readFileSync: () => sealedDoc,
+        existsSync: ( path: string ) => path.endsWith( 'credentials.yml.enc' )
+      } ) );
+
+      const provider = await loadProvider();
+      const result = provider.loadGlobal( { environment: undefined } );
+
+      expect( result ).toEqual( { db: { host: 'localhost', password: 'secret' } } );
+    } );
+
+    it( 'should throw SealedRecipientMismatchError when the private key is for a different keypair', async () => {
+      process.env.OUTPUT_CREDENTIALS_KEY = generateKeypair().privateKey;
+
+      vi.doMock( 'node:fs', () => ( {
+        readFileSync: () => sealedDoc,
+        existsSync: ( path: string ) => path.endsWith( 'credentials.yml.enc' )
+      } ) );
+
+      const provider = await loadProvider();
+      const { SealedRecipientMismatchError } = await import( './errors.js' );
+
+      expect( () => provider.loadGlobal( { environment: undefined } ) )
+        .toThrow( SealedRecipientMismatchError );
+      expect( () => provider.loadGlobal( { environment: undefined } ) )
+        .toThrow( /sealed for a different key/ );
+    } );
+
+    it( 'should throw MalformedCredentialsKeyError when the key is not 64 hex chars', async () => {
+      process.env.OUTPUT_CREDENTIALS_KEY = 'too-short';
+
+      vi.doMock( 'node:fs', () => ( {
+        readFileSync: () => sealedDoc,
+        existsSync: ( path: string ) => path.endsWith( 'credentials.yml.enc' )
+      } ) );
+
+      const provider = await loadProvider();
+      const { MalformedCredentialsKeyError } = await import( './errors.js' );
+
+      expect( () => provider.loadGlobal( { environment: undefined } ) )
+        .toThrow( MalformedCredentialsKeyError );
     } );
   } );
 } );

--- a/sdk/credentials/src/encrypted_yaml_provider.ts
+++ b/sdk/credentials/src/encrypted_yaml_provider.ts
@@ -1,7 +1,12 @@
 import { readFileSync, existsSync } from 'node:fs';
 import { load as parseYaml } from 'js-yaml';
 import { decrypt } from './encryption.js';
-import { InvalidCredentialsKeyError, MalformedCredentialsKeyError, MissingKeyError } from './errors.js';
+import { isSealedParsed, openSealedParsed } from './sealedbox.js';
+import {
+  InvalidCredentialsKeyError,
+  MalformedCredentialsKeyError,
+  MissingKeyError
+} from './errors.js';
 import {
   resolveKeyEnvVar,
   resolveCredentialsPath,
@@ -66,9 +71,28 @@ const safeDecrypt = ( ciphertext: string, key: string, credPath: string ): strin
   }
 };
 
+// A legacy blob that fails to parse is treated as legacy (handed to the symmetric
+// decryptor) rather than surfacing a raw YAML error, matching the CLI's detectFormat.
+const tryParseYaml = ( content: string ): unknown => {
+  try {
+    return parseYaml( content );
+  } catch {
+    return null;
+  }
+};
+
 const decryptYaml = ( credPath: string, key: string ): Record<string, unknown> => {
-  const ciphertext = readFileSync( credPath, 'utf8' ).trim();
-  const plaintext = safeDecrypt( ciphertext, key, credPath );
+  const content = readFileSync( credPath, 'utf8' ).trim();
+
+  // A sealed file parses to a header object; a legacy file is a base64 scalar. Parse
+  // once and branch so the sealed path doesn't re-parse the document.
+  const parsed = tryParseYaml( content );
+
+  if ( isSealedParsed( parsed ) ) {
+    return openSealedParsed( parsed, key, credPath );
+  }
+
+  const plaintext = safeDecrypt( content, key, credPath );
   return ( parseYaml( plaintext ) as Record<string, unknown> ) || {};
 };
 

--- a/sdk/credentials/src/encryption.ts
+++ b/sdk/credentials/src/encryption.ts
@@ -1,12 +1,17 @@
 import { gcm } from '@noble/ciphers/aes.js';
 import { managedNonce, randomBytes, hexToBytes, bytesToHex } from '@noble/ciphers/utils.js';
 
-const aes = managedNonce( gcm );
+/**
+ * Shared AES-256-GCM primitive with a random managed nonce. Exported so the sealed
+ * (asymmetric) scheme reuses the exact same AEAD construction — a single source of
+ * truth keeps the on-disk ciphertext format consistent across symmetric and sealed.
+ */
+export const aesGcm = managedNonce( gcm );
 
 export const generateKey = (): string => bytesToHex( randomBytes( 32 ) );
 
 export const encrypt = ( plaintext: string, keyHex: string ): string =>
-  Buffer.from( aes( hexToBytes( keyHex ) ).encrypt( new TextEncoder().encode( plaintext ) ) ).toString( 'base64' );
+  Buffer.from( aesGcm( hexToBytes( keyHex ) ).encrypt( new TextEncoder().encode( plaintext ) ) ).toString( 'base64' );
 
 export const decrypt = ( ciphertext: string, keyHex: string ): string =>
-  new TextDecoder().decode( aes( hexToBytes( keyHex ) ).decrypt( Buffer.from( ciphertext, 'base64' ) ) );
+  new TextDecoder().decode( aesGcm( hexToBytes( keyHex ) ).decrypt( Buffer.from( ciphertext, 'base64' ) ) );

--- a/sdk/credentials/src/errors.ts
+++ b/sdk/credentials/src/errors.ts
@@ -41,3 +41,25 @@ export class MalformedCredentialsKeyError extends Error {
     this.name = 'MalformedCredentialsKeyError';
   }
 }
+
+export class SealedRecipientMismatchError extends Error {
+  constructor( credentialsPath: string, expectedRecipient: string, actualRecipient: string ) {
+    super(
+      `Sealed credentials ${credentialsPath} were sealed for a different key. ` +
+      `The file's recipient public key is ${actualRecipient}, but the configured private key ` +
+      `corresponds to ${expectedRecipient}. The file was sealed for a different keypair, or the ` +
+      'wrong OUTPUT_CREDENTIALS_KEY is configured. Run "output credentials verify" to diagnose.'
+    );
+    this.name = 'SealedRecipientMismatchError';
+  }
+}
+
+export class SealedValueError extends Error {
+  constructor( credentialsPath: string, detail: string ) {
+    super(
+      `Failed to open a sealed value in ${credentialsPath}: ${detail}. ` +
+      'The value may be corrupted or sealed for a different key.'
+    );
+    this.name = 'SealedValueError';
+  }
+}

--- a/sdk/credentials/src/index.ts
+++ b/sdk/credentials/src/index.ts
@@ -4,14 +4,43 @@ export { credentials, resolveCredentialRefs } from './credentials.js';
 export { setProvider, getProvider } from './provider_registry.js';
 export { encryptedYamlProvider } from './encrypted_yaml_provider.js';
 export { encrypt, decrypt, generateKey } from './encryption.js';
-export { InvalidCredentialsKeyError, MalformedCredentialsKeyError, MissingCredentialError, MissingKeyError } from './errors.js';
+export {
+  generateKeypair,
+  publicKeyFromPrivate,
+  isValidKeyHex,
+  seal,
+  open,
+  sealTree,
+  openTree,
+  resealTree,
+  openSealedDocument,
+  isSealedValue,
+  detectFormat,
+  parseSealedDocument,
+  serializeSealedDocument,
+  SEALED_FORMAT,
+  SEALED_PREFIX,
+  FORMAT_FIELD,
+  RECIPIENT_FIELD
+} from './sealedbox.js';
+export type { Keypair, SealedDocument } from './sealedbox.js';
+export {
+  InvalidCredentialsKeyError,
+  MalformedCredentialsKeyError,
+  MissingCredentialError,
+  MissingKeyError,
+  SealedRecipientMismatchError,
+  SealedValueError
+} from './errors.js';
 export {
   getNestedValue,
   resolveCredentialsPath,
   resolveKeyPath,
   resolveKeyEnvVar,
+  resolvePublicKeyPath,
   resolveWorkflowCredentialsPath,
   resolveWorkflowKeyPath,
-  resolveWorkflowKeyEnvVar
+  resolveWorkflowKeyEnvVar,
+  resolveWorkflowPublicKeyPath
 } from './paths.js';
 export type { CredentialsProvider, GlobalContext, WorkflowContext } from './types.js';

--- a/sdk/credentials/src/paths.ts
+++ b/sdk/credentials/src/paths.ts
@@ -15,11 +15,18 @@ export const resolveKeyPath = ( baseDir: string, environment?: string ): string 
   resolve( baseDir, `config/credentials/${environment}.key` ) :
   resolve( baseDir, 'config/credentials.key' );
 
+export const resolvePublicKeyPath = ( baseDir: string, environment?: string ): string => environment ?
+  resolve( baseDir, `config/credentials/${environment}.pub` ) :
+  resolve( baseDir, 'config/credentials.pub' );
+
 export const resolveWorkflowCredentialsPath = ( workflowDir: string ): string =>
   resolve( workflowDir, 'credentials.yml.enc' );
 
 export const resolveWorkflowKeyPath = ( workflowDir: string ): string =>
   resolve( workflowDir, 'credentials.key' );
+
+export const resolveWorkflowPublicKeyPath = ( workflowDir: string ): string =>
+  resolve( workflowDir, 'credentials.pub' );
 
 export const getNestedValue = ( obj: unknown, dotPath: string ): unknown =>
   dotPath.split( '.' ).reduce(

--- a/sdk/credentials/src/sealedbox.spec.ts
+++ b/sdk/credentials/src/sealedbox.spec.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateKeypair,
+  publicKeyFromPrivate,
+  isValidKeyHex,
+  seal,
+  open,
+  sealTree,
+  openTree,
+  resealTree,
+  openSealedDocument,
+  isSealedValue,
+  detectFormat,
+  parseSealedDocument,
+  serializeSealedDocument,
+  SEALED_PREFIX,
+  SEALED_FORMAT
+} from './sealedbox.js';
+import { SealedRecipientMismatchError, SealedValueError, MalformedCredentialsKeyError } from './errors.js';
+
+describe( 'sealedbox', () => {
+  describe( 'generateKeypair', () => {
+    it( 'should return 64-char hex private and public keys', () => {
+      const { privateKey, publicKey } = generateKeypair();
+
+      expect( privateKey ).toMatch( /^[0-9a-f]{64}$/ );
+      expect( publicKey ).toMatch( /^[0-9a-f]{64}$/ );
+      expect( privateKey ).not.toBe( publicKey );
+    } );
+
+    it( 'should produce unique keypairs', () => {
+      const keys = Array.from( { length: 10 }, () => generateKeypair().privateKey );
+
+      expect( new Set( keys ).size ).toBe( 10 );
+    } );
+  } );
+
+  describe( 'publicKeyFromPrivate', () => {
+    it( 'should derive the keypair public key from its private key', () => {
+      const { privateKey, publicKey } = generateKeypair();
+
+      expect( publicKeyFromPrivate( privateKey ) ).toBe( publicKey );
+    } );
+  } );
+
+  describe( 'isValidKeyHex', () => {
+    it( 'should accept 64 hex chars and reject anything else', () => {
+      expect( isValidKeyHex( 'a'.repeat( 64 ) ) ).toBe( true );
+      expect( isValidKeyHex( 'a'.repeat( 63 ) ) ).toBe( false );
+      expect( isValidKeyHex( 'z'.repeat( 64 ) ) ).toBe( false );
+      expect( isValidKeyHex( '' ) ).toBe( false );
+    } );
+  } );
+
+  describe( 'seal + open', () => {
+    it( 'should round-trip a value with the recipient keypair', () => {
+      const { privateKey, publicKey } = generateKeypair();
+      const token = seal( 'sk-ant-secret', publicKey );
+
+      expect( token.startsWith( SEALED_PREFIX ) ).toBe( true );
+      expect( open( token, privateKey ) ).toBe( 'sk-ant-secret' );
+    } );
+
+    it( 'should handle empty and unicode values', () => {
+      const { privateKey, publicKey } = generateKeypair();
+
+      expect( open( seal( '', publicKey ), privateKey ) ).toBe( '' );
+      expect( open( seal( 'sk-🔑-日本語', publicKey ), privateKey ) ).toBe( 'sk-🔑-日本語' );
+    } );
+
+    it( 'should produce different tokens for the same value (ephemeral key)', () => {
+      const { publicKey } = generateKeypair();
+
+      expect( seal( 'same', publicKey ) ).not.toBe( seal( 'same', publicKey ) );
+    } );
+
+    it( 'should fail to open with the wrong private key', () => {
+      const { publicKey } = generateKeypair();
+      const wrong = generateKeypair().privateKey;
+
+      expect( () => open( seal( 'secret', publicKey ), wrong ) ).toThrow();
+    } );
+
+    it( 'should fail to open a tampered token', () => {
+      const { privateKey, publicKey } = generateKeypair();
+      const token = seal( 'secret', publicKey );
+      const raw = Buffer.from( token.slice( SEALED_PREFIX.length ), 'base64' );
+      raw[raw.length - 1] = ( raw[raw.length - 1] + 1 ) % 256;
+      const tampered = SEALED_PREFIX + raw.toString( 'base64' );
+
+      expect( () => open( tampered, privateKey ) ).toThrow();
+    } );
+
+    it( 'should reject a recipient public key that is not 64 hex chars', () => {
+      expect( () => seal( 'secret', 'not-a-key' ) ).toThrow( /Invalid recipient public key/ );
+      expect( () => seal( 'secret', 'a'.repeat( 63 ) ) ).toThrow( /Invalid recipient public key/ );
+    } );
+
+    it( 'should reject a truncated token instead of producing garbage', () => {
+      const { privateKey } = generateKeypair();
+      const truncated = SEALED_PREFIX + Buffer.from( 'too-short' ).toString( 'base64' );
+
+      expect( () => open( truncated, privateKey ) ).toThrow( /Malformed sealed token/ );
+    } );
+  } );
+
+  describe( 'isSealedValue', () => {
+    it( 'should detect sealed tokens', () => {
+      expect( isSealedValue( `${SEALED_PREFIX}abc` ) ).toBe( true );
+      expect( isSealedValue( 'plain' ) ).toBe( false );
+      expect( isSealedValue( 42 ) ).toBe( false );
+      expect( isSealedValue( null ) ).toBe( false );
+    } );
+  } );
+
+  describe( 'sealTree + openTree', () => {
+    it( 'should round-trip a nested credential tree', () => {
+      const { privateKey, publicKey } = generateKeypair();
+      const tree = {
+        anthropic: { api_key: 'sk-ant' },
+        aws: { access_key_id: 'AKIA', secret_access_key: 'shh', region: 'us-east-1' }
+      };
+
+      const sealed = sealTree( tree, publicKey );
+
+      expect( isSealedValue( ( sealed.anthropic as Record<string, unknown> ).api_key ) ).toBe( true );
+      expect( openTree( sealed, privateKey ) ).toEqual( tree );
+    } );
+
+    it( 'should seal every string leaf unconditionally (input is plaintext)', () => {
+      const { privateKey, publicKey } = generateKeypair();
+      // A value that already looks like a token is treated as plaintext and sealed,
+      // so it is never written to disk in the clear.
+      const sealed = sealTree( { a: `${SEALED_PREFIX}${'A'.repeat( 120 )}` }, publicKey );
+
+      expect( sealed.a ).not.toContain( 'A'.repeat( 120 ) );
+      expect( open( sealed.a as string, privateKey ) ).toBe( `${SEALED_PREFIX}${'A'.repeat( 120 )}` );
+    } );
+
+    it( 'should pass through non-string leaves untouched', () => {
+      const { publicKey } = generateKeypair();
+      const sealed = sealTree( { n: 7, b: true }, publicKey );
+
+      expect( sealed.n ).toBe( 7 );
+      expect( sealed.b ).toBe( true );
+    } );
+
+    it( 'should seal a plaintext value that merely starts with "sealed:"', () => {
+      const { privateKey, publicKey } = generateKeypair();
+      const sealed = sealTree( { token: 'sealed:prod-db' }, publicKey );
+
+      // The look-alike plaintext must be encrypted, not stored verbatim.
+      expect( sealed.token ).not.toBe( 'sealed:prod-db' );
+      expect( open( sealed.token as string, privateKey ) ).toBe( 'sealed:prod-db' );
+    } );
+  } );
+
+  describe( 'resealTree', () => {
+    it( 'should keep the existing token for unchanged values and re-seal only changes', () => {
+      const { privateKey, publicKey } = generateKeypair();
+      const previous = sealTree( { a: { x: 'one', y: 'two' } }, publicKey );
+
+      const next = resealTree(
+        { a: { x: 'one', y: 'CHANGED' } },
+        previous,
+        publicKey,
+        privateKey
+      );
+
+      const prevInner = previous.a as Record<string, unknown>;
+      const nextInner = next.a as Record<string, unknown>;
+
+      // Unchanged value keeps the same ciphertext (no diff churn); changed value is re-sealed.
+      expect( nextInner.x ).toBe( prevInner.x );
+      expect( nextInner.y ).not.toBe( prevInner.y );
+      expect( openTree( next, privateKey ) ).toEqual( { a: { x: 'one', y: 'CHANGED' } } );
+    } );
+
+    it( 'should seal a new "sealed:"-lookalike plaintext rather than storing it verbatim', () => {
+      const { privateKey, publicKey } = generateKeypair();
+      const lookalike = `${SEALED_PREFIX}${'A'.repeat( 120 )}`;
+
+      const next = resealTree( { k: lookalike }, {}, publicKey, privateKey );
+
+      expect( next.k ).not.toBe( lookalike );
+      expect( open( next.k as string, privateKey ) ).toBe( lookalike );
+    } );
+  } );
+
+  describe( 'detectFormat', () => {
+    it( 'should detect sealed documents', () => {
+      const { publicKey } = generateKeypair();
+      const doc = serializeSealedDocument( publicKey, sealTree( { a: 'x' }, publicKey ) );
+
+      expect( detectFormat( doc ) ).toBe( SEALED_FORMAT );
+    } );
+
+    it( 'should treat a base64 blob as legacy', () => {
+      expect( detectFormat( Buffer.from( 'anything' ).toString( 'base64' ) ) ).toBe( 'legacy' );
+    } );
+  } );
+
+  describe( 'parseSealedDocument + serializeSealedDocument', () => {
+    it( 'should round-trip recipient and data, stripping header fields', () => {
+      const { publicKey } = generateKeypair();
+      const data = sealTree( { anthropic: { api_key: 'sk' } }, publicKey );
+      const doc = serializeSealedDocument( publicKey, data );
+
+      const parsed = parseSealedDocument( doc );
+
+      expect( parsed.recipient ).toBe( publicKey );
+      expect( parsed.data ).toEqual( data );
+      expect( parsed.data.__format__ ).toBeUndefined();
+      expect( parsed.data.__recipient__ ).toBeUndefined();
+    } );
+  } );
+
+  describe( 'openSealedDocument', () => {
+    const credPath = '/tmp/credentials.yml.enc';
+
+    it( 'should open a valid document with the matching private key', () => {
+      const { privateKey, publicKey } = generateKeypair();
+      const doc = serializeSealedDocument( publicKey, sealTree( { db: { password: 'shh' } }, publicKey ) );
+
+      expect( openSealedDocument( doc, privateKey, credPath ) ).toEqual( { db: { password: 'shh' } } );
+    } );
+
+    it( 'should throw MalformedCredentialsKeyError for a non-hex key', () => {
+      const { publicKey } = generateKeypair();
+      const doc = serializeSealedDocument( publicKey, sealTree( { a: 'x' }, publicKey ) );
+
+      expect( () => openSealedDocument( doc, 'too-short', credPath ) ).toThrow( MalformedCredentialsKeyError );
+    } );
+
+    it( 'should throw SealedRecipientMismatchError when the key is for a different keypair', () => {
+      const { publicKey } = generateKeypair();
+      const doc = serializeSealedDocument( publicKey, sealTree( { a: 'x' }, publicKey ) );
+
+      expect( () => openSealedDocument( doc, generateKeypair().privateKey, credPath ) )
+        .toThrow( SealedRecipientMismatchError );
+    } );
+
+    it( 'should fail closed when the __recipient__ header is missing instead of opening blindly', () => {
+      const { privateKey, publicKey } = generateKeypair();
+      const doc = serializeSealedDocument( '', sealTree( { a: 'x' }, publicKey ) );
+
+      expect( () => openSealedDocument( doc, privateKey, credPath ) ).toThrow( SealedValueError );
+    } );
+  } );
+} );

--- a/sdk/credentials/src/sealedbox.ts
+++ b/sdk/credentials/src/sealedbox.ts
@@ -1,0 +1,288 @@
+import { concatBytes, bytesToHex, hexToBytes } from '@noble/ciphers/utils.js';
+import { x25519 } from '@noble/curves/ed25519.js';
+import { hkdf } from '@noble/hashes/hkdf.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { load as parseYaml, dump as stringifyYaml } from 'js-yaml';
+import { aesGcm } from './encryption.js';
+import {
+  MalformedCredentialsKeyError,
+  SealedRecipientMismatchError,
+  SealedValueError
+} from './errors.js';
+
+/**
+ * Asymmetric ("sealed") credentials.
+ *
+ * Each credential value is sealed individually to a recipient X25519 public key
+ * using a libsodium `crypto_box_seal`-style construction: an ephemeral X25519
+ * keypair performs ECDH with the recipient public key, HKDF-SHA256 derives an
+ * AES-256-GCM key, and the value is encrypted under it. The ephemeral public key
+ * is prepended to the ciphertext so the recipient (holder of the private key) can
+ * reconstruct the shared secret.
+ *
+ * The win over the symmetric scheme: sealing needs only the *public* key, so
+ * adding a credential never requires a secret on the contributor's machine, and
+ * the public key (the encryption identity) is committed to the repo — there is no
+ * secret encryption key to misconfigure.
+ */
+
+export const SEALED_FORMAT = 'sealed-v1';
+export const SEALED_PREFIX = 'sealed:';
+export const FORMAT_FIELD = '__format__';
+export const RECIPIENT_FIELD = '__recipient__';
+
+const HKDF_INFO = new TextEncoder().encode( 'output-sealed-v1' );
+const EPHEMERAL_KEY_BYTES = 32;
+const GCM_NONCE_BYTES = 12;
+const GCM_TAG_BYTES = 16;
+/** Smallest possible sealed body: ephemeral pubkey + managed nonce + GCM tag (empty plaintext). */
+const SEALED_MIN_BYTES = EPHEMERAL_KEY_BYTES + GCM_NONCE_BYTES + GCM_TAG_BYTES;
+const KEY_HEX_PATTERN = /^[0-9a-fA-F]{64}$/;
+
+export interface Keypair {
+  publicKey: string;
+  privateKey: string;
+}
+
+export interface SealedDocument {
+  recipient: string;
+  data: Record<string, unknown>;
+}
+
+export const generateKeypair = (): Keypair => {
+  const privateKey = x25519.utils.randomSecretKey();
+  return {
+    privateKey: bytesToHex( privateKey ),
+    publicKey: bytesToHex( x25519.getPublicKey( privateKey ) )
+  };
+};
+
+export const publicKeyFromPrivate = ( privateKeyHex: string ): string =>
+  bytesToHex( x25519.getPublicKey( hexToBytes( privateKeyHex ) ) );
+
+export const isValidKeyHex = ( keyHex: string ): boolean => KEY_HEX_PATTERN.test( keyHex );
+
+const deriveKey = ( shared: Uint8Array, ephemeralPub: Uint8Array, recipientPub: Uint8Array ): Uint8Array =>
+  hkdf( sha256, shared, concatBytes( ephemeralPub, recipientPub ), HKDF_INFO, 32 );
+
+/** Seal a single plaintext value to a recipient public key. Returns a `sealed:` token. */
+export const seal = ( plaintext: string, recipientPublicKeyHex: string ): string => {
+  if ( !isValidKeyHex( recipientPublicKeyHex ) ) {
+    throw new Error( `Invalid recipient public key (expected 64 hex characters): "${recipientPublicKeyHex}".` );
+  }
+
+  const recipientPub = hexToBytes( recipientPublicKeyHex );
+  const ephemeralSecret = x25519.utils.randomSecretKey();
+  const ephemeralPub = x25519.getPublicKey( ephemeralSecret );
+  const shared = x25519.getSharedSecret( ephemeralSecret, recipientPub );
+  const key = deriveKey( shared, ephemeralPub, recipientPub );
+  const ciphertext = aesGcm( key ).encrypt( new TextEncoder().encode( plaintext ) );
+  return SEALED_PREFIX + Buffer.from( concatBytes( ephemeralPub, ciphertext ) ).toString( 'base64' );
+};
+
+/** Open a `sealed:` token with the recipient private key. */
+export const open = ( token: string, recipientPrivateKeyHex: string ): string => {
+  const body = token.startsWith( SEALED_PREFIX ) ? token.slice( SEALED_PREFIX.length ) : token;
+  const raw = new Uint8Array( Buffer.from( body, 'base64' ) );
+
+  if ( raw.length < SEALED_MIN_BYTES ) {
+    throw new Error( `Malformed sealed token: ${raw.length} bytes, expected at least ${SEALED_MIN_BYTES}.` );
+  }
+
+  const ephemeralPub = raw.subarray( 0, EPHEMERAL_KEY_BYTES );
+  const ciphertext = raw.subarray( EPHEMERAL_KEY_BYTES );
+  const recipientPriv = hexToBytes( recipientPrivateKeyHex );
+  const recipientPub = x25519.getPublicKey( recipientPriv );
+  const shared = x25519.getSharedSecret( recipientPriv, ephemeralPub );
+  const key = deriveKey( shared, ephemeralPub, recipientPub );
+  return new TextDecoder().decode( aesGcm( key ).decrypt( ciphertext ) );
+};
+
+/** True when a value merely *looks* sealed (has the prefix) — used to decide whether to attempt opening. */
+export const isSealedValue = ( value: unknown ): value is string =>
+  typeof value === 'string' && value.startsWith( SEALED_PREFIX );
+
+/**
+ * True when a value is structurally a sealed token: the prefix plus a base64 body
+ * large enough to hold the ephemeral key, nonce, and GCM tag. Used by {@link resealTree}
+ * to recognize a genuine *previous* token worth preserving — never to decide whether an
+ * incoming value is plaintext (the seal paths always treat their input as plaintext).
+ */
+const isWellFormedSealedToken = ( value: unknown ): value is string =>
+  typeof value === 'string' &&
+  value.startsWith( SEALED_PREFIX ) &&
+  Buffer.from( value.slice( SEALED_PREFIX.length ), 'base64' ).length >= SEALED_MIN_BYTES;
+
+const isPlainObject = ( value: unknown ): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray( value );
+
+/**
+ * Recursively seal every string leaf of a *plaintext* credential tree. Every string is
+ * sealed unconditionally — the tree is assumed to be plaintext, so a value that merely
+ * starts with `sealed:` is sealed like any other rather than written to disk in the clear.
+ * To re-seal while preserving unchanged ciphertext, use {@link resealTree}.
+ */
+export const sealTree = ( tree: Record<string, unknown>, recipientPublicKeyHex: string ): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+
+  for ( const [ key, value ] of Object.entries( tree ) ) {
+    if ( isPlainObject( value ) ) {
+      out[key] = sealTree( value, recipientPublicKeyHex );
+    } else if ( typeof value === 'string' ) {
+      out[key] = seal( value, recipientPublicKeyHex );
+    } else {
+      out[key] = value;
+    }
+  }
+
+  return out;
+};
+
+const safeOpen = ( token: string, recipientPrivateKeyHex: string ): string | null => {
+  try {
+    return open( token, recipientPrivateKeyHex );
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Re-seal a plaintext tree against a `previous` sealed tree, preserving the existing
+ * token for any leaf whose plaintext is unchanged. Because each {@link seal} uses a
+ * fresh ephemeral key, blindly re-sealing rewrites every value's ciphertext; this keeps
+ * an edit's git diff scoped to the values that actually changed. Requires the private
+ * key to compare previous values; callers without a key should use {@link sealTree}.
+ */
+export const resealTree = (
+  tree: Record<string, unknown>,
+  previous: Record<string, unknown>,
+  recipientPublicKeyHex: string,
+  recipientPrivateKeyHex: string
+): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+
+  for ( const [ key, value ] of Object.entries( tree ) ) {
+    const prev = previous[key];
+
+    if ( isPlainObject( value ) ) {
+      out[key] = resealTree( value, isPlainObject( prev ) ? prev : {}, recipientPublicKeyHex, recipientPrivateKeyHex );
+    } else if ( typeof value === 'string' ) {
+      // value is plaintext: reuse the previous token only when it decrypts to the same
+      // plaintext; otherwise seal afresh. The incoming value is never stored verbatim.
+      out[key] = isWellFormedSealedToken( prev ) && safeOpen( prev, recipientPrivateKeyHex ) === value ?
+        prev :
+        seal( value, recipientPublicKeyHex );
+    } else {
+      out[key] = value;
+    }
+  }
+
+  return out;
+};
+
+/** Recursively open every sealed leaf of a credential tree. Non-sealed values pass through. */
+export const openTree = ( tree: Record<string, unknown>, recipientPrivateKeyHex: string ): Record<string, unknown> => {
+  const out: Record<string, unknown> = {};
+
+  for ( const [ key, value ] of Object.entries( tree ) ) {
+    if ( isPlainObject( value ) ) {
+      out[key] = openTree( value, recipientPrivateKeyHex );
+    } else if ( isSealedValue( value ) ) {
+      out[key] = open( value, recipientPrivateKeyHex );
+    } else {
+      out[key] = value;
+    }
+  }
+
+  return out;
+};
+
+/** True when an already-parsed YAML value carries the sealed-document header. */
+export const isSealedParsed = ( parsed: unknown ): parsed is Record<string, unknown> =>
+  isPlainObject( parsed ) && parsed[FORMAT_FIELD] === SEALED_FORMAT;
+
+/** Returns `'sealed-v1'` when the file is a sealed document, otherwise `'legacy'` (symmetric blob). */
+export const detectFormat = ( content: string ): typeof SEALED_FORMAT | 'legacy' => {
+  try {
+    if ( isSealedParsed( parseYaml( content ) ) ) {
+      return SEALED_FORMAT;
+    }
+  } catch {
+    // A legacy file is a single base64 blob; treat any parse failure as legacy.
+  }
+
+  return 'legacy';
+};
+
+/** Split a parsed sealed-document object into its recipient and (still-sealed) credential tree. */
+const splitSealedHeader = ( parsed: Record<string, unknown> ): SealedDocument => {
+  const recipient = parsed[RECIPIENT_FIELD];
+  const data = { ...parsed };
+  delete data[FORMAT_FIELD];
+  delete data[RECIPIENT_FIELD];
+
+  return { recipient: typeof recipient === 'string' ? recipient : '', data };
+};
+
+/** Parse a sealed document into its recipient public key and the (still-sealed) credential tree. */
+export const parseSealedDocument = ( content: string ): SealedDocument => {
+  const parsed = parseYaml( content );
+
+  if ( !isPlainObject( parsed ) ) {
+    throw new Error( 'Sealed credentials file is not a valid YAML document.' );
+  }
+
+  return splitSealedHeader( parsed );
+};
+
+/**
+ * Open a parsed sealed document, applying every integrity check in one place: the
+ * private key must be well-formed, the recipient is mandatory and must match the key,
+ * and each value must decrypt. This is the single source of truth shared by the runtime
+ * provider and the CLI so they cannot diverge on which files are openable.
+ */
+export const openSealedParsed = (
+  parsed: Record<string, unknown>,
+  privateKeyHex: string,
+  credPath: string
+): Record<string, unknown> => {
+  if ( !isValidKeyHex( privateKeyHex ) ) {
+    throw new MalformedCredentialsKeyError( credPath, 'expected 64 hex characters' );
+  }
+
+  const { recipient, data } = splitSealedHeader( parsed );
+
+  if ( !recipient ) {
+    throw new SealedValueError( credPath, 'the file has no __recipient__ public key' );
+  }
+
+  const derivedRecipient = publicKeyFromPrivate( privateKeyHex );
+  if ( recipient !== derivedRecipient ) {
+    throw new SealedRecipientMismatchError( credPath, derivedRecipient, recipient );
+  }
+
+  try {
+    return openTree( data, privateKeyHex );
+  } catch ( error ) {
+    throw new SealedValueError( credPath, error instanceof Error ? error.message : String( error ) );
+  }
+};
+
+/** Open a sealed document from its serialized content. Convenience wrapper over {@link openSealedParsed}. */
+export const openSealedDocument = (
+  content: string,
+  privateKeyHex: string,
+  credPath: string
+): Record<string, unknown> => {
+  const parsed = parseYaml( content );
+
+  if ( !isPlainObject( parsed ) ) {
+    throw new SealedValueError( credPath, 'the file is not a valid sealed YAML document' );
+  }
+
+  return openSealedParsed( parsed, privateKeyHex, credPath );
+};
+
+/** Serialize a sealed document (format + recipient header followed by the sealed credential tree). */
+export const serializeSealedDocument = ( recipient: string, data: Record<string, unknown> ): string =>
+  stringifyYaml( { [FORMAT_FIELD]: SEALED_FORMAT, [RECIPIENT_FIELD]: recipient, ...data } );


### PR DESCRIPTION
## Summary

Adds an opt-in **sealed** credentials mode alongside the existing symmetric scheme. Sealed credentials are encrypted to a **committed public key** and decrypted with a **private key only the runtime needs** — so contributors can add credentials without any secret on their machine, and there's no shared encryption key to misconfigure. Legacy symmetric credentials keep working unchanged; adoption is per-environment and optional.

## Why

The default scheme is symmetric — one key both encrypts and decrypts. So everyone who edits credentials needs the shared secret, and committing a file encrypted with the **wrong** `OUTPUT_CREDENTIALS_KEY_PRODUCTION` fails *silently*: production can't decrypt it, every workflow that uses those credentials breaks, and you only find out at runtime, in prod, on first use. The natural failsafes don't help: a startup check only runs once the bad file is already committed and deploying (too late to prevent it), and a CI decrypt check would mean handing the decryption key to CI — so the failsafe becomes the exposure.

Sealed mode splits the roles: the public key (encrypt) is committed; the private key (decrypt) lives only in the runtime and your secret manager. There's no secret encryption key to get wrong in the first place, and because the encryption identity is public, `verify` can confirm a file was sealed for the canonical key with **no secret at all** — so it runs in CI, *before merge*, and exposes nothing. A wrong-key commit fails that check instead of reaching production.

## How it works

Each value is sealed individually with a libsodium `crypto_box_seal`-style construction: an ephemeral X25519 keypair does ECDH with the recipient public key, HKDF-SHA256 derives an AES-256-GCM key, and the value is encrypted under it; the ephemeral public key is prepended so the private-key holder can reconstruct the shared secret. (Built on `@noble/curves` + `@noble/ciphers` + `@noble/hashes`.)

Files stay plain YAML — names are visible (they aren't secret), only values are encrypted:

```yaml
# config/credentials/production.yml.enc (sealed)
__format__: sealed-v1
__recipient__: 29964e49...        # the committed public key
anthropic:
  api_key: "sealed:BcqmP+jqI2N2..."
openai:
  api_key: "sealed:fCkZn2jgrRSW..."
```

## CLI

| Command | What it does |
|---|---|
| `output credentials init --sealed` | Generate a keypair; write the gitignored private key, the committed public key, and a sealed file. |
| `output credentials set <path> <value>` | Seal a value with the committed public key — **no private key needed**. |
| `output credentials verify` | Confirm the file was sealed for the committed public key. **Needs no secret** → safe in CI. With a private key present, also confirms every value opens. |
| `output credentials migrate --to-sealed` | Convert a legacy symmetric file to sealed form; emit the new private key to configure in the runtime. |
| `edit` / `show` / `get` | Work transparently on sealed files (private key required — they decrypt). |

The runtime private key uses the **same** env var as before (`OUTPUT_CREDENTIALS_KEY[_ENV]`) — it now holds the X25519 private key.

## ⚠️ Security model & the write-access trade-off

Because the encryption key is **committed**, sealing is a public operation: **anyone who can write to the repo can add or change a credential value** (they cannot *read* existing values — that still requires the private key). This is the deliberate trade for keyless contribution; with the symmetric scheme only key-holders could write.

Move write-control to the repo, where it belongs:

- **CODEOWNERS** on `config/credentials/**` and the `.pub` files
- **Branch protection**: required review (so CODEOWNERS approval is mandatory) + signed commits
- The key-free **`verify`** in CI to catch a wrong-key commit before it deploys

The private key never enters the repo, so even a malicious write can only *add* a value sealed to the canonical key — never exfiltrate an existing one. See the operations guide for the full setup.

Additional hardening:

- **Fail-fast**: a wrong/missing private key throws `SealedRecipientMismatchError` at load, not a generic decrypt error surfaced lazily on first use. The recipient header is mandatory and must match the key.
- `seal()` validates the recipient public key; `open()` rejects malformed tokens.
- `migrate` writes atomically (temp + fsync + rename) with rollback, so a failed migration is non-destructive; key files are written `0600`.
- `edit` preserves the ciphertext of unchanged values, so a single edit only diffs what actually changed.

## Backward compatibility

Fully opt-in. Legacy symmetric files are auto-detected and handled exactly as before. Migration is per-environment; nothing changes until you run `init --sealed` or `migrate --to-sealed`.

## Open questions for reviewers

- **Rotation / re-keying** is currently done via `edit` (decrypt with the old key, reseal to the new recipient). There's no dedicated `rotate` command in v1 — acceptable?
- The **`verify` guarantee is scoped**: the key-free CI check catches a wrong *recipient*; catching a corrupt *value* requires a key-holding verify. Documented as such.

## Testing

- New unit suites for the crypto core (`sealedbox`) and the sealed provider path.
- Integration tests for `init --sealed`, `set` without a key, `migrate`, wrong-key rejection, `0600` perms, edit diff-preservation, and recipient-rotation safety.
- Full suite green: 2079 tests.

New dependencies: `@noble/curves`, `@noble/hashes` (both `2.2.0`, same vendor as the existing `@noble/ciphers`).

## Background

This isn't theoretical — it's the production incident that prompted the feature. A credentials file was committed encrypted with the wrong `OUTPUT_CREDENTIALS_KEY_PRODUCTION`; production didn't have a matching key, couldn't decrypt, and every workflow that relied on those credentials broke. Nobody caught it until runtime in prod, and recovery meant redeploying a corrected file and re-encrypting the affected secrets. Under sealed mode that commit never reaches production — there's no secret key to mismatch, and the key-free `verify` flags a wrong recipient in CI, before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
