### PR TITLE
feat(core): add @outputai/core/logger for traceable step logs (OUT-255)

### DIFF
--- a/.changeset/out-255-step-logger.md
+++ b/.changeset/out-255-step-logger.md
@@ -1,0 +1,9 @@
+---
+"@outputai/core": minor
+---
+
+Add `@outputai/core/logger` — a step logger that auto-attaches workflow execution metadata to logs, so step output is traceable in production (e.g. filterable by `workflowId` in Render).
+
+- `import { logger } from '@outputai/core/logger'` exposes `info`/`warn`/`error`/`debug` (plus a `log` alias) as a drop-in for `console.*` inside steps. Each line is enriched with the current `workflowId`, `runId`, `activityId`, `activityType`, and `workflowType`, matching the framework's own lifecycle logs (structured JSON in production).
+- Reads the execution context from `AsyncLocalStorage` at call time; called outside a step it logs without context fields and never throws.
+- Use it in steps, evaluators, and shared step code only — not in workflow bodies, which run in a sandbox that cannot load the underlying logger.

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -12,6 +12,10 @@
       "types": "./src/hooks/index.d.ts",
       "import": "./src/hooks/index.js"
     },
+    "./logger": {
+      "types": "./src/logger/public.d.ts",
+      "import": "./src/logger/public.js"
+    },
     "./sdk_activity_integration": {
       "types": "./src/activity_integration/index.d.ts",
       "import": "./src/activity_integration/index.js"

--- a/sdk/core/src/logger/context_fields.js
+++ b/sdk/core/src/logger/context_fields.js
@@ -1,0 +1,14 @@
+/**
+ * Flat execution-context fields attached to logs. Shared by the worker
+ * lifecycle log hooks and the public step logger so both stay consistent.
+ *
+ * @param {import('@temporalio/activity').Info} activityInfo
+ * @returns {{ activityId: string, activityType: string, workflowId: string, workflowType: string, runId: string }}
+ */
+export const serializedActivityFields = activityInfo => ( {
+  activityId: activityInfo.activityId,
+  activityType: activityInfo.activityType,
+  workflowId: activityInfo.workflowExecution.workflowId,
+  workflowType: activityInfo.workflowType,
+  runId: activityInfo.workflowExecution.runId
+} );

--- a/sdk/core/src/logger/context_fields.spec.js
+++ b/sdk/core/src/logger/context_fields.spec.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { serializedActivityFields } from './context_fields.js';
+
+describe( 'serializedActivityFields', () => {
+  it( 'flattens Temporal activityInfo into log context fields', () => {
+    const activityInfo = {
+      activityId: 'activity-1',
+      activityType: 'myActivity',
+      workflowExecution: { workflowId: 'wf-1', runId: 'run-1' },
+      workflowType: 'myWorkflow'
+    };
+
+    expect( serializedActivityFields( activityInfo ) ).toEqual( {
+      activityId: 'activity-1',
+      activityType: 'myActivity',
+      workflowId: 'wf-1',
+      workflowType: 'myWorkflow',
+      runId: 'run-1'
+    } );
+  } );
+} );

--- a/sdk/core/src/logger/public.d.ts
+++ b/sdk/core/src/logger/public.d.ts
@@ -1,0 +1,52 @@
+/**
+ * A log entry's optional structured metadata. Merged into each line alongside
+ * the auto-injected workflow execution fields (workflowId, runId, activityId,
+ * activityType, workflowType). On key collision, the values you pass win.
+ */
+export type LogMeta = Record<string, unknown>;
+
+/**
+ * Step logger — a drop-in replacement for `console.*` inside steps.
+ *
+ * Every line is automatically enriched with the current workflow execution
+ * context (workflowId, runId, activityId, activityType, workflowType), so logs
+ * emitted from steps are traceable in production (e.g. filterable by
+ * `workflowId` in Render). Output matches the framework's own lifecycle logs:
+ * structured JSON in production, a readable colored line in development.
+ *
+ * Called outside a step (scripts, tests), it still logs — just without the
+ * execution context fields, and never throws.
+ *
+ * @example
+ * ```js
+ * import { logger } from '@outputai/core/logger';
+ *
+ * export const fetchRows = step( {
+ *   name: 'fetchRows',
+ *   fn: async () => {
+ *     logger.info( 'fetched rows', { count: 12 } );
+ *     // prod: {"level":"info","message":"fetched rows","workflowId":"...","count":12,...}
+ *   }
+ * } );
+ * ```
+ *
+ * @remarks
+ * Use this in steps, evaluators, and shared code that runs inside a step — **not
+ * in workflow bodies**. Workflows run in a Temporal sandbox that cannot load the
+ * underlying logger; importing this into workflow code (or a module shared with
+ * one) fails the workflow bundle build.
+ */
+export interface Logger {
+  /** Log at the `info` level. */
+  info( message: string, meta?: LogMeta ): void;
+  /** Log at the `warn` level. */
+  warn( message: string, meta?: LogMeta ): void;
+  /** Log at the `error` level. */
+  error( message: string, meta?: LogMeta ): void;
+  /** Log at the `debug` level. */
+  debug( message: string, meta?: LogMeta ): void;
+  /** Alias for {@link Logger.info} — for `console.log` muscle memory. */
+  log( message: string, meta?: LogMeta ): void;
+}
+
+export declare const logger: Logger;

--- a/sdk/core/src/logger/public.js
+++ b/sdk/core/src/logger/public.js
@@ -1,0 +1,32 @@
+import { createChildLogger } from './index.js';
+import { Storage } from '#async_storage';
+import { serializedActivityFields } from './context_fields.js';
+
+const log = createChildLogger( 'Step' );
+
+/**
+ * Reads the current step execution context from AsyncLocalStorage at call time
+ * and returns its flat fields, or {} when there is no active context (called
+ * outside a step, or in tests).
+ *
+ * @returns {object}
+ */
+const contextFields = () => {
+  const ctx = Storage.load();
+  return ctx?.activityInfo ? serializedActivityFields( ctx.activityInfo ) : {};
+};
+
+const emit = level => ( message, meta ) =>
+  log[level]( message, { ...contextFields(), ...meta } );
+
+/**
+ * Step logger that auto-attaches the current workflow execution context
+ * (workflowId, runId, activityId, activityType, workflowType) to every line.
+ */
+export const logger = {
+  info: emit( 'info' ),
+  warn: emit( 'warn' ),
+  error: emit( 'error' ),
+  debug: emit( 'debug' ),
+  log: emit( 'info' )
+};

--- a/sdk/core/src/logger/public.spec.js
+++ b/sdk/core/src/logger/public.spec.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const loadMock = vi.fn();
+const infoMock = vi.fn();
+const warnMock = vi.fn();
+const errorMock = vi.fn();
+const debugMock = vi.fn();
+
+vi.mock( '#async_storage', () => ( {
+  Storage: { load: loadMock }
+} ) );
+
+vi.mock( './index.js', () => ( {
+  createChildLogger: () => ( {
+    info: infoMock,
+    warn: warnMock,
+    error: errorMock,
+    debug: debugMock
+  } )
+} ) );
+
+const activityInfo = {
+  activityId: 'activity-1',
+  activityType: 'myActivity',
+  workflowExecution: { workflowId: 'wf-1', runId: 'run-1' },
+  workflowType: 'myWorkflow'
+};
+
+const expectedContext = {
+  activityId: 'activity-1',
+  activityType: 'myActivity',
+  workflowId: 'wf-1',
+  workflowType: 'myWorkflow',
+  runId: 'run-1'
+};
+
+describe( 'logger (public step logger)', () => {
+  beforeEach( () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  } );
+
+  it( 'injects workflow execution context when a step context is active', async () => {
+    loadMock.mockReturnValue( { activityInfo } );
+    const { logger } = await import( './public.js' );
+
+    logger.info( 'hello', { foo: 1 } );
+
+    expect( infoMock ).toHaveBeenCalledWith( 'hello', { ...expectedContext, foo: 1 } );
+  } );
+
+  it( 'logs with no context fields and does not throw when called outside a step', async () => {
+    loadMock.mockReturnValue( undefined );
+    const { logger } = await import( './public.js' );
+
+    expect( () => logger.info( 'hi' ) ).not.toThrow();
+    expect( infoMock ).toHaveBeenCalledWith( 'hi', {} );
+  } );
+
+  it( 'routes log() to the info level', async () => {
+    loadMock.mockReturnValue( undefined );
+    const { logger } = await import( './public.js' );
+
+    logger.log( 'aliased' );
+
+    expect( infoMock ).toHaveBeenCalledWith( 'aliased', {} );
+  } );
+
+  it( 'routes warn, error and debug to their levels', async () => {
+    loadMock.mockReturnValue( undefined );
+    const { logger } = await import( './public.js' );
+
+    logger.warn( 'w' );
+    logger.error( 'e' );
+    logger.debug( 'd' );
+
+    expect( warnMock ).toHaveBeenCalledWith( 'w', {} );
+    expect( errorMock ).toHaveBeenCalledWith( 'e', {} );
+    expect( debugMock ).toHaveBeenCalledWith( 'd', {} );
+  } );
+
+  it( 'lets user metadata override injected context fields', async () => {
+    loadMock.mockReturnValue( { activityInfo } );
+    const { logger } = await import( './public.js' );
+
+    logger.info( 'override', { workflowId: 'custom' } );
+
+    expect( infoMock ).toHaveBeenCalledWith( 'override', { ...expectedContext, workflowId: 'custom' } );
+  } );
+} );

--- a/sdk/core/src/worker/log_hooks.js
+++ b/sdk/core/src/worker/log_hooks.js
@@ -1,6 +1,7 @@
 import { messageBus } from '#bus';
 import { createChildLogger } from '#logger';
 import { ACTIVITY_GET_TRACE_DESTINATIONS, BusEventType, LifecycleEvent, WORKFLOW_CATALOG } from '#consts';
+import { serializedActivityFields } from '../logger/context_fields.js';
 
 const activityLog = createChildLogger( 'Activity' );
 const workflowLog = createChildLogger( 'Workflow' );
@@ -14,14 +15,6 @@ const workflowLog = createChildLogger( 'Workflow' );
 ║ Activity events ║
 ╚═════════════════╝
 */
-
-const serializedActivityFields = activityInfo => ( {
-  activityId: activityInfo.activityId,
-  activityType: activityInfo.activityType,
-  workflowId: activityInfo.workflowExecution.workflowId,
-  workflowType: activityInfo.workflowType,
-  runId: activityInfo.workflowExecution.runId
-} );
 
 const shouldLogActivity = activityInfo => activityInfo.activityType !== ACTIVITY_GET_TRACE_DESTINATIONS;
 


### PR DESCRIPTION
## Problem

- `console.log()` inside a step (a Temporal activity) lands in production (Render) logs with **no workflow metadata** — there's no way to tell which workflow run produced a line. Workflow bodies already get a `[workflowName(workflowId)]` prefix from the Temporal sandbox; steps get nothing.
- The execution context (`workflowId`, `runId`, `activityId`, …) is already captured in `AsyncLocalStorage` by the activity interceptor and used by the framework's own lifecycle logs — it was just never exposed to user code.

## Solution

- New `@outputai/core/logger` export: a `logger` singleton (`info`/`warn`/`error`/`debug`, plus a `log` alias) that reads the execution context **at call time** and merges `workflowId`, `runId`, `activityId`, `activityType`, `workflowType` into every line. Output matches the framework's lifecycle logs — structured JSON in prod, a readable colored line in dev.
- Extracted the shared `serializedActivityFields` helper into `logger/context_fields.js` so `worker/log_hooks.js` and the public logger stay consistent (DRY).
- Called outside a step (scripts, tests) it logs without the context fields and never throws.

## Interface

```js
import { logger } from '@outputai/core/logger';
import { step } from '@outputai/core';

export const fetchRows = step( {
  name: 'fetchRows',
  fn: async () => {
    logger.info( 'fetched rows', { count: 12 } );
  }
} );

// prod stdout (filterable by workflowId in Render):
// {"level":"info","message":"fetched rows","workflowId":"…","runId":"…",
//  "activityId":"…","activityType":"…","workflowType":"…","count":12, …}
```

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` — logger suite 16/16 (new `public.spec.js` + `context_fields.spec.js`) and `log_hooks` 12/12 after the DRY extraction
- [x] `npm run build:packages` clean for every package that compiles
- [x] Real (unmocked) run: prod emits a top-level `workflowId`, dev renders `[info] Step: … { workflowId, … }`, outside-a-step logs cleanly without throwing
- [x] Sandbox guardrail verified: importing the logger into a workflow body fails the Temporal bundle (`UnhandledSchemeError: node:async_hooks not handled`); a control workflow with no logger import bundles fine

## Notes for reviewers

- **Subpath export of `core`, not a new `@outputai/logger` package** — the logger depends on core's `AsyncLocalStorage` (populated only by core's activity interceptor) and reuses the single Winston root, so it belongs in core.
- **Workflow-body misuse fails the bundle on purpose** — importing this into workflow code pulls `node:async_hooks`/Winston into the Temporal sandbox bundle and errors at build / `output-worker --check` time. We chose the loud failure over a sandbox no-op shim: logging from a workflow body is wrong (replay double-logs), so surfacing it early is the right call. Documented in the type `@remarks`.

## Follow-up (out of scope)

`sdk/cli` `build` fails on a `native-copyfiles` glob incompatibility (`options.exclude must be of type function`). Pre-existing — reproduces on `main` with this branch's changes stashed — and unrelated to this change.

Closes [OUT-255](https://linear.app/growthx/issue/OUT-255/core-add-workflowid-to-activity-logs)