### PR TITLE
refactor(llm): registry-driven prompt block parsing

### DIFF
--- a/.changeset/prompt-caching-support.md
+++ b/.changeset/prompt-caching-support.md
@@ -1,0 +1,9 @@
+---
+"@outputai/llm": minor
+---
+
+Add per-message prompt caching to `.prompt` files.
+
+- `cache` shorthand on a block (`<system cache>`, `<system cache="1h">`) sets an Anthropic cache breakpoint covering the prompt prefix up to and including that block.
+- General `messageOptions` named sets in front matter, attached to blocks via `options="<name>"`, attach arbitrary per-message `providerOptions`.
+- `cache` resolves to `anthropic.cacheControl` for `provider: anthropic` and Claude models on `vertex`; for other providers it is ignored with a warning (use `messageOptions` with that provider's namespace).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,49 @@ AI SDK uses `Record<string, Record<string, JSONValue>>` for `providerOptions` to
 
 The nesting is intentional architecture, not redundancy.
 
+### Per-Message Caching (Anthropic Prompt Cache)
+
+Anthropic prompt caching is a **per-message** directive, not a call-level one. Mark the block that ends your static prefix; that prefix is then cached and reused across calls.
+
+**Shorthand — `cache` on a block:**
+
+```text
+<system cache>
+{{ long static instructions }}
+</system>
+
+<user>
+{{ per-call input }}
+</user>
+```
+
+- `<system cache>` → default 5-minute TTL; `<system cache="1h">` → 1-hour TTL.
+- Applies to `provider: anthropic` and `provider: vertex` with a Claude model. Ignored (with a warning) for other providers — use `messageOptions` instead.
+
+**General — `messageOptions` sets** (any provider, any per-message option):
+
+```yaml
+messageOptions:
+  cached: { anthropic: { cacheControl: { type: ephemeral } } }
+```
+```text
+<system options="cached">
+{{ long static instructions }}
+</system>
+```
+
+Each set is a provider-namespaced `providerOptions` object (same namespace rules as call-level `providerOptions`). A block may list multiple sets: `options="cached fast"`. The `cache` shorthand desugars onto this mechanism.
+
+**Rules:**
+- Mark the **last static block**, never one containing per-call `{{ variables }}` — a breakpoint on changing content rewrites the cache every call and never hits.
+- Order blocks **static-first, dynamic-last**.
+- Minimum cacheable prefix is model-specific (~1,024 tokens for most Sonnet/Opus; higher for some). Below it, caching is silently skipped — verify via the cost trace (`cachedInputTokens`).
+- Max 4 cache breakpoints per request.
+
+❌ caching a dynamic block: `<user cache>{{ topic }}</user>` (never hits)
+
+✅ caching the static prefix: `<system cache>{{ guide }}</system>` then `<user>{{ topic }}</user>`
+
 ## Schema Constraints for LLM Structured Output
 
 When using `Output.object()` with `generateText`, the Zod schema is converted to JSON Schema and sent to the LLM provider as a tool definition. **Anthropic does not support many JSON Schema constraints**, which means certain Zod methods will cause errors or be silently ignored when the schema is sent to the provider.

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -691,6 +691,72 @@ model: claude-haiku-4-5
 
 Built-in providers use Output's default fetch configuration, including longer Undici response timeouts for LLM calls that take time before returning headers or body chunks. Custom registered providers are used exactly as you register them; they do not automatically receive that custom fetch. If your custom provider also needs longer network timeouts, configure its provider instance directly.
 
+## Prompt Caching
+
+When a prompt sends the same large prefix on every call — a long system prompt, few-shot examples, a pasted reference document — you can cache that prefix so the provider skips reprocessing it. Cached input is about 90% cheaper and faster to first token. Mark the block that ends your static prefix and Output sets the cache breakpoint for you.
+
+### The cache shorthand
+
+Add `cache` to the block that ends your static prefix. Everything up to and including that block is cached and reused on the next call:
+
+```text prompts/generate_summary@v1.prompt
+---
+provider: anthropic
+model: claude-sonnet-4-20250514
+---
+
+<system cache>
+You write concise company summaries for sales teams. Follow this style guide:
+{{ style_guide }}
+</system>
+
+<user>
+Summarize {{ companyName }}.
+</user>
+```
+
+Only the `<user>` block — the part that changes each call — is re-billed at full price; the cached `<system>` prefix is charged at the much cheaper cache-read rate. Use `cache="1h"` for the 1-hour cache instead of the default 5 minutes.
+
+<Warning>
+Mark the last **static** block, never one containing per-call `{{ variables }}`. A breakpoint on changing content rewrites the cache on every call and never gets a hit. Order your blocks static-first, dynamic-last.
+</Warning>
+
+The shorthand targets Anthropic models — `provider: anthropic`, or `provider: vertex` with a Claude model. On any other provider it is ignored with a warning; use `messageOptions` with that provider's namespace instead.
+
+### messageOptions
+
+`cache` is shorthand over a general mechanism: per-message `providerOptions`. Define named option sets in front matter and attach them to blocks with `options`:
+
+```text prompts/enrich_company@v1.prompt
+---
+provider: anthropic
+model: claude-sonnet-4-20250514
+messageOptions:
+  cached:
+    anthropic:
+      cacheControl:
+        type: ephemeral
+---
+
+<system options="cached">
+{{ enrichment_playbook }}
+</system>
+
+<user>
+Enrich {{ company }}.
+</user>
+```
+
+Each set is a provider-namespaced `providerOptions` object — the same shape and [namespace rules](/prompts#provider-options) as call-level `providerOptions`. A block can reference several sets (`options="cached fast"`), and a set can be reused across blocks. Use this to cache on providers whose namespace differs from Anthropic's, or to attach any other per-message provider option.
+
+### Confirming a cache hit
+
+Cache activity appears in the response usage and the [cost event](/costs/cost-events): the first call reports cache-creation tokens, and later calls within the TTL report cache-read tokens (`cachedInputTokens`), already priced at the cheaper rate in `response.cost`.
+
+<Note>
+Anthropic caches only prefixes above a model-specific minimum — around 1,024 tokens for most Sonnet and Opus models, higher for some. Shorter prefixes are silently not cached, with no error. A request supports at most four cache breakpoints.
+</Note>
+
 ## Provider Tools
 
 Many providers offer built-in tools like web search. Configure them in YAML front matter:

--- a/sdk/llm/src/ai_sdk_options.js
+++ b/sdk/llm/src/ai_sdk_options.js
@@ -2,6 +2,67 @@ import { loadImageModel, loadTextModel, loadTools } from './ai_model.js';
 import { FatalError } from '@outputai/core';
 
 /**
+ * Resolve the provider-options namespace for the `cache` shorthand. Anthropic prompt caching is
+ * expressed under the `anthropic` namespace, including Claude models served through Vertex.
+ */
+const cacheNamespace = ( { provider, model } ) => {
+  if ( provider === 'anthropic' ) {
+    return 'anthropic';
+  }
+  if ( provider === 'vertex' && /claude/i.test( model ) ) {
+    return 'anthropic';
+  }
+  return null;
+};
+
+/** Shallow-merge two provider-options objects, combining keys within each provider namespace. */
+const mergeProviderOptions = ( base = {}, extra = {} ) => {
+  const merged = { ...base };
+  for ( const [ namespace, options ] of Object.entries( extra ) ) {
+    merged[namespace] = { ...merged[namespace], ...options };
+  }
+  return merged;
+};
+
+/** Expand the `cache` shorthand into a provider-namespaced `cacheControl` options object. */
+const cacheShorthandOptions = ( cache, config, promptName ) => {
+  const namespace = cacheNamespace( config );
+  if ( !namespace ) {
+    console.warn(
+      `[output-llm] Prompt "${promptName}": "cache" shorthand only supports Anthropic models; ` +
+      `ignoring for provider "${config.provider}". Use messageOptions to cache on other providers.`
+    );
+    return {};
+  }
+  const cacheControl = { type: 'ephemeral', ...( typeof cache === 'string' && { ttl: cache } ) };
+  return { [namespace]: { cacheControl } };
+};
+
+/**
+ * Resolve per-message provider options from `messageOptions` set references and the `cache`
+ * shorthand into AI SDK per-message `providerOptions`, returning clean messages with the
+ * `cache`/`options` authoring helpers stripped.
+ */
+const resolveMessageProviderOptions = ( { name, config, messages } ) => {
+  const sets = config.messageOptions ?? {};
+
+  return messages.map( ( { cache, options, providerOptions, ...message } ) => {
+    const fromSets = ( options ?? [] ).reduce( ( acc, setName ) => {
+      if ( !sets[setName] ) {
+        throw new FatalError( `Prompt "${name}" references unknown messageOptions set "${setName}"` );
+      }
+      return mergeProviderOptions( acc, sets[setName] );
+    }, providerOptions ?? {} );
+
+    const resolved = cache ?
+      mergeProviderOptions( fromSets, cacheShorthandOptions( cache, config, name ) ) :
+      fromSets;
+
+    return Object.keys( resolved ).length > 0 ? { ...message, providerOptions: resolved } : message;
+  } );
+};
+
+/**
  * Convert a loaded prompt into AI SDK text generation options.
  *
  * @param {object} prompt - Loaded prompt object
@@ -13,7 +74,7 @@ export const loadAiSdkTextOptions = prompt => {
   }
   const options = {
     model: loadTextModel( prompt ),
-    messages: prompt.messages,
+    messages: resolveMessageProviderOptions( prompt ),
     providerOptions: prompt.config.providerOptions
   };
 

--- a/sdk/llm/src/ai_sdk_options.js
+++ b/sdk/llm/src/ai_sdk_options.js
@@ -1,66 +1,6 @@
 import { loadImageModel, loadTextModel, loadTools } from './ai_model.js';
+import { resolveMessageProviderOptions } from './prompt/block_options.js';
 import { FatalError } from '@outputai/core';
-
-/**
- * Resolve the provider-options namespace for the `cache` shorthand. Anthropic prompt caching is
- * expressed under the `anthropic` namespace, including Claude models served through Vertex.
- */
-const cacheNamespace = ( { provider, model } ) => {
-  if ( provider === 'anthropic' ) {
-    return 'anthropic';
-  }
-  if ( provider === 'vertex' && /claude/i.test( model ) ) {
-    return 'anthropic';
-  }
-  return null;
-};
-
-/** Shallow-merge two provider-options objects, combining keys within each provider namespace. */
-const mergeProviderOptions = ( base = {}, extra = {} ) => {
-  const merged = { ...base };
-  for ( const [ namespace, options ] of Object.entries( extra ) ) {
-    merged[namespace] = { ...merged[namespace], ...options };
-  }
-  return merged;
-};
-
-/** Expand the `cache` shorthand into a provider-namespaced `cacheControl` options object. */
-const cacheShorthandOptions = ( cache, config, promptName ) => {
-  const namespace = cacheNamespace( config );
-  if ( !namespace ) {
-    console.warn(
-      `[output-llm] Prompt "${promptName}": "cache" shorthand only supports Anthropic models; ` +
-      `ignoring for provider "${config.provider}". Use messageOptions to cache on other providers.`
-    );
-    return {};
-  }
-  const cacheControl = { type: 'ephemeral', ...( typeof cache === 'string' && { ttl: cache } ) };
-  return { [namespace]: { cacheControl } };
-};
-
-/**
- * Resolve per-message provider options from `messageOptions` set references and the `cache`
- * shorthand into AI SDK per-message `providerOptions`, returning clean messages with the
- * `cache`/`options` authoring helpers stripped.
- */
-const resolveMessageProviderOptions = ( { name, config, messages } ) => {
-  const sets = config.messageOptions ?? {};
-
-  return messages.map( ( { cache, options, providerOptions, ...message } ) => {
-    const fromSets = ( options ?? [] ).reduce( ( acc, setName ) => {
-      if ( !sets[setName] ) {
-        throw new FatalError( `Prompt "${name}" references unknown messageOptions set "${setName}"` );
-      }
-      return mergeProviderOptions( acc, sets[setName] );
-    }, providerOptions ?? {} );
-
-    const resolved = cache ?
-      mergeProviderOptions( fromSets, cacheShorthandOptions( cache, config, name ) ) :
-      fromSets;
-
-    return Object.keys( resolved ).length > 0 ? { ...message, providerOptions: resolved } : message;
-  } );
-};
 
 /**
  * Convert a loaded prompt into AI SDK text generation options.

--- a/sdk/llm/src/ai_sdk_options.spec.js
+++ b/sdk/llm/src/ai_sdk_options.spec.js
@@ -162,12 +162,12 @@ describe( 'ai_sdk_options', () => {
     expect( loadImageModelImpl ).not.toHaveBeenCalled();
   } );
 
-  it( 'expands the cache shorthand into per-message anthropic cacheControl', async () => {
+  it( 'resolves block attributes into per-message providerOptions', async () => {
     const prompt = {
       name: 'cache@v1',
       config: { provider: 'anthropic', model: 'claude-sonnet-4-5' },
       messages: [
-        { role: 'system', content: 'Static instructions', cache: true },
+        { role: 'system', content: 'Static', attributes: { cache: '1h' } },
         { role: 'user', content: 'Hello' }
       ],
       instructions: null
@@ -179,117 +179,10 @@ describe( 'ai_sdk_options', () => {
     expect( result.messages ).toEqual( [
       {
         role: 'system',
-        content: 'Static instructions',
-        providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } }
+        content: 'Static',
+        providerOptions: { anthropic: { cacheControl: { type: 'ephemeral', ttl: '1h' } } }
       },
       { role: 'user', content: 'Hello' }
     ] );
-  } );
-
-  it( 'passes the 1h ttl through the cache shorthand', async () => {
-    const prompt = {
-      name: 'cache@v1',
-      config: { provider: 'anthropic', model: 'claude-sonnet-4-5' },
-      messages: [
-        { role: 'system', content: 'Static', cache: '1h' },
-        { role: 'user', content: 'Hello' }
-      ],
-      instructions: null
-    };
-
-    const { loadAiSdkTextOptions } = await importSut();
-    const result = loadAiSdkTextOptions( prompt );
-
-    expect( result.messages[0].providerOptions ).toEqual( {
-      anthropic: { cacheControl: { type: 'ephemeral', ttl: '1h' } }
-    } );
-  } );
-
-  it( 'resolves messageOptions set references into per-message providerOptions', async () => {
-    const prompt = {
-      name: 'opts@v1',
-      config: {
-        provider: 'anthropic',
-        model: 'claude-sonnet-4-5',
-        messageOptions: { cached: { anthropic: { cacheControl: { type: 'ephemeral' } } } }
-      },
-      messages: [
-        { role: 'system', content: 'Docs', options: [ 'cached' ] },
-        { role: 'user', content: 'Question' }
-      ],
-      instructions: null
-    };
-
-    const { loadAiSdkTextOptions } = await importSut();
-    const result = loadAiSdkTextOptions( prompt );
-
-    expect( result.messages[0] ).toEqual( {
-      role: 'system',
-      content: 'Docs',
-      providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } }
-    } );
-    expect( result.messages[1] ).toEqual( { role: 'user', content: 'Question' } );
-  } );
-
-  it( 'resolves the cache shorthand for Claude models on vertex', async () => {
-    const prompt = {
-      name: 'vertex@v1',
-      config: { provider: 'vertex', model: 'claude-sonnet-4@vertex' },
-      messages: [
-        { role: 'system', content: 'Static', cache: true },
-        { role: 'user', content: 'Hello' }
-      ],
-      instructions: null
-    };
-
-    const { loadAiSdkTextOptions } = await importSut();
-    const result = loadAiSdkTextOptions( prompt );
-
-    expect( result.messages[0].providerOptions ).toEqual( {
-      anthropic: { cacheControl: { type: 'ephemeral' } }
-    } );
-  } );
-
-  it( 'warns and skips the cache shorthand for non-anthropic providers', async () => {
-    const warnSpy = vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
-    const prompt = {
-      name: 'openai@v1',
-      config: { provider: 'openai', model: 'gpt-4o' },
-      messages: [
-        { role: 'system', content: 'Static', cache: true },
-        { role: 'user', content: 'Hello' }
-      ],
-      instructions: null
-    };
-
-    const { loadAiSdkTextOptions } = await importSut();
-    const result = loadAiSdkTextOptions( prompt );
-
-    expect( result.messages ).toEqual( [
-      { role: 'system', content: 'Static' },
-      { role: 'user', content: 'Hello' }
-    ] );
-    expect( warnSpy ).toHaveBeenCalledWith(
-      expect.stringContaining( '"cache" shorthand only supports Anthropic models' )
-    );
-
-    warnSpy.mockRestore();
-  } );
-
-  it( 'throws when a message references an unknown messageOptions set', async () => {
-    const prompt = {
-      name: 'bad@v1',
-      config: { provider: 'anthropic', model: 'claude-sonnet-4-5' },
-      messages: [
-        { role: 'user', content: 'Hello', options: [ 'missing' ] }
-      ],
-      instructions: null
-    };
-
-    const { loadAiSdkTextOptions } = await importSut();
-
-    expect( () => loadAiSdkTextOptions( prompt ) ).toThrow(
-      'Prompt "bad@v1" references unknown messageOptions set "missing"'
-    );
   } );
 } );

--- a/sdk/llm/src/ai_sdk_options.spec.js
+++ b/sdk/llm/src/ai_sdk_options.spec.js
@@ -161,4 +161,135 @@ describe( 'ai_sdk_options', () => {
     );
     expect( loadImageModelImpl ).not.toHaveBeenCalled();
   } );
+
+  it( 'expands the cache shorthand into per-message anthropic cacheControl', async () => {
+    const prompt = {
+      name: 'cache@v1',
+      config: { provider: 'anthropic', model: 'claude-sonnet-4-5' },
+      messages: [
+        { role: 'system', content: 'Static instructions', cache: true },
+        { role: 'user', content: 'Hello' }
+      ],
+      instructions: null
+    };
+
+    const { loadAiSdkTextOptions } = await importSut();
+    const result = loadAiSdkTextOptions( prompt );
+
+    expect( result.messages ).toEqual( [
+      {
+        role: 'system',
+        content: 'Static instructions',
+        providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } }
+      },
+      { role: 'user', content: 'Hello' }
+    ] );
+  } );
+
+  it( 'passes the 1h ttl through the cache shorthand', async () => {
+    const prompt = {
+      name: 'cache@v1',
+      config: { provider: 'anthropic', model: 'claude-sonnet-4-5' },
+      messages: [
+        { role: 'system', content: 'Static', cache: '1h' },
+        { role: 'user', content: 'Hello' }
+      ],
+      instructions: null
+    };
+
+    const { loadAiSdkTextOptions } = await importSut();
+    const result = loadAiSdkTextOptions( prompt );
+
+    expect( result.messages[0].providerOptions ).toEqual( {
+      anthropic: { cacheControl: { type: 'ephemeral', ttl: '1h' } }
+    } );
+  } );
+
+  it( 'resolves messageOptions set references into per-message providerOptions', async () => {
+    const prompt = {
+      name: 'opts@v1',
+      config: {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5',
+        messageOptions: { cached: { anthropic: { cacheControl: { type: 'ephemeral' } } } }
+      },
+      messages: [
+        { role: 'system', content: 'Docs', options: [ 'cached' ] },
+        { role: 'user', content: 'Question' }
+      ],
+      instructions: null
+    };
+
+    const { loadAiSdkTextOptions } = await importSut();
+    const result = loadAiSdkTextOptions( prompt );
+
+    expect( result.messages[0] ).toEqual( {
+      role: 'system',
+      content: 'Docs',
+      providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } }
+    } );
+    expect( result.messages[1] ).toEqual( { role: 'user', content: 'Question' } );
+  } );
+
+  it( 'resolves the cache shorthand for Claude models on vertex', async () => {
+    const prompt = {
+      name: 'vertex@v1',
+      config: { provider: 'vertex', model: 'claude-sonnet-4@vertex' },
+      messages: [
+        { role: 'system', content: 'Static', cache: true },
+        { role: 'user', content: 'Hello' }
+      ],
+      instructions: null
+    };
+
+    const { loadAiSdkTextOptions } = await importSut();
+    const result = loadAiSdkTextOptions( prompt );
+
+    expect( result.messages[0].providerOptions ).toEqual( {
+      anthropic: { cacheControl: { type: 'ephemeral' } }
+    } );
+  } );
+
+  it( 'warns and skips the cache shorthand for non-anthropic providers', async () => {
+    const warnSpy = vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
+    const prompt = {
+      name: 'openai@v1',
+      config: { provider: 'openai', model: 'gpt-4o' },
+      messages: [
+        { role: 'system', content: 'Static', cache: true },
+        { role: 'user', content: 'Hello' }
+      ],
+      instructions: null
+    };
+
+    const { loadAiSdkTextOptions } = await importSut();
+    const result = loadAiSdkTextOptions( prompt );
+
+    expect( result.messages ).toEqual( [
+      { role: 'system', content: 'Static' },
+      { role: 'user', content: 'Hello' }
+    ] );
+    expect( warnSpy ).toHaveBeenCalledWith(
+      expect.stringContaining( '"cache" shorthand only supports Anthropic models' )
+    );
+
+    warnSpy.mockRestore();
+  } );
+
+  it( 'throws when a message references an unknown messageOptions set', async () => {
+    const prompt = {
+      name: 'bad@v1',
+      config: { provider: 'anthropic', model: 'claude-sonnet-4-5' },
+      messages: [
+        { role: 'user', content: 'Hello', options: [ 'missing' ] }
+      ],
+      instructions: null
+    };
+
+    const { loadAiSdkTextOptions } = await importSut();
+
+    expect( () => loadAiSdkTextOptions( prompt ) ).toThrow(
+      'Prompt "bad@v1" references unknown messageOptions set "missing"'
+    );
+  } );
 } );

--- a/sdk/llm/src/index.d.ts
+++ b/sdk/llm/src/index.d.ts
@@ -57,6 +57,18 @@ export type PromptMessage = {
   role: string;
   /** The content of the message */
   content: string;
+  /**
+   * Shorthand marking this block as an Anthropic prompt-cache breakpoint (caches the prompt
+   * prefix up to and including this block). `true` uses the default 5-minute TTL; `'1h'` uses
+   * the 1-hour TTL. Applied only for Anthropic models (provider `anthropic`, or `vertex` with a
+   * Claude model). Authored in a prompt file as `<system cache>` or `<user cache="1h">`.
+   */
+  cache?: boolean | '5m' | '1h';
+  /**
+   * Names of frontmatter `messageOptions` sets to merge into this block's per-message
+   * `providerOptions`. Authored as `<system options="set_a set_b">`.
+   */
+  options?: string[];
 };
 
 /**
@@ -139,6 +151,13 @@ export type Prompt = {
 
     /** Provider-specific options */
     providerOptions?: Record<string, unknown>;
+
+    /**
+     * Named, reusable per-message `providerOptions` sets, referenced from message blocks via the
+     * `options="<name>"` attribute. Each value is a provider-namespaced options object, e.g.
+     * `{ anthropic: { cacheControl: { type: 'ephemeral' } } }`.
+     */
+    messageOptions?: Record<string, Record<string, Record<string, unknown>>>;
   };
 
   /** Array of messages in the conversation */

--- a/sdk/llm/src/index.d.ts
+++ b/sdk/llm/src/index.d.ts
@@ -58,17 +58,12 @@ export type PromptMessage = {
   /** The content of the message */
   content: string;
   /**
-   * Shorthand marking this block as an Anthropic prompt-cache breakpoint (caches the prompt
-   * prefix up to and including this block). `true` uses the default 5-minute TTL; `'1h'` uses
-   * the 1-hour TTL. Applied only for Anthropic models (provider `anthropic`, or `vertex` with a
-   * Claude model). Authored in a prompt file as `<system cache>` or `<user cache="1h">`.
+   * Parsed opening-tag attributes for the block (e.g. `cache`, `options`). Interpreted into
+   * per-message `providerOptions` at call time and stripped before the request is sent.
+   * Authored in a prompt file as `<system cache>`, `<system cache="1h">`, or
+   * `<system options="set_a set_b">`.
    */
-  cache?: boolean | '5m' | '1h';
-  /**
-   * Names of frontmatter `messageOptions` sets to merge into this block's per-message
-   * `providerOptions`. Authored as `<system options="set_a set_b">`.
-   */
-  options?: string[];
+  attributes?: Record<string, string | boolean>;
 };
 
 /**

--- a/sdk/llm/src/prompt/block_options.js
+++ b/sdk/llm/src/prompt/block_options.js
@@ -1,0 +1,90 @@
+import { FatalError, z } from '@outputai/core';
+
+/**
+ * Resolve the providerOptions namespace for the `cache` shorthand. Anthropic prompt caching is
+ * expressed under the `anthropic` namespace, including Claude models served through Vertex.
+ */
+const cacheNamespace = ( { provider, model } ) => {
+  if ( provider === 'anthropic' ) {
+    return 'anthropic';
+  }
+  if ( provider === 'vertex' && /claude/i.test( model ) ) {
+    return 'anthropic';
+  }
+  return null;
+};
+
+/** Shallow-merge two providerOptions objects, combining keys within each provider namespace. */
+const mergeProviderOptions = ( base = {}, extra = {} ) => {
+  const merged = { ...base };
+  for ( const [ namespace, options ] of Object.entries( extra ) ) {
+    merged[namespace] = { ...merged[namespace], ...options };
+  }
+  return merged;
+};
+
+/** Expand the `cache` shorthand into a provider-namespaced `cacheControl` providerOptions object. */
+const resolveCache = ( value, { name, config } ) => {
+  const namespace = cacheNamespace( config );
+  if ( !namespace ) {
+    console.warn(
+      `[output-llm] Prompt "${name}": "cache" shorthand only supports Anthropic models; ` +
+      `ignoring for provider "${config.provider}". Use messageOptions to cache on other providers.`
+    );
+    return {};
+  }
+  const cacheControl = { type: 'ephemeral', ...( typeof value === 'string' && { ttl: value } ) };
+  return { [namespace]: { cacheControl } };
+};
+
+/** Merge the named `messageOptions` sets referenced by a block's `options` attribute. */
+const resolveOptions = ( value, { name, config } ) => {
+  const sets = config.messageOptions ?? {};
+  return value.trim().split( /\s+/ ).reduce( ( acc, setName ) => {
+    if ( !sets[setName] ) {
+      throw new FatalError( `Prompt "${name}" references unknown messageOptions set "${setName}"` );
+    }
+    return mergeProviderOptions( acc, sets[setName] );
+  }, {} );
+};
+
+/**
+ * Registry of supported block attributes. Each entry declares how the attribute is validated
+ * (`schema`) and how it contributes to a message's per-message `providerOptions` (`resolve`).
+ * Add an entry to support a new block option — validation ({@link attributesSchema}) and
+ * resolution ({@link resolveMessageProviderOptions}) both derive from this table.
+ */
+const BLOCK_OPTIONS = {
+  cache: {
+    schema: z.union( [ z.boolean(), z.enum( [ '5m', '1h' ] ) ] ),
+    resolve: resolveCache
+  },
+  options: {
+    schema: z.string().min( 1 ),
+    resolve: resolveOptions
+  }
+};
+
+/** Zod schema for a block's `attributes` object, derived from the option registry. */
+export const attributesSchema = z.object(
+  Object.fromEntries(
+    Object.entries( BLOCK_OPTIONS ).map( ( [ name, def ] ) => [ name, def.schema.optional() ] )
+  )
+).strict();
+
+/**
+ * Resolve each message's authoring `attributes` into AI SDK per-message `providerOptions`,
+ * returning clean messages with the `attributes` helper stripped.
+ *
+ * @param {object} prompt - Loaded prompt object (`{ name, config, messages }`)
+ * @returns {Array<object>} Messages with resolved `providerOptions`
+ */
+export const resolveMessageProviderOptions = ( { name, config, messages } ) =>
+  messages.map( ( { attributes, providerOptions, ...message } ) => {
+    const resolved = Object.entries( attributes ?? {} ).reduce( ( acc, [ key, value ] ) => {
+      const option = BLOCK_OPTIONS[key];
+      return option ? mergeProviderOptions( acc, option.resolve( value, { name, config } ) ) : acc;
+    }, providerOptions ?? {} );
+
+    return Object.keys( resolved ).length > 0 ? { ...message, providerOptions: resolved } : message;
+  } );

--- a/sdk/llm/src/prompt/block_options.spec.js
+++ b/sdk/llm/src/prompt/block_options.spec.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from 'vitest';
+import { FatalError } from '@outputai/core';
+import { attributesSchema, resolveMessageProviderOptions } from './block_options.js';
+
+const textPrompt = ( { config = {}, messages } ) => ( {
+  name: 'test@v1',
+  config: { provider: 'anthropic', model: 'claude-sonnet-4-5', ...config },
+  messages
+} );
+
+describe( 'attributesSchema', () => {
+  it( 'accepts known attributes with valid values', () => {
+    expect( attributesSchema.safeParse( { cache: true } ).success ).toBe( true );
+    expect( attributesSchema.safeParse( { cache: '1h' } ).success ).toBe( true );
+    expect( attributesSchema.safeParse( { options: 'a b' } ).success ).toBe( true );
+  } );
+
+  it( 'rejects invalid values and unknown attributes', () => {
+    expect( attributesSchema.safeParse( { cache: '2h' } ).success ).toBe( false );
+    expect( attributesSchema.safeParse( { unknown: 'x' } ).success ).toBe( false );
+  } );
+} );
+
+describe( 'resolveMessageProviderOptions', () => {
+  it( 'expands the cache attribute into anthropic cacheControl', () => {
+    const result = resolveMessageProviderOptions( textPrompt( {
+      messages: [
+        { role: 'system', content: 'Static', attributes: { cache: true } },
+        { role: 'user', content: 'Hello' }
+      ]
+    } ) );
+
+    expect( result ).toEqual( [
+      {
+        role: 'system',
+        content: 'Static',
+        providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } }
+      },
+      { role: 'user', content: 'Hello' }
+    ] );
+  } );
+
+  it( 'passes the 1h ttl through', () => {
+    const [ system ] = resolveMessageProviderOptions( textPrompt( {
+      messages: [ { role: 'system', content: 'Static', attributes: { cache: '1h' } } ]
+    } ) );
+
+    expect( system.providerOptions ).toEqual( {
+      anthropic: { cacheControl: { type: 'ephemeral', ttl: '1h' } }
+    } );
+  } );
+
+  it( 'merges referenced messageOptions sets from the options attribute', () => {
+    const [ system ] = resolveMessageProviderOptions( textPrompt( {
+      config: { messageOptions: { cached: { anthropic: { cacheControl: { type: 'ephemeral' } } } } },
+      messages: [ { role: 'system', content: 'Docs', attributes: { options: 'cached' } } ]
+    } ) );
+
+    expect( system.providerOptions ).toEqual( { anthropic: { cacheControl: { type: 'ephemeral' } } } );
+  } );
+
+  it( 'resolves the cache attribute for Claude models on vertex', () => {
+    const [ system ] = resolveMessageProviderOptions( textPrompt( {
+      config: { provider: 'vertex', model: 'claude-sonnet-4@vertex' },
+      messages: [ { role: 'system', content: 'Static', attributes: { cache: true } } ]
+    } ) );
+
+    expect( system.providerOptions ).toEqual( { anthropic: { cacheControl: { type: 'ephemeral' } } } );
+  } );
+
+  it( 'warns and skips the cache attribute for non-anthropic providers', () => {
+    const warnSpy = vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
+    const [ system ] = resolveMessageProviderOptions( textPrompt( {
+      config: { provider: 'openai', model: 'gpt-4o' },
+      messages: [ { role: 'system', content: 'Static', attributes: { cache: true } } ]
+    } ) );
+
+    expect( system ).toEqual( { role: 'system', content: 'Static' } );
+    expect( warnSpy ).toHaveBeenCalledWith(
+      expect.stringContaining( '"cache" shorthand only supports Anthropic models' )
+    );
+    warnSpy.mockRestore();
+  } );
+
+  it( 'throws when the options attribute references an unknown set', () => {
+    expect( () => resolveMessageProviderOptions( textPrompt( {
+      messages: [ { role: 'user', content: 'Hello', attributes: { options: 'missing' } } ]
+    } ) ) ).toThrow( FatalError );
+  } );
+
+  it( 'leaves messages without attributes unchanged', () => {
+    const messages = [ { role: 'user', content: 'Hello' } ];
+    expect( resolveMessageProviderOptions( textPrompt( { messages } ) ) ).toEqual( messages );
+  } );
+} );

--- a/sdk/llm/src/prompt/blocks.js
+++ b/sdk/llm/src/prompt/blocks.js
@@ -1,0 +1,47 @@
+/**
+ * Roles that introduce a message block. Add a role here to support a new
+ * `<role>...</role>` block — the tokenizer pattern is derived from this set,
+ * so no other parser change is required.
+ */
+export const BLOCK_ROLES = new Set( [ 'system', 'user', 'assistant', 'tool' ] );
+
+const BLOCK_PATTERN = new RegExp(
+  `<(${[ ...BLOCK_ROLES ].join( '|' )})((?:\\s[^>]*)?)>([\\s\\S]*?)<\\/\\1>`,
+  'gm'
+);
+
+const ATTRIBUTE_PATTERN = /([a-zA-Z][\w-]*)(?:=(?:"([^"]*)"|'([^']*)'|(\S+)))?/g;
+
+/**
+ * Parse a raw opening-tag attribute string into a plain object. Supports bare booleans
+ * (`cache`), double/single-quoted values, and unquoted values:
+ * `cache options="a b" ttl='1h'` → `{ cache: true, options: 'a b', ttl: '1h' }`.
+ *
+ * @param {string} [raw] - Raw attribute text between the role and the closing `>`
+ * @returns {Record<string, string | true>} Parsed attributes
+ */
+export const parseAttributes = ( raw = '' ) =>
+  Object.fromEntries(
+    [ ...raw.matchAll( ATTRIBUTE_PATTERN ) ].map(
+      ( [ _, key, doubleQuoted, singleQuoted, bare ] ) =>
+        [ key, doubleQuoted ?? singleQuoted ?? bare ?? true ]
+    )
+  );
+
+/**
+ * Tokenize a rendered prompt body into message blocks. Each block is `{ role, content }`,
+ * plus `attributes` when the opening tag carried any. Content between role tags is treated
+ * as opaque text, so prompt bodies may freely contain other angle-bracket markup.
+ *
+ * @param {string} content - Rendered prompt body (after frontmatter is stripped)
+ * @returns {Array<{ role: string, content: string, attributes?: Record<string, string | true> }>}
+ */
+export const tokenizeBlocks = content =>
+  [ ...content.matchAll( BLOCK_PATTERN ) ].map( ( [ _, role, rawAttributes, text ] ) => {
+    const attributes = parseAttributes( rawAttributes.trim() );
+    return {
+      role,
+      content: text.trim(),
+      ...( Object.keys( attributes ).length > 0 && { attributes } )
+    };
+  } );

--- a/sdk/llm/src/prompt/blocks.spec.js
+++ b/sdk/llm/src/prompt/blocks.spec.js
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { parseAttributes, tokenizeBlocks, BLOCK_ROLES } from './blocks.js';
+
+describe( 'parseAttributes', () => {
+  it( 'parses a bare attribute as boolean true', () => {
+    expect( parseAttributes( 'cache' ) ).toEqual( { cache: true } );
+  } );
+
+  it( 'parses double- and single-quoted values', () => {
+    expect( parseAttributes( 'cache="1h" mode=\'fast\'' ) ).toEqual( { cache: '1h', mode: 'fast' } );
+  } );
+
+  it( 'parses unquoted values', () => {
+    expect( parseAttributes( 'cache=1h' ) ).toEqual( { cache: '1h' } );
+  } );
+
+  it( 'parses multiple attributes and preserves spaces inside quotes', () => {
+    expect( parseAttributes( 'cache options="cached fast"' ) ).toEqual( {
+      cache: true,
+      options: 'cached fast'
+    } );
+  } );
+
+  it( 'returns an empty object for blank input', () => {
+    expect( parseAttributes( '' ) ).toEqual( {} );
+    expect( parseAttributes() ).toEqual( {} );
+  } );
+} );
+
+describe( 'tokenizeBlocks', () => {
+  it( 'tokenizes plain blocks without an attributes key', () => {
+    const blocks = tokenizeBlocks( '<system>Hi</system>\n<user>Yo</user>' );
+    expect( blocks ).toEqual( [
+      { role: 'system', content: 'Hi' },
+      { role: 'user', content: 'Yo' }
+    ] );
+  } );
+
+  it( 'attaches parsed attributes to the block', () => {
+    const blocks = tokenizeBlocks( '<system cache="1h" options="a b">Hi</system>' );
+    expect( blocks[0] ).toEqual( {
+      role: 'system',
+      content: 'Hi',
+      attributes: { cache: '1h', options: 'a b' }
+    } );
+  } );
+
+  it( 'does not mistake options="cache" for a cache attribute', () => {
+    const blocks = tokenizeBlocks( '<system options="cache">Hi</system>' );
+    expect( blocks[0].attributes ).toEqual( { options: 'cache' } );
+  } );
+
+  it( 'captures unknown attributes generically (validation rejects them later)', () => {
+    const blocks = tokenizeBlocks( '<user data="x">Hi</user>' );
+    expect( blocks[0].attributes ).toEqual( { data: 'x' } );
+  } );
+
+  it( 'treats angle-bracket markup inside a block as opaque content', () => {
+    const blocks = tokenizeBlocks( '<user>Compare <div> and <span> tags</user>' );
+    expect( blocks[0] ).toEqual( { role: 'user', content: 'Compare <div> and <span> tags' } );
+  } );
+
+  it( 'tokenizes every registered role', () => {
+    const body = [ ...BLOCK_ROLES ].map( role => `<${role}>${role} body</${role}>` ).join( '\n' );
+    const blocks = tokenizeBlocks( body );
+    expect( blocks.map( block => block.role ) ).toEqual( [ ...BLOCK_ROLES ] );
+  } );
+} );

--- a/sdk/llm/src/prompt/parser.js
+++ b/sdk/llm/src/prompt/parser.js
@@ -1,28 +1,6 @@
 import matter from 'gray-matter';
 import { FatalError } from '@outputai/core';
-
-const BLOCK_EXTRACTOR = /<(system|user|assistant|tool)(\s[^>]*)?>([\s\S]*?)<\/\1>/gm;
-
-/**
- * Parse optional attributes on a role block's opening tag into authoring helpers:
- * - `cache` / `cache="1h"` → Anthropic prompt-cache breakpoint shorthand
- * - `options="set_a set_b"` → references to frontmatter `messageOptions` sets
- */
-const parseBlockAttributes = ( attrs = '' ) => {
-  const result = {};
-
-  const cache = attrs.match( /(?:^|\s)cache(?:=["']?([^"'\s]+)["']?)?(?=\s|$)/ );
-  if ( cache ) {
-    result.cache = cache[1] ?? true;
-  }
-
-  const options = attrs.match( /\boptions=["']([^"']+)["']/ );
-  if ( options ) {
-    result.options = options[1].trim().split( /\s+/ );
-  }
-
-  return result;
-};
+import { tokenizeBlocks } from './blocks.js';
 
 export function parsePrompt( { name, raw } ) {
   const { data: config, content } = matter( raw );
@@ -31,14 +9,7 @@ export function parsePrompt( { name, raw } ) {
     throw new FatalError( `Prompt "${name}" has no content after frontmatter` );
   }
 
-  const messages = [ ...content.matchAll( BLOCK_EXTRACTOR ) ].map(
-    ( [ _, role, attrs, text ] ) => ( {
-      role,
-      content: text.trim(),
-      ...parseBlockAttributes( attrs )
-    } )
-  );
-
+  const messages = tokenizeBlocks( content );
   const instructions = messages.length === 0 ? content.trim() : null;
 
   return { config, messages, instructions };

--- a/sdk/llm/src/prompt/parser.js
+++ b/sdk/llm/src/prompt/parser.js
@@ -1,6 +1,29 @@
 import matter from 'gray-matter';
 import { FatalError } from '@outputai/core';
 
+const BLOCK_EXTRACTOR = /<(system|user|assistant|tool)(\s[^>]*)?>([\s\S]*?)<\/\1>/gm;
+
+/**
+ * Parse optional attributes on a role block's opening tag into authoring helpers:
+ * - `cache` / `cache="1h"` → Anthropic prompt-cache breakpoint shorthand
+ * - `options="set_a set_b"` → references to frontmatter `messageOptions` sets
+ */
+const parseBlockAttributes = ( attrs = '' ) => {
+  const result = {};
+
+  const cache = attrs.match( /(?:^|\s)cache(?:=["']?([^"'\s]+)["']?)?(?=\s|$)/ );
+  if ( cache ) {
+    result.cache = cache[1] ?? true;
+  }
+
+  const options = attrs.match( /\boptions=["']([^"']+)["']/ );
+  if ( options ) {
+    result.options = options[1].trim().split( /\s+/ );
+  }
+
+  return result;
+};
+
 export function parsePrompt( { name, raw } ) {
   const { data: config, content } = matter( raw );
 
@@ -8,9 +31,12 @@ export function parsePrompt( { name, raw } ) {
     throw new FatalError( `Prompt "${name}" has no content after frontmatter` );
   }
 
-  const infoExtractor = /<(system|user|assistant|tool)>([\s\S]*?)<\/\1>/gm;
-  const messages = [ ...content.matchAll( infoExtractor ) ].map(
-    ( [ _, role, text ] ) => ( { role, content: text.trim() } )
+  const messages = [ ...content.matchAll( BLOCK_EXTRACTOR ) ].map(
+    ( [ _, role, attrs, text ] ) => ( {
+      role,
+      content: text.trim(),
+      ...parseBlockAttributes( attrs )
+    } )
   );
 
   const instructions = messages.length === 0 ? content.trim() : null;

--- a/sdk/llm/src/prompt/parser.spec.js
+++ b/sdk/llm/src/prompt/parser.spec.js
@@ -165,104 +165,22 @@ model: claude-3-5-sonnet-20241022
     expect( result.instructions ).toBeNull();
   } );
 
-  it( 'parses the cache shorthand as a boolean breakpoint marker', () => {
+  it( 'surfaces block opening-tag attributes as an attributes object', () => {
     const raw = `---
 provider: anthropic
 model: claude-sonnet-4-5
 ---
 
-<system cache>Static instructions.</system>
-<user>Question</user>`;
-
-    const result = parsePrompt( { name: 'test', raw } );
-
-    expect( result.messages ).toEqual( [
-      { role: 'system', content: 'Static instructions.', cache: true },
-      { role: 'user', content: 'Question' }
-    ] );
-  } );
-
-  it( 'parses the cache shorthand ttl value', () => {
-    const raw = `---
-provider: anthropic
-model: claude-sonnet-4-5
----
-
-<system cache="1h">Static instructions.</system>
+<system cache="1h">Static.</system>
 <user>Question</user>`;
 
     const result = parsePrompt( { name: 'test', raw } );
 
     expect( result.messages[0] ).toEqual( {
       role: 'system',
-      content: 'Static instructions.',
-      cache: '1h'
+      content: 'Static.',
+      attributes: { cache: '1h' }
     } );
-  } );
-
-  it( 'parses options set references, single and space-separated', () => {
-    const raw = `---
-provider: anthropic
-model: claude-sonnet-4-5
----
-
-<system options="cached">Docs.</system>
-<user options="cached fast">Question</user>`;
-
-    const result = parsePrompt( { name: 'test', raw } );
-
-    expect( result.messages[0].options ).toEqual( [ 'cached' ] );
-    expect( result.messages[1].options ).toEqual( [ 'cached', 'fast' ] );
-  } );
-
-  it( 'parses cache and options on the same block', () => {
-    const raw = `---
-provider: anthropic
-model: claude-sonnet-4-5
----
-
-<user cache="1h" options="extra">Question</user>`;
-
-    const result = parsePrompt( { name: 'test', raw } );
-
-    expect( result.messages[0] ).toEqual( {
-      role: 'user',
-      content: 'Question',
-      cache: '1h',
-      options: [ 'extra' ]
-    } );
-  } );
-
-  it( 'does not mistake options="cache" for the cache shorthand', () => {
-    const raw = `---
-provider: anthropic
-model: claude-sonnet-4-5
----
-
-<system options="cache">Docs.</system>`;
-
-    const result = parsePrompt( { name: 'test', raw } );
-
-    expect( result.messages[0] ).toEqual( {
-      role: 'system',
-      content: 'Docs.',
-      options: [ 'cache' ]
-    } );
-    expect( result.messages[0].cache ).toBeUndefined();
-  } );
-
-  it( 'leaves plain blocks without cache or options keys', () => {
-    const raw = `---
-provider: anthropic
-model: claude-sonnet-4-5
----
-
-<system>Plain.</system>`;
-
-    const result = parsePrompt( { name: 'test', raw } );
-
-    expect( result.messages[0] ).toEqual( { role: 'system', content: 'Plain.' } );
-    expect( Object.hasOwn( result.messages[0], 'cache' ) ).toBe( false );
-    expect( Object.hasOwn( result.messages[0], 'options' ) ).toBe( false );
+    expect( result.messages[1] ).toEqual( { role: 'user', content: 'Question' } );
   } );
 } );

--- a/sdk/llm/src/prompt/parser.spec.js
+++ b/sdk/llm/src/prompt/parser.spec.js
@@ -164,4 +164,105 @@ model: claude-3-5-sonnet-20241022
     ] );
     expect( result.instructions ).toBeNull();
   } );
+
+  it( 'parses the cache shorthand as a boolean breakpoint marker', () => {
+    const raw = `---
+provider: anthropic
+model: claude-sonnet-4-5
+---
+
+<system cache>Static instructions.</system>
+<user>Question</user>`;
+
+    const result = parsePrompt( { name: 'test', raw } );
+
+    expect( result.messages ).toEqual( [
+      { role: 'system', content: 'Static instructions.', cache: true },
+      { role: 'user', content: 'Question' }
+    ] );
+  } );
+
+  it( 'parses the cache shorthand ttl value', () => {
+    const raw = `---
+provider: anthropic
+model: claude-sonnet-4-5
+---
+
+<system cache="1h">Static instructions.</system>
+<user>Question</user>`;
+
+    const result = parsePrompt( { name: 'test', raw } );
+
+    expect( result.messages[0] ).toEqual( {
+      role: 'system',
+      content: 'Static instructions.',
+      cache: '1h'
+    } );
+  } );
+
+  it( 'parses options set references, single and space-separated', () => {
+    const raw = `---
+provider: anthropic
+model: claude-sonnet-4-5
+---
+
+<system options="cached">Docs.</system>
+<user options="cached fast">Question</user>`;
+
+    const result = parsePrompt( { name: 'test', raw } );
+
+    expect( result.messages[0].options ).toEqual( [ 'cached' ] );
+    expect( result.messages[1].options ).toEqual( [ 'cached', 'fast' ] );
+  } );
+
+  it( 'parses cache and options on the same block', () => {
+    const raw = `---
+provider: anthropic
+model: claude-sonnet-4-5
+---
+
+<user cache="1h" options="extra">Question</user>`;
+
+    const result = parsePrompt( { name: 'test', raw } );
+
+    expect( result.messages[0] ).toEqual( {
+      role: 'user',
+      content: 'Question',
+      cache: '1h',
+      options: [ 'extra' ]
+    } );
+  } );
+
+  it( 'does not mistake options="cache" for the cache shorthand', () => {
+    const raw = `---
+provider: anthropic
+model: claude-sonnet-4-5
+---
+
+<system options="cache">Docs.</system>`;
+
+    const result = parsePrompt( { name: 'test', raw } );
+
+    expect( result.messages[0] ).toEqual( {
+      role: 'system',
+      content: 'Docs.',
+      options: [ 'cache' ]
+    } );
+    expect( result.messages[0].cache ).toBeUndefined();
+  } );
+
+  it( 'leaves plain blocks without cache or options keys', () => {
+    const raw = `---
+provider: anthropic
+model: claude-sonnet-4-5
+---
+
+<system>Plain.</system>`;
+
+    const result = parsePrompt( { name: 'test', raw } );
+
+    expect( result.messages[0] ).toEqual( { role: 'system', content: 'Plain.' } );
+    expect( Object.hasOwn( result.messages[0], 'cache' ) ).toBe( false );
+    expect( Object.hasOwn( result.messages[0], 'options' ) ).toBe( false );
+  } );
 } );

--- a/sdk/llm/src/prompt/validations.js
+++ b/sdk/llm/src/prompt/validations.js
@@ -3,6 +3,9 @@ import { ValidationError, z } from '@outputai/core';
 const toolConfigSchema = z.record( z.string(), z.unknown() );
 const toolsConfigSchema = z.record( z.string(), toolConfigSchema );
 
+// A provider-namespaced options object, e.g. { anthropic: { cacheControl: { type: 'ephemeral' } } }
+const providerOptionsSchema = z.record( z.string(), z.record( z.string(), z.unknown() ) );
+
 export const promptSchema = z.object( {
   name: z.string(),
   config: z.object( {
@@ -22,12 +25,15 @@ export const promptSchema = z.object( {
         type: z.enum( [ 'enabled', 'disabled' ] ),
         budgetTokens: z.number().optional()
       } ).loose().optional()
-    } ).loose().optional()
+    } ).loose().optional(),
+    messageOptions: z.record( z.string(), providerOptionsSchema ).optional()
   } ).loose(),
   messages: z.array(
     z.object( {
       role: z.string(),
-      content: z.string()
+      content: z.string(),
+      cache: z.union( [ z.boolean(), z.enum( [ '5m', '1h' ] ) ] ).optional(),
+      options: z.array( z.string().min( 1 ) ).optional()
     } ).strict()
   ),
   instructions: z.string().trim().min( 1 ).nullable().optional()

--- a/sdk/llm/src/prompt/validations.js
+++ b/sdk/llm/src/prompt/validations.js
@@ -1,4 +1,5 @@
 import { ValidationError, z } from '@outputai/core';
+import { attributesSchema } from './block_options.js';
 
 const toolConfigSchema = z.record( z.string(), z.unknown() );
 const toolsConfigSchema = z.record( z.string(), toolConfigSchema );
@@ -32,8 +33,7 @@ export const promptSchema = z.object( {
     z.object( {
       role: z.string(),
       content: z.string(),
-      cache: z.union( [ z.boolean(), z.enum( [ '5m', '1h' ] ) ] ).optional(),
-      options: z.array( z.string().min( 1 ) ).optional()
+      attributes: attributesSchema.optional()
     } ).strict()
   ),
   instructions: z.string().trim().min( 1 ).nullable().optional()

--- a/sdk/llm/src/prompt/validations.spec.js
+++ b/sdk/llm/src/prompt/validations.spec.js
@@ -597,7 +597,7 @@ describe( 'validatePrompt', () => {
     expect( () => validatePrompt( maxTokensSnakeCase ) ).not.toThrow();
   } );
 
-  it( 'should validate per-message cache shorthand values', () => {
+  it( 'should validate per-message cache attribute values', () => {
     const promptWithCache = {
       name: 'cache-prompt',
       config: {
@@ -605,15 +605,15 @@ describe( 'validatePrompt', () => {
         model: 'claude-sonnet-4-5'
       },
       messages: [
-        { role: 'system', content: 'Static instructions.', cache: true },
-        { role: 'user', content: 'Question', cache: '1h' }
+        { role: 'system', content: 'Static instructions.', attributes: { cache: true } },
+        { role: 'user', content: 'Question', attributes: { cache: '1h' } }
       ]
     };
 
     expect( () => validatePrompt( promptWithCache ) ).not.toThrow();
   } );
 
-  it( 'should validate messageOptions sets referenced by message options', () => {
+  it( 'should validate the options attribute referencing messageOptions sets', () => {
     const promptWithMessageOptions = {
       name: 'message-options-prompt',
       config: {
@@ -624,7 +624,7 @@ describe( 'validatePrompt', () => {
         }
       },
       messages: [
-        { role: 'system', content: 'Docs.', options: [ 'cached' ] },
+        { role: 'system', content: 'Docs.', attributes: { options: 'cached' } },
         { role: 'user', content: 'Question' }
       ]
     };
@@ -632,7 +632,7 @@ describe( 'validatePrompt', () => {
     expect( () => validatePrompt( promptWithMessageOptions ) ).not.toThrow();
   } );
 
-  it( 'should throw ValidationError for an invalid cache shorthand value', () => {
+  it( 'should throw ValidationError for an invalid cache attribute value', () => {
     const invalidCachePrompt = {
       name: 'invalid-cache-prompt',
       config: {
@@ -640,14 +640,29 @@ describe( 'validatePrompt', () => {
         model: 'claude-sonnet-4-5'
       },
       messages: [
-        { role: 'system', content: 'Static.', cache: '2h' }
+        { role: 'system', content: 'Static.', attributes: { cache: '2h' } }
       ]
     };
 
     expect( () => validatePrompt( invalidCachePrompt ) ).toThrow( ValidationError );
   } );
 
-  it( 'should throw ValidationError for unknown per-message fields', () => {
+  it( 'should throw ValidationError for an unknown block attribute', () => {
+    const unknownAttributePrompt = {
+      name: 'unknown-attribute-prompt',
+      config: {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5'
+      },
+      messages: [
+        { role: 'user', content: 'Hi', attributes: { cacheControl: { type: 'ephemeral' } } }
+      ]
+    };
+
+    expect( () => validatePrompt( unknownAttributePrompt ) ).toThrow( ValidationError );
+  } );
+
+  it( 'should throw ValidationError for unknown top-level message fields', () => {
     const unknownFieldPrompt = {
       name: 'unknown-field-prompt',
       config: {
@@ -655,7 +670,7 @@ describe( 'validatePrompt', () => {
         model: 'claude-sonnet-4-5'
       },
       messages: [
-        { role: 'user', content: 'Hi', cacheControl: { type: 'ephemeral' } }
+        { role: 'user', content: 'Hi', cache: true }
       ]
     };
 

--- a/sdk/llm/src/prompt/validations.spec.js
+++ b/sdk/llm/src/prompt/validations.spec.js
@@ -596,4 +596,69 @@ describe( 'validatePrompt', () => {
 
     expect( () => validatePrompt( maxTokensSnakeCase ) ).not.toThrow();
   } );
+
+  it( 'should validate per-message cache shorthand values', () => {
+    const promptWithCache = {
+      name: 'cache-prompt',
+      config: {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5'
+      },
+      messages: [
+        { role: 'system', content: 'Static instructions.', cache: true },
+        { role: 'user', content: 'Question', cache: '1h' }
+      ]
+    };
+
+    expect( () => validatePrompt( promptWithCache ) ).not.toThrow();
+  } );
+
+  it( 'should validate messageOptions sets referenced by message options', () => {
+    const promptWithMessageOptions = {
+      name: 'message-options-prompt',
+      config: {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5',
+        messageOptions: {
+          cached: { anthropic: { cacheControl: { type: 'ephemeral' } } }
+        }
+      },
+      messages: [
+        { role: 'system', content: 'Docs.', options: [ 'cached' ] },
+        { role: 'user', content: 'Question' }
+      ]
+    };
+
+    expect( () => validatePrompt( promptWithMessageOptions ) ).not.toThrow();
+  } );
+
+  it( 'should throw ValidationError for an invalid cache shorthand value', () => {
+    const invalidCachePrompt = {
+      name: 'invalid-cache-prompt',
+      config: {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5'
+      },
+      messages: [
+        { role: 'system', content: 'Static.', cache: '2h' }
+      ]
+    };
+
+    expect( () => validatePrompt( invalidCachePrompt ) ).toThrow( ValidationError );
+  } );
+
+  it( 'should throw ValidationError for unknown per-message fields', () => {
+    const unknownFieldPrompt = {
+      name: 'unknown-field-prompt',
+      config: {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-5'
+      },
+      messages: [
+        { role: 'user', content: 'Hi', cacheControl: { type: 'ephemeral' } }
+      ]
+    };
+
+    expect( () => validatePrompt( unknownFieldPrompt ) ).toThrow( ValidationError );
+  } );
 } );


### PR DESCRIPTION
## Problem

Adding a new prompt block role or block option meant editing the grammar in three places, because roles and attributes were hardcoded:

- Block roles lived in the tokenizer's regex alternation (`(system|user|assistant|tool)`)
- Each attribute had its own bespoke regex in `parseBlockAttributes` (the source of the `options="cache"` false-positive footgun)
- The `.strict()` message schema enumerated allowed fields, and resolution branched per option

A general HTML/XML parser isn't a safe swap here: `escape.js` only escapes Liquid *variable* output, so static prompt bodies legitimately contain arbitrary `<...>` markup a markup parser would misparse — and it would own entity decoding, colliding with the existing escape/`decode()` contract.

## Solution

Separate **tokenizing** from **interpreting**, and make both data-driven:

- **`prompt/blocks.js`** — a focused tokenizer. Roles come from a `BLOCK_ROLES` set (the pattern is generated from it); one generic attribute parser turns the opening tag into `{ key: value | true }`. Content between role tags stays opaque, preserving the escape/decode contract.
- **`prompt/block_options.js`** — one registry where each option declares its `schema` *and* its `resolve`. `attributesSchema` (validation) and `resolveMessageProviderOptions` (AI-SDK boundary) both derive from this table.
- `parser.js` drops to frontmatter + `tokenizeBlocks`; validation validates a generic `attributes` object; `PromptMessage` carries `attributes` instead of `cache`/`options`.

Net effect: a new block role is one line in `BLOCK_ROLES`; a new option is one entry in the registry — no regex, no schema surgery, no resolver branching. `cache` and `options` from #252 are now the first two registry entries.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` — 2055 pass; only the 2 pre-existing `sdk/cli` copy-assets failures remain (unrelated; see #252)
- [x] New unit specs: `blocks.spec.js` (tokenizer, incl. opaque angle-bracket content + the `options="cache"` guard) and `block_options.spec.js` (registry schema + resolver); `ai_sdk_options.spec.js` keeps one integration test
- [x] Public `.d.ts` typechecks against the new `attributes` shape

## Notes for reviewers

- **Kept a (registry-generated) regex tokenizer rather than adding a parser dependency** — the body grammar is tiny and the content-safety constraint above makes a general markup parser a poor fit. The `tokenizeBlocks` interface (`{ role, attributes, content }`) lets us swap in a hand scanner later with no downstream change.
- **`PromptMessage` now exposes `attributes` instead of `cache`/`options`** — a shape change to a type only introduced in #252 (unreleased), so no migration. No new changeset for the same reason: this refactors unreleased code and the #252 changeset covers the release.

Builds on #252 (stacked — base retargets to `main` once #252 merges).