### PR TITLE
feat(api): expose workflow failure details and log Temporal errors

### DIFF
--- a/.changeset/out-233-workflow-failure-details.md
+++ b/.changeset/out-233-workflow-failure-details.md
@@ -1,0 +1,5 @@
+---
+"output-api": patch
+---
+
+Expose structured workflow failure details (`failure` object with `message`, `type`, `retryable`, and a sanitized `cause` chain) in `/workflow/run` and `/workflow/:id/result` responses, alongside the existing `error` string. Also log Temporal/gRPC client errors with full nested context (cause chain, gRPC `code`/`details`, redacted metadata keys, `workflowId`/`runId`/`taskQueue`/query) while keeping client-facing HTTP responses sanitized.

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -376,7 +376,7 @@
             "nullable": true,
             "description": "Error message if workflow failed, null otherwise"
           },
-          "failure": {
+          "errorDetails": {
             "type": "object",
             "nullable": true,
             "description": "Structured failure details if the workflow failed, null otherwise",
@@ -395,6 +395,11 @@
                 "type": "boolean",
                 "nullable": true,
                 "description": "Whether Temporal flagged the failure retryable; null if unknown"
+              },
+              "activityId": {
+                "type": "string",
+                "nullable": true,
+                "description": "Failing activity key (\"workflow#step\"); null if no activity failed"
               },
               "cause": {
                 "type": "object",

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -386,21 +386,21 @@
                 "nullable": true,
                 "description": "Friendly failure message (from the underlying application error)"
               },
-              "type": {
+              "name": {
                 "type": "string",
                 "nullable": true,
-                "description": "Error type (the original error's class name)"
+                "description": "Error name/type (the original error's class)"
               },
               "retryable": {
                 "type": "boolean",
                 "nullable": true,
-                "description": "Whether the failure was retryable; null if not reported by Temporal"
+                "description": "Whether Temporal flagged the failure retryable; null if unknown"
               },
               "cause": {
                 "type": "object",
                 "nullable": true,
                 "additionalProperties": true,
-                "description": "Sanitized error cause chain (name/type/message per level, no stack)"
+                "description": "Sanitized error cause chain (name/message per level, no stack)"
               }
             }
           }

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -375,6 +375,34 @@
             "type": "string",
             "nullable": true,
             "description": "Error message if workflow failed, null otherwise"
+          },
+          "failure": {
+            "type": "object",
+            "nullable": true,
+            "description": "Structured failure details if the workflow failed, null otherwise",
+            "properties": {
+              "message": {
+                "type": "string",
+                "nullable": true,
+                "description": "Friendly failure message (from the underlying application error)"
+              },
+              "type": {
+                "type": "string",
+                "nullable": true,
+                "description": "Error type (the original error's class name)"
+              },
+              "retryable": {
+                "type": "boolean",
+                "nullable": true,
+                "description": "Whether the failure was retryable; null if not reported by Temporal"
+              },
+              "cause": {
+                "type": "object",
+                "nullable": true,
+                "additionalProperties": true,
+                "description": "Sanitized error cause chain (name/type/message per level, no stack)"
+              }
+            }
           }
         }
       },

--- a/api/src/clients/temporal_client.js
+++ b/api/src/clients/temporal_client.js
@@ -171,7 +171,7 @@ export const extractWorkflowInput = history => {
  * @property {string|number|boolean|object|array|undefined|null} output - The workflow output
  * @property {object|null} trace - Trace information
  * @property {string|null} error - Error message if failed
- * @property {object|null} failure - Structured failure details if failed (message, type, retryable, cause), null otherwise
+ * @property {object|null} errorDetails - Structured failure details if failed (message, name, retryable, activityId, cause), null otherwise
  */
 
 /**
@@ -205,10 +205,10 @@ const buildWorkflowResult = ( { workflowId, status, runId, input, result, error 
       trace: extractErrorDetail( error, 'trace' ),
       aggregations: extractErrorDetail( error, 'aggregations' ),
       error: extractErrorMessage( error ),
-      failure: extractFailure( error )
+      errorDetails: extractFailure( error )
     } : {
       error: null,
-      failure: null
+      errorDetails: null
     } )
   } );
 

--- a/api/src/clients/temporal_client.js
+++ b/api/src/clients/temporal_client.js
@@ -1,6 +1,6 @@
 import { Client, Connection, defaultPayloadConverter } from '@temporalio/client';
 import { temporal as temporalConfig } from '#configs';
-import { buildWorkflowId, extractErrorDetail, extractErrorMessage, extractFailure, serializeTemporalError, takeFromAsyncIterable } from '#utils';
+import { buildWorkflowId, extractErrorDetail, extractErrorMessage, extractFailure, takeFromAsyncIterable } from '#utils';
 import { logger } from '#logger';
 import {
   WorkflowNotFoundError,
@@ -41,12 +41,10 @@ const getCatalog = async ( { client, taskQueue } ) => {
     if ( error instanceof WorkflowNotFoundError ) {
       throw new CatalogNotAvailableError( 3 );
     }
-    // Annotate context the error_handler's serializer can't recover on its own, then log the full
-    // nested Temporal/gRPC detail here — the only place that knows the task queue + query name.
+    // Annotate the catalog/query context (the only place that knows it) so the error_handler can
+    // surface it when it logs the failure centrally.
     error.taskQueue = taskQueue;
     error.query = 'get';
-    logger.error( 'Catalog query failed', { taskQueue, query: 'get', ...serializeTemporalError( error ) } );
-    error.alreadyLogged = true;
     throw error;
   }
 };
@@ -299,9 +297,7 @@ export default {
           }
           // Other errors (timeout, not found, etc.) are still thrown
           error.workflowId = workflowId;
-          if ( runId ) {
-            error.runId = runId;
-          }
+          error.runId = runId;
           throw error;
         }
       },

--- a/api/src/clients/temporal_client.js
+++ b/api/src/clients/temporal_client.js
@@ -1,6 +1,6 @@
 import { Client, Connection, defaultPayloadConverter } from '@temporalio/client';
 import { temporal as temporalConfig } from '#configs';
-import { buildWorkflowId, extractErrorDetail, extractErrorMessage, takeFromAsyncIterable } from '#utils';
+import { buildWorkflowId, extractErrorDetail, extractErrorMessage, extractFailure, serializeTemporalError, takeFromAsyncIterable } from '#utils';
 import { logger } from '#logger';
 import {
   WorkflowNotFoundError,
@@ -41,6 +41,12 @@ const getCatalog = async ( { client, taskQueue } ) => {
     if ( error instanceof WorkflowNotFoundError ) {
       throw new CatalogNotAvailableError( 3 );
     }
+    // Annotate context the error_handler's serializer can't recover on its own, then log the full
+    // nested Temporal/gRPC detail here — the only place that knows the task queue + query name.
+    error.taskQueue = taskQueue;
+    error.query = 'get';
+    logger.error( 'Catalog query failed', { taskQueue, query: 'get', ...serializeTemporalError( error ) } );
+    error.alreadyLogged = true;
     throw error;
   }
 };
@@ -167,6 +173,7 @@ export const extractWorkflowInput = history => {
  * @property {string|number|boolean|object|array|undefined|null} output - The workflow output
  * @property {object|null} trace - Trace information
  * @property {string|null} error - Error message if failed
+ * @property {object|null} failure - Structured failure details if failed (message, type, retryable, cause), null otherwise
  */
 
 /**
@@ -199,9 +206,11 @@ const buildWorkflowResult = ( { workflowId, status, runId, input, result, error 
     ...( error ? {
       trace: extractErrorDetail( error, 'trace' ),
       aggregations: extractErrorDetail( error, 'aggregations' ),
-      error: extractErrorMessage( error )
+      error: extractErrorMessage( error ),
+      failure: extractFailure( error )
     } : {
-      error: null
+      error: null,
+      failure: null
     } )
   } );
 
@@ -290,6 +299,9 @@ export default {
           }
           // Other errors (timeout, not found, etc.) are still thrown
           error.workflowId = workflowId;
+          if ( runId ) {
+            error.runId = runId;
+          }
           throw error;
         }
       },

--- a/api/src/clients/temporal_client.spec.js
+++ b/api/src/clients/temporal_client.spec.js
@@ -125,7 +125,7 @@ vi.mock( '#utils', () => ( {
   buildWorkflowId: vi.fn( () => 'test-uuid' ),
   extractErrorDetail: vi.fn( ( e, key ) => e?.details?.find?.( d => Object.prototype.hasOwnProperty.call( d, key ) )?.[key] ?? null ),
   extractErrorMessage: vi.fn( e => walkCause( e ) ),
-  extractFailure: vi.fn( e => e ? { message: walkCause( e ), name: e.name ?? null, retryable: null, cause: null } : null ),
+  extractFailure: vi.fn( e => e ? { message: walkCause( e ), name: e.name ?? null, retryable: null, activityId: null, cause: null } : null ),
   takeFromAsyncIterable: async ( iterable, count ) => {
     const items = [];
     for await ( const item of iterable ) {
@@ -221,7 +221,7 @@ describe( 'temporal_client', () => {
         trace: tracePayload,
         aggregations,
         error: 'step error message',
-        failure: { message: 'step error message', name: 'WorkflowFailedError', retryable: null, cause: null }
+        errorDetails: { message: 'step error message', name: 'WorkflowFailedError', retryable: null, activityId: null, cause: null }
       } );
       expect( mockLoggerWarn ).toHaveBeenCalledWith( 'Workflow execution failed', expect.objectContaining( {
         workflowId: 'test-uuid',
@@ -258,7 +258,7 @@ describe( 'temporal_client', () => {
         trace: { local: '/tmp/trace.json' },
         aggregations: { cost: { total: 1 }, tokens: { total: 10 }, httpRequests: { total: 0 } },
         error: null,
-        failure: null
+        errorDetails: null
       } );
     } );
 
@@ -433,7 +433,7 @@ describe( 'temporal_client', () => {
         trace: { local: '/tmp/trace.json' },
         aggregations: { cost: { total: 0 }, tokens: { total: 0 }, httpRequests: { total: 1 } },
         error: null,
-        failure: null
+        errorDetails: null
       } );
     } );
 
@@ -521,7 +521,7 @@ describe( 'temporal_client', () => {
         trace: tracePayload,
         aggregations,
         error: 'step error message',
-        failure: { message: 'step error message', name: 'WorkflowFailedError', retryable: null, cause: null }
+        errorDetails: { message: 'step error message', name: 'WorkflowFailedError', retryable: null, activityId: null, cause: null }
       } );
     } );
 
@@ -570,7 +570,7 @@ describe( 'temporal_client', () => {
         trace: null,
         aggregations: null,
         error: null,
-        failure: null
+        errorDetails: null
       } );
     } );
 

--- a/api/src/clients/temporal_client.spec.js
+++ b/api/src/clients/temporal_client.spec.js
@@ -125,9 +125,7 @@ vi.mock( '#utils', () => ( {
   buildWorkflowId: vi.fn( () => 'test-uuid' ),
   extractErrorDetail: vi.fn( ( e, key ) => e?.details?.find?.( d => Object.prototype.hasOwnProperty.call( d, key ) )?.[key] ?? null ),
   extractErrorMessage: vi.fn( e => walkCause( e ) ),
-  extractFailure: vi.fn( e => e ? { message: walkCause( e ), type: e.name ?? null, retryable: null, cause: null } : null ),
-  serializeErrorChain: vi.fn( () => null ),
-  serializeTemporalError: vi.fn( e => ( { name: e?.name ?? 'Error', message: e?.message } ) ),
+  extractFailure: vi.fn( e => e ? { message: walkCause( e ), name: e.name ?? null, retryable: null, cause: null } : null ),
   takeFromAsyncIterable: async ( iterable, count ) => {
     const items = [];
     for await ( const item of iterable ) {
@@ -223,7 +221,7 @@ describe( 'temporal_client', () => {
         trace: tracePayload,
         aggregations,
         error: 'step error message',
-        failure: { message: 'step error message', type: 'WorkflowFailedError', retryable: null, cause: null }
+        failure: { message: 'step error message', name: 'WorkflowFailedError', retryable: null, cause: null }
       } );
       expect( mockLoggerWarn ).toHaveBeenCalledWith( 'Workflow execution failed', expect.objectContaining( {
         workflowId: 'test-uuid',
@@ -366,7 +364,7 @@ describe( 'temporal_client', () => {
   } );
 
   describe( 'getCatalog', () => {
-    it( 'maps WorkflowNotFoundError to CatalogNotAvailableError without logging at error level', async () => {
+    it( 'maps WorkflowNotFoundError to CatalogNotAvailableError', async () => {
       mockQuery.mockRejectedValue( new WorkflowNotFoundError( 'catalog not found' ) );
       mockGetHandle.mockReturnValue( { query: mockQuery } );
 
@@ -376,10 +374,9 @@ describe( 'temporal_client', () => {
       await expect( client.startWorkflow( 'test-workflow', {} ) )
         .rejects
         .toBeInstanceOf( CatalogNotAvailableError );
-      expect( mockLoggerError ).not.toHaveBeenCalledWith( 'Catalog query failed', expect.anything() );
     } );
 
-    it( 'logs rich Temporal detail, annotates context, marks alreadyLogged, and re-throws the original error', async () => {
+    it( 'annotates taskQueue/query and re-throws other errors unchanged (logging is centralized in error_handler)', async () => {
       const grpcError = Object.assign( new Error( 'Failed to query Workflow' ), {
         cause: { message: '14 UNAVAILABLE: worker unavailable', code: 14, details: 'unavailable', metadata: {} }
       } );
@@ -392,11 +389,7 @@ describe( 'temporal_client', () => {
       await expect( client.startWorkflow( 'test-workflow', {} ) ).rejects.toBe( grpcError );
       expect( grpcError.taskQueue ).toBe( 'test-queue' );
       expect( grpcError.query ).toBe( 'get' );
-      expect( grpcError.alreadyLogged ).toBe( true );
-      expect( mockLoggerError ).toHaveBeenCalledWith(
-        'Catalog query failed',
-        expect.objectContaining( { taskQueue: 'test-queue', query: 'get' } )
-      );
+      expect( mockLoggerError ).not.toHaveBeenCalled();
     } );
   } );
 
@@ -528,7 +521,7 @@ describe( 'temporal_client', () => {
         trace: tracePayload,
         aggregations,
         error: 'step error message',
-        failure: { message: 'step error message', type: 'WorkflowFailedError', retryable: null, cause: null }
+        failure: { message: 'step error message', name: 'WorkflowFailedError', retryable: null, cause: null }
       } );
     } );
 

--- a/api/src/clients/temporal_client.spec.js
+++ b/api/src/clients/temporal_client.spec.js
@@ -5,6 +5,7 @@ import {
   StepNotFoundError,
   StepNotCompletedError,
   WorkflowNotFoundError,
+  CatalogNotAvailableError,
   InvalidPageTokenError
 }
   from './errors.js';
@@ -124,6 +125,9 @@ vi.mock( '#utils', () => ( {
   buildWorkflowId: vi.fn( () => 'test-uuid' ),
   extractErrorDetail: vi.fn( ( e, key ) => e?.details?.find?.( d => Object.prototype.hasOwnProperty.call( d, key ) )?.[key] ?? null ),
   extractErrorMessage: vi.fn( e => walkCause( e ) ),
+  extractFailure: vi.fn( e => e ? { message: walkCause( e ), type: e.name ?? null, retryable: null, cause: null } : null ),
+  serializeErrorChain: vi.fn( () => null ),
+  serializeTemporalError: vi.fn( e => ( { name: e?.name ?? 'Error', message: e?.message } ) ),
   takeFromAsyncIterable: async ( iterable, count ) => {
     const items = [];
     for await ( const item of iterable ) {
@@ -218,7 +222,8 @@ describe( 'temporal_client', () => {
         output: null,
         trace: tracePayload,
         aggregations,
-        error: 'step error message'
+        error: 'step error message',
+        failure: { message: 'step error message', type: 'WorkflowFailedError', retryable: null, cause: null }
       } );
       expect( mockLoggerWarn ).toHaveBeenCalledWith( 'Workflow execution failed', expect.objectContaining( {
         workflowId: 'test-uuid',
@@ -254,7 +259,8 @@ describe( 'temporal_client', () => {
         output: { data: 'result' },
         trace: { local: '/tmp/trace.json' },
         aggregations: { cost: { total: 1 }, tokens: { total: 10 }, httpRequests: { total: 0 } },
-        error: null
+        error: null,
+        failure: null
       } );
     } );
 
@@ -314,6 +320,7 @@ describe( 'temporal_client', () => {
 
       mockQuery.mockResolvedValue( { workflows: [ { name: 'test-workflow' } ] } );
       mockStart.mockResolvedValue( {
+        firstExecutionRunId: 'run-zzz',
         result: () => Promise.reject( timeoutError )
       } );
       mockGetHandle
@@ -326,6 +333,10 @@ describe( 'temporal_client', () => {
       await expect( client.runWorkflow( 'test-workflow', { input: 'data' } ) )
         .rejects
         .toThrow( WorkflowExecutionTimedOutError );
+
+      // Context annotated onto the re-thrown error so the error_handler serializer can surface it
+      expect( timeoutError.workflowId ).toBe( 'test-uuid' );
+      expect( timeoutError.runId ).toBe( 'run-zzz' );
     } );
   } );
 
@@ -351,6 +362,41 @@ describe( 'temporal_client', () => {
         resolvedName: 'new_name',
         taskQueue: 'test-queue'
       } );
+    } );
+  } );
+
+  describe( 'getCatalog', () => {
+    it( 'maps WorkflowNotFoundError to CatalogNotAvailableError without logging at error level', async () => {
+      mockQuery.mockRejectedValue( new WorkflowNotFoundError( 'catalog not found' ) );
+      mockGetHandle.mockReturnValue( { query: mockQuery } );
+
+      const temporalClient = ( await import( './temporal_client.js' ) ).default;
+      const client = await temporalClient.init();
+
+      await expect( client.startWorkflow( 'test-workflow', {} ) )
+        .rejects
+        .toBeInstanceOf( CatalogNotAvailableError );
+      expect( mockLoggerError ).not.toHaveBeenCalledWith( 'Catalog query failed', expect.anything() );
+    } );
+
+    it( 'logs rich Temporal detail, annotates context, marks alreadyLogged, and re-throws the original error', async () => {
+      const grpcError = Object.assign( new Error( 'Failed to query Workflow' ), {
+        cause: { message: '14 UNAVAILABLE: worker unavailable', code: 14, details: 'unavailable', metadata: {} }
+      } );
+      mockQuery.mockRejectedValue( grpcError );
+      mockGetHandle.mockReturnValue( { query: mockQuery } );
+
+      const temporalClient = ( await import( './temporal_client.js' ) ).default;
+      const client = await temporalClient.init();
+
+      await expect( client.startWorkflow( 'test-workflow', {} ) ).rejects.toBe( grpcError );
+      expect( grpcError.taskQueue ).toBe( 'test-queue' );
+      expect( grpcError.query ).toBe( 'get' );
+      expect( grpcError.alreadyLogged ).toBe( true );
+      expect( mockLoggerError ).toHaveBeenCalledWith(
+        'Catalog query failed',
+        expect.objectContaining( { taskQueue: 'test-queue', query: 'get' } )
+      );
     } );
   } );
 
@@ -393,7 +439,8 @@ describe( 'temporal_client', () => {
         output: { data: 'result' },
         trace: { local: '/tmp/trace.json' },
         aggregations: { cost: { total: 0 }, tokens: { total: 0 }, httpRequests: { total: 1 } },
-        error: null
+        error: null,
+        failure: null
       } );
     } );
 
@@ -480,7 +527,8 @@ describe( 'temporal_client', () => {
         output: null,
         trace: tracePayload,
         aggregations,
-        error: 'step error message'
+        error: 'step error message',
+        failure: { message: 'step error message', type: 'WorkflowFailedError', retryable: null, cause: null }
       } );
     } );
 
@@ -528,7 +576,8 @@ describe( 'temporal_client', () => {
         output: null,
         trace: null,
         aggregations: null,
-        error: null
+        error: null,
+        failure: null
       } );
     } );
 

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -366,19 +366,19 @@ app.use( ( req, res, next ) => {
  *               type: string
  *               nullable: true
  *               description: Friendly failure message (from the underlying application error)
- *             type:
+ *             name:
  *               type: string
  *               nullable: true
- *               description: Error type (the original error's class name)
+ *               description: Error name/type (the original error's class)
  *             retryable:
  *               type: boolean
  *               nullable: true
- *               description: Whether the failure was retryable; null if not reported by Temporal
+ *               description: Whether Temporal flagged the failure retryable; null if unknown
  *             cause:
  *               type: object
  *               nullable: true
  *               additionalProperties: true
- *               description: Sanitized error cause chain (name/type/message per level, no stack)
+ *               description: Sanitized error cause chain (name/message per level, no stack)
  *     StopWorkflowResponse:
  *       type: object
  *       properties:

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -357,6 +357,28 @@ app.use( ( req, res, next ) => {
  *           type: string
  *           nullable: true
  *           description: Error message if workflow failed, null otherwise
+ *         failure:
+ *           type: object
+ *           nullable: true
+ *           description: Structured failure details if the workflow failed, null otherwise
+ *           properties:
+ *             message:
+ *               type: string
+ *               nullable: true
+ *               description: Friendly failure message (from the underlying application error)
+ *             type:
+ *               type: string
+ *               nullable: true
+ *               description: Error type (the original error's class name)
+ *             retryable:
+ *               type: boolean
+ *               nullable: true
+ *               description: Whether the failure was retryable; null if not reported by Temporal
+ *             cause:
+ *               type: object
+ *               nullable: true
+ *               additionalProperties: true
+ *               description: Sanitized error cause chain (name/type/message per level, no stack)
  *     StopWorkflowResponse:
  *       type: object
  *       properties:

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -357,7 +357,7 @@ app.use( ( req, res, next ) => {
  *           type: string
  *           nullable: true
  *           description: Error message if workflow failed, null otherwise
- *         failure:
+ *         errorDetails:
  *           type: object
  *           nullable: true
  *           description: Structured failure details if the workflow failed, null otherwise
@@ -374,6 +374,10 @@ app.use( ( req, res, next ) => {
  *               type: boolean
  *               nullable: true
  *               description: Whether Temporal flagged the failure retryable; null if unknown
+ *             activityId:
+ *               type: string
+ *               nullable: true
+ *               description: Failing activity key ("workflow#step"); null if no activity failed
  *             cause:
  *               type: object
  *               nullable: true

--- a/api/src/middleware/error_handler.js
+++ b/api/src/middleware/error_handler.js
@@ -5,7 +5,7 @@ import {
 } from '../clients/errors.js';
 import { isGrpcServiceError } from '@temporalio/client';
 import { logger } from '#logger';
-import { serializeTemporalError } from '#utils';
+import { serializeErrorChain } from '#utils';
 import { ZodError } from 'zod';
 
 // gRPC status codes we surface as HTTP errors. Keeps the lookup numeric so we don't
@@ -55,11 +55,18 @@ export default function errorHandler( error, req, res, _next ) {
   response.workflowId = error.workflowId;
 
   const status = NAMED_ERROR_STATUSES[error.constructor.name] ?? grpcHttpStatus( error ) ?? error.status ?? 500;
-  // Log unhandled 500s with the full nested Temporal/gRPC context. Skip if a deeper layer (e.g.
-  // getCatalog) already logged the rich detail, to avoid duplicate entries. Client response is
-  // unchanged — the serialized detail goes only to logs, never to res.json.
-  if ( status === 500 && !error.alreadyLogged ) {
-    logger.error( `${error.constructor.name}: ${error.message}`, { requestId: req?.id, ...serializeTemporalError( error ) } );
+  // Log unhandled 500s with the full nested Temporal/gRPC context (cause chain, gRPC code, redacted
+  // metadata) plus any catalog/query context annotated upstream. The serialized detail and stack go
+  // only to logs — the client response (built above) stays sanitized.
+  if ( status === 500 ) {
+    logger.error( `${error.constructor.name}: ${error.message}`, {
+      requestId: req?.id,
+      ...( error.workflowId && { workflowId: error.workflowId } ),
+      ...( error.taskQueue && { taskQueue: error.taskQueue } ),
+      ...( error.query && { query: error.query } ),
+      stack: error.stack,
+      cause: serializeErrorChain( error )
+    } );
   }
 
   if ( status === 503 && error.retryAfter ) {

--- a/api/src/middleware/error_handler.js
+++ b/api/src/middleware/error_handler.js
@@ -5,7 +5,7 @@ import {
 } from '../clients/errors.js';
 import { isGrpcServiceError } from '@temporalio/client';
 import { logger } from '#logger';
-import { isProduction } from '#configs';
+import { serializeTemporalError } from '#utils';
 import { ZodError } from 'zod';
 
 // gRPC status codes we surface as HTTP errors. Keeps the lookup numeric so we don't
@@ -55,8 +55,11 @@ export default function errorHandler( error, req, res, _next ) {
   response.workflowId = error.workflowId;
 
   const status = NAMED_ERROR_STATUSES[error.constructor.name] ?? grpcHttpStatus( error ) ?? error.status ?? 500;
-  if ( status === 500 ) {
-    logger.error( `${error.constructor.name}: ${error.message}`, { requestId: req?.id, stack: isProduction ? undefined : error.stack } );
+  // Log unhandled 500s with the full nested Temporal/gRPC context. Skip if a deeper layer (e.g.
+  // getCatalog) already logged the rich detail, to avoid duplicate entries. Client response is
+  // unchanged — the serialized detail goes only to logs, never to res.json.
+  if ( status === 500 && !error.alreadyLogged ) {
+    logger.error( `${error.constructor.name}: ${error.message}`, { requestId: req?.id, ...serializeTemporalError( error ) } );
   }
 
   if ( status === 503 && error.retryAfter ) {

--- a/api/src/middleware/error_handler.spec.js
+++ b/api/src/middleware/error_handler.spec.js
@@ -98,20 +98,26 @@ describe( 'error_handler', () => {
     expect( logger.error ).toHaveBeenCalledWith(
       'Error: top',
       expect.objectContaining( {
-        name: 'Error',
-        cause: expect.objectContaining( { message: 'root cause' } )
+        cause: expect.objectContaining( {
+          name: 'Error',
+          message: 'top',
+          cause: expect.objectContaining( { message: 'root cause' } )
+        } )
       } )
     );
   } );
 
-  it( 'does not log a 500 that was already logged deeper in the stack', async () => {
-    const error = new Error( 'already handled' );
-    error.alreadyLogged = true;
+  it( 'includes annotated catalog context (taskQueue/query) in the 500 log', async () => {
+    const error = new Error( 'Failed to query Workflow' );
+    error.taskQueue = 'main';
+    error.query = 'get';
 
-    const { httpRes } = await sendError( error );
+    await sendError( error );
 
-    expect( httpRes.status ).toBe( 500 );
-    expect( logger.error ).not.toHaveBeenCalled();
+    expect( logger.error ).toHaveBeenCalledWith(
+      'Error: Failed to query Workflow',
+      expect.objectContaining( { taskQueue: 'main', query: 'get' } )
+    );
   } );
 
   it( 'keeps the client response body sanitized (no rootCause/stack/cause), even for gRPC cause chains', async () => {

--- a/api/src/middleware/error_handler.spec.js
+++ b/api/src/middleware/error_handler.spec.js
@@ -89,6 +89,48 @@ describe( 'error_handler', () => {
     );
   } );
 
+  it( 'logs the nested cause chain for unhandled 500 errors', async () => {
+    const error = new Error( 'top' );
+    error.cause = new Error( 'root cause' );
+
+    await sendError( error );
+
+    expect( logger.error ).toHaveBeenCalledWith(
+      'Error: top',
+      expect.objectContaining( {
+        name: 'Error',
+        cause: expect.objectContaining( { message: 'root cause' } )
+      } )
+    );
+  } );
+
+  it( 'does not log a 500 that was already logged deeper in the stack', async () => {
+    const error = new Error( 'already handled' );
+    error.alreadyLogged = true;
+
+    const { httpRes } = await sendError( error );
+
+    expect( httpRes.status ).toBe( 500 );
+    expect( logger.error ).not.toHaveBeenCalled();
+  } );
+
+  it( 'keeps the client response body sanitized (no rootCause/stack/cause), even for gRPC cause chains', async () => {
+    const error = new Error( 'top' );
+    error.cause = new Error( '14 UNAVAILABLE: catalog down' );
+    error.workflowId = 'wf-1';
+
+    const { httpRes } = await sendError( error );
+
+    expect( httpRes.body ).toEqual( {
+      error: 'Error',
+      message: 'top',
+      workflowId: 'wf-1'
+    } );
+    expect( httpRes.body.rootCause ).toBeUndefined();
+    expect( httpRes.body.stack ).toBeUndefined();
+    expect( httpRes.body.cause ).toBeUndefined();
+  } );
+
   it( 'should not log for non-500 errors', async () => {
     const error = new WorkflowNotFoundError( 'Workflow not found' );
 

--- a/api/src/utils.js
+++ b/api/src/utils.js
@@ -142,10 +142,11 @@ const collectChain = ( e, depth = 20 ) =>
   !e || depth <= 0 ? [] : [ e, ...collectChain( e.cause, depth - 1 ) ];
 
 /**
- * @typedef {object} WorkflowFailure
+ * @typedef {object} WorkflowErrorDetails
  * @property {string|null} message - Friendly failure message (from the user's ApplicationFailure)
  * @property {string|null} name - Error name/type (the original error's class)
  * @property {boolean|null} retryable - Whether Temporal flagged the failure retryable; null if unknown
+ * @property {string|null} activityId - The failing activity key ("workflow#step"); null if no activity failed
  * @property {object|null} cause - Serialized error cause chain ({ name, message, cause? }); no stack
  */
 
@@ -156,7 +157,7 @@ const collectChain = ( e, depth = 20 ) =>
  * pick the deepest ApplicationFailure whose type is the user's error to surface the friendly message.
  *
  * @param {Error} error
- * @returns {WorkflowFailure|null}
+ * @returns {WorkflowErrorDetails|null}
  */
 export const extractFailure = error => {
   if ( !error ) {
@@ -169,10 +170,13 @@ export const extractFailure = error => {
     null;
   // Retryability lives on whichever link Temporal flagged (usually the activity wrapper).
   const flagged = chain.find( link => typeof link.nonRetryable === 'boolean' );
+  // The failing step surfaces as an ActivityFailure whose activityType is the "workflow#step" key.
+  const activityFailure = chain.find( link => typeof link.activityType === 'string' );
   return {
     message: userFailure?.message ?? extractErrorMessage( error ),
     name: userFailure?.type ?? error.constructor?.name ?? error.name ?? null,
     retryable: flagged ? !flagged.nonRetryable : null,
+    activityId: activityFailure?.activityType ?? null,
     cause: serializeErrorChain( error )
   };
 };

--- a/api/src/utils.js
+++ b/api/src/utils.js
@@ -68,6 +68,150 @@ export const extractErrorDetail = ( e, key ) =>
 export const extractErrorMessage = ( e, depth = 20 ) => depth > 0 && e?.cause ? extractErrorMessage( e.cause, depth - 1 ) : ( e?.message ?? null );
 
 /**
+ * Duck-types a Temporal ApplicationFailure node. The worker interceptor wraps user errors as
+ * ApplicationFailure( message, type = constructorName, nonRetryable, details, cause ); only that
+ * node carries .type / .nonRetryable. We duck-type to keep this module free of @temporalio imports.
+ *
+ * @param {unknown} e
+ * @returns {boolean}
+ */
+const isApplicationFailure = e =>
+  Boolean( e ) && ( typeof e.type === 'string' || typeof e.nonRetryable === 'boolean' );
+
+/**
+ * Walks the .cause chain and returns the first ApplicationFailure-like node, or null.
+ *
+ * @param {Error} e
+ * @param {number} [depth=20]
+ * @returns {object|null}
+ */
+const findApplicationFailure = ( e, depth = 20 ) => {
+  if ( !e || depth <= 0 ) {
+    return null;
+  }
+  return isApplicationFailure( e ) ? e : findApplicationFailure( e.cause, depth - 1 );
+};
+
+/**
+ * Recursively serializes an error's .cause chain into a sanitized, transport-safe shape for
+ * client responses. Includes name/message always, and type only when present (ApplicationFailure
+ * nodes). Deliberately excludes stack and details (security + payload size).
+ *
+ * @param {Error} e
+ * @param {number} [depth=0]
+ * @returns {object|null}
+ */
+export const serializeErrorChain = ( e, depth = 0 ) => {
+  if ( !e ) {
+    return null;
+  }
+  if ( depth > 10 ) {
+    return { name: 'Error', message: 'Cause chain too deep' };
+  }
+  return {
+    name: e.constructor?.name ?? e.name ?? 'Error',
+    ...( typeof e.type === 'string' ? { type: e.type } : {} ),
+    message: e.message ?? null,
+    ...( e.cause ? { cause: serializeErrorChain( e.cause, depth + 1 ) } : {} )
+  };
+};
+
+/**
+ * @typedef {object} WorkflowFailure
+ * @property {string|null} message - Friendly failure message (from the ApplicationFailure node)
+ * @property {string|null} type - Error type (the original error's class name)
+ * @property {boolean|null} retryable - Whether the failure was retryable; null if Temporal did not report it
+ * @property {object|null} cause - Sanitized error cause chain ({ name, type?, message, cause? }); no stack
+ */
+
+/**
+ * Extracts structured failure details from a Temporal workflow error chain. Returns null for falsy
+ * input so callers can omit the field. The friendly message/type come from the first
+ * ApplicationFailure node (skipping the WorkflowFailedError/ActivityFailure wrappers).
+ *
+ * @param {Error} error
+ * @returns {WorkflowFailure|null}
+ */
+export const extractFailure = error => {
+  if ( !error ) {
+    return null;
+  }
+  const appFailure = findApplicationFailure( error );
+  return {
+    message: appFailure?.message ?? extractErrorMessage( error ),
+    type: appFailure?.type ?? error.constructor?.name ?? error.name ?? null,
+    retryable: appFailure && typeof appFailure.nonRetryable === 'boolean' ? !appFailure.nonRetryable : null,
+    cause: serializeErrorChain( error )
+  };
+};
+
+// gRPC status integers we may surface by name in logs (subset of @grpc/grpc-js Status).
+const GRPC_STATUS_NAMES = {
+  3: 'INVALID_ARGUMENT',
+  4: 'DEADLINE_EXCEEDED',
+  5: 'NOT_FOUND',
+  8: 'RESOURCE_EXHAUSTED',
+  9: 'FAILED_PRECONDITION',
+  13: 'INTERNAL',
+  14: 'UNAVAILABLE'
+};
+
+// gRPC metadata can carry auth headers/tokens, so we log only key NAMES plus an allowlist of
+// non-sensitive diagnostic values.
+const SAFE_METADATA_KEYS = [ 'grpc-status-details-bin', 'content-type' ];
+
+/**
+ * Redacts a gRPC Metadata instance (or plain record) to key names plus an allowlist of safe values.
+ *
+ * @param {object} metadata
+ * @returns {{ keys: string[] }|undefined}
+ */
+const redactMetadata = metadata => {
+  const map = typeof metadata?.getMap === 'function' ? metadata.getMap() : metadata;
+  const keys = map && typeof map === 'object' ? Object.keys( map ) : [];
+  return keys.length === 0 ? undefined : {
+    keys,
+    ...Object.fromEntries( SAFE_METADATA_KEYS.filter( k => k in map ).map( k => [ k, String( map[k] ) ] ) )
+  };
+};
+
+/**
+ * Recursively serializes an error and its .cause chain into a plain object for structured logging
+ * (winston meta). Captures gRPC ServiceError fields (code, codeName, details, redacted metadata)
+ * when a link duck-types as a gRPC error, includes the top node's stack, and surfaces context
+ * annotations (workflowId, runId, taskQueue, query). For server logs only — never sent to clients.
+ *
+ * @param {unknown} error
+ * @param {number} [depth=0]
+ * @returns {object}
+ */
+export const serializeTemporalError = ( error, depth = 0 ) => {
+  if ( depth > 10 ) {
+    return { name: 'Error', message: 'Cause chain too deep' };
+  }
+  if ( !error || typeof error !== 'object' ) {
+    return { value: String( error ) };
+  }
+  const isGrpc = typeof error.details === 'string' && typeof error.metadata === 'object' && error.metadata !== null;
+  return {
+    name: error.constructor?.name ?? error.name ?? 'Error',
+    message: error.message,
+    ...( depth === 0 && error.stack ? { stack: error.stack } : {} ),
+    ...( isGrpc ? {
+      code: error.code,
+      codeName: GRPC_STATUS_NAMES[error.code] ?? 'UNKNOWN',
+      details: error.details,
+      metadata: redactMetadata( error.metadata )
+    } : {} ),
+    ...( error.workflowId ? { workflowId: error.workflowId } : {} ),
+    ...( error.runId ? { runId: error.runId } : {} ),
+    ...( error.taskQueue ? { taskQueue: error.taskQueue } : {} ),
+    ...( error.query ? { query: error.query } : {} ),
+    ...( error.cause ? { cause: serializeTemporalError( error.cause, depth + 1 ) } : {} )
+  };
+};
+
+/**
  * Take up to N items from an async iterable
  * @template T
  * @param {AsyncIterable<T>} iterable - The async iterable to take from

--- a/api/src/utils.js
+++ b/api/src/utils.js
@@ -79,18 +79,24 @@ const isApplicationFailure = e =>
   Boolean( e ) && ( typeof e.type === 'string' || typeof e.nonRetryable === 'boolean' );
 
 /**
- * Walks the .cause chain and returns the first ApplicationFailure-like node, or null.
+ * Temporal's own failure wrappers. When one of these is itself wrapped in an ApplicationFailure, the
+ * wrapper's `type` names the transport layer (e.g. "ActivityFailure"), not the user's error. We skip
+ * them so we surface the original throw (e.g. "Foo"/"Error") instead of "Activity task failed".
+ */
+const TEMPORAL_FAILURE_TYPES = new Set( [
+  'ActivityFailure', 'ChildWorkflowFailure', 'TimeoutFailure',
+  'CancelledFailure', 'TerminatedFailure', 'ServerFailure', 'ApplicationFailure'
+] );
+
+/**
+ * Flattens an error's .cause chain into an array, outermost first (depth-limited).
  *
  * @param {Error} e
  * @param {number} [depth=20]
- * @returns {object|null}
+ * @returns {object[]}
  */
-const findApplicationFailure = ( e, depth = 20 ) => {
-  if ( !e || depth <= 0 ) {
-    return null;
-  }
-  return isApplicationFailure( e ) ? e : findApplicationFailure( e.cause, depth - 1 );
-};
+const collectChain = ( e, depth = 20 ) =>
+  !e || depth <= 0 ? [] : [ e, ...collectChain( e.cause, depth - 1 ) ];
 
 /**
  * Recursively serializes an error's .cause chain into a sanitized, transport-safe shape for
@@ -136,11 +142,20 @@ export const extractFailure = error => {
   if ( !error ) {
     return null;
   }
-  const appFailure = findApplicationFailure( error );
+  const chain = collectChain( error );
+  // Temporal double-wraps: WorkflowFailedError -> ApplicationFailure(type=ActivityFailure) ->
+  // ActivityFailure -> ApplicationFailure(type=<user error>). Prefer the deepest ApplicationFailure
+  // whose type is the user's error, so we surface the friendly message rather than the wrapper.
+  const deepestFirst = chain.filter( isApplicationFailure ).reverse();
+  const userFailure = deepestFirst.find( link => typeof link.type === 'string' && !TEMPORAL_FAILURE_TYPES.has( link.type ) ) ??
+    deepestFirst[0] ??
+    null;
+  // Retryability lives on whichever link Temporal flagged (usually the activity wrapper).
+  const flagged = chain.find( link => typeof link.nonRetryable === 'boolean' );
   return {
-    message: appFailure?.message ?? extractErrorMessage( error ),
-    type: appFailure?.type ?? error.constructor?.name ?? error.name ?? null,
-    retryable: appFailure && typeof appFailure.nonRetryable === 'boolean' ? !appFailure.nonRetryable : null,
+    message: userFailure?.message ?? extractErrorMessage( error ),
+    type: userFailure?.type ?? error.constructor?.name ?? error.name ?? null,
+    retryable: flagged ? !flagged.nonRetryable : null,
     cause: serializeErrorChain( error )
   };
 };

--- a/api/src/utils.js
+++ b/api/src/utils.js
@@ -67,100 +67,7 @@ export const extractErrorDetail = ( e, key ) =>
  */
 export const extractErrorMessage = ( e, depth = 20 ) => depth > 0 && e?.cause ? extractErrorMessage( e.cause, depth - 1 ) : ( e?.message ?? null );
 
-/**
- * Duck-types a Temporal ApplicationFailure node. The worker interceptor wraps user errors as
- * ApplicationFailure( message, type = constructorName, nonRetryable, details, cause ); only that
- * node carries .type / .nonRetryable. We duck-type to keep this module free of @temporalio imports.
- *
- * @param {unknown} e
- * @returns {boolean}
- */
-const isApplicationFailure = e =>
-  Boolean( e ) && ( typeof e.type === 'string' || typeof e.nonRetryable === 'boolean' );
-
-/**
- * Temporal's own failure wrappers. When one of these is itself wrapped in an ApplicationFailure, the
- * wrapper's `type` names the transport layer (e.g. "ActivityFailure"), not the user's error. We skip
- * them so we surface the original throw (e.g. "Foo"/"Error") instead of "Activity task failed".
- */
-const TEMPORAL_FAILURE_TYPES = new Set( [
-  'ActivityFailure', 'ChildWorkflowFailure', 'TimeoutFailure',
-  'CancelledFailure', 'TerminatedFailure', 'ServerFailure', 'ApplicationFailure'
-] );
-
-/**
- * Flattens an error's .cause chain into an array, outermost first (depth-limited).
- *
- * @param {Error} e
- * @param {number} [depth=20]
- * @returns {object[]}
- */
-const collectChain = ( e, depth = 20 ) =>
-  !e || depth <= 0 ? [] : [ e, ...collectChain( e.cause, depth - 1 ) ];
-
-/**
- * Recursively serializes an error's .cause chain into a sanitized, transport-safe shape for
- * client responses. Includes name/message always, and type only when present (ApplicationFailure
- * nodes). Deliberately excludes stack and details (security + payload size).
- *
- * @param {Error} e
- * @param {number} [depth=0]
- * @returns {object|null}
- */
-export const serializeErrorChain = ( e, depth = 0 ) => {
-  if ( !e ) {
-    return null;
-  }
-  if ( depth > 10 ) {
-    return { name: 'Error', message: 'Cause chain too deep' };
-  }
-  return {
-    name: e.constructor?.name ?? e.name ?? 'Error',
-    ...( typeof e.type === 'string' ? { type: e.type } : {} ),
-    message: e.message ?? null,
-    ...( e.cause ? { cause: serializeErrorChain( e.cause, depth + 1 ) } : {} )
-  };
-};
-
-/**
- * @typedef {object} WorkflowFailure
- * @property {string|null} message - Friendly failure message (from the ApplicationFailure node)
- * @property {string|null} type - Error type (the original error's class name)
- * @property {boolean|null} retryable - Whether the failure was retryable; null if Temporal did not report it
- * @property {object|null} cause - Sanitized error cause chain ({ name, type?, message, cause? }); no stack
- */
-
-/**
- * Extracts structured failure details from a Temporal workflow error chain. Returns null for falsy
- * input so callers can omit the field. The friendly message/type come from the first
- * ApplicationFailure node (skipping the WorkflowFailedError/ActivityFailure wrappers).
- *
- * @param {Error} error
- * @returns {WorkflowFailure|null}
- */
-export const extractFailure = error => {
-  if ( !error ) {
-    return null;
-  }
-  const chain = collectChain( error );
-  // Temporal double-wraps: WorkflowFailedError -> ApplicationFailure(type=ActivityFailure) ->
-  // ActivityFailure -> ApplicationFailure(type=<user error>). Prefer the deepest ApplicationFailure
-  // whose type is the user's error, so we surface the friendly message rather than the wrapper.
-  const deepestFirst = chain.filter( isApplicationFailure ).reverse();
-  const userFailure = deepestFirst.find( link => typeof link.type === 'string' && !TEMPORAL_FAILURE_TYPES.has( link.type ) ) ??
-    deepestFirst[0] ??
-    null;
-  // Retryability lives on whichever link Temporal flagged (usually the activity wrapper).
-  const flagged = chain.find( link => typeof link.nonRetryable === 'boolean' );
-  return {
-    message: userFailure?.message ?? extractErrorMessage( error ),
-    type: userFailure?.type ?? error.constructor?.name ?? error.name ?? null,
-    retryable: flagged ? !flagged.nonRetryable : null,
-    cause: serializeErrorChain( error )
-  };
-};
-
-// gRPC status integers we may surface by name in logs (subset of @grpc/grpc-js Status).
+// gRPC status integers we surface by name (subset of @grpc/grpc-js Status).
 const GRPC_STATUS_NAMES = {
   3: 'INVALID_ARGUMENT',
   4: 'DEADLINE_EXCEEDED',
@@ -171,7 +78,7 @@ const GRPC_STATUS_NAMES = {
   14: 'UNAVAILABLE'
 };
 
-// gRPC metadata can carry auth headers/tokens, so we log only key NAMES plus an allowlist of
+// gRPC metadata can carry auth headers/tokens, so we keep only key NAMES plus an allowlist of
 // non-sensitive diagnostic values.
 const SAFE_METADATA_KEYS = [ 'grpc-status-details-bin', 'content-type' ];
 
@@ -191,38 +98,82 @@ const redactMetadata = metadata => {
 };
 
 /**
- * Recursively serializes an error and its .cause chain into a plain object for structured logging
- * (winston meta). Captures gRPC ServiceError fields (code, codeName, details, redacted metadata)
- * when a link duck-types as a gRPC error, includes the top node's stack, and surfaces context
- * annotations (workflowId, runId, taskQueue, query). For server logs only — never sent to clients.
+ * Recursively serializes an error's .cause chain into a plain object. `name` is the Temporal
+ * ApplicationFailure `type` when present (e.g. "ValidationError"), otherwise the constructor name.
+ * gRPC ServiceError links also contribute code/codeName/details/redacted-metadata. Stack is excluded
+ * so the same shape is safe in client responses; loggers add `stack` themselves at the call site.
  *
- * @param {unknown} error
+ * @param {unknown} e
  * @param {number} [depth=0]
- * @returns {object}
+ * @returns {object|null}
  */
-export const serializeTemporalError = ( error, depth = 0 ) => {
+export const serializeErrorChain = ( e, depth = 0 ) => {
+  if ( !e ) {
+    return null;
+  }
   if ( depth > 10 ) {
     return { name: 'Error', message: 'Cause chain too deep' };
   }
-  if ( !error || typeof error !== 'object' ) {
-    return { value: String( error ) };
-  }
-  const isGrpc = typeof error.details === 'string' && typeof error.metadata === 'object' && error.metadata !== null;
+  const isGrpc = typeof e.details === 'string' && typeof e.metadata === 'object' && e.metadata !== null;
   return {
-    name: error.constructor?.name ?? error.name ?? 'Error',
-    message: error.message,
-    ...( depth === 0 && error.stack ? { stack: error.stack } : {} ),
-    ...( isGrpc ? {
-      code: error.code,
-      codeName: GRPC_STATUS_NAMES[error.code] ?? 'UNKNOWN',
-      details: error.details,
-      metadata: redactMetadata( error.metadata )
-    } : {} ),
-    ...( error.workflowId ? { workflowId: error.workflowId } : {} ),
-    ...( error.runId ? { runId: error.runId } : {} ),
-    ...( error.taskQueue ? { taskQueue: error.taskQueue } : {} ),
-    ...( error.query ? { query: error.query } : {} ),
-    ...( error.cause ? { cause: serializeTemporalError( error.cause, depth + 1 ) } : {} )
+    name: e.type ?? e.constructor?.name ?? e.name ?? 'Error',
+    message: e.message ?? null,
+    ...( isGrpc && { code: e.code, codeName: GRPC_STATUS_NAMES[e.code] ?? 'UNKNOWN', details: e.details, metadata: redactMetadata( e.metadata ) } ),
+    ...( e.cause && { cause: serializeErrorChain( e.cause, depth + 1 ) } )
+  };
+};
+
+// Temporal's own failure wrappers. When one is wrapped in an ApplicationFailure, that wrapper's
+// `type` names the transport layer (e.g. "ActivityFailure"), not the user's error — so we skip them
+// when choosing the friendly failure name/message.
+const TEMPORAL_FAILURE_TYPES = new Set( [
+  'ActivityFailure', 'ChildWorkflowFailure', 'TimeoutFailure',
+  'CancelledFailure', 'TerminatedFailure', 'ServerFailure', 'ApplicationFailure'
+] );
+
+/**
+ * Flattens an error's .cause chain into an array, outermost first (depth-limited).
+ *
+ * @param {Error} e
+ * @param {number} [depth=20]
+ * @returns {object[]}
+ */
+const collectChain = ( e, depth = 20 ) =>
+  !e || depth <= 0 ? [] : [ e, ...collectChain( e.cause, depth - 1 ) ];
+
+/**
+ * @typedef {object} WorkflowFailure
+ * @property {string|null} message - Friendly failure message (from the user's ApplicationFailure)
+ * @property {string|null} name - Error name/type (the original error's class)
+ * @property {boolean|null} retryable - Whether Temporal flagged the failure retryable; null if unknown
+ * @property {object|null} cause - Serialized error cause chain ({ name, message, cause? }); no stack
+ */
+
+/**
+ * Extracts structured failure details from a Temporal workflow error chain. Returns null for falsy
+ * input so callers can omit the field. Temporal double-wraps (WorkflowFailedError ->
+ * ApplicationFailure(ActivityFailure) -> ActivityFailure -> ApplicationFailure(<user error>)), so we
+ * pick the deepest ApplicationFailure whose type is the user's error to surface the friendly message.
+ *
+ * @param {Error} error
+ * @returns {WorkflowFailure|null}
+ */
+export const extractFailure = error => {
+  if ( !error ) {
+    return null;
+  }
+  const chain = collectChain( error );
+  const deepestFirst = chain.filter( link => typeof link.type === 'string' || typeof link.nonRetryable === 'boolean' ).reverse();
+  const userFailure = deepestFirst.find( link => typeof link.type === 'string' && !TEMPORAL_FAILURE_TYPES.has( link.type ) ) ??
+    deepestFirst[0] ??
+    null;
+  // Retryability lives on whichever link Temporal flagged (usually the activity wrapper).
+  const flagged = chain.find( link => typeof link.nonRetryable === 'boolean' );
+  return {
+    message: userFailure?.message ?? extractErrorMessage( error ),
+    name: userFailure?.type ?? error.constructor?.name ?? error.name ?? null,
+    retryable: flagged ? !flagged.nonRetryable : null,
+    cause: serializeErrorChain( error )
   };
 };
 

--- a/api/src/utils.spec.js
+++ b/api/src/utils.spec.js
@@ -313,6 +313,22 @@ describe( 'utils spec', () => {
         cause: { name: 'X', message: 'mid' }
       } );
     } );
+
+    it( 'reports the failing activity key under activityId', () => {
+      const chain = {
+        name: 'WorkflowFailedError', message: 'Workflow execution failed',
+        cause: {
+          activityType: 'test_error#thrower', message: 'Activity task failed',
+          cause: { type: 'Error', message: 'Foo' }
+        }
+      };
+
+      expect( extractFailure( chain ).activityId ).toBe( 'test_error#thrower' );
+    } );
+
+    it( 'sets activityId to null when no activity failed (workflow-level throw)', () => {
+      expect( extractFailure( { type: 'Error', message: 'boom' } ).activityId ).toBeNull();
+    } );
   } );
 
   describe( 'serializeErrorChain', () => {

--- a/api/src/utils.spec.js
+++ b/api/src/utils.spec.js
@@ -258,6 +258,27 @@ describe( 'utils spec', () => {
       expect( failure.retryable ).toBe( false );
     } );
 
+    it( 'picks the innermost user error over the outer ActivityFailure wrapper (real double-wrapped chain)', () => {
+      // Mirrors the live Temporal chain captured from a step throwing new Error('Foo'):
+      // WorkflowFailedError -> ApplicationFailure(type=ActivityFailure) -> ActivityFailure -> ApplicationFailure(type=Error)
+      const chain = {
+        name: 'WorkflowFailedError', message: 'Workflow execution failed',
+        cause: {
+          type: 'ActivityFailure', nonRetryable: false, message: 'Activity task failed',
+          cause: {
+            message: 'Activity task failed',
+            cause: { type: 'Error', message: 'Foo' }
+          }
+        }
+      };
+
+      const failure = extractFailure( chain );
+
+      expect( failure.message ).toBe( 'Foo' );
+      expect( failure.type ).toBe( 'Error' );
+      expect( failure.retryable ).toBe( true );
+    } );
+
     it( 'returns retryable true when nonRetryable is false', () => {
       const appFailure = { type: 'SomeError', nonRetryable: false, message: 'oops' };
 

--- a/api/src/utils.spec.js
+++ b/api/src/utils.spec.js
@@ -7,7 +7,6 @@ import {
   extractErrorMessage,
   serializeErrorChain,
   extractFailure,
-  serializeTemporalError,
   takeFromAsyncIterable
 } from './utils.js';
 
@@ -254,7 +253,7 @@ describe( 'utils spec', () => {
       const failure = extractFailure( workflowError );
 
       expect( failure.message ).toBe( 'bad input' );
-      expect( failure.type ).toBe( 'ValidationError' );
+      expect( failure.name ).toBe( 'ValidationError' );
       expect( failure.retryable ).toBe( false );
     } );
 
@@ -275,7 +274,7 @@ describe( 'utils spec', () => {
       const failure = extractFailure( chain );
 
       expect( failure.message ).toBe( 'Foo' );
-      expect( failure.type ).toBe( 'Error' );
+      expect( failure.name ).toBe( 'Error' );
       expect( failure.retryable ).toBe( true );
     } );
 
@@ -301,17 +300,17 @@ describe( 'utils spec', () => {
       const failure = extractFailure( workflowError );
 
       expect( failure.message ).toBe( 'root cause' );
-      expect( failure.type ).toBe( 'Error' );
+      expect( failure.name ).toBe( 'Error' );
       expect( failure.retryable ).toBeNull();
     } );
 
-    it( 'includes a sanitized cause chain', () => {
+    it( 'includes a sanitized cause chain (ApplicationFailure type becomes the node name)', () => {
       const workflowError = { message: 'top', cause: { type: 'X', nonRetryable: true, message: 'mid' } };
 
       expect( extractFailure( workflowError ).cause ).toEqual( {
         name: 'Object',
         message: 'top',
-        cause: { name: 'Object', type: 'X', message: 'mid' }
+        cause: { name: 'X', message: 'mid' }
       } );
     } );
   } );
@@ -329,10 +328,9 @@ describe( 'utils spec', () => {
       expect( node.stack ).toBeUndefined();
     } );
 
-    it( 'includes type only when present', () => {
+    it( 'uses the ApplicationFailure type as the node name when present', () => {
       expect( serializeErrorChain( { type: 'ValidationError', message: 'x' } ) )
-        .toEqual( { name: 'Object', type: 'ValidationError', message: 'x' } );
-      expect( serializeErrorChain( { message: 'x' } ).type ).toBeUndefined();
+        .toEqual( { name: 'ValidationError', message: 'x' } );
     } );
 
     it( 'serializes a nested cause chain', () => {
@@ -345,83 +343,46 @@ describe( 'utils spec', () => {
       } );
     } );
 
-    it( 'stops at depth > 10 with a sentinel', () => {
-      const build = n => n === 0 ? { message: 'deep' } : { message: `l${n}`, cause: build( n - 1 ) };
-      const deepest = node => node.cause ? deepest( node.cause ) : node;
-
-      expect( deepest( serializeErrorChain( build( 12 ) ) ) ).toEqual( { name: 'Error', message: 'Cause chain too deep' } );
-    } );
-  } );
-
-  describe( 'serializeTemporalError', () => {
-    it( 'serializes a plain Error with name, message and stack but no gRPC fields or cause', () => {
-      const out = serializeTemporalError( new Error( 'boom' ) );
-
-      expect( out.name ).toBe( 'Error' );
-      expect( out.message ).toBe( 'boom' );
-      expect( out.stack ).toBeDefined();
-      expect( out.code ).toBeUndefined();
-      expect( out.cause ).toBeUndefined();
-    } );
-
-    it( 'nests the cause chain and keeps stack on the top node only', () => {
-      const top = new Error( 'top' );
-      top.cause = new Error( 'root' );
-
-      const out = serializeTemporalError( top );
-
-      expect( out.stack ).toBeDefined();
-      expect( out.cause.message ).toBe( 'root' );
-      expect( out.cause.stack ).toBeUndefined();
-    } );
-
     it( 'captures gRPC code/codeName/details and redacts metadata to key names plus an allowlist', () => {
-      const out = serializeTemporalError( {
+      const node = serializeErrorChain( {
         message: '14 UNAVAILABLE: connection failed',
         code: 14,
         details: 'connection failed',
         metadata: { authorization: 'Bearer secret', 'content-type': 'application/grpc' }
       } );
 
-      expect( out.code ).toBe( 14 );
-      expect( out.codeName ).toBe( 'UNAVAILABLE' );
-      expect( out.details ).toBe( 'connection failed' );
-      expect( out.metadata.keys ).toEqual( [ 'authorization', 'content-type' ] );
-      expect( out.metadata.authorization ).toBeUndefined();
-      expect( out.metadata['content-type'] ).toBe( 'application/grpc' );
+      expect( node.code ).toBe( 14 );
+      expect( node.codeName ).toBe( 'UNAVAILABLE' );
+      expect( node.details ).toBe( 'connection failed' );
+      expect( node.metadata.keys ).toEqual( [ 'authorization', 'content-type' ] );
+      expect( node.metadata.authorization ).toBeUndefined();
+      expect( node.metadata['content-type'] ).toBe( 'application/grpc' );
     } );
 
     it( 'finds the gRPC code one cause level down (the "Failed to query Workflow" wrapper)', () => {
-      const out = serializeTemporalError( {
+      const node = serializeErrorChain( {
         message: 'Failed to query Workflow',
         cause: { message: '14 UNAVAILABLE', code: 14, details: 'x', metadata: {} }
       } );
 
-      expect( out.code ).toBeUndefined();
-      expect( out.cause.code ).toBe( 14 );
-      expect( out.cause.codeName ).toBe( 'UNAVAILABLE' );
+      expect( node.code ).toBeUndefined();
+      expect( node.cause.code ).toBe( 14 );
+      expect( node.cause.codeName ).toBe( 'UNAVAILABLE' );
     } );
 
-    it( 'returns { value } for non-Error throwables', () => {
-      expect( serializeTemporalError( 'boom' ) ).toEqual( { value: 'boom' } );
-      expect( serializeTemporalError( 42 ) ).toEqual( { value: '42' } );
-      expect( serializeTemporalError( null ) ).toEqual( { value: 'null' } );
-    } );
+    it( 'never includes stack, even when the error has one', () => {
+      const node = serializeErrorChain( new Error( 'boom' ) );
 
-    it( 'surfaces context annotations', () => {
-      const err = new Error( 'x' );
-      Object.assign( err, { workflowId: 'wf1', runId: 'run1', taskQueue: 'q', query: 'get' } );
-
-      expect( serializeTemporalError( err ) ).toMatchObject( {
-        workflowId: 'wf1', runId: 'run1', taskQueue: 'q', query: 'get'
-      } );
+      expect( node.name ).toBe( 'Error' );
+      expect( node.message ).toBe( 'boom' );
+      expect( node.stack ).toBeUndefined();
     } );
 
     it( 'stops at depth > 10 with a sentinel', () => {
       const build = n => n === 0 ? { message: 'deep' } : { message: `l${n}`, cause: build( n - 1 ) };
       const deepest = node => node.cause ? deepest( node.cause ) : node;
 
-      expect( deepest( serializeTemporalError( build( 12 ) ) ) ).toEqual( { name: 'Error', message: 'Cause chain too deep' } );
+      expect( deepest( serializeErrorChain( build( 12 ) ) ) ).toEqual( { name: 'Error', message: 'Cause chain too deep' } );
     } );
   } );
 

--- a/api/src/utils.spec.js
+++ b/api/src/utils.spec.js
@@ -5,6 +5,9 @@ import {
   parseS3Url,
   extractErrorDetail,
   extractErrorMessage,
+  serializeErrorChain,
+  extractFailure,
+  serializeTemporalError,
   takeFromAsyncIterable
 } from './utils.js';
 
@@ -234,6 +237,170 @@ describe( 'utils spec', () => {
       const result = extractErrorMessage( chain );
       expect( result ).toBeDefined();
       expect( result ).not.toBe( 'level 0' );
+    } );
+  } );
+
+  describe( 'extractFailure', () => {
+    it( 'returns null for null and undefined', () => {
+      expect( extractFailure( null ) ).toBeNull();
+      expect( extractFailure( undefined ) ).toBeNull();
+    } );
+
+    it( 'extracts message/type/retryable from the ApplicationFailure node, skipping wrappers', () => {
+      const appFailure = { type: 'ValidationError', nonRetryable: true, message: 'bad input', cause: { message: 'bad input' } };
+      const activityFailure = { message: 'Activity task failed', cause: appFailure };
+      const workflowError = { message: 'Workflow execution failed', cause: activityFailure };
+
+      const failure = extractFailure( workflowError );
+
+      expect( failure.message ).toBe( 'bad input' );
+      expect( failure.type ).toBe( 'ValidationError' );
+      expect( failure.retryable ).toBe( false );
+    } );
+
+    it( 'returns retryable true when nonRetryable is false', () => {
+      const appFailure = { type: 'SomeError', nonRetryable: false, message: 'oops' };
+
+      expect( extractFailure( appFailure ).retryable ).toBe( true );
+    } );
+
+    it( 'returns retryable null when nonRetryable is absent', () => {
+      const appFailure = { type: 'SomeError', message: 'oops' };
+
+      expect( extractFailure( appFailure ).retryable ).toBeNull();
+    } );
+
+    it( 'falls back to the deepest message and a null retryable when there is no ApplicationFailure node', () => {
+      const root = new Error( 'root cause' );
+      const activity = new Error( 'Activity task failed' );
+      activity.cause = root;
+      const workflowError = new Error( 'Workflow execution failed' );
+      workflowError.cause = activity;
+
+      const failure = extractFailure( workflowError );
+
+      expect( failure.message ).toBe( 'root cause' );
+      expect( failure.type ).toBe( 'Error' );
+      expect( failure.retryable ).toBeNull();
+    } );
+
+    it( 'includes a sanitized cause chain', () => {
+      const workflowError = { message: 'top', cause: { type: 'X', nonRetryable: true, message: 'mid' } };
+
+      expect( extractFailure( workflowError ).cause ).toEqual( {
+        name: 'Object',
+        message: 'top',
+        cause: { name: 'Object', type: 'X', message: 'mid' }
+      } );
+    } );
+  } );
+
+  describe( 'serializeErrorChain', () => {
+    it( 'returns null for falsy input', () => {
+      expect( serializeErrorChain( null ) ).toBeNull();
+      expect( serializeErrorChain( undefined ) ).toBeNull();
+    } );
+
+    it( 'serializes a single node and omits stack, details, and cause', () => {
+      const node = serializeErrorChain( { message: 'x', stack: 'STACK', details: [ { trace: {} } ] } );
+
+      expect( node ).toEqual( { name: 'Object', message: 'x' } );
+      expect( node.stack ).toBeUndefined();
+    } );
+
+    it( 'includes type only when present', () => {
+      expect( serializeErrorChain( { type: 'ValidationError', message: 'x' } ) )
+        .toEqual( { name: 'Object', type: 'ValidationError', message: 'x' } );
+      expect( serializeErrorChain( { message: 'x' } ).type ).toBeUndefined();
+    } );
+
+    it( 'serializes a nested cause chain', () => {
+      const chain = { message: 'a', cause: { message: 'b', cause: { message: 'c' } } };
+
+      expect( serializeErrorChain( chain ) ).toEqual( {
+        name: 'Object',
+        message: 'a',
+        cause: { name: 'Object', message: 'b', cause: { name: 'Object', message: 'c' } }
+      } );
+    } );
+
+    it( 'stops at depth > 10 with a sentinel', () => {
+      const build = n => n === 0 ? { message: 'deep' } : { message: `l${n}`, cause: build( n - 1 ) };
+      const deepest = node => node.cause ? deepest( node.cause ) : node;
+
+      expect( deepest( serializeErrorChain( build( 12 ) ) ) ).toEqual( { name: 'Error', message: 'Cause chain too deep' } );
+    } );
+  } );
+
+  describe( 'serializeTemporalError', () => {
+    it( 'serializes a plain Error with name, message and stack but no gRPC fields or cause', () => {
+      const out = serializeTemporalError( new Error( 'boom' ) );
+
+      expect( out.name ).toBe( 'Error' );
+      expect( out.message ).toBe( 'boom' );
+      expect( out.stack ).toBeDefined();
+      expect( out.code ).toBeUndefined();
+      expect( out.cause ).toBeUndefined();
+    } );
+
+    it( 'nests the cause chain and keeps stack on the top node only', () => {
+      const top = new Error( 'top' );
+      top.cause = new Error( 'root' );
+
+      const out = serializeTemporalError( top );
+
+      expect( out.stack ).toBeDefined();
+      expect( out.cause.message ).toBe( 'root' );
+      expect( out.cause.stack ).toBeUndefined();
+    } );
+
+    it( 'captures gRPC code/codeName/details and redacts metadata to key names plus an allowlist', () => {
+      const out = serializeTemporalError( {
+        message: '14 UNAVAILABLE: connection failed',
+        code: 14,
+        details: 'connection failed',
+        metadata: { authorization: 'Bearer secret', 'content-type': 'application/grpc' }
+      } );
+
+      expect( out.code ).toBe( 14 );
+      expect( out.codeName ).toBe( 'UNAVAILABLE' );
+      expect( out.details ).toBe( 'connection failed' );
+      expect( out.metadata.keys ).toEqual( [ 'authorization', 'content-type' ] );
+      expect( out.metadata.authorization ).toBeUndefined();
+      expect( out.metadata['content-type'] ).toBe( 'application/grpc' );
+    } );
+
+    it( 'finds the gRPC code one cause level down (the "Failed to query Workflow" wrapper)', () => {
+      const out = serializeTemporalError( {
+        message: 'Failed to query Workflow',
+        cause: { message: '14 UNAVAILABLE', code: 14, details: 'x', metadata: {} }
+      } );
+
+      expect( out.code ).toBeUndefined();
+      expect( out.cause.code ).toBe( 14 );
+      expect( out.cause.codeName ).toBe( 'UNAVAILABLE' );
+    } );
+
+    it( 'returns { value } for non-Error throwables', () => {
+      expect( serializeTemporalError( 'boom' ) ).toEqual( { value: 'boom' } );
+      expect( serializeTemporalError( 42 ) ).toEqual( { value: '42' } );
+      expect( serializeTemporalError( null ) ).toEqual( { value: 'null' } );
+    } );
+
+    it( 'surfaces context annotations', () => {
+      const err = new Error( 'x' );
+      Object.assign( err, { workflowId: 'wf1', runId: 'run1', taskQueue: 'q', query: 'get' } );
+
+      expect( serializeTemporalError( err ) ).toMatchObject( {
+        workflowId: 'wf1', runId: 'run1', taskQueue: 'q', query: 'get'
+      } );
+    } );
+
+    it( 'stops at depth > 10 with a sentinel', () => {
+      const build = n => n === 0 ? { message: 'deep' } : { message: `l${n}`, cause: build( n - 1 ) };
+      const deepest = node => node.cause ? deepest( node.cause ) : node;
+
+      expect( deepest( serializeTemporalError( build( 12 ) ) ) ).toEqual( { name: 'Error', message: 'Cause chain too deep' } );
     } );
   } );
 

--- a/docs/guides/openapi.json
+++ b/docs/guides/openapi.json
@@ -376,7 +376,7 @@
             "nullable": true,
             "description": "Error message if workflow failed, null otherwise"
           },
-          "failure": {
+          "errorDetails": {
             "type": "object",
             "nullable": true,
             "description": "Structured failure details if the workflow failed, null otherwise",
@@ -395,6 +395,11 @@
                 "type": "boolean",
                 "nullable": true,
                 "description": "Whether Temporal flagged the failure retryable; null if unknown"
+              },
+              "activityId": {
+                "type": "string",
+                "nullable": true,
+                "description": "Failing activity key (\"workflow#step\"); null if no activity failed"
               },
               "cause": {
                 "type": "object",

--- a/docs/guides/openapi.json
+++ b/docs/guides/openapi.json
@@ -386,21 +386,21 @@
                 "nullable": true,
                 "description": "Friendly failure message (from the underlying application error)"
               },
-              "type": {
+              "name": {
                 "type": "string",
                 "nullable": true,
-                "description": "Error type (the original error's class name)"
+                "description": "Error name/type (the original error's class)"
               },
               "retryable": {
                 "type": "boolean",
                 "nullable": true,
-                "description": "Whether the failure was retryable; null if not reported by Temporal"
+                "description": "Whether Temporal flagged the failure retryable; null if unknown"
               },
               "cause": {
                 "type": "object",
                 "nullable": true,
                 "additionalProperties": true,
-                "description": "Sanitized error cause chain (name/type/message per level, no stack)"
+                "description": "Sanitized error cause chain (name/message per level, no stack)"
               }
             }
           }

--- a/docs/guides/openapi.json
+++ b/docs/guides/openapi.json
@@ -375,6 +375,34 @@
             "type": "string",
             "nullable": true,
             "description": "Error message if workflow failed, null otherwise"
+          },
+          "failure": {
+            "type": "object",
+            "nullable": true,
+            "description": "Structured failure details if the workflow failed, null otherwise",
+            "properties": {
+              "message": {
+                "type": "string",
+                "nullable": true,
+                "description": "Friendly failure message (from the underlying application error)"
+              },
+              "type": {
+                "type": "string",
+                "nullable": true,
+                "description": "Error type (the original error's class name)"
+              },
+              "retryable": {
+                "type": "boolean",
+                "nullable": true,
+                "description": "Whether the failure was retryable; null if not reported by Temporal"
+              },
+              "cause": {
+                "type": "object",
+                "nullable": true,
+                "additionalProperties": true,
+                "description": "Sanitized error cause chain (name/type/message per level, no stack)"
+              }
+            }
           }
         }
       },

--- a/sdk/cli/src/api/generated/api.ts
+++ b/sdk/cli/src/api/generated/api.ts
@@ -251,6 +251,33 @@ export const WorkflowResultResponseStatus = {
   continued: 'continued',
 } as const;
 
+/**
+ * Structured failure details if the workflow failed, null otherwise
+ * @nullable
+ */
+export type WorkflowResultResponseFailure = {
+  /**
+     * Friendly failure message (from the underlying application error)
+     * @nullable
+     */
+  message?: string | null;
+  /**
+     * Error type (the original error's class name)
+     * @nullable
+     */
+  type?: string | null;
+  /**
+     * Whether the failure was retryable; null if not reported by Temporal
+     * @nullable
+     */
+  retryable?: boolean | null;
+  /**
+     * Sanitized error cause chain (name/type/message per level, no stack)
+     * @nullable
+     */
+  cause?: { [key: string]: unknown } | null;
+} | null | null;
+
 export interface WorkflowResultResponse {
   /** The workflow execution id */
   workflowId?: string;
@@ -273,6 +300,11 @@ export interface WorkflowResultResponse {
      * @nullable
      */
   error?: string | null;
+  /**
+     * Structured failure details if the workflow failed, null otherwise
+     * @nullable
+     */
+  failure?: WorkflowResultResponseFailure;
 }
 
 export interface StopWorkflowResponse {

--- a/sdk/cli/src/api/generated/api.ts
+++ b/sdk/cli/src/api/generated/api.ts
@@ -255,7 +255,7 @@ export const WorkflowResultResponseStatus = {
  * Structured failure details if the workflow failed, null otherwise
  * @nullable
  */
-export type WorkflowResultResponseFailure = {
+export type WorkflowResultResponseErrorDetails = {
   /**
      * Friendly failure message (from the underlying application error)
      * @nullable
@@ -271,6 +271,11 @@ export type WorkflowResultResponseFailure = {
      * @nullable
      */
   retryable?: boolean | null;
+  /**
+     * Failing activity key ("workflow#step"); null if no activity failed
+     * @nullable
+     */
+  activityId?: string | null;
   /**
      * Sanitized error cause chain (name/message per level, no stack)
      * @nullable
@@ -304,7 +309,7 @@ export interface WorkflowResultResponse {
      * Structured failure details if the workflow failed, null otherwise
      * @nullable
      */
-  failure?: WorkflowResultResponseFailure;
+  errorDetails?: WorkflowResultResponseErrorDetails;
 }
 
 export interface StopWorkflowResponse {

--- a/sdk/cli/src/api/generated/api.ts
+++ b/sdk/cli/src/api/generated/api.ts
@@ -262,17 +262,17 @@ export type WorkflowResultResponseFailure = {
      */
   message?: string | null;
   /**
-     * Error type (the original error's class name)
+     * Error name/type (the original error's class)
      * @nullable
      */
-  type?: string | null;
+  name?: string | null;
   /**
-     * Whether the failure was retryable; null if not reported by Temporal
+     * Whether Temporal flagged the failure retryable; null if unknown
      * @nullable
      */
   retryable?: boolean | null;
   /**
-     * Sanitized error cause chain (name/type/message per level, no stack)
+     * Sanitized error cause chain (name/message per level, no stack)
      * @nullable
      */
   cause?: { [key: string]: unknown } | null;


### PR DESCRIPTION
## Problem

- When a workflow fails, `/workflow/run` and `/workflow/:id/result` returned only a single `error` string from the deepest cause — the friendly message, error type, and retryable flag were lost, so Atlas/Studio couldn't present meaningful failures. (It also tended to surface "activity failure" while hiding the real message in the stack.)
- When a Temporal client call failed in production (e.g. `ServiceError: Failed to query Workflow`), API logs showed only that one line — no gRPC `code`/`details`/`metadata`, cause chain, query name, or task queue — making it impossible to tell catalog-unavailable from worker saturation, a query timeout, or bad routing.

## Solution

- **API responses** — failed `WorkflowResult`s now include a structured `errorDetails { message, name, retryable, activityId, cause }` alongside the existing `error` string (additive, backward-compatible). `message`/`name` come from the **innermost** `ApplicationFailure` (the user's actual error), skipping Temporal's `WorkflowFailedError`/`ActivityFailure` wrappers — so you get "Foo"/`Error`, not "Activity task failed". `retryable` reflects Temporal's `nonRetryable` flag (`null` when unreported); `activityId` is the failing activity key (`"{workflow}#{step}"`, e.g. `test_error#thrower`; `null` for workflow-level/child-workflow failures); `cause` is a sanitized chain (`name`/`message`, **no stack**).
- **Logging** — a single `serializeErrorChain()` walks the `.cause` chain and folds in gRPC `code`/`codeName`/`details` + **redacted** metadata (key names + safe allowlist; auth headers never logged). `error_handler` logs unhandled 500s with that chain + `stack` + annotated `taskQueue`/`query`/`workflowId`. **Client-facing HTTP responses stay sanitized** (no stack/cause/metadata).
- **Docs** — `errorDetails` added to the `WorkflowResultResponse` OpenAPI schema; `api/openapi.json`, the docs copy, and the Orval-generated CLI client regenerated.

Closes OUT-233 — Ref: [OUT-233](https://linear.app/growthx/issue/OUT-233/expose-workflow-failure-details-in-output-api-responses)

## Proof

**Surface A** — `POST /workflow/run` of a deliberately failing workflow (`test_error`):
```json
{
  "status": "failed",
  "error": "Foo",
  "errorDetails": {
    "message": "Foo",
    "name": "Error",
    "retryable": true,
    "activityId": "test_error#thrower",
    "cause": { "name": "WorkflowFailedError",
      "cause": { "name": "ActivityFailure",
        "cause": { "name": "ActivityFailure",
          "cause": { "name": "Error", "message": "Foo" } } } }
  }
}
```

**Surface B** — catalog query against an unreachable Temporal; rich server log, client still gets a sanitized 500:
```
[error] ServiceError: Failed to query Workflow {"taskQueue":"main","query":"get","stack":"… at getCatalog … at runWorkflow …","cause":{"name":"ServiceError","message":"Failed to query Workflow","cause":{"name":"Error","message":"14 UNAVAILABLE: … ECONNREFUSED …:7233","code":14,"codeName":"UNAVAILABLE","details":"…"}}}
[http] POST /workflow/run 500 61b
```

## Test plan

- [x] `npm run lint` passes
- [x] API unit tests — pass across `utils.spec.js`, `temporal_client.spec.js`, `error_handler.spec.js` (incl. the double-wrapped-chain regression + `activityId` extraction)
- [x] Manual smoke (`./run.sh dev`, Node 24): both surfaces verified live (failure shape confirmed pre-rename; activity-key format `test_error#thrower` confirmed from the live trace)
- [ ] `npm test` full suite — green except 2 pre-existing `sdk/cli` copy-assets tests (see Follow-up)

## Notes for reviewers

- Addresses @szanata's review (see inline replies): unified the two serializers into `serializeErrorChain`, removed the `alreadyLogged` flag (logging centralized in `error_handler`), inlined the duck-type, `type`→`name`, `&&`-spreads.
- **Renamed `failure` → `errorDetails`** (type `WorkflowErrorDetails`) and added `activityId` (the failing step) — see commit 5146ed2. Kept `error` (string) + `errorDetails` (object) rather than collapsing to one field: `error` is a string in the shipped API and read as one by Atlas/Studio/CLI, so collapsing is a breaking change; OUT-233 is additive. The rename sharpens the summary-vs-structured split. Open to a single structured field in a future major bump.
- **Duck-typing the Temporal failure** (`typeof e.type === 'string'`) instead of `instanceof ApplicationFailure` keeps `utils.js` free of a `@temporalio` import and works on the protobuf-reconstructed chain.

## Follow-up (out of scope)

- gRPC availability errors (`UNAVAILABLE`/`DEADLINE_EXCEEDED`/`RESOURCE_EXHAUSTED`) → clean `503 CatalogNotAvailableError` + sanitized `rootCause`. Deferred. Related: OUT-452.
- `native-copyfiles@2.0.1` breaks `build:packages` / `./run.sh dev` on current Node (`fs.glob` `exclude` must be a function) — reproduced on Node 22 **and** 24. Fixed locally in `copyassets.sh` (find/cp) but kept out of this PR — worth its own `fix(cli)` PR.
