### PR TITLE
feat(cli): show aliases and honor OUTPUT_CATALOG_ID in workflow list

### DIFF
--- a/.changeset/out-444-489-workflow-list-aliases-and-catalog.md
+++ b/.changeset/out-444-489-workflow-list-aliases-and-catalog.md
@@ -1,0 +1,8 @@
+---
+"@outputai/cli": patch
+---
+
+Surface workflow aliases and honor `OUTPUT_CATALOG_ID` in `output workflow list`.
+
+- The default list output now appends `(aliases: ...)` to workflows that have registered aliases, which previously only appeared in `--format table`/`--format json` (OUT-444).
+- Add a `--catalog` flag (env `OUTPUT_CATALOG_ID`) that resolves workflows from a specific catalog, falling back to the server-default catalog — matching the existing behavior of `run` and `start` (OUT-489).

--- a/sdk/cli/src/api/workflow_catalog.spec.ts
+++ b/sdk/cli/src/api/workflow_catalog.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as api from './generated/api.js';
+import { fetchWorkflowCatalog } from './workflow_catalog.js';
+
+vi.mock( './generated/api.js', () => ( {
+  getWorkflowCatalog: vi.fn(),
+  getWorkflowCatalogId: vi.fn()
+} ) );
+
+describe( 'fetchWorkflowCatalog', () => {
+  beforeEach( () => {
+    vi.clearAllMocks();
+  } );
+
+  it( 'fetches the default catalog when no catalog id is provided', async () => {
+    vi.mocked( api.getWorkflowCatalog ).mockResolvedValue( { data: { workflows: [ { name: 'a' } ] } } as never );
+
+    const result = await fetchWorkflowCatalog();
+
+    expect( api.getWorkflowCatalog ).toHaveBeenCalledTimes( 1 );
+    expect( api.getWorkflowCatalogId ).not.toHaveBeenCalled();
+    expect( result ).toEqual( [ { name: 'a' } ] );
+  } );
+
+  it( 'fetches a specific catalog by id when one is provided', async () => {
+    vi.mocked( api.getWorkflowCatalogId ).mockResolvedValue( { data: { workflows: [ { name: 'b' } ] } } as never );
+
+    const result = await fetchWorkflowCatalog( 'my-catalog' );
+
+    expect( api.getWorkflowCatalogId ).toHaveBeenCalledWith( 'my-catalog' );
+    expect( api.getWorkflowCatalog ).not.toHaveBeenCalled();
+    expect( result ).toEqual( [ { name: 'b' } ] );
+  } );
+
+  it( 'returns an empty array when the catalog response has no workflows', async () => {
+    vi.mocked( api.getWorkflowCatalog ).mockResolvedValue( { data: {} } as never );
+
+    expect( await fetchWorkflowCatalog() ).toEqual( [] );
+  } );
+} );

--- a/sdk/cli/src/api/workflow_catalog.ts
+++ b/sdk/cli/src/api/workflow_catalog.ts
@@ -1,0 +1,12 @@
+import { getWorkflowCatalog, getWorkflowCatalogId, type GetWorkflowCatalog200, type Workflow } from './generated/api.js';
+
+/**
+ * Resolve the workflows in a catalog. When `catalog` is provided (e.g. from
+ * `--catalog`/`OUTPUT_CATALOG_ID`) it resolves that specific catalog, otherwise
+ * the API server's default catalog. Returns `[]` when the catalog has no workflows.
+ */
+export async function fetchWorkflowCatalog( catalog?: string ): Promise<Workflow[]> {
+  const response = catalog ? await getWorkflowCatalogId( catalog ) : await getWorkflowCatalog();
+  const data = response?.data as GetWorkflowCatalog200 | undefined;
+  return data?.workflows ?? [];
+}

--- a/sdk/cli/src/commands/workflow/list.spec.ts
+++ b/sdk/cli/src/commands/workflow/list.spec.ts
@@ -1,9 +1,15 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockListScenarios = vi.fn().mockReturnValue( [] );
 
 vi.mock( '#utils/scenario_resolver.js', () => ( {
   listScenariosForWorkflow: mockListScenarios
+} ) );
+
+vi.mock( '#api/generated/api.js', () => ( {
+  getWorkflowCatalog: vi.fn(),
+  getWorkflowCatalogId: vi.fn()
 } ) );
 
 describe( 'workflow list command', () => {
@@ -19,6 +25,13 @@ describe( 'workflow list command', () => {
       expect( WorkflowList.flags ).toHaveProperty( 'format' );
       expect( WorkflowList.flags ).toHaveProperty( 'detailed' );
       expect( WorkflowList.flags ).toHaveProperty( 'filter' );
+      expect( WorkflowList.flags ).toHaveProperty( 'catalog' );
+    } );
+
+    it( 'reads the catalog flag from OUTPUT_CATALOG_ID', async () => {
+      const WorkflowList = ( await import( './list.js' ) ).default;
+      expect( WorkflowList.flags.catalog.env ).toBe( 'OUTPUT_CATALOG_ID' );
+      expect( WorkflowList.flags.catalog.char ).toBe( 'c' );
     } );
 
     it( 'should have correct flag configuration', async () => {
@@ -160,5 +173,52 @@ describe( 'formatWorkflowsAsList', () => {
 
     expect( output ).toContain( '- simple' );
     expect( output ).not.toContain( 'aliases:' );
+  } );
+} );
+
+describe( 'run() catalog resolution', () => {
+  beforeEach( () => {
+    vi.clearAllMocks();
+  } );
+
+  const catalogResponse = {
+    data: { workflows: [ { name: 'simple' } ] },
+    status: 200,
+    headers: new Headers()
+  };
+
+  const createCommand = async ( flagOverrides: Record<string, unknown> ) => {
+    const WorkflowList = ( await import( './list.js' ) ).default;
+    const cmd = new WorkflowList( [], {} as any );
+    cmd.log = vi.fn();
+    cmd.error = vi.fn( () => {
+      throw new Error( 'error called' );
+    } ) as any;
+    ( cmd as any ).parse = vi.fn().mockResolvedValue( {
+      flags: { format: 'list', detailed: false, filter: undefined, catalog: undefined, ...flagOverrides }
+    } );
+    return cmd;
+  };
+
+  it( 'fetches a specific catalog by id when a catalog is provided', async () => {
+    const { getWorkflowCatalog, getWorkflowCatalogId } = await import( '#api/generated/api.js' );
+    vi.mocked( getWorkflowCatalogId ).mockResolvedValue( catalogResponse as any );
+
+    const cmd = await createCommand( { catalog: 'my-catalog' } );
+    await cmd.run();
+
+    expect( getWorkflowCatalogId ).toHaveBeenCalledWith( 'my-catalog' );
+    expect( getWorkflowCatalog ).not.toHaveBeenCalled();
+  } );
+
+  it( 'falls back to the default catalog when no catalog is provided', async () => {
+    const { getWorkflowCatalog, getWorkflowCatalogId } = await import( '#api/generated/api.js' );
+    vi.mocked( getWorkflowCatalog ).mockResolvedValue( catalogResponse as any );
+
+    const cmd = await createCommand( { catalog: undefined } );
+    await cmd.run();
+
+    expect( getWorkflowCatalog ).toHaveBeenCalledTimes( 1 );
+    expect( getWorkflowCatalogId ).not.toHaveBeenCalled();
   } );
 } );

--- a/sdk/cli/src/commands/workflow/list.spec.ts
+++ b/sdk/cli/src/commands/workflow/list.spec.ts
@@ -141,3 +141,24 @@ describe( 'workflow list parsing', () => {
     expect( parsed.inputs ).toContain( 'user.email: string' );
   } );
 } );
+
+describe( 'formatWorkflowsAsList', () => {
+  it( 'appends aliases to the default list when present', async () => {
+    const { formatWorkflowsAsList } = await import( './list.js' );
+
+    const output = formatWorkflowsAsList( [
+      { name: 'galileoExtractKeyword', aliases: [ 'seoContentExtractKeywordWorkflow' ] }
+    ] );
+
+    expect( output ).toContain( '- galileoExtractKeyword (aliases: seoContentExtractKeywordWorkflow)' );
+  } );
+
+  it( 'omits the aliases segment when a workflow has none', async () => {
+    const { formatWorkflowsAsList } = await import( './list.js' );
+
+    const output = formatWorkflowsAsList( [ { name: 'simple' } ] );
+
+    expect( output ).toContain( '- simple' );
+    expect( output ).not.toContain( 'aliases:' );
+  } );
+} );

--- a/sdk/cli/src/commands/workflow/list.spec.ts
+++ b/sdk/cli/src/commands/workflow/list.spec.ts
@@ -7,9 +7,8 @@ vi.mock( '#utils/scenario_resolver.js', () => ( {
   listScenariosForWorkflow: mockListScenarios
 } ) );
 
-vi.mock( '#api/generated/api.js', () => ( {
-  getWorkflowCatalog: vi.fn(),
-  getWorkflowCatalogId: vi.fn()
+vi.mock( '#api/workflow_catalog.js', () => ( {
+  fetchWorkflowCatalog: vi.fn()
 } ) );
 
 describe( 'workflow list command', () => {
@@ -181,11 +180,7 @@ describe( 'run() catalog resolution', () => {
     vi.clearAllMocks();
   } );
 
-  const catalogResponse = {
-    data: { workflows: [ { name: 'simple' } ] },
-    status: 200,
-    headers: new Headers()
-  };
+  const catalogWorkflows = [ { name: 'simple' } ];
 
   const createCommand = async ( flagOverrides: Record<string, unknown> ) => {
     const WorkflowList = ( await import( './list.js' ) ).default;
@@ -201,24 +196,22 @@ describe( 'run() catalog resolution', () => {
   };
 
   it( 'fetches a specific catalog by id when a catalog is provided', async () => {
-    const { getWorkflowCatalog, getWorkflowCatalogId } = await import( '#api/generated/api.js' );
-    vi.mocked( getWorkflowCatalogId ).mockResolvedValue( catalogResponse as any );
+    const { fetchWorkflowCatalog } = await import( '#api/workflow_catalog.js' );
+    vi.mocked( fetchWorkflowCatalog ).mockResolvedValue( catalogWorkflows as any );
 
     const cmd = await createCommand( { catalog: 'my-catalog' } );
     await cmd.run();
 
-    expect( getWorkflowCatalogId ).toHaveBeenCalledWith( 'my-catalog' );
-    expect( getWorkflowCatalog ).not.toHaveBeenCalled();
+    expect( fetchWorkflowCatalog ).toHaveBeenCalledWith( 'my-catalog' );
   } );
 
   it( 'falls back to the default catalog when no catalog is provided', async () => {
-    const { getWorkflowCatalog, getWorkflowCatalogId } = await import( '#api/generated/api.js' );
-    vi.mocked( getWorkflowCatalog ).mockResolvedValue( catalogResponse as any );
+    const { fetchWorkflowCatalog } = await import( '#api/workflow_catalog.js' );
+    vi.mocked( fetchWorkflowCatalog ).mockResolvedValue( catalogWorkflows as any );
 
     const cmd = await createCommand( { catalog: undefined } );
     await cmd.run();
 
-    expect( getWorkflowCatalog ).toHaveBeenCalledTimes( 1 );
-    expect( getWorkflowCatalogId ).not.toHaveBeenCalled();
+    expect( fetchWorkflowCatalog ).toHaveBeenCalledWith( undefined );
   } );
 } );

--- a/sdk/cli/src/commands/workflow/list.ts
+++ b/sdk/cli/src/commands/workflow/list.ts
@@ -86,11 +86,15 @@ function createWorkflowTable( workflows: Workflow[], detailed: boolean ): string
   return table.toString();
 }
 
-function formatWorkflowsAsList( workflows: Workflow[] ): string {
-  const sortedWorkflows = sortWorkflowsByName( workflows );
-  const names = sortedWorkflows.map( w => parseWorkflowForDisplay( w ).name );
+function formatWorkflowAsListItem( workflow: Workflow ): string {
+  const { name, aliases } = parseWorkflowForDisplay( workflow );
+  return aliases === 'none' ? `- ${name}` : `- ${name} (aliases: ${aliases})`;
+}
 
-  return `\nWorkflows:\n\n${names.map( name => `- ${name}` ).join( '\n' )}`;
+export function formatWorkflowsAsList( workflows: Workflow[] ): string {
+  const lines = sortWorkflowsByName( workflows ).map( formatWorkflowAsListItem );
+
+  return `\nWorkflows:\n\n${lines.join( '\n' )}`;
 }
 
 function formatWorkflowsAsJson( workflows: Workflow[] ): string {

--- a/sdk/cli/src/commands/workflow/list.ts
+++ b/sdk/cli/src/commands/workflow/list.ts
@@ -1,6 +1,7 @@
 import { Command, Flags } from '@oclif/core';
 import Table from 'cli-table3';
-import { getWorkflowCatalog, getWorkflowCatalogId, type GetWorkflowCatalog200, type Workflow } from '#api/generated/api.js';
+import { type Workflow } from '#api/generated/api.js';
+import { fetchWorkflowCatalog } from '#api/workflow_catalog.js';
 import { parseWorkflowDefinition, formatParameters } from '#api/parser.js';
 import { handleApiError } from '#utils/error_handler.js';
 import { listScenariosForWorkflow } from '#utils/scenario_resolver.js';
@@ -167,31 +168,16 @@ export default class WorkflowList extends Command {
     const { flags } = await this.parse( WorkflowList );
 
     this.log( flags.catalog ? `Fetching workflow catalog: ${flags.catalog}...` : 'Fetching workflow catalog...' );
-    const response = flags.catalog ?
-      await getWorkflowCatalogId( flags.catalog ) :
-      await getWorkflowCatalog();
+    const catalogWorkflows = await fetchWorkflowCatalog( flags.catalog );
 
-    if ( !response ) {
-      this.error( 'Failed to connect to API server. Is it running?', { exit: 1 } );
-    }
-
-    if ( !response.data ) {
-      this.error( 'API returned invalid response (missing data)', { exit: 1 } );
-    }
-
-    const data = response.data as GetWorkflowCatalog200;
-    if ( !data.workflows ) {
-      this.error( 'API returned invalid response (missing workflows)', { exit: 1 } );
-    }
-
-    if ( data.workflows.length === 0 ) {
+    if ( catalogWorkflows.length === 0 ) {
       this.log( 'No workflows found in catalog.' );
       return;
     }
 
     const workflows = flags.filter ?
-      data.workflows.filter( matchName( flags.filter ) ) :
-      data.workflows;
+      catalogWorkflows.filter( matchName( flags.filter ) ) :
+      catalogWorkflows;
 
     if ( workflows.length === 0 && flags.filter ) {
       this.log( `No workflows matching filter: ${flags.filter}` );

--- a/sdk/cli/src/commands/workflow/list.ts
+++ b/sdk/cli/src/commands/workflow/list.ts
@@ -1,6 +1,6 @@
 import { Command, Flags } from '@oclif/core';
 import Table from 'cli-table3';
-import { getWorkflowCatalog, type GetWorkflowCatalog200, type Workflow } from '#api/generated/api.js';
+import { getWorkflowCatalog, getWorkflowCatalogId, type GetWorkflowCatalog200, type Workflow } from '#api/generated/api.js';
 import { parseWorkflowDefinition, formatParameters } from '#api/parser.js';
 import { handleApiError } from '#utils/error_handler.js';
 import { listScenariosForWorkflow } from '#utils/scenario_resolver.js';
@@ -134,10 +134,19 @@ export default class WorkflowList extends Command {
     '<%= config.bin %> <%= command.id %> --format table',
     '<%= config.bin %> <%= command.id %> --format json',
     '<%= config.bin %> <%= command.id %> --detailed',
-    '<%= config.bin %> <%= command.id %> --filter simple'
+    '<%= config.bin %> <%= command.id %> --filter simple',
+    '<%= config.bin %> <%= command.id %> --catalog my-catalog'
   ];
 
   static override flags = {
+    catalog: Flags.string( {
+      char: 'c',
+      aliases: [ 'task-queue' ],
+      charAliases: [ 'q' ],
+      deprecateAliases: true,
+      description: 'Catalog to list workflows from (defaults to OUTPUT_CATALOG_ID)',
+      env: 'OUTPUT_CATALOG_ID'
+    } ),
     format: Flags.string( {
       char: 'f',
       description: 'Output format',
@@ -157,8 +166,10 @@ export default class WorkflowList extends Command {
   async run(): Promise<void> {
     const { flags } = await this.parse( WorkflowList );
 
-    this.log( 'Fetching workflow catalog...' );
-    const response = await getWorkflowCatalog();
+    this.log( flags.catalog ? `Fetching workflow catalog: ${flags.catalog}...` : 'Fetching workflow catalog...' );
+    const response = flags.catalog ?
+      await getWorkflowCatalogId( flags.catalog ) :
+      await getWorkflowCatalog();
 
     if ( !response ) {
       this.error( 'Failed to connect to API server. Is it running?', { exit: 1 } );

--- a/sdk/cli/src/utils/scenario_resolver.spec.ts
+++ b/sdk/cli/src/utils/scenario_resolver.spec.ts
@@ -7,27 +7,23 @@ import {
   listScenariosForWorkflow
 } from './scenario_resolver.js';
 import * as fs from 'node:fs';
-import * as api from '#api/generated/api.js';
+import * as catalog from '#api/workflow_catalog.js';
 
 vi.mock( 'node:fs', () => ( {
   existsSync: vi.fn(),
   readdirSync: vi.fn()
 } ) );
 
-vi.mock( '#api/generated/api.js', () => ( {
-  getWorkflowCatalog: vi.fn()
+vi.mock( '#api/workflow_catalog.js', () => ( {
+  fetchWorkflowCatalog: vi.fn()
 } ) );
 
 function mockCatalog( workflows: Array<{ name: string; path?: string }> ) {
-  vi.mocked( api.getWorkflowCatalog ).mockResolvedValue( {
-    data: { workflows },
-    status: 200,
-    headers: new Headers()
-  } as never );
+  vi.mocked( catalog.fetchWorkflowCatalog ).mockResolvedValue( workflows as never );
 }
 
 function mockCatalogFailure() {
-  vi.mocked( api.getWorkflowCatalog ).mockRejectedValue( new Error( 'API unavailable' ) );
+  vi.mocked( catalog.fetchWorkflowCatalog ).mockRejectedValue( new Error( 'API unavailable' ) );
 }
 
 describe( 'extractWorkflowRelativePath', () => {

--- a/sdk/cli/src/utils/scenario_resolver.ts
+++ b/sdk/cli/src/utils/scenario_resolver.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
-import { getWorkflowCatalog, type GetWorkflowCatalog200 } from '#api/generated/api.js';
+import { fetchWorkflowCatalog } from '#api/workflow_catalog.js';
 import { getWorkflowsBasePath } from '#utils/paths.js';
 
 const SCENARIOS_DIR = 'scenarios';
@@ -52,19 +52,9 @@ export function findWorkflowDirectoryFromPath(
 
 async function fetchWorkflowPath( workflowName: string ): Promise<string | null> {
   try {
-    const response = await getWorkflowCatalog();
-    const data = response?.data as GetWorkflowCatalog200 | undefined;
-    const workflows = data?.workflows;
-    if ( !workflows ) {
-      return null;
-    }
-
+    const workflows = await fetchWorkflowCatalog();
     const workflow = workflows.find( w => w.name === workflowName );
-    if ( !workflow ) {
-      return null;
-    }
-
-    return workflow.path ?? null;
+    return workflow?.path ?? null;
   } catch {
     return null;
   }

--- a/sdk/cli/src/views/dev/hooks/use_workflow_catalog.ts
+++ b/sdk/cli/src/views/dev/hooks/use_workflow_catalog.ts
@@ -1,9 +1,6 @@
 import { useState } from 'react';
-import {
-  getWorkflowCatalog,
-  type GetWorkflowCatalog200,
-  type Workflow
-} from '#api/generated/api.js';
+import { type Workflow } from '#api/generated/api.js';
+import { fetchWorkflowCatalog } from '#api/workflow_catalog.js';
 import { usePoll } from '#views/dev/hooks/use_poll.js';
 
 const CATALOG_INTERVAL_MS = 10_000;
@@ -13,11 +10,7 @@ export const useWorkflowCatalog = ( enabled: boolean ): Workflow[] => {
 
   usePoll( enabled, CATALOG_INTERVAL_MS, async () => {
     try {
-      const response = await getWorkflowCatalog();
-      const data = response?.data as GetWorkflowCatalog200 | undefined;
-      if ( data?.workflows ) {
-        setWorkflows( data.workflows );
-      }
+      setWorkflows( await fetchWorkflowCatalog() );
     } catch {
       // API may not be ready yet
     }


### PR DESCRIPTION
## Problem

- **Aliases (OUT-444)** — the default `output workflow list` output mapped each workflow to its canonical name only, dropping registered aliases. They already appear in `--format table` and `--format json`, so aliased workflows were needlessly hard to discover in the default view.
- **Catalog (OUT-489)** — `list` always read the API server's startup (default) catalog and ignored `OUTPUT_CATALOG_ID`, unlike `run` and `start` which already honor it. This was inconsistent in shared local dev and git worktree setups.

## Solution

- **Aliases (OUT-444)** — `formatWorkflowsAsList` now appends `(aliases: ...)` to each list item when a workflow has aliases; lines without aliases are unchanged.
- **Catalog (OUT-489)** — add a `--catalog` flag mirroring `run`/`start` (`env: OUTPUT_CATALOG_ID`); when set, `list` resolves workflows via the existing by-id catalog endpoint (`getWorkflowCatalogId`), otherwise it falls back to the server-default catalog.

## Refactor (separate commit `752e87b9`)

All three workflow-catalog readers — `workflow list`, `scenario_resolver`, and the dev-panel polling hook — duplicated the same `getWorkflowCatalog()` → cast `response.data as GetWorkflowCatalog200` → read `.workflows` dance (and `list` branched default-vs-by-id inline). Extracted one `fetchWorkflowCatalog(catalog?): Promise<Workflow[]>` helper (`sdk/cli/src/api/workflow_catalog.ts`) that owns endpoint selection, the cast, and extraction; all three sites delegate to it. Net -42 lines.

- `list`'s three granular "invalid response" branches collapse into the shared empty-catalog path; real network/HTTP errors still surface via the command's `catch()` (incl. the 404 "Catalog not found." mapping for a bad `--catalog`).

## Test plan

- [x] `npx tsc --noEmit` (`sdk/cli`) — clean
- [x] `eslint` on changed files — clean
- [x] `npm test` (`sdk/cli`) — 679 pass, incl. new `workflow_catalog.spec.ts` (3) plus alias + catalog coverage in `list.spec.ts`; only the pre-existing `copy_assets.spec.ts` failures remain (known `copy-assets`/`native-copyfiles` build bug — reproduces on `main`, unrelated to this diff)
- [ ] Manual smoke against a running dev server: `npx output workflow list`, `OUTPUT_CATALOG_ID=... npx output workflow list`, `--catalog ...` — not run locally because the `oclif` build is blocked by the same `copy-assets` bug

## Notes for reviewers

- **Mirrored the `--catalog` flag verbatim from `run`/`start`** (including the deprecated `task-queue` alias + `deprecateAliases`) so the flag is identical across the three verbs. `list` never had a legacy `--task-queue`, so that alias is effectively dead on arrival here — kept only for cross-command consistency. Happy to drop it if you'd rather keep `list` clean.
- **The refactor commit touches two files outside the tickets' scope** (`scenario_resolver.ts`, `use_workflow_catalog.ts`). It's an isolated, behavior-preserving dedup kept in its own commit (`752e87b9`) — easy to split into a separate PR if you'd prefer the ticket diff stay minimal.

## Follow-up (out of scope)

- The dev TUI's catalog hook (`use_workflow_catalog.ts`) now reads via `fetchWorkflowCatalog()` but still doesn't pass a catalog, so the dev panel continues to ignore `OUTPUT_CATALOG_ID`. Both tickets scope to `output workflow list`, so I left that behavior alone — worth a separate ticket if we want the dev panel to honor the catalog too.

Closes OUT-444
Closes OUT-489