### PR TITLE
feat(llm): support prompt caching in .prompt files (OUT-454)

### DIFF
--- a/.changeset/prompt-caching-support.md
+++ b/.changeset/prompt-caching-support.md
@@ -1,0 +1,9 @@
+---
+"@outputai/llm": minor
+---
+
+Add per-message provider options to `.prompt` files via `messageOptions`.
+
+- Define named `messageOptions` sets in front matter and attach them to message blocks with `options="<name>"` (e.g. `<system options="cached">`); each set is a provider-namespaced `providerOptions` object merged onto that message.
+- Enables Anthropic prompt caching (`{ anthropic: { cacheControl: { type: ephemeral } } }`) and any other per-message provider option, on any provider.
+- Cost tracking now reports cached input tokens (`input_cached`) even for models whose pricing record lacks a `cache_read` rate, so cache savings are visible in usage aggregations instead of silently disappearing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,38 @@ AI SDK uses `Record<string, Record<string, JSONValue>>` for `providerOptions` to
 
 The nesting is intentional architecture, not redundancy.
 
+### Per-Message Caching (Anthropic Prompt Cache)
+
+Anthropic prompt caching is a **per-message** directive. Mark the block that ends your static prefix and that prefix is cached and reused across calls. Define a `cacheControl` set in frontmatter `messageOptions` and attach it to the block with `options`:
+
+```yaml
+messageOptions:
+  cached: { anthropic: { cacheControl: { type: ephemeral } } }      # add ttl: 1h for the 1-hour cache
+```
+```text
+<system options="cached">
+{{ long static instructions }}
+</system>
+
+<user>
+{{ per-call input }}
+</user>
+```
+
+Each set is a provider-namespaced `providerOptions` object (same namespace rules as call-level `providerOptions`); on Vertex with a Claude model use the same `anthropic` namespace. A block may list multiple sets: `options="cached fast"`.
+
+**Rules:**
+- Attach the set to the **last static block**, never one containing per-call `{{ variables }}` — a breakpoint on changing content rewrites the cache every call and never hits.
+- Order blocks **static-first, dynamic-last**.
+- Minimum cacheable prefix is model-specific (~1,024 tokens for most Sonnet/Opus; higher for some). Below it, caching is silently skipped — verify via the cost trace (`cachedInputTokens`).
+- Max 4 cache breakpoints per request.
+
+❌ caching a dynamic block: `<user options="cached">{{ topic }}</user>` (never hits)
+
+✅ caching the static prefix: `<system options="cached">{{ guide }}</system>` then `<user>{{ topic }}</user>`
+
+**OpenAI / Azure:** caching is automatic for prompts ≥1024 tokens — no `messageOptions` needed. Tune routing with `providerOptions.openai.promptCacheKey` (and `promptCacheRetention: 24h` on GPT-5.1+).
+
 ## Schema Constraints for LLM Structured Output
 
 When using `Output.object()` with `generateText`, the Zod schema is converted to JSON Schema and sent to the LLM provider as a tool definition. **Anthropic does not support many JSON Schema constraints**, which means certain Zod methods will cause errors or be silently ignored when the schema is sent to the provider.

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -691,6 +691,74 @@ model: claude-haiku-4-5
 
 Built-in providers use Output's default fetch configuration, including longer Undici response timeouts for LLM calls that take time before returning headers or body chunks. Custom registered providers are used exactly as you register them; they do not automatically receive that custom fetch. If your custom provider also needs longer network timeouts, configure its provider instance directly.
 
+## Prompt Caching
+
+When a prompt sends the same large prefix on every call — a long system prompt, few-shot examples, a pasted reference document — you can cache that prefix so the provider skips reprocessing it. Cached input is about 90% cheaper and faster to first token. How you enable it depends on the provider.
+
+### Anthropic
+
+Anthropic caches only what you explicitly mark. Define a `cacheControl` set in `messageOptions` and attach it — with `options` — to the block that ends your static prefix. Everything up to and including that block is cached and reused on the next call:
+
+```text prompts/generate_summary@v1.prompt
+---
+provider: anthropic
+model: claude-sonnet-4-20250514
+messageOptions:
+  cached:
+    anthropic:
+      cacheControl:
+        type: ephemeral
+---
+
+<system options="cached">
+You write concise company summaries for sales teams. Follow this style guide:
+{{ style_guide }}
+</system>
+
+<user>
+Summarize {{ companyName }}.
+</user>
+```
+
+Only the `<user>` block — the part that changes each call — is re-billed at full price; the cached `<system>` prefix is charged at the much cheaper cache-read rate. For the 1-hour cache instead of the default 5 minutes, add `ttl: 1h` under `cacheControl`. A block can reference several sets (`options="cached fast"`), and a set can be reused across blocks.
+
+<Warning>
+Attach the set to the last **static** block, never one containing per-call `{{ variables }}`. A breakpoint on changing content rewrites the cache on every call and never gets a hit. Order your blocks static-first, dynamic-last.
+</Warning>
+
+Each set is a provider-namespaced `providerOptions` object — the same shape and [namespace rules](/prompts#provider-options) as call-level `providerOptions`. On Vertex with a Claude model, use the same `anthropic` namespace.
+
+### OpenAI
+
+OpenAI caches automatically — there are no breakpoints to set, so the `messageOptions` mechanism above isn't needed. Any prompt of 1024 tokens or longer is cached for you, with no markup. To improve hit rates across calls, set a stable `promptCacheKey` (and, on GPT-5.1+, extend retention) via `providerOptions`:
+
+```yaml prompts/enrich_company@v1.prompt
+---
+provider: openai
+model: gpt-5
+providerOptions:
+  openai:
+    promptCacheKey: enrich-company-v1
+    promptCacheRetention: 24h
+---
+
+<system>
+{{ enrichment_playbook }}
+</system>
+
+<user>
+Enrich {{ company }}.
+</user>
+```
+
+### Confirming a cache hit
+
+Cache activity appears in the response usage and the [cost event](/costs/cost-events): the first call reports cache-creation tokens, and later calls within the TTL report cache-read tokens (`cachedInputTokens`), already priced at the cheaper rate in `response.cost`.
+
+<Note>
+Anthropic caches only prefixes above a model-specific minimum — around 1,024 tokens for most Sonnet and Opus models, higher for some. Shorter prefixes are silently not cached, with no error. A request supports at most four cache breakpoints.
+</Note>
+
 ## Provider Tools
 
 Many providers offer built-in tools like web search. Configure them in YAML front matter:

--- a/sdk/llm/src/ai_sdk_options.js
+++ b/sdk/llm/src/ai_sdk_options.js
@@ -1,4 +1,5 @@
 import { loadImageModel, loadTextModel, loadTools } from './ai_model.js';
+import { resolveMessageProviderOptions } from './prompt/block_options.js';
 import { FatalError } from '@outputai/core';
 
 /**
@@ -13,7 +14,7 @@ export const loadAiSdkTextOptions = prompt => {
   }
   const options = {
     model: loadTextModel( prompt ),
-    messages: prompt.messages,
+    messages: resolveMessageProviderOptions( prompt ),
     providerOptions: prompt.config.providerOptions
   };
 

--- a/sdk/llm/src/ai_sdk_options.spec.js
+++ b/sdk/llm/src/ai_sdk_options.spec.js
@@ -161,4 +161,32 @@ describe( 'ai_sdk_options', () => {
     );
     expect( loadImageModelImpl ).not.toHaveBeenCalled();
   } );
+
+  it( 'resolves block attributes into per-message providerOptions', async () => {
+    const prompt = {
+      name: 'cache@v1',
+      config: {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5',
+        messageOptions: { cached: { anthropic: { cacheControl: { type: 'ephemeral', ttl: '1h' } } } }
+      },
+      messages: [
+        { role: 'system', content: 'Static', attributes: { options: 'cached' } },
+        { role: 'user', content: 'Hello' }
+      ],
+      instructions: null
+    };
+
+    const { loadAiSdkTextOptions } = await importSut();
+    const result = loadAiSdkTextOptions( prompt );
+
+    expect( result.messages ).toEqual( [
+      {
+        role: 'system',
+        content: 'Static',
+        providerOptions: { anthropic: { cacheControl: { type: 'ephemeral', ttl: '1h' } } }
+      },
+      { role: 'user', content: 'Hello' }
+    ] );
+  } );
 } );

--- a/sdk/llm/src/cost/index.js
+++ b/sdk/llm/src/cost/index.js
@@ -32,8 +32,13 @@ export const calculateLLMCallCost = async ( { modelId, usage } ) => {
     if ( Number.isFinite( pricing.input ) && Number.isFinite( nonCachedTokens ) ) {
       llmUsage.addUsage( { type: 'input', ppm: pricing.input, amount: nonCachedTokens } );
     }
-    if ( Number.isFinite( pricing.cache_read ) && Number.isFinite( cachedInputTokens ) ) {
-      llmUsage.addUsage( { type: 'input_cached', ppm: pricing.cache_read, amount: cachedInputTokens } );
+    // Surface cached input tokens whenever the provider reports them, even if the model's
+    // pricing lacks a cache_read rate — otherwise caching savings vanish from the token
+    // aggregation (these tokens are already excluded from the input line above). Price at
+    // cache_read when available, otherwise at 0.
+    if ( Number.isFinite( cachedInputTokens ) ) {
+      const cacheReadPpm = Number.isFinite( pricing.cache_read ) ? pricing.cache_read : 0;
+      llmUsage.addUsage( { type: 'input_cached', ppm: cacheReadPpm, amount: cachedInputTokens } );
     }
     if ( Number.isFinite( pricing.output ) && Number.isFinite( outputTokens ) ) {
       llmUsage.addUsage( { type: 'output', ppm: pricing.output, amount: outputTokens } );

--- a/sdk/llm/src/cost/index.spec.js
+++ b/sdk/llm/src/cost/index.spec.js
@@ -132,7 +132,7 @@ describe( 'calculateLLMCallCost', () => {
     } );
   } );
 
-  it( 'omits cached usage when model has no cache_read rate', async () => {
+  it( 'still counts cached tokens when the model has no cache_read rate', async () => {
     mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'no-cache', { input: 2, output: 10 } ] ] ) );
 
     const result = await calculateLLMCallCost( {
@@ -140,14 +140,17 @@ describe( 'calculateLLMCallCost', () => {
       usage: { inputTokens: 1_000_000, cachedInputTokens: 200_000, outputTokens: 0 }
     } );
 
+    // Cached tokens are surfaced (priced at 0 without a cache_read rate) so caching is
+    // visible in the aggregation; cost is unchanged since they are excluded from `input`.
     expectLLMUsage( result, {
       modelId: 'no-cache',
       usage: [
         { type: 'input', ppm: 2, amount: 800_000, total: 1.6 },
+        { type: 'input_cached', ppm: 0, amount: 200_000, total: 0 },
         { type: 'output', ppm: 10, amount: 0, total: 0 }
       ],
       total: 1.6,
-      tokensUsed: 800_000
+      tokensUsed: 1_000_000
     } );
   } );
 

--- a/sdk/llm/src/index.d.ts
+++ b/sdk/llm/src/index.d.ts
@@ -57,6 +57,12 @@ export type PromptMessage = {
   role: string;
   /** The content of the message */
   content: string;
+  /**
+   * Parsed opening-tag attributes for the block. Currently `options` — a space-separated list of
+   * frontmatter `messageOptions` set names — which is resolved into per-message `providerOptions`
+   * at call time and stripped before the request is sent. Authored as `<system options="set_a set_b">`.
+   */
+  attributes?: Record<string, string | boolean>;
 };
 
 /**
@@ -139,6 +145,13 @@ export type Prompt = {
 
     /** Provider-specific options */
     providerOptions?: Record<string, unknown>;
+
+    /**
+     * Named, reusable per-message `providerOptions` sets, referenced from message blocks via the
+     * `options="<name>"` attribute. Each value is a provider-namespaced options object, e.g.
+     * `{ anthropic: { cacheControl: { type: 'ephemeral' } } }`.
+     */
+    messageOptions?: Record<string, Record<string, Record<string, unknown>>>;
   };
 
   /** Array of messages in the conversation */

--- a/sdk/llm/src/prompt/block_options.js
+++ b/sdk/llm/src/prompt/block_options.js
@@ -1,0 +1,58 @@
+import { FatalError, z } from '@outputai/core';
+
+/** Shallow-merge two providerOptions objects, combining keys within each provider namespace. */
+const mergeProviderOptions = ( base = {}, extra = {} ) => {
+  const merged = { ...base };
+  for ( const [ namespace, options ] of Object.entries( extra ) ) {
+    merged[namespace] = { ...merged[namespace], ...options };
+  }
+  return merged;
+};
+
+/** Merge the named `messageOptions` sets referenced by a block's `options` attribute. */
+const resolveOptions = ( value, { name, config } ) => {
+  const sets = config.messageOptions ?? {};
+  return value.trim().split( /\s+/ ).reduce( ( acc, setName ) => {
+    if ( !sets[setName] ) {
+      throw new FatalError( `Prompt "${name}" references unknown messageOptions set "${setName}"` );
+    }
+    return mergeProviderOptions( acc, sets[setName] );
+  }, {} );
+};
+
+/**
+ * Registry of supported block attributes. Each entry declares how the attribute is validated
+ * (`schema`) and how it contributes to a message's per-message `providerOptions` (`resolve`).
+ * Add an entry to support a new block option — validation ({@link attributesSchema}) and
+ * resolution ({@link resolveMessageProviderOptions}) both derive from this table.
+ */
+const BLOCK_OPTIONS = {
+  options: {
+    schema: z.string().min( 1 ),
+    resolve: resolveOptions
+  }
+};
+
+/** Zod schema for a block's `attributes` object, derived from the option registry. */
+export const attributesSchema = z.object(
+  Object.fromEntries(
+    Object.entries( BLOCK_OPTIONS ).map( ( [ name, def ] ) => [ name, def.schema.optional() ] )
+  )
+).strict();
+
+/**
+ * Resolve each message's authoring `attributes` into AI SDK per-message `providerOptions`,
+ * returning clean messages with the `attributes` helper stripped.
+ *
+ * @param {object} prompt - Loaded prompt object (`{ name, config, messages }`)
+ * @returns {Array<object>} Messages with resolved `providerOptions`
+ */
+export const resolveMessageProviderOptions = ( { name, config, messages } ) =>
+  messages.map( ( { attributes, providerOptions, ...message } ) => {
+    const resolved = Object.entries( attributes ?? {} ).reduce( ( acc, [ key, value ] ) => {
+      const option = BLOCK_OPTIONS[key];
+      return option ? mergeProviderOptions( acc, option.resolve( value, { name, config } ) ) : acc;
+    }, providerOptions ?? {} );
+
+    return Object.keys( resolved ).length > 0 ? { ...message, providerOptions: resolved } : message;
+  } );

--- a/sdk/llm/src/prompt/block_options.spec.js
+++ b/sdk/llm/src/prompt/block_options.spec.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { FatalError } from '@outputai/core';
+import { attributesSchema, resolveMessageProviderOptions } from './block_options.js';
+
+const textPrompt = ( { config = {}, messages } ) => ( {
+  name: 'test@v1',
+  config: { provider: 'anthropic', model: 'claude-sonnet-4-5', ...config },
+  messages
+} );
+
+describe( 'attributesSchema', () => {
+  it( 'accepts the options attribute', () => {
+    expect( attributesSchema.safeParse( { options: 'cached' } ).success ).toBe( true );
+    expect( attributesSchema.safeParse( { options: 'cached fast' } ).success ).toBe( true );
+    expect( attributesSchema.safeParse( {} ).success ).toBe( true );
+  } );
+
+  it( 'rejects unknown attributes, including the removed cache shorthand', () => {
+    expect( attributesSchema.safeParse( { cache: true } ).success ).toBe( false );
+    expect( attributesSchema.safeParse( { unknown: 'x' } ).success ).toBe( false );
+  } );
+} );
+
+describe( 'resolveMessageProviderOptions', () => {
+  it( 'merges a referenced messageOptions set into per-message providerOptions', () => {
+    const result = resolveMessageProviderOptions( textPrompt( {
+      config: { messageOptions: { cached: { anthropic: { cacheControl: { type: 'ephemeral' } } } } },
+      messages: [
+        { role: 'system', content: 'Docs', attributes: { options: 'cached' } },
+        { role: 'user', content: 'Hello' }
+      ]
+    } ) );
+
+    expect( result ).toEqual( [
+      {
+        role: 'system',
+        content: 'Docs',
+        providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } }
+      },
+      { role: 'user', content: 'Hello' }
+    ] );
+  } );
+
+  it( 'merges multiple referenced sets onto one block', () => {
+    const [ system ] = resolveMessageProviderOptions( textPrompt( {
+      config: {
+        messageOptions: {
+          cached: { anthropic: { cacheControl: { type: 'ephemeral', ttl: '1h' } } },
+          openaiKey: { openai: { promptCacheKey: 'enrich-v1' } }
+        }
+      },
+      messages: [ { role: 'system', content: 'Docs', attributes: { options: 'cached openaiKey' } } ]
+    } ) );
+
+    expect( system.providerOptions ).toEqual( {
+      anthropic: { cacheControl: { type: 'ephemeral', ttl: '1h' } },
+      openai: { promptCacheKey: 'enrich-v1' }
+    } );
+  } );
+
+  it( 'throws when the options attribute references an unknown set', () => {
+    expect( () => resolveMessageProviderOptions( textPrompt( {
+      messages: [ { role: 'user', content: 'Hello', attributes: { options: 'missing' } } ]
+    } ) ) ).toThrow( FatalError );
+  } );
+
+  it( 'leaves messages without attributes unchanged', () => {
+    const messages = [ { role: 'user', content: 'Hello' } ];
+    expect( resolveMessageProviderOptions( textPrompt( { messages } ) ) ).toEqual( messages );
+  } );
+} );

--- a/sdk/llm/src/prompt/blocks.js
+++ b/sdk/llm/src/prompt/blocks.js
@@ -1,0 +1,47 @@
+/**
+ * Roles that introduce a message block. Add a role here to support a new
+ * `<role>...</role>` block — the tokenizer pattern is derived from this set,
+ * so no other parser change is required.
+ */
+export const BLOCK_ROLES = new Set( [ 'system', 'user', 'assistant', 'tool' ] );
+
+const BLOCK_PATTERN = new RegExp(
+  `<(${[ ...BLOCK_ROLES ].join( '|' )})((?:\\s[^>]*)?)>([\\s\\S]*?)<\\/\\1>`,
+  'gm'
+);
+
+const ATTRIBUTE_PATTERN = /([a-zA-Z][\w-]*)(?:=(?:"([^"]*)"|'([^']*)'|(\S+)))?/g;
+
+/**
+ * Parse a raw opening-tag attribute string into a plain object. Supports bare booleans
+ * (`cache`), double/single-quoted values, and unquoted values:
+ * `cache options="a b" ttl='1h'` → `{ cache: true, options: 'a b', ttl: '1h' }`.
+ *
+ * @param {string} [raw] - Raw attribute text between the role and the closing `>`
+ * @returns {Record<string, string | true>} Parsed attributes
+ */
+export const parseAttributes = ( raw = '' ) =>
+  Object.fromEntries(
+    [ ...raw.matchAll( ATTRIBUTE_PATTERN ) ].map(
+      ( [ _, key, doubleQuoted, singleQuoted, bare ] ) =>
+        [ key, doubleQuoted ?? singleQuoted ?? bare ?? true ]
+    )
+  );
+
+/**
+ * Tokenize a rendered prompt body into message blocks. Each block is `{ role, content }`,
+ * plus `attributes` when the opening tag carried any. Content between role tags is treated
+ * as opaque text, so prompt bodies may freely contain other angle-bracket markup.
+ *
+ * @param {string} content - Rendered prompt body (after frontmatter is stripped)
+ * @returns {Array<{ role: string, content: string, attributes?: Record<string, string | true> }>}
+ */
+export const tokenizeBlocks = content =>
+  [ ...content.matchAll( BLOCK_PATTERN ) ].map( ( [ _, role, rawAttributes, text ] ) => {
+    const attributes = parseAttributes( rawAttributes.trim() );
+    return {
+      role,
+      content: text.trim(),
+      ...( Object.keys( attributes ).length > 0 && { attributes } )
+    };
+  } );

--- a/sdk/llm/src/prompt/blocks.spec.js
+++ b/sdk/llm/src/prompt/blocks.spec.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { parseAttributes, tokenizeBlocks, BLOCK_ROLES } from './blocks.js';
+
+describe( 'parseAttributes', () => {
+  it( 'parses a bare attribute as boolean true', () => {
+    expect( parseAttributes( 'pinned' ) ).toEqual( { pinned: true } );
+  } );
+
+  it( 'parses double- and single-quoted values', () => {
+    expect( parseAttributes( 'ttl="1h" mode=\'fast\'' ) ).toEqual( { ttl: '1h', mode: 'fast' } );
+  } );
+
+  it( 'parses unquoted values', () => {
+    expect( parseAttributes( 'ttl=1h' ) ).toEqual( { ttl: '1h' } );
+  } );
+
+  it( 'parses multiple attributes and preserves spaces inside quotes', () => {
+    expect( parseAttributes( 'pinned options="cached fast"' ) ).toEqual( {
+      pinned: true,
+      options: 'cached fast'
+    } );
+  } );
+
+  it( 'returns an empty object for blank input', () => {
+    expect( parseAttributes( '' ) ).toEqual( {} );
+    expect( parseAttributes() ).toEqual( {} );
+  } );
+} );
+
+describe( 'tokenizeBlocks', () => {
+  it( 'tokenizes plain blocks without an attributes key', () => {
+    const blocks = tokenizeBlocks( '<system>Hi</system>\n<user>Yo</user>' );
+    expect( blocks ).toEqual( [
+      { role: 'system', content: 'Hi' },
+      { role: 'user', content: 'Yo' }
+    ] );
+  } );
+
+  it( 'attaches parsed attributes to the block', () => {
+    const blocks = tokenizeBlocks( '<system options="a b" pinned>Hi</system>' );
+    expect( blocks[0] ).toEqual( {
+      role: 'system',
+      content: 'Hi',
+      attributes: { options: 'a b', pinned: true }
+    } );
+  } );
+
+  it( 'captures unknown attributes generically (validation rejects them later)', () => {
+    const blocks = tokenizeBlocks( '<user data="x">Hi</user>' );
+    expect( blocks[0].attributes ).toEqual( { data: 'x' } );
+  } );
+
+  it( 'treats angle-bracket markup inside a block as opaque content', () => {
+    const blocks = tokenizeBlocks( '<user>Compare <div> and <span> tags</user>' );
+    expect( blocks[0] ).toEqual( { role: 'user', content: 'Compare <div> and <span> tags' } );
+  } );
+
+  it( 'tokenizes every registered role', () => {
+    const body = [ ...BLOCK_ROLES ].map( role => `<${role}>${role} body</${role}>` ).join( '\n' );
+    const blocks = tokenizeBlocks( body );
+    expect( blocks.map( block => block.role ) ).toEqual( [ ...BLOCK_ROLES ] );
+  } );
+} );

--- a/sdk/llm/src/prompt/parser.js
+++ b/sdk/llm/src/prompt/parser.js
@@ -1,5 +1,6 @@
 import matter from 'gray-matter';
 import { FatalError } from '@outputai/core';
+import { tokenizeBlocks } from './blocks.js';
 
 export function parsePrompt( { name, raw } ) {
   const { data: config, content } = matter( raw );
@@ -8,11 +9,7 @@ export function parsePrompt( { name, raw } ) {
     throw new FatalError( `Prompt "${name}" has no content after frontmatter` );
   }
 
-  const infoExtractor = /<(system|user|assistant|tool)>([\s\S]*?)<\/\1>/gm;
-  const messages = [ ...content.matchAll( infoExtractor ) ].map(
-    ( [ _, role, text ] ) => ( { role, content: text.trim() } )
-  );
-
+  const messages = tokenizeBlocks( content );
   const instructions = messages.length === 0 ? content.trim() : null;
 
   return { config, messages, instructions };

--- a/sdk/llm/src/prompt/parser.spec.js
+++ b/sdk/llm/src/prompt/parser.spec.js
@@ -164,4 +164,23 @@ model: claude-3-5-sonnet-20241022
     ] );
     expect( result.instructions ).toBeNull();
   } );
+
+  it( 'surfaces block opening-tag attributes as an attributes object', () => {
+    const raw = `---
+provider: anthropic
+model: claude-sonnet-4-5
+---
+
+<system options="cached">Static.</system>
+<user>Question</user>`;
+
+    const result = parsePrompt( { name: 'test', raw } );
+
+    expect( result.messages[0] ).toEqual( {
+      role: 'system',
+      content: 'Static.',
+      attributes: { options: 'cached' }
+    } );
+    expect( result.messages[1] ).toEqual( { role: 'user', content: 'Question' } );
+  } );
 } );

--- a/sdk/llm/src/prompt/validations.js
+++ b/sdk/llm/src/prompt/validations.js
@@ -1,7 +1,11 @@
 import { ValidationError, z } from '@outputai/core';
+import { attributesSchema } from './block_options.js';
 
 const toolConfigSchema = z.record( z.string(), z.unknown() );
 const toolsConfigSchema = z.record( z.string(), toolConfigSchema );
+
+// A provider-namespaced options object, e.g. { anthropic: { cacheControl: { type: 'ephemeral' } } }
+const providerOptionsSchema = z.record( z.string(), z.record( z.string(), z.unknown() ) );
 
 export const promptSchema = z.object( {
   name: z.string(),
@@ -22,12 +26,14 @@ export const promptSchema = z.object( {
         type: z.enum( [ 'enabled', 'disabled' ] ),
         budgetTokens: z.number().optional()
       } ).loose().optional()
-    } ).loose().optional()
+    } ).loose().optional(),
+    messageOptions: z.record( z.string(), providerOptionsSchema ).optional()
   } ).loose(),
   messages: z.array(
     z.object( {
       role: z.string(),
-      content: z.string()
+      content: z.string(),
+      attributes: attributesSchema.optional()
     } ).strict()
   ),
   instructions: z.string().trim().min( 1 ).nullable().optional()

--- a/sdk/llm/src/prompt/validations.spec.js
+++ b/sdk/llm/src/prompt/validations.spec.js
@@ -596,4 +596,53 @@ describe( 'validatePrompt', () => {
 
     expect( () => validatePrompt( maxTokensSnakeCase ) ).not.toThrow();
   } );
+
+  it( 'should validate the options attribute referencing messageOptions sets', () => {
+    const promptWithMessageOptions = {
+      name: 'message-options-prompt',
+      config: {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5',
+        messageOptions: {
+          cached: { anthropic: { cacheControl: { type: 'ephemeral' } } }
+        }
+      },
+      messages: [
+        { role: 'system', content: 'Docs.', attributes: { options: 'cached' } },
+        { role: 'user', content: 'Question' }
+      ]
+    };
+
+    expect( () => validatePrompt( promptWithMessageOptions ) ).not.toThrow();
+  } );
+
+  it( 'should reject the removed cache shorthand as an unknown block attribute', () => {
+    const cacheShorthandPrompt = {
+      name: 'cache-shorthand-prompt',
+      config: {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5'
+      },
+      messages: [
+        { role: 'system', content: 'Static.', attributes: { cache: true } }
+      ]
+    };
+
+    expect( () => validatePrompt( cacheShorthandPrompt ) ).toThrow( ValidationError );
+  } );
+
+  it( 'should throw ValidationError for unknown top-level message fields', () => {
+    const unknownFieldPrompt = {
+      name: 'unknown-field-prompt',
+      config: {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5'
+      },
+      messages: [
+        { role: 'user', content: 'Hi', options: 'cached' }
+      ]
+    };
+
+    expect( () => validatePrompt( unknownFieldPrompt ) ).toThrow( ValidationError );
+  } );
 } );

--- a/test_workflows/src/workflows/generate_text/prompt@v1.prompt
+++ b/test_workflows/src/workflows/generate_text/prompt@v1.prompt
@@ -1,13 +1,64 @@
 ---
 provider: anthropic
-model: claude-haiku-4-5
+model: claude-sonnet-4-20250514
 temperature: 0.7
 maxTokens: 4000
+messageOptions:
+  cached:
+    anthropic:
+      cacheControl:
+        type: ephemeral
 ---
 
-<assistant>
-You are a concise assistant.
-</assistant>
+<system options="cached">
+You are Output Explainer, a meticulous technical educator whose job is to explain any topic clearly, accurately, and memorably to a curious non-expert. The instructions below are your permanent operating manual. They do not change between requests, so treat them as a stable reference you can rely on for every explanation you produce.
+
+## Your role
+
+You turn complicated subjects into explanations that a motivated newcomer can follow on the first read. You are patient, precise, and honest. You never pad an answer to sound impressive, and you never oversimplify to the point of being wrong. Your north star is that the reader should be able to do something new after reading your explanation: hold a more accurate mental model, make a better decision, or ask a sharper follow-up question.
+
+## Audience assumptions
+
+Assume the reader is intelligent but unfamiliar with the specific topic. They have general world knowledge and can handle a new idea if you introduce it carefully. They cannot read your mind, so define every term the first time you use it. When a topic has both a casual meaning and a technical meaning, name the difference explicitly so the reader does not carry a misconception forward.
+
+## How to structure an explanation
+
+1. Open with a one-sentence answer to "what is this and why does it matter." This orients the reader before any detail arrives.
+2. Give the simplest correct mental model next. It is acceptable for this model to be incomplete, as long as it is not misleading. Tell the reader it is a starting point.
+3. Layer in detail progressively. Introduce at most two or three new concepts before pausing to connect them back to something the reader already understands.
+4. Show a concrete example as early as possible. Abstract definitions stick only after the reader has seen the idea in action.
+5. Close by naming the boundary of the explanation: what you did not cover, and where the reader could go next.
+
+## Accuracy and intellectual honesty
+
+State facts confidently when you are confident, and flag uncertainty plainly when you are not. If a topic is genuinely contested, say so and summarize the main positions rather than pretending there is one settled answer. Never invent specific numbers, dates, citations, or quotations. If you do not know a precise figure, describe the magnitude qualitatively instead of fabricating precision. Correcting a common misconception is often the most valuable part of an explanation, so call out the mistake people usually make and explain why the intuition fails.
+
+## Use of examples and analogies
+
+Prefer concrete, everyday examples drawn from cooking, travel, money, sports, or simple machines, because these domains are widely shared. Use exactly one analogy to anchor a hard concept, then drop it before it gets stretched too far. Every analogy leaks somewhere, so when you use one, briefly note where it stops being accurate. A worked example that walks through real steps is usually more useful than a metaphor.
+
+## Formatting conventions
+
+Write in short paragraphs, each carrying a single idea. Use headings only when the answer spans several distinct sub-questions. Use numbered lists for sequences and ordered procedures, and bulleted lists for sets of independent items. Put key terms in emphasis the first time they appear. Keep sentences mostly short; vary the rhythm so the prose does not feel mechanical. Avoid walls of text, and avoid choppy fragments that force the reader to reassemble your meaning.
+
+## Language and tone
+
+Write in plain, direct language. Choose the common word over the fancy one when both are precise. Avoid corporate filler and hedging phrases that add length without meaning. Address the reader as "you" and keep the tone that of a knowledgeable friend explaining something over coffee: warm, unhurried, and respectful of the reader's intelligence. Do not lecture, do not condescend, and do not apologize for the topic being hard.
+
+## Common pitfalls to avoid
+
+Do not bury the answer under throat-clearing preamble. Do not define a term using a more obscure term. Do not list facts without explaining how they connect. Do not mistake naming a thing for explaining it. Do not let an analogy do the work that a clear definition should do. Do not end abruptly the moment the facts run out; give the reader a sense of closure and a direction to explore further.
+
+## Handling uncertainty and scope
+
+If the request is ambiguous, choose the most useful reasonable interpretation and state the interpretation you chose in one short sentence, then proceed. If the topic is enormous, scope it down to the part that gives the reader the most leverage, and say what you scoped out. It is better to explain one slice well than to skim the whole surface and leave the reader with nothing to hold onto.
+
+## Length guidance
+
+Match length to the difficulty of the topic. A simple question deserves a few tight paragraphs. A genuinely hard topic earns more room, but every added sentence must carry its weight. When in doubt, stop sooner: a shorter explanation the reader finishes beats a longer one they abandon.
+
+Follow this manual on every request. The user's specific topic appears below.
+</system>
 
 <user>
 Explain about "{{ topic }}"


### PR DESCRIPTION
## Overview

- Add per-message provider options to `.prompt` files, resolved into AI SDK per-message `providerOptions` at the prompt→call boundary.
- Define named `messageOptions` sets in front matter and attach them to message blocks with `options="<name>"`. Anthropic prompt caching is one use: `{ anthropic: { cacheControl: { type: ephemeral } } }`.
- Parsing is **registry-driven**: `prompt/blocks.js` tokenizes via a `BLOCK_ROLES` set (the pattern is generated from it) plus one generic attribute parser → `{ role, attributes, content }`; `prompt/block_options.js` holds a registry where each option declares its `schema` *and* its `resolve`. Validation (`attributesSchema`) and resolution (`resolveMessageProviderOptions`) both derive from that table, so a new block role or option is a one-line change.
- **Cost tracking** now reports cached input tokens (`input_cached`) even for models whose pricing record lacks a `cache_read` rate, so cache savings show up in usage aggregations instead of silently disappearing.
- `PromptMessage` carries a generic `attributes` bag; docs added to `docs/guides/packages/llm.mdx` and the `CLAUDE.md` ProviderOptions guide.
- **Worked example**: `test_workflows/src/workflows/generate_text` caches its `explainTopic` system prompt via `messageOptions`.

## Interface

```text prompts/generate_summary@v1.prompt
---
provider: anthropic
model: claude-sonnet-4-20250514
messageOptions:
  cached: { anthropic: { cacheControl: { type: ephemeral } } }   # add ttl: 1h for the 1-hour cache
---

<system options="cached">{{ style_guide }}</system>
<user>{{ topic }}</user>
```

A block can reference several sets (`options="cached fast"`); each set is a provider-namespaced `providerOptions` object merged onto that message.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` — 2049 pass; only 2 pre-existing `sdk/cli` copy-assets failures remain (unrelated; see Follow-up)
- [x] `sdk/llm` suite: 276 pass, incl. `blocks.spec.js`, `block_options.spec.js`, and the cost spec
- [x] Public `.d.ts` typechecks against the `attributes` shape
- [x] **Live, end-to-end**: ran `generate_text` twice on the dev stack — run 1 wrote the cache (`cache_creation_input_tokens: 1098`), run 2 read it (`cache_read_input_tokens: 1098`) and the workflow aggregation reported `input_cached: 1098` (0 before the cost fix)

## Notes for reviewers

- **Registry-driven parsing instead of a parser dependency** — block roles come from a `BLOCK_ROLES` set and attributes from one generic tokenizer; each option lives in a single registry (`schema` + `resolve`) that both validation and resolution read. A general HTML/XML parser was rejected: `escape.js` only escapes Liquid *variable* output, so static prompt bodies legitimately contain arbitrary `<...>` markup a markup parser would misparse, and it would own entity decoding (colliding with the escape/`decode()` contract).
- **No per-provider cache sugar** — caching is authored explicitly via a `messageOptions` set, so the author writes the correct namespace (`anthropic`, `bedrock`, …) and the framework owns no provider→namespace mapping. OpenAI caches automatically; `providerOptions.openai.promptCacheKey` tunes routing.
- **Cost-aggregation fix** — `input_cached` was previously gated on the model having a `cache_read` price, so cached tokens vanished from the aggregation for models with incomplete pricing (e.g. `claude-sonnet-4-20250514`). Now emitted whenever the provider reports them; priced at `cache_read` when available, else 0 (cost unchanged — they're already excluded from `input`).

## Follow-up (out of scope)

`npm run build:packages` fails in `sdk/cli` at its `copy-assets` step — `native-copyfiles@2.0.1` throws `options.exclude must be a function, received an Array`. Pre-existing tooling bug, unrelated to this change (`@outputai/llm` has no build step), and the reason the 2 `copy_assets` tests can't find templates in `dist/`. Worth a separate ticket.

Closes OUT-454