### PR TITLE
fix(core): Fixing sendHttpRequest workflow feature

### DIFF
--- a/sdk/core/src/interface/webhook.js
+++ b/sdk/core/src/interface/webhook.js
@@ -24,7 +24,7 @@ export async function sendHttpRequest( { url, method = 'GET', payload = undefine
       nonRetryableErrorTypes: [ FatalError.name ]
     }
   } )[ACTIVITY_SEND_HTTP_REQUEST]( { method, url, payload, headers } );
-  return res;
+  return res.output;
 };
 
 /**

--- a/sdk/core/src/interface/webhook.spec.js
+++ b/sdk/core/src/interface/webhook.spec.js
@@ -10,6 +10,12 @@ vi.mock( './validations/static.js', () => ( {
   validateRequestPayload: validateRequestPayloadMock
 } ) );
 
+const activityEnvelope = output => ( {
+  __output_activity_wrapper_version: 1,
+  output,
+  aggregations: null
+} );
+
 // Minimal, legible mock of @temporalio/workflow APIs used by webhook.js
 const activityFnMock = vi.fn();
 const proxyActivitiesMock = vi.fn( () => ( { ['__internal#sendHttpRequest']: activityFnMock } ) );
@@ -70,7 +76,7 @@ describe( 'interface/webhook', () => {
       headers: { 'content-type': 'application/json' },
       body: { ok: true }
     };
-    activityFnMock.mockResolvedValueOnce( fakeSerializedResponse );
+    activityFnMock.mockResolvedValueOnce( activityEnvelope( fakeSerializedResponse ) );
 
     const args = { url: 'https://example.com/api', method: 'GET' };
     const res = await sendHttpRequest( args );
@@ -97,14 +103,14 @@ describe( 'interface/webhook', () => {
     const { sendPostRequestAndAwaitWebhook } = await import( './webhook.js' );
 
     // Make the inner activity resolve (through sendHttpRequest)
-    activityFnMock.mockResolvedValueOnce( {
+    activityFnMock.mockResolvedValueOnce( activityEnvelope( {
       url: 'https://webhook.site',
       status: 200,
       statusText: 'OK',
       ok: true,
       headers: {},
       body: null
-    } );
+    } ) );
 
     const url = 'https://webhook.site/ingest';
     const promise = sendPostRequestAndAwaitWebhook( { url, payload: { x: 1 }, headers: { a: 'b' } } );


### PR DESCRIPTION
## Summary

The public function `sendHttpRequest` was not returning the new activity envelope (#236). This fix extracts its output value and keep the old contract.

## Test plan

- [x] unit
- [x] manual
