### PR TITLE
chore: sdk/llm support cache control for Agents

### DIFF
--- a/sdk/llm/src/agent.js
+++ b/sdk/llm/src/agent.js
@@ -5,7 +5,7 @@ import { loadAiSdkTextOptions } from './ai_sdk_options.js';
 import { prepareTextPrompt } from './prompt/prepare_text.js';
 import { startTrace, endTraceWithError } from './utils/trace.js';
 import { wrapTextResponse, wrapStreamOnFinishResponse } from './utils/response_wrappers.js';
-import { ROLE, isRole, getContent } from './utils/message.js';
+import { ROLE, isRole } from './utils/message.js';
 export { skill } from './prompt/skill.js';
 
 export const createMemoryConversationStore = () => {
@@ -47,12 +47,13 @@ export class Agent extends AIToolLoopAgent {
 
     // Extract system messages as `instructions` for the ToolLoopAgent constructor
     // and keep user messages for generate() calls — avoids provider errors
-    // with multiple system messages during multi-step tool loops
-    const systemContent = allMessages.filter( isRole( ROLE.SYSTEM ) ).map( getContent ).join( '\n\n' );
+    // with multiple system messages during multi-step tool loops.
+    // Pass message objects (not a string) so per-message providerOptions are preserved.
+    const systemMessages = allMessages.filter( isRole( ROLE.SYSTEM ) );
 
     super( {
       ...constructorOptions,
-      ...( systemContent ? { instructions: systemContent } : {} ),
+      ...( systemMessages.length > 0 ? { instructions: systemMessages } : {} ),
       ...( tools ? { tools } : {} ),
       stopWhen: stopWhen ?? stepCountIs( maxSteps ),
       ...rest

--- a/sdk/llm/src/agent.spec.js
+++ b/sdk/llm/src/agent.spec.js
@@ -86,7 +86,8 @@ vi.mock( './utils/trace.js', () => ( {
 
 vi.mock( './utils/response_wrappers.js', () => ( {
   wrapTextResponse: ( ...args ) => wrapMocks.wrapTextResponse( ...args ),
-  wrapStreamOnFinishResponse: ( ...args ) => wrapMocks.wrapStreamOnFinishResponse( ...args )
+  wrapStreamOnFinishResponse: ( ...args ) =>
+    wrapMocks.wrapStreamOnFinishResponse( ...args )
 } ) );
 
 vi.mock( './prompt/skill.js', () => ( {
@@ -131,7 +132,9 @@ describe( 'Agent', () => {
     aiMocks.superConstructor.mockReset();
     aiMocks.superGenerate.mockReset().mockResolvedValue( aiResponse );
     aiMocks.superStream.mockReset().mockReturnValue( { textStream: 'stream' } );
-    aiMocks.stepCountIs.mockReset().mockImplementation( count => ( { type: 'step-count', count } ) );
+    aiMocks.stepCountIs
+      .mockReset()
+      .mockImplementation( count => ( { type: 'step-count', count } ) );
 
     promptMocks.prepareTextPrompt.mockReset().mockReturnValue( {
       loadedPrompt,
@@ -143,7 +146,9 @@ describe( 'Agent', () => {
     traceMocks.startTrace.mockReset().mockReturnValue( 'trace-id' );
     traceMocks.endTraceWithError.mockReset();
 
-    wrapMocks.wrapTextResponse.mockReset().mockImplementation( async ( { response } ) => response );
+    wrapMocks.wrapTextResponse
+      .mockReset()
+      .mockImplementation( async ( { response } ) => response );
     wrapMocks.wrapStreamOnFinishResponse.mockReset().mockReturnValue( {
       onFinish: vi.fn()
     } );
@@ -175,7 +180,9 @@ describe( 'Agent', () => {
 
   it( 'prepares the prompt using the resolved invocation dir', async () => {
     const { Agent } = await importSut();
-    const skills = [ { name: 'style', description: 'Style', instructions: '# Style' } ];
+    const skills = [
+      { name: 'style', description: 'Style', instructions: '# Style' }
+    ];
     const tools = { search: { description: 'Search' } };
 
     new Agent( {
@@ -199,9 +206,11 @@ describe( 'Agent', () => {
 
     new Agent( { prompt: 'test@v1', promptDir: '/explicit/prompts' } );
 
-    expect( promptMocks.prepareTextPrompt ).toHaveBeenCalledWith( expect.objectContaining( {
-      promptDir: '/explicit/prompts'
-    } ) );
+    expect( promptMocks.prepareTextPrompt ).toHaveBeenCalledWith(
+      expect.objectContaining( {
+        promptDir: '/explicit/prompts'
+      } )
+    );
   } );
 
   it( 'constructs ToolLoopAgent with text options, instructions, tools, and default stopWhen', async () => {
@@ -215,10 +224,31 @@ describe( 'Agent', () => {
       model,
       providerOptions: { test: true },
       temperature: 0.3,
-      instructions: 'You are concise.',
+      instructions: [ { role: 'system', content: 'You are concise.' } ],
       tools: preparedTools,
       stopWhen: { type: 'step-count', count: 10 }
     } );
+  } );
+
+  it( 'preserves per-message providerOptions on system messages passed as instructions', async () => {
+    const { Agent } = await importSut();
+    const systemMessage = {
+      role: 'system',
+      content: 'You are concise.',
+      providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } }
+    };
+    optionMocks.loadAiSdkTextOptions.mockReturnValueOnce( {
+      model,
+      messages: [ systemMessage, { role: 'user', content: 'Hello' } ]
+    } );
+
+    new Agent( { prompt: 'test@v1' } );
+
+    expect( aiMocks.superConstructor ).toHaveBeenCalledWith(
+      expect.objectContaining( {
+        instructions: [ systemMessage ]
+      } )
+    );
   } );
 
   it( 'omits tools when prompt preparation returns null tools', async () => {
@@ -234,7 +264,7 @@ describe( 'Agent', () => {
       model,
       providerOptions: { test: true },
       temperature: 0.3,
-      instructions: 'You are concise.',
+      instructions: [ { role: 'system', content: 'You are concise.' } ],
       stopWhen: { type: 'step-count', count: 10 }
     } );
   } );
@@ -246,9 +276,11 @@ describe( 'Agent', () => {
     new Agent( { prompt: 'test@v1', stopWhen } );
 
     expect( aiMocks.stepCountIs ).not.toHaveBeenCalled();
-    expect( aiMocks.superConstructor ).toHaveBeenCalledWith( expect.objectContaining( {
-      stopWhen
-    } ) );
+    expect( aiMocks.superConstructor ).toHaveBeenCalledWith(
+      expect.objectContaining( {
+        stopWhen
+      } )
+    );
   } );
 
   it( 'passes custom constructor options through', async () => {
@@ -256,10 +288,12 @@ describe( 'Agent', () => {
 
     new Agent( { prompt: 'test@v1', temperature: 0.8, seed: 42 } );
 
-    expect( aiMocks.superConstructor ).toHaveBeenCalledWith( expect.objectContaining( {
-      temperature: 0.8,
-      seed: 42
-    } ) );
+    expect( aiMocks.superConstructor ).toHaveBeenCalledWith(
+      expect.objectContaining( {
+        temperature: 0.8,
+        seed: 42
+      } )
+    );
   } );
 
   it( 'keeps only user prompt messages as initial generate messages', async () => {
@@ -275,7 +309,9 @@ describe( 'Agent', () => {
 
   it( 'combines initial, stored, and caller messages for generate', async () => {
     const store = {
-      getMessages: vi.fn( () => [ { role: 'assistant', content: 'Stored reply' } ] ),
+      getMessages: vi.fn( () => [
+        { role: 'assistant', content: 'Stored reply' }
+      ] ),
       addMessages: vi.fn()
     };
     const callerMessage = { role: 'user', content: 'New question' };
@@ -336,7 +372,9 @@ describe( 'Agent', () => {
 
   it( 'streams with initial, stored, and caller messages', async () => {
     const store = {
-      getMessages: vi.fn( () => [ { role: 'assistant', content: 'Stored reply' } ] ),
+      getMessages: vi.fn( () => [
+        { role: 'assistant', content: 'Stored reply' }
+      ] ),
       addMessages: vi.fn()
     };
     const onFinish = vi.fn();
@@ -345,7 +383,12 @@ describe( 'Agent', () => {
     const { Agent } = await importSut();
     const agent = new Agent( { prompt: 'test@v1', conversationStore: store } );
 
-    const result = await agent.stream( { messages: [ callerMessage ], onFinish, onError, maxRetries: 1 } );
+    const result = await agent.stream( {
+      messages: [ callerMessage ],
+      onFinish,
+      onError,
+      maxRetries: 1
+    } );
 
     expect( traceMocks.startTrace ).toHaveBeenCalledWith( {
       name: 'Agent.stream',

--- a/sdk/llm/src/index.d.ts
+++ b/sdk/llm/src/index.d.ts
@@ -62,7 +62,7 @@ export type PromptMessage = {
    * frontmatter `messageOptions` set names — which is resolved into per-message `providerOptions`
    * at call time and stripped before the request is sent. Authored as `<system options="set_a set_b">`.
    */
-  attributes?: Record<string, string | boolean>;
+  attributes?: Record<string, string | true>;
 };
 
 /**


### PR DESCRIPTION
## Summary

#252 added per-message `providerOptions` resolution via `resolveMessageProviderOptions`, but didn't update `Agent()`, which was still flattening system messages to a plain string before passing them as instructions. This silently discarded any resolved `providerOptions` (including `cacheControl`) on system blocks. `generateText()` was unaffected. The flattening code predates this PR, but it only became lossy once this PR started attaching providerOptions to messages.

The test in `agent.spec.js` on line 233 demonstrates the issue.

Also narrows `PromptMessage.attributes` in `index.d.ts` from `string | boolean` to `string | true`: bare tag attributes can only ever be `true` at runtime and `parseAttributes` never produces `false`, so the wider type was misleading.