### PR TITLE
feat(cli): warn before re-encrypting credentials with a mismatched key

### DIFF
--- a/.changeset/warn-reencrypt-credentials-mismatched-key.md
+++ b/.changeset/warn-reencrypt-credentials-mismatched-key.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+`credentials set` and `credentials edit` now check whether the current key can decrypt the existing credentials file before re-encrypting. On a key mismatch they abort with a clear warning that the wrong key may be in use and the file would be re-encrypted under a different key. Pass `--force` / `-f` to proceed anyway (re-encrypts from empty, discarding the undecryptable values).

--- a/sdk/cli/src/commands/credentials/edit.spec.ts
+++ b/sdk/cli/src/commands/credentials/edit.spec.ts
@@ -27,6 +27,8 @@ describe( 'credentials edit command', () => {
   beforeEach( () => {
     vi.clearAllMocks();
     vi.mocked( credentialsService.credentialsExist ).mockReturnValue( true );
+    vi.mocked( credentialsService.checkKeyMatchesCredentials ).mockReturnValue( 'match' );
+    vi.mocked( credentialsService.reEncryptKeyMismatchMessage ).mockReturnValue( 'KEY_MISMATCH_WARNING' );
     vi.mocked( credentialsService.decryptCredentials ).mockReturnValue( 'anthropic:\n  api_key: sk-test\n' );
   } );
 
@@ -39,13 +41,14 @@ describe( 'credentials edit command', () => {
   ) => {
     const cmd = new CredentialsEdit( [], {} as any );
     cmd.log = vi.fn();
+    cmd.warn = vi.fn() as any;
     cmd.error = vi.fn( ( msg: string ) => {
       throw new Error( msg );
     } ) as any;
     Object.defineProperty( cmd, 'parse', {
       value: vi.fn().mockResolvedValue( {
         args: {},
-        flags: { environment: undefined, workflow: undefined, ...flags }
+        flags: { environment: undefined, workflow: undefined, force: false, ...flags }
       } ),
       configurable: true
     } );
@@ -57,9 +60,10 @@ describe( 'credentials edit command', () => {
       expect( CredentialsEdit.description ).toContain( 'Edit' );
     } );
 
-    it( 'should have environment and workflow flags', () => {
+    it( 'should have environment, workflow, and force flags', () => {
       expect( CredentialsEdit.flags.environment ).toBeDefined();
       expect( CredentialsEdit.flags.workflow ).toBeDefined();
+      expect( CredentialsEdit.flags.force ).toBeDefined();
     } );
   } );
 
@@ -85,6 +89,29 @@ describe( 'credentials edit command', () => {
       const cmd = createTestCommand();
 
       await expect( cmd.run() ).rejects.toThrow( 'No credentials file found' );
+    } );
+  } );
+
+  describe( 'key mismatch handling', () => {
+    it( 'should error and not decrypt when the key cannot decrypt and --force is absent', async () => {
+      vi.mocked( credentialsService.checkKeyMatchesCredentials ).mockReturnValue( 'mismatch' );
+      const cmd = createTestCommand();
+
+      await expect( cmd.run() ).rejects.toThrow( 'KEY_MISMATCH_WARNING' );
+      expect( credentialsService.decryptCredentials ).not.toHaveBeenCalled();
+      expect( credentialsService.writeEncrypted ).not.toHaveBeenCalled();
+    } );
+
+    it( 'should warn, edit from empty, and re-encrypt when --force is passed', async () => {
+      vi.mocked( credentialsService.checkKeyMatchesCredentials ).mockReturnValue( 'mismatch' );
+      vi.mocked( fs.readFileSync ).mockReturnValue( 'edited: content\n' );
+      const cmd = createTestCommand( { force: true } );
+
+      await cmd.run();
+
+      expect( cmd.warn ).toHaveBeenCalledWith( 'KEY_MISMATCH_WARNING' );
+      expect( credentialsService.decryptCredentials ).not.toHaveBeenCalled();
+      expect( credentialsService.writeEncrypted ).toHaveBeenCalledWith( undefined, 'edited: content\n', undefined );
     } );
   } );
 

--- a/sdk/cli/src/commands/credentials/edit.ts
+++ b/sdk/cli/src/commands/credentials/edit.ts
@@ -8,7 +8,9 @@ import {
   decryptCredentials,
   writeEncrypted,
   credentialsExist,
-  resolveCredentialsPath
+  resolveCredentialsPath,
+  checkKeyMatchesCredentials,
+  reEncryptKeyMismatchMessage
 } from '#services/credentials_service.js';
 
 export default class CredentialsEdit extends Command {
@@ -28,6 +30,11 @@ export default class CredentialsEdit extends Command {
     workflow: Flags.string( {
       char: 'w',
       description: 'Target a specific workflow directory'
+    } ),
+    force: Flags.boolean( {
+      char: 'f',
+      description: 'Edit on an empty file and re-encrypt with the current key when it cannot decrypt the existing file (discards existing values)',
+      default: false
     } )
   };
 
@@ -46,9 +53,17 @@ export default class CredentialsEdit extends Command {
       );
     }
 
+    const keyMismatch = checkKeyMatchesCredentials( environment, workflow ) === 'mismatch';
+    if ( keyMismatch && !flags.force ) {
+      this.error( reEncryptKeyMismatchMessage( resolveCredentialsPath( environment, workflow ) ) );
+    }
+    if ( keyMismatch ) {
+      this.warn( reEncryptKeyMismatchMessage( resolveCredentialsPath( environment, workflow ) ) );
+    }
+
     const editorEnv = process.env.EDITOR || process.env.VISUAL || 'vi';
     const [ editorCmd, ...editorArgs ] = editorEnv.split( /\s+/ );
-    const plaintext = decryptCredentials( environment, workflow );
+    const plaintext = keyMismatch ? '' : decryptCredentials( environment, workflow );
     const tmpFile = path.join( os.tmpdir(), `output-credentials-${Date.now()}.yml` );
 
     try {

--- a/sdk/cli/src/commands/credentials/set.spec.ts
+++ b/sdk/cli/src/commands/credentials/set.spec.ts
@@ -28,6 +28,8 @@ describe( 'credentials set command', () => {
   beforeEach( () => {
     vi.clearAllMocks();
     vi.mocked( credentialsService.credentialsExist ).mockReturnValue( true );
+    vi.mocked( credentialsService.checkKeyMatchesCredentials ).mockReturnValue( 'match' );
+    vi.mocked( credentialsService.reEncryptKeyMismatchMessage ).mockReturnValue( 'KEY_MISMATCH_WARNING' );
     vi.mocked( credentialsService.decryptCredentials ).mockReturnValue( 'anthropic:\n  api_key: sk-existing\n' );
     vi.mocked( credentialsService.writeEncrypted ).mockImplementation( () => {} );
     vi.mocked( confirm ).mockResolvedValue( true );
@@ -50,7 +52,7 @@ describe( 'credentials set command', () => {
     Object.defineProperty( cmd, 'parse', {
       value: vi.fn().mockResolvedValue( {
         args: { path: 'anthropic.api_key', value: 'sk-new-key', ...parsedArgs },
-        flags: { environment: undefined, workflow: undefined, yes: false, ...flags }
+        flags: { environment: undefined, workflow: undefined, yes: false, force: false, ...flags }
       } ),
       configurable: true
     } );
@@ -69,10 +71,11 @@ describe( 'credentials set command', () => {
       expect( CredentialsSet.args.value.required ).toBe( true );
     } );
 
-    it( 'should have environment, workflow, and yes flags', () => {
+    it( 'should have environment, workflow, yes, and force flags', () => {
       expect( CredentialsSet.flags.environment ).toBeDefined();
       expect( CredentialsSet.flags.workflow ).toBeDefined();
       expect( CredentialsSet.flags.yes ).toBeDefined();
+      expect( CredentialsSet.flags.force ).toBeDefined();
     } );
   } );
 
@@ -149,6 +152,29 @@ describe( 'credentials set command', () => {
       const cmd = createTestCommand();
 
       await expect( cmd.run() ).rejects.toThrow( 'Failed to update credentials: Permission denied' );
+    } );
+  } );
+
+  describe( 'key mismatch handling', () => {
+    it( 'should error and not write when the key cannot decrypt and --force is absent', async () => {
+      vi.mocked( credentialsService.checkKeyMatchesCredentials ).mockReturnValue( 'mismatch' );
+      const cmd = createTestCommand();
+
+      await expect( cmd.run() ).rejects.toThrow( 'KEY_MISMATCH_WARNING' );
+      expect( credentialsService.decryptCredentials ).not.toHaveBeenCalled();
+      expect( credentialsService.writeEncrypted ).not.toHaveBeenCalled();
+    } );
+
+    it( 'should warn, skip decryption, and re-encrypt from empty when --force is passed', async () => {
+      vi.mocked( credentialsService.checkKeyMatchesCredentials ).mockReturnValue( 'mismatch' );
+      const cmd = createTestCommand( {}, { force: true } );
+
+      await cmd.run();
+
+      expect( cmd.warn ).toHaveBeenCalledWith( 'KEY_MISMATCH_WARNING' );
+      expect( credentialsService.decryptCredentials ).not.toHaveBeenCalled();
+      expect( credentialsService.writeEncrypted ).toHaveBeenCalledTimes( 1 );
+      expect( cmd.log ).toHaveBeenCalledWith( 'Set anthropic.api_key' );
     } );
   } );
 

--- a/sdk/cli/src/commands/credentials/set.ts
+++ b/sdk/cli/src/commands/credentials/set.ts
@@ -6,7 +6,9 @@ import {
   decryptCredentials,
   credentialsExist,
   writeEncrypted,
-  resolveCredentialsPath
+  resolveCredentialsPath,
+  checkKeyMatchesCredentials,
+  reEncryptKeyMismatchMessage
 } from '#services/credentials_service.js';
 
 type CredentialsObject = Record<string, unknown>;
@@ -104,6 +106,11 @@ export default class CredentialsSet extends Command {
       char: 'y',
       description: 'Skip confirmation prompts when overwriting a value of a different shape',
       default: false
+    } ),
+    force: Flags.boolean( {
+      char: 'f',
+      description: 'Re-encrypt with the current key even if it cannot decrypt the existing file (discards existing values)',
+      default: false
     } )
   };
 
@@ -137,8 +144,17 @@ export default class CredentialsSet extends Command {
       );
     }
 
+    const keyMismatch = checkKeyMatchesCredentials( environment, workflow ) === 'mismatch';
+    if ( keyMismatch && !flags.force ) {
+      this.error( reEncryptKeyMismatchMessage( resolveCredentialsPath( environment, workflow ) ) );
+    }
+
     try {
-      const plaintext = decryptCredentials( environment, workflow );
+      if ( keyMismatch ) {
+        this.warn( reEncryptKeyMismatchMessage( resolveCredentialsPath( environment, workflow ) ) );
+      }
+
+      const plaintext = keyMismatch ? '' : decryptCredentials( environment, workflow );
       const data = ( parseYaml( plaintext ) || {} ) as CredentialsObject;
 
       const conflict = detectPathConflict( data, args.path );

--- a/sdk/cli/src/services/credentials_service.integration.test.ts
+++ b/sdk/cli/src/services/credentials_service.integration.test.ts
@@ -7,7 +7,8 @@ import { encrypt, decrypt, generateKey } from '@outputai/credentials';
 import {
   initCredentials,
   decryptCredentials,
-  writeEncrypted
+  writeEncrypted,
+  checkKeyMatchesCredentials
 } from './credentials_service.js';
 
 describe( 'credentials service integration', () => {
@@ -167,6 +168,44 @@ describe( 'credentials service integration', () => {
 
       expect( fs.readFileSync( prod.keyPath ).equals( prodKeyBytes ) ).toBe( true );
       expect( fs.readFileSync( prod.credPath ).equals( prodCredBytes ) ).toBe( true );
+    } ) );
+  } );
+
+  describe( 'checkKeyMatchesCredentials', () => {
+    const withIsolatedProject = ( body: () => void ): void => {
+      const originalCwd = process.cwd();
+      const originalKey = process.env.OUTPUT_CREDENTIALS_KEY;
+      delete process.env.OUTPUT_CREDENTIALS_KEY;
+      const projectDir = fs.mkdtempSync( path.join( os.tmpdir(), 'output-creds-keymatch-' ) );
+      process.chdir( projectDir );
+      try {
+        body();
+      } finally {
+        process.chdir( originalCwd );
+        if ( originalKey === undefined ) {
+          delete process.env.OUTPUT_CREDENTIALS_KEY;
+        } else {
+          process.env.OUTPUT_CREDENTIALS_KEY = originalKey;
+        }
+        fs.rmSync( projectDir, { recursive: true, force: true } );
+      }
+    };
+
+    it( 'returns "no_file" when no credentials file exists', () => withIsolatedProject( () => {
+      expect( checkKeyMatchesCredentials( undefined ) ).toBe( 'no_file' );
+    } ) );
+
+    it( 'returns "match" when the current key decrypts the file', () => withIsolatedProject( () => {
+      initCredentials( undefined );
+
+      expect( checkKeyMatchesCredentials( undefined ) ).toBe( 'match' );
+    } ) );
+
+    it( 'returns "mismatch" when the key cannot decrypt the file', () => withIsolatedProject( () => {
+      const { keyPath } = initCredentials( undefined );
+      fs.writeFileSync( keyPath, generateKey(), { mode: 0o600 } );
+
+      expect( checkKeyMatchesCredentials( undefined ) ).toBe( 'mismatch' );
     } ) );
   } );
 } );

--- a/sdk/cli/src/services/credentials_service.ts
+++ b/sdk/cli/src/services/credentials_service.ts
@@ -64,6 +64,31 @@ export const resolveKey = ( environment: CredentialsEnvironment, workflow?: Work
 export const credentialsExist = ( environment: CredentialsEnvironment, workflow?: WorkflowTarget ): boolean =>
   fs.existsSync( resolveCredentialsPath( environment, workflow ) );
 
+export type KeyMatch = 'no_file' | 'match' | 'mismatch';
+
+export const checkKeyMatchesCredentials = ( environment: CredentialsEnvironment, workflow?: WorkflowTarget ): KeyMatch => {
+  const credPath = resolveCredentialsPath( environment, workflow );
+
+  if ( !fs.existsSync( credPath ) ) {
+    return 'no_file';
+  }
+
+  try {
+    const key = resolveKey( environment, workflow );
+    const ciphertext = fs.readFileSync( credPath, 'utf8' ).trim();
+    decrypt( ciphertext, key );
+    return 'match';
+  } catch {
+    return 'mismatch';
+  }
+};
+
+export const reEncryptKeyMismatchMessage = ( credPath: string ): string =>
+  `The current credentials key cannot decrypt ${credPath}. ` +
+  'Continuing will re-encrypt the file with a different key — the wrong key ' +
+  '(OUTPUT_CREDENTIALS_KEY env var or key file) may be in use, and the existing values will be discarded. ' +
+  'Re-run with --force to proceed anyway.';
+
 export const decryptCredentials = ( environment: CredentialsEnvironment, workflow?: WorkflowTarget ): string => {
   const key = resolveKey( environment, workflow );
   const credPath = resolveCredentialsPath( environment, workflow );


### PR DESCRIPTION
## Problem

The `credentials set` and `credentials edit` commands re-encrypt the credentials file using the currently-resolved key (`OUTPUT_CREDENTIALS_KEY` env var or key file). If the wrong key is in use — e.g. a stale env var, or the wrong environment's key — the file can be silently re-encrypted under that key.

- Until now the only signal was a cryptic AES-GCM decryption failure with no clear remediation.
- There was no supported way to intentionally proceed (re-key) when that's actually what you want.

## Solution

- **Service** — add `checkKeyMatchesCredentials()` (returns `no_file` / `match` / `mismatch` by attempting a real `decrypt()` with the resolved key) and a shared `reEncryptKeyMismatchMessage()` in `credentials_service.ts`.
- **`set` / `edit`** — after the existing-file check, gate on the result: a `mismatch` without `--force` aborts with a clear warning that the wrong key may be in use and values would be discarded. New `--force` / `-f` flag proceeds anyway, skipping decryption and re-encrypting from an empty file under the current key.

Scope is intentionally limited to `set` and `edit`. `init` is unchanged — it already guards via its existence check and always generates a fresh key by design.

> Note: credentials use symmetric AES-256-GCM, so the issue's "private key" maps to the single `credentials.key` / `OUTPUT_CREDENTIALS_KEY`.

## Test plan

- [x] `npm run lint` passes
- [x] `sdk/cli` `tsc --noEmit` passes (0 errors)
- [x] Unit specs (`set`/`edit`/service) — 40 pass, incl. new mismatch-with/without-`--force` cases
- [x] `credentials_service.integration` — 24 pass, incl. new `no_file` / `match` / `mismatch` cases for the helper
- [ ] Reviewer: manual smoke — `init`, point `OUTPUT_CREDENTIALS_KEY` at a different key, then `credentials set` (expect abort) and `credentials set --force` (expect warn + write)

## Follow-up (out of scope)

`copy_assets.spec.ts` fails locally in this worktree because the build's `copy-assets` step hits a `native-copyfiles`/Node glob incompatibility (`options.exclude must be of type function`), leaving `dist/templates/` empty. Pre-existing and unrelated to this change.

Ref: [OUT-478](https://linear.app/growthx/issue/OUT-478)