### PR TITLE
fix(llm): route system blocks to the AI SDK system option (OUT-494)

### DIFF
--- a/.changeset/out-494-system-message-warning.md
+++ b/.changeset/out-494-system-message-warning.md
@@ -1,0 +1,8 @@
+---
+"@outputai/llm": patch
+---
+
+Route `<system>` blocks to the AI SDK `system` option instead of leaving them in the `messages` array.
+
+- `loadAiSdkTextOptions` now splits resolved messages: system blocks go to the top-level `system` option (as `SystemModelMessage[]`, so per-message `cacheControl`/`providerOptions` are preserved); only user/assistant/tool messages stay in `messages`. `Agent` consumes the split `system` directly as its `instructions`.
+- Silences the AI SDK warning that system messages in `messages` are a prompt-injection risk; `generateText`/`streamText`/`Agent` also set `allowSystemInMessages: true` as defense-in-depth for caller-supplied message histories.

--- a/sdk/llm/src/agent.js
+++ b/sdk/llm/src/agent.js
@@ -43,17 +43,14 @@ export class Agent extends AIToolLoopAgent {
 
     const { loadedPrompt, tools } = prepareTextPrompt( { prompt, variables, promptDir: resolvedPromptDir, skills, tools: toolsArg } );
 
-    const { messages: allMessages, ...constructorOptions } = loadAiSdkTextOptions( loadedPrompt );
+    const { system, messages, ...constructorOptions } = loadAiSdkTextOptions( loadedPrompt );
 
-    // Extract system messages as `instructions` for the ToolLoopAgent constructor
-    // and keep user messages for generate() calls — avoids provider errors
-    // with multiple system messages during multi-step tool loops.
-    // Pass message objects (not a string) so per-message providerOptions are preserved.
-    const systemMessages = allMessages.filter( isRole( ROLE.SYSTEM ) );
-
+    // loadAiSdkTextOptions already routes system blocks to the `system` slot
+    // (preserving per-message providerOptions); pass them as the agent's
+    // `instructions` and keep the user messages for generate()/stream() calls.
     super( {
       ...constructorOptions,
-      ...( systemMessages.length > 0 ? { instructions: systemMessages } : {} ),
+      ...( system ? { instructions: system } : {} ),
       ...( tools ? { tools } : {} ),
       stopWhen: stopWhen ?? stepCountIs( maxSteps ),
       ...rest
@@ -61,7 +58,7 @@ export class Agent extends AIToolLoopAgent {
 
     this.#prompt = prompt;
     this.#modelId = loadedPrompt.config.model;
-    this.#initialMessages = allMessages.filter( isRole( ROLE.USER ) );
+    this.#initialMessages = messages.filter( isRole( ROLE.USER ) );
     this.#store = conversationStore ?? null;
   }
 
@@ -80,7 +77,7 @@ export class Agent extends AIToolLoopAgent {
     const traceId = startTrace( { name: 'Agent.generate', prompt: this.#prompt } );
     try {
       const messages = await this.#fetchMessages( userMessages );
-      const response = await super.generate( { messages, ...callOptions } );
+      const response = await super.generate( { messages, allowSystemInMessages: true, ...callOptions } );
       const wrapped = await wrapTextResponse( { traceId, response, modelId: this.#modelId } );
       await this.#storeMessages( userMessages, wrapped );
       return wrapped;
@@ -96,6 +93,7 @@ export class Agent extends AIToolLoopAgent {
       const messages = await this.#fetchMessages( userMessages );
       return super.stream( {
         messages,
+        allowSystemInMessages: true,
         ...callOptions,
         ...wrapStreamOnFinishResponse( { traceId, modelId: this.#modelId, onFinish } ),
         onError( event ) {

--- a/sdk/llm/src/agent.js
+++ b/sdk/llm/src/agent.js
@@ -45,12 +45,11 @@ export class Agent extends AIToolLoopAgent {
 
     const { system, messages, ...constructorOptions } = loadAiSdkTextOptions( loadedPrompt );
 
-    // loadAiSdkTextOptions already routes system blocks to the `system` slot
-    // (preserving per-message providerOptions); pass them as the agent's
-    // `instructions` and keep the user messages for generate()/stream() calls.
+    // loadAiSdkTextOptions routes system blocks to the `system` slot (preserving
+    // per-message providerOptions); pass them as the agent's `instructions`.
     super( {
       ...constructorOptions,
-      ...( system ? { instructions: system } : {} ),
+      ...( system.length > 0 ? { instructions: system } : {} ),
       ...( tools ? { tools } : {} ),
       stopWhen: stopWhen ?? stepCountIs( maxSteps ),
       ...rest
@@ -58,6 +57,8 @@ export class Agent extends AIToolLoopAgent {
 
     this.#prompt = prompt;
     this.#modelId = loadedPrompt.config.model;
+    // `messages` is system-free but may still hold authored <assistant>/<tool>
+    // blocks; seed only <user> turns into each generate()/stream() call.
     this.#initialMessages = messages.filter( isRole( ROLE.USER ) );
     this.#store = conversationStore ?? null;
   }

--- a/sdk/llm/src/agent.spec.js
+++ b/sdk/llm/src/agent.spec.js
@@ -113,7 +113,8 @@ const model = { id: 'MODEL' };
 
 const textOptions = {
   model,
-  messages: loadedPrompt.messages,
+  system: [ { role: 'system', content: 'You are concise.' } ],
+  messages: [ { role: 'user', content: 'Initial user message' } ],
   providerOptions: { test: true },
   temperature: 0.3
 };
@@ -239,7 +240,8 @@ describe( 'Agent', () => {
     };
     optionMocks.loadAiSdkTextOptions.mockReturnValueOnce( {
       model,
-      messages: [ systemMessage, { role: 'user', content: 'Hello' } ]
+      system: [ systemMessage ],
+      messages: [ { role: 'user', content: 'Hello' } ]
     } );
 
     new Agent( { prompt: 'test@v1' } );
@@ -303,7 +305,8 @@ describe( 'Agent', () => {
     await agent.generate();
 
     expect( aiMocks.superGenerate ).toHaveBeenCalledWith( {
-      messages: [ { role: 'user', content: 'Initial user message' } ]
+      messages: [ { role: 'user', content: 'Initial user message' } ],
+      allowSystemInMessages: true
     } );
   } );
 
@@ -326,6 +329,7 @@ describe( 'Agent', () => {
         { role: 'assistant', content: 'Stored reply' },
         callerMessage
       ],
+      allowSystemInMessages: true,
       maxRetries: 1
     } );
   } );
@@ -405,6 +409,7 @@ describe( 'Agent', () => {
         { role: 'assistant', content: 'Stored reply' },
         callerMessage
       ],
+      allowSystemInMessages: true,
       maxRetries: 1,
       onFinish: expect.any( Function ),
       onError: expect.any( Function )

--- a/sdk/llm/src/agent.spec.js
+++ b/sdk/llm/src/agent.spec.js
@@ -310,6 +310,26 @@ describe( 'Agent', () => {
     } );
   } );
 
+  it( 'excludes authored assistant/tool blocks from the initial generate messages', async () => {
+    const { Agent } = await importSut();
+    optionMocks.loadAiSdkTextOptions.mockReturnValueOnce( {
+      model,
+      system: [ { role: 'system', content: 'You are concise.' } ],
+      messages: [
+        { role: 'user', content: 'Initial user message' },
+        { role: 'assistant', content: 'Authored assistant block' }
+      ]
+    } );
+    const agent = new Agent( { prompt: 'test@v1' } );
+
+    await agent.generate();
+
+    expect( aiMocks.superGenerate ).toHaveBeenCalledWith( {
+      messages: [ { role: 'user', content: 'Initial user message' } ],
+      allowSystemInMessages: true
+    } );
+  } );
+
   it( 'combines initial, stored, and caller messages for generate', async () => {
     const store = {
       getMessages: vi.fn( () => [

--- a/sdk/llm/src/ai_sdk.js
+++ b/sdk/llm/src/ai_sdk.js
@@ -22,6 +22,7 @@ export async function generateText( { prompt, variables, promptDir, skills = [],
   try {
     const response = await AI.generateText( {
       ...loadAiSdkTextOptions( loadedPrompt ),
+      allowSystemInMessages: true,
       maxRetries: 0,
       ...aiSdkArgs,
       ...( tools && { tools } ),
@@ -50,6 +51,7 @@ export function streamText( { prompt, variables, promptDir, skills = [], maxStep
   try {
     return AI.streamText( {
       ...loadAiSdkTextOptions( loadedPrompt ),
+      allowSystemInMessages: true,
       maxRetries: 0,
       ...aiSdkArgs,
       ...( tools && { tools } ),

--- a/sdk/llm/src/ai_sdk.spec.js
+++ b/sdk/llm/src/ai_sdk.spec.js
@@ -190,6 +190,7 @@ describe( 'ai_sdk', () => {
       expect( aiFns.stepCountIs ).toHaveBeenCalledWith( 4 );
       expect( aiFns.generateText ).toHaveBeenCalledWith( {
         ...textOptions,
+        allowSystemInMessages: true,
         maxRetries: 0,
         tools,
         temperature: 0.2,
@@ -225,6 +226,7 @@ describe( 'ai_sdk', () => {
       expect( aiFns.stepCountIs ).not.toHaveBeenCalled();
       expect( aiFns.generateText ).toHaveBeenCalledWith( {
         ...textOptions,
+        allowSystemInMessages: true,
         maxRetries: 0
       } );
     } );
@@ -326,6 +328,7 @@ describe( 'ai_sdk', () => {
       expect( aiFns.stepCountIs ).toHaveBeenCalledWith( 4 );
       expect( aiFns.streamText ).toHaveBeenCalledWith( {
         ...textOptions,
+        allowSystemInMessages: true,
         maxRetries: 0,
         tools,
         temperature: 0.2,
@@ -373,6 +376,7 @@ describe( 'ai_sdk', () => {
       expect( aiFns.stepCountIs ).not.toHaveBeenCalled();
       expect( aiFns.streamText ).toHaveBeenCalledWith( {
         ...textOptions,
+        allowSystemInMessages: true,
         maxRetries: 0,
         onFinish: expect.any( Function ),
         onError: expect.any( Function )

--- a/sdk/llm/src/ai_sdk_options.js
+++ b/sdk/llm/src/ai_sdk_options.js
@@ -1,9 +1,15 @@
 import { loadImageModel, loadTextModel, loadTools } from './ai_model.js';
 import { resolveMessageProviderOptions } from './prompt/block_options.js';
+import { ROLE, isRole } from './utils/message.js';
 import { FatalError } from '@outputai/core';
 
 /**
  * Convert a loaded prompt into AI SDK text generation options.
+ *
+ * System blocks are routed to the `system` option (as `SystemModelMessage[]`, so
+ * per-message providerOptions like `cacheControl` are preserved) rather than left
+ * in `messages` — the AI SDK flags system roles inside `messages` as a prompt
+ * injection risk, and `system` is the provider-recommended slot.
  *
  * @param {object} prompt - Loaded prompt object
  * @returns {object} Options for AI SDK text calls
@@ -12,9 +18,14 @@ export const loadAiSdkTextOptions = prompt => {
   if ( prompt.messages.length === 0 ) {
     throw new FatalError( `Prompt "${prompt.name}" has no chat-style messages. Add role-tagged blocks like <system> or <user>.` );
   }
+  const isSystem = isRole( ROLE.SYSTEM );
+  const resolvedMessages = resolveMessageProviderOptions( prompt );
+  const system = resolvedMessages.filter( isSystem );
+
   const options = {
     model: loadTextModel( prompt ),
-    messages: resolveMessageProviderOptions( prompt ),
+    ...( system.length > 0 ? { system } : {} ),
+    messages: resolvedMessages.filter( message => !isSystem( message ) ),
     providerOptions: prompt.config.providerOptions
   };
 

--- a/sdk/llm/src/ai_sdk_options.js
+++ b/sdk/llm/src/ai_sdk_options.js
@@ -20,11 +20,10 @@ export const loadAiSdkTextOptions = prompt => {
   }
   const isSystem = isRole( ROLE.SYSTEM );
   const resolvedMessages = resolveMessageProviderOptions( prompt );
-  const system = resolvedMessages.filter( isSystem );
 
   const options = {
     model: loadTextModel( prompt ),
-    ...( system.length > 0 ? { system } : {} ),
+    system: resolvedMessages.filter( isSystem ),
     messages: resolvedMessages.filter( message => !isSystem( message ) ),
     providerOptions: prompt.config.providerOptions
   };

--- a/sdk/llm/src/ai_sdk_options.spec.js
+++ b/sdk/llm/src/ai_sdk_options.spec.js
@@ -191,7 +191,7 @@ describe( 'ai_sdk_options', () => {
     expect( result.messages ).toEqual( [ { role: 'user', content: 'Hello' } ] );
   } );
 
-  it( 'omits the system option when the prompt has no system block', async () => {
+  it( 'returns an empty system array when the prompt has no system block', async () => {
     const prompt = {
       name: 'no-system@v1',
       config: { provider: 'anthropic', model: 'claude-haiku-4-5' },
@@ -202,7 +202,7 @@ describe( 'ai_sdk_options', () => {
     const { loadAiSdkTextOptions } = await importSut();
     const result = loadAiSdkTextOptions( prompt );
 
-    expect( result.system ).toBeUndefined();
+    expect( result.system ).toEqual( [] );
     expect( result.messages ).toEqual( [ { role: 'user', content: 'Hello' } ] );
   } );
 

--- a/sdk/llm/src/ai_sdk_options.spec.js
+++ b/sdk/llm/src/ai_sdk_options.spec.js
@@ -60,7 +60,8 @@ describe( 'ai_sdk_options', () => {
     expect( loadToolsImpl ).toHaveBeenCalledWith( prompt );
     expect( result ).toEqual( {
       model: 'MODEL',
-      messages: prompt.messages,
+      system: [ { role: 'system', content: 'You are concise.' } ],
+      messages: [ { role: 'user', content: 'Hello' } ],
       providerOptions: prompt.config.providerOptions,
       temperature: 0.3,
       maxOutputTokens: 1000
@@ -180,13 +181,50 @@ describe( 'ai_sdk_options', () => {
     const { loadAiSdkTextOptions } = await importSut();
     const result = loadAiSdkTextOptions( prompt );
 
-    expect( result.messages ).toEqual( [
+    expect( result.system ).toEqual( [
       {
         role: 'system',
         content: 'Static',
         providerOptions: { anthropic: { cacheControl: { type: 'ephemeral', ttl: '1h' } } }
-      },
-      { role: 'user', content: 'Hello' }
+      }
     ] );
+    expect( result.messages ).toEqual( [ { role: 'user', content: 'Hello' } ] );
+  } );
+
+  it( 'omits the system option when the prompt has no system block', async () => {
+    const prompt = {
+      name: 'no-system@v1',
+      config: { provider: 'anthropic', model: 'claude-haiku-4-5' },
+      messages: [ { role: 'user', content: 'Hello' } ],
+      instructions: null
+    };
+
+    const { loadAiSdkTextOptions } = await importSut();
+    const result = loadAiSdkTextOptions( prompt );
+
+    expect( result.system ).toBeUndefined();
+    expect( result.messages ).toEqual( [ { role: 'user', content: 'Hello' } ] );
+  } );
+
+  it( 'groups multiple system blocks into the system option and keeps them out of messages', async () => {
+    const prompt = {
+      name: 'multi-system@v1',
+      config: { provider: 'anthropic', model: 'claude-haiku-4-5' },
+      messages: [
+        { role: 'system', content: 'First' },
+        { role: 'system', content: 'Second' },
+        { role: 'user', content: 'Hello' }
+      ],
+      instructions: null
+    };
+
+    const { loadAiSdkTextOptions } = await importSut();
+    const result = loadAiSdkTextOptions( prompt );
+
+    expect( result.system ).toEqual( [
+      { role: 'system', content: 'First' },
+      { role: 'system', content: 'Second' }
+    ] );
+    expect( result.messages ).toEqual( [ { role: 'user', content: 'Hello' } ] );
   } );
 } );


### PR DESCRIPTION
## Problem

The AI SDK emits this warning on every `generateText`/`streamText` call, flooding worker logs and inflating our Datadog bill:

> System messages in the prompt or messages fields can be a security risk because they may enable prompt injection attacks. Use the system option instead when possible. Set `allowSystemInMessages` to true to suppress this warning, or false to throw an error.

- Root cause: `loadAiSdkTextOptions` placed every `<system>` block into the `messages` array as a `role:'system'` entry — exactly what the AI SDK flags. The top-level `system` option is the provider-recommended slot.
- `generateText`/`streamText` were affected; the `Agent` class already routed system content through the `instructions`/`system` slot.

## Solution

- **`loadAiSdkTextOptions`** — splits resolved messages: `<system>` blocks → top-level `system` option (as `SystemModelMessage[]`, so per-message `cacheControl`/`providerOptions` survive); user/assistant/tool stay in `messages`.
- **`Agent`** — consumes the split `system` directly as `instructions`, removing the system-filtering it previously did by hand.
- **Defense-in-depth** — `generateText`/`streamText` and the Agent's generate/stream set `allowSystemInMessages: true` (overridable) for caller-supplied message histories.

## Proof

Real AI SDK (`ai@6.0.168`) + `MockLanguageModelV3`, fed the exact shape `loadAiSdkTextOptions` now produces:

```
PASS: call resolved, text = "ok"
system delivered to provider: [{"role":"system","content":"You are concise.","providerOptions":{"anthropic":{"cacheControl":{"type":"ephemeral"}}}}]
cacheControl preserved on system: {"anthropic":{"cacheControl":{"type":"ephemeral"}}}
```

System content travels via the `system` slot with Anthropic `cacheControl` intact — caching is preserved.

## Test plan

- [x] `npm run lint` passes (full repo)
- [x] `npm test` — `@outputai/llm` suite green (279 tests), incl. new coverage in `ai_sdk_options.spec.js` (system hoisting, providerOptions preserved, multi-system, no-system) and updated `agent.spec.js`/`ai_sdk.spec.js`
- [ ] `npm run build:packages` — pre-existing unrelated failure at `sdk/cli` `copy-assets` (`native-copyfiles` `options.exclude` type error); `sdk/llm` has no build step
- [ ] Staging smoke (needs the newer `ai` that emits the warning): confirm the warning is gone from worker logs and `cachedInputTokens > 0` on a workflow using a `<system options="cached">` prompt

## Notes for reviewers

- **Hoisting does not break prompt caching.** The AI SDK `system` option is typed `string | SystemModelMessage | Array<SystemModelMessage>` and `SystemModelMessage` carries `providerOptions`, so `cacheControl` on a `<system options="cached">` block rides along (see Proof). That's why we hoist rather than only suppressing.
- **`allowSystemInMessages` is a no-op on our pinned `ai@6.0.168`** — the warning and the option are both from a newer 6.x. The hoist is the version-independent fix; the flag is belt-and-suspenders for when we bump.

## Follow-up (out of scope)

The warning is observed in a deployed environment running a newer `ai` than the lockfile pin (`6.0.168` contains neither the warning nor `allowSystemInMessages`), and `package.json` devDeps have drifted ahead of the installed store. Worth reconciling the deployed `ai` version with the lockfile separately.

Closes OUT-494