### PR TITLE
fix(cli): recursive dataset/eval discovery for nested workflow folders (OUT-496)

### DIFF
--- a/.changeset/out-496-recursive-dataset-discovery.md
+++ b/.changeset/out-496-recursive-dataset-discovery.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Resolve datasets and evals for nested workflow folders by the workflow's registered name (via the worker catalog), keeping the flat-path lookup as an offline fast path. `output workflow test`, `dataset generate`, and `dataset list` now work for workflows in nested directories (e.g. `src/workflows/a/b/c` registered as `a_b_c`) without a symlink. `output workflow test` also fails fast with an actionable message when a `<wf>_eval` workflow's source exists but didn't compile to `dist`.

--- a/docs/guides/evaluators/datasets-and-cli.mdx
+++ b/docs/guides/evaluators/datasets-and-cli.mdx
@@ -135,6 +135,10 @@ output workflow test blog_generator --dataset happy_path,edge_case
 
 Use `--cached` during development when iterating on evaluators — it's fast because it skips the workflow entirely. Use `--save` when you want to capture fresh output and eval results.
 
+<Note>
+Nested workflow folders work without any extra setup. `output workflow test content_writing_style_anchor` resolves datasets by the workflow's registered name — `src/workflows/content/writing/style_anchor/tests/datasets/` — and `output workflow dataset generate` writes new datasets to that same folder. Keep the worker running so the CLI can map the registered name to its folder; flat layouts resolve offline exactly as before.
+</Note>
+
 ## Putting It All Together
 
 Here's the complete setup for a blog generator workflow:

--- a/docs/guides/evaluators/workflow-evaluators.mdx
+++ b/docs/guides/evaluators/workflow-evaluators.mdx
@@ -50,6 +50,22 @@ src/workflows/
 
 The eval workflow file (`tests/evals/workflow.ts`) is discovered automatically by the worker alongside your regular workflow.
 
+### Nested workflow folders
+
+Workflow folders nest to any depth. A workflow at `src/workflows/content/writing/style_anchor/` registered as `content_writing_style_anchor` keeps its evals and datasets in its own `tests/` directory, and the CLI resolves them by the registered name — no symlink and no flat folder required.
+
+<Warning>
+The eval workflow only registers if `tests/evals/workflow.ts` compiles to `dist` — the worker loads workflows from the compiled output, not from source. A `tsconfig` that excludes the whole `src/**/tests` tree silently drops it, and `output workflow test` then can't find `<workflow>_eval`. Exclude test files individually instead:
+
+```json tsconfig.json
+{
+  "exclude": ["node_modules", "dist", "**/*.spec.ts", "**/*.test.ts"]
+}
+```
+
+When the eval source exists but isn't registered, `output workflow test` says so and points at this fix instead of failing with a generic "workflow not found".
+</Warning>
+
 ## Writing Evaluators with verify()
 
 `verify()` creates a typed evaluator that receives the workflow's input, output, and optional ground truth from the dataset. It wraps `evaluator()` from `@outputai/core`, so it integrates with both the eval workflow and the Temporal worker.

--- a/sdk/cli/src/commands/workflow/dataset/generate.ts
+++ b/sdk/cli/src/commands/workflow/dataset/generate.ts
@@ -125,7 +125,7 @@ export default class DatasetGenerate extends Command {
       executionTimeMs
     );
 
-    const dir = resolveDefaultDatasetsDir( workflowName );
+    const dir = await resolveDefaultDatasetsDir( workflowName );
     const filePath = join( dir, `${datasetName}.yml` );
     await writeDataset( dataset, filePath );
 
@@ -152,7 +152,7 @@ export default class DatasetGenerate extends Command {
       extracted.executionTimeMs
     );
 
-    const dir = resolveDefaultDatasetsDir( workflowName );
+    const dir = await resolveDefaultDatasetsDir( workflowName );
     const filePath = join( dir, `${datasetName}.yml` );
     await writeDataset( dataset, filePath );
 
@@ -173,7 +173,7 @@ export default class DatasetGenerate extends Command {
 
     this.log( `Found ${traces.length} trace(s). Downloading...` );
 
-    const dir = resolveDefaultDatasetsDir( workflowName );
+    const dir = await resolveDefaultDatasetsDir( workflowName );
 
     for ( const trace of traces ) {
       const traceData = await downloadRemoteTrace( trace.key );

--- a/sdk/cli/src/commands/workflow/test_eval.ts
+++ b/sdk/cli/src/commands/workflow/test_eval.ts
@@ -3,6 +3,8 @@ import { Args, Command, Flags } from '@oclif/core';
 import { postWorkflowRun } from '#api/generated/api.js';
 import type { WorkflowResultResponse } from '#api/generated/api.js';
 import { readAllDatasets, writeDataset } from '#services/datasets.js';
+import { fetchWorkflowCatalog } from '#api/workflow_catalog.js';
+import { diagnoseMissingEvalWorkflow } from '#utils/eval_diagnostics.js';
 import { handleApiError } from '#utils/error_handler.js';
 import {
   getEvalWorkflowName,
@@ -59,6 +61,9 @@ export default class WorkflowTest extends Command {
     const { args, flags } = await this.parse( WorkflowTest );
     const filterNames = flags.dataset?.split( ',' ).map( s => s.trim() );
 
+    const evalName = getEvalWorkflowName( args.workflowName );
+    await this.ensureEvalWorkflowRegistered( args.workflowName, evalName );
+
     const { datasets, dir } = await readAllDatasets( args.workflowName, filterNames );
 
     if ( datasets.length === 0 ) {
@@ -73,7 +78,6 @@ export default class WorkflowTest extends Command {
       this.validateDatasets( datasets ) :
       await this.runWorkflowForDatasets( args.workflowName, datasets, flags.save, dir );
 
-    const evalName = getEvalWorkflowName( args.workflowName );
     this.log( `Running eval workflow "${evalName}"...\n` );
 
     const response = await postWorkflowRun( {
@@ -103,6 +107,16 @@ export default class WorkflowTest extends Command {
     const exitCode = computeExitCode( evalOutput );
     if ( exitCode !== 0 ) {
       this.exit( exitCode );
+    }
+  }
+
+  private async ensureEvalWorkflowRegistered(
+    workflowName: string,
+    evalName: string
+  ): Promise<void> {
+    const catalog = await fetchWorkflowCatalog().catch( () => null );
+    if ( catalog && !catalog.some( w => w.name === evalName ) ) {
+      this.error( await diagnoseMissingEvalWorkflow( workflowName ), { exit: 1 } );
     }
   }
 

--- a/sdk/cli/src/services/datasets.test.ts
+++ b/sdk/cli/src/services/datasets.test.ts
@@ -1,14 +1,23 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtemp, rm, writeFile, readFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import yaml from 'js-yaml';
-import { readDatasetFile, readAllDatasets, writeDataset, listDatasets } from './datasets.js';
+import { readDatasetFile, readAllDatasets, writeDataset, listDatasets, resolveDefaultDatasetsDir } from './datasets.js';
+import * as catalog from '#api/workflow_catalog.js';
+
+vi.mock( '#api/workflow_catalog.js', () => ( {
+  fetchWorkflowCatalog: vi.fn()
+} ) );
 
 const ctx = { tmpDir: '' };
 
 beforeEach( async () => {
   ctx.tmpDir = await mkdtemp( join( tmpdir(), 'output-datasets-test-' ) );
+  // Default: no API. Flat-layout cases resolve offline before this is hit;
+  // nested cases override with a resolved catalog.
+  vi.mocked( catalog.fetchWorkflowCatalog ).mockReset();
+  vi.mocked( catalog.fetchWorkflowCatalog ).mockRejectedValue( new Error( 'API unavailable' ) );
 } );
 
 afterEach( async () => {
@@ -132,6 +141,23 @@ describe( 'readAllDatasets', () => {
 
     expect( datasets ).toHaveLength( 2 );
     expect( datasets.map( d => d.name ).sort() ).toEqual( [ 'case_2', 'case_3' ] );
+  } );
+
+  it( 'resolves a nested workflow folder via the catalog', async () => {
+    const datasetsDir = join( ctx.tmpDir, 'src', 'workflows', 'a', 'b', 'c', 'tests', 'datasets' );
+    await mkdir( datasetsDir, { recursive: true } );
+    await writeYaml( join( datasetsDir, 'cases.yml' ), {
+      nested_case: { input: { x: 1 } }
+    } );
+
+    vi.mocked( catalog.fetchWorkflowCatalog ).mockResolvedValue(
+      [ { name: 'a_b_c', path: '/app/dist/workflows/a/b/c/workflow.js' } ] as never
+    );
+
+    const { datasets, dir } = await readAllDatasets( 'a_b_c', undefined, ctx.tmpDir );
+
+    expect( datasets.map( d => d.name ) ).toEqual( [ 'nested_case' ] );
+    expect( dir ).toBe( datasetsDir );
   } );
 
   it( 'returns empty datasets and a default dir when workflow has no datasets dir', async () => {
@@ -270,5 +296,30 @@ describe( 'listDatasets', () => {
   it( 'returns empty array when no datasets directory exists', async () => {
     const infos = await listDatasets( 'nonexistent_workflow', ctx.tmpDir );
     expect( infos ).toHaveLength( 0 );
+  } );
+} );
+
+// ---------------------------------------------------------------------------
+// resolveDefaultDatasetsDir
+// ---------------------------------------------------------------------------
+
+describe( 'resolveDefaultDatasetsDir', () => {
+  it( 'returns the nested workflow tests/datasets for first-time generation via catalog', async () => {
+    // Workflow dir exists; its tests/datasets does not yet (first generation).
+    await mkdir( join( ctx.tmpDir, 'src', 'workflows', 'a', 'b', 'c' ), { recursive: true } );
+
+    vi.mocked( catalog.fetchWorkflowCatalog ).mockResolvedValue(
+      [ { name: 'a_b_c', path: '/app/dist/workflows/a/b/c/workflow.js' } ] as never
+    );
+
+    const dir = await resolveDefaultDatasetsDir( 'a_b_c', ctx.tmpDir );
+
+    expect( dir ).toBe( join( ctx.tmpDir, 'src', 'workflows', 'a', 'b', 'c', 'tests', 'datasets' ) );
+  } );
+
+  it( 'falls back to the flat convention when the workflow cannot be resolved', async () => {
+    const dir = await resolveDefaultDatasetsDir( 'unknown_flow', ctx.tmpDir );
+
+    expect( dir ).toBe( join( ctx.tmpDir, 'src', 'workflows', 'unknown_flow', 'tests', 'datasets' ) );
   } );
 } );

--- a/sdk/cli/src/services/datasets.ts
+++ b/sdk/cli/src/services/datasets.ts
@@ -6,9 +6,10 @@ import { DatasetSchema } from '@outputai/evals';
 import type { Dataset } from '@outputai/evals';
 import { getTrace } from '#services/trace_reader.js';
 import { sanitizeSecrets } from '#utils/secret_sanitizer.js';
+import { resolveWorkflowDir, WORKFLOWS_PATHS } from '#utils/workflow_dir.js';
+import { getWorkflowsBasePath } from '#utils/paths.js';
 
 const DATASETS_DIR = 'tests/datasets';
-const WORKFLOWS_PATHS = [ 'src/workflows', 'workflows' ];
 
 export interface DatasetInfo {
   name: string;
@@ -18,30 +19,33 @@ export interface DatasetInfo {
   lastEvalDate?: string;
 }
 
-export function resolveDatasetsDir(
+export async function resolveDatasetsDir(
   workflowName: string,
-  basePath: string = process.cwd()
-): string | null {
-  for ( const workflowsDir of WORKFLOWS_PATHS ) {
-    const candidate = resolve( basePath, workflowsDir, workflowName, DATASETS_DIR );
-    if ( existsSync( candidate ) ) {
-      return candidate;
-    }
+  basePath?: string,
+  workflowPath?: string
+): Promise<string | null> {
+  const workflowDir = await resolveWorkflowDir( workflowName, basePath, workflowPath );
+  if ( !workflowDir ) {
+    return null;
   }
-  return null;
+  const datasetsDir = resolve( workflowDir, DATASETS_DIR );
+  return existsSync( datasetsDir ) ? datasetsDir : null;
 }
 
-export function resolveDefaultDatasetsDir(
+export async function resolveDefaultDatasetsDir(
   workflowName: string,
-  basePath: string = process.cwd()
-): string {
-  const existing = resolveDatasetsDir( workflowName, basePath );
-  if ( existing ) {
-    return existing;
+  basePath?: string,
+  workflowPath?: string
+): Promise<string> {
+  // Write into the resolved workflow's tests/datasets — even when it doesn't
+  // exist yet (first generation) — so nested workflows get the right location.
+  const workflowDir = await resolveWorkflowDir( workflowName, basePath, workflowPath );
+  if ( workflowDir ) {
+    return resolve( workflowDir, DATASETS_DIR );
   }
 
-  // Default to first workflows path
-  return resolve( basePath, WORKFLOWS_PATHS[0], workflowName, DATASETS_DIR );
+  // Workflow not found (unknown name / API unavailable): flat convention.
+  return resolve( basePath ?? getWorkflowsBasePath(), WORKFLOWS_PATHS[0], workflowName, DATASETS_DIR );
 }
 
 export async function readDatasetFile( filePath: string ): Promise<Dataset[]> {
@@ -66,9 +70,9 @@ export async function readAllDatasets(
   filterNames?: string[],
   basePath?: string
 ): Promise<{ datasets: Dataset[]; dir: string }> {
-  const dir = resolveDatasetsDir( workflowName, basePath );
+  const dir = await resolveDatasetsDir( workflowName, basePath );
   if ( !dir ) {
-    return { datasets: [], dir: resolveDefaultDatasetsDir( workflowName, basePath ) };
+    return { datasets: [], dir: await resolveDefaultDatasetsDir( workflowName, basePath ) };
   }
 
   const files = await readdir( dir );
@@ -115,7 +119,7 @@ export async function listDatasets(
   workflowName: string,
   basePath?: string
 ): Promise<DatasetInfo[]> {
-  const dir = resolveDatasetsDir( workflowName, basePath );
+  const dir = await resolveDatasetsDir( workflowName, basePath );
   if ( !dir ) {
     return [];
   }

--- a/sdk/cli/src/utils/eval_diagnostics.ts
+++ b/sdk/cli/src/utils/eval_diagnostics.ts
@@ -1,0 +1,42 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { getEvalWorkflowName } from '@outputai/evals';
+import { resolveWorkflowDir } from '#utils/workflow_dir.js';
+
+const EVAL_WORKFLOW_FILES = [ 'tests/evals/workflow.ts', 'tests/evals/workflow.js' ];
+
+/**
+ * Explain why a `<wf>_eval` workflow isn't registered. When the eval source
+ * exists on disk but isn't in the catalog, it almost always means tests/evals
+ * never compiled to dist (a tsconfig exclude dropped it) — so point at that
+ * instead of a bare WorkflowNotFoundError.
+ */
+export async function diagnoseMissingEvalWorkflow(
+  workflowName: string,
+  basePath?: string
+): Promise<string> {
+  const evalName = getEvalWorkflowName( workflowName );
+  const workflowDir = await resolveWorkflowDir( workflowName, basePath );
+  const evalSource = workflowDir ?
+    EVAL_WORKFLOW_FILES.map( file => resolve( workflowDir, file ) ).find( existsSync ) :
+    undefined;
+
+  if ( evalSource ) {
+    return [
+      `Eval workflow "${evalName}" is not registered, but its source exists at:`,
+      `  ${evalSource}`,
+      '',
+      'This usually means tests/evals did not compile to dist. Check your tsconfig:',
+      '  - Ensure tests/evals is not excluded (avoid excluding "src/**/tests").',
+      '  - Prefer excluding "**/*.spec.ts" and "**/*.test.ts" instead.',
+      '',
+      'Rebuild the worker so dist/.../tests/evals/workflow.js exists, then retry.'
+    ].join( '\n' );
+  }
+
+  return [
+    `No eval workflow defined for "${workflowName}".`,
+    '',
+    `Create an eval workflow at tests/evals/workflow.ts that registers "${evalName}".`
+  ].join( '\n' );
+}

--- a/sdk/cli/src/utils/scenario_resolver.ts
+++ b/sdk/cli/src/utils/scenario_resolver.ts
@@ -1,10 +1,15 @@
 import { existsSync, readdirSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fetchWorkflowCatalog } from '#api/workflow_catalog.js';
+import { resolve } from 'node:path';
 import { getWorkflowsBasePath } from '#utils/paths.js';
+import {
+  WORKFLOWS_PATHS,
+  candidateWorkflowDirsFromPath,
+  fetchWorkflowPath
+} from '#utils/workflow_dir.js';
+
+export { extractWorkflowRelativePath, findWorkflowDirectoryFromPath } from '#utils/workflow_dir.js';
 
 const SCENARIOS_DIR = 'scenarios';
-const WORKFLOWS_PATHS = [ 'src/workflows', 'workflows' ];
 
 export interface ScenarioResolutionResult {
   found: boolean;
@@ -12,52 +17,9 @@ export interface ScenarioResolutionResult {
   searchedPaths: string[];
 }
 
-export function extractWorkflowRelativePath( path: string ): string | null {
-  const match = path.match( /(?:^|\/)workflows\/(.+)\/workflow\.[jt]s$/ );
-  return match ? match[1] : null;
-}
-
-function unique( values: string[] ): string[] {
-  return [ ...new Set( values ) ];
-}
-
-function workflowPathSuffixes( workflowPath: string ): string[][] {
-  const parts = dirname( workflowPath ).split( /[/\\]+/ ).filter( Boolean );
-  return parts.map( ( _, index ) => parts.slice( index ) );
-}
-
-function candidateWorkflowDirsFromPath( workflowPath: string, basePath: string ): string[] {
-  return unique(
-    workflowPathSuffixes( workflowPath ).flatMap( suffix =>
-      WORKFLOWS_PATHS.map( workflowsDir => resolve( basePath, workflowsDir, ...suffix ) )
-    )
-  );
-}
-
 function candidateScenarioDirsFromPath( workflowPath: string, basePath: string ): string[] {
   return candidateWorkflowDirsFromPath( workflowPath, basePath )
     .map( workflowDir => resolve( workflowDir, SCENARIOS_DIR ) );
-}
-
-export function findWorkflowDirectoryFromPath(
-  workflowPath: string | undefined,
-  basePath: string = getWorkflowsBasePath()
-): string | null {
-  if ( !workflowPath ) {
-    return null;
-  }
-
-  return candidateWorkflowDirsFromPath( workflowPath, basePath ).find( existsSync ) ?? null;
-}
-
-async function fetchWorkflowPath( workflowName: string ): Promise<string | null> {
-  try {
-    const workflows = await fetchWorkflowCatalog();
-    const workflow = workflows.find( w => w.name === workflowName );
-    return workflow?.path ?? null;
-  } catch {
-    return null;
-  }
 }
 
 function resolveScenarioFromDirectory(

--- a/sdk/cli/src/utils/workflow_dir.spec.ts
+++ b/sdk/cli/src/utils/workflow_dir.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { resolveWorkflowDir } from './workflow_dir.js';
+import * as fs from 'node:fs';
+import * as catalog from '#api/workflow_catalog.js';
+
+vi.mock( 'node:fs', () => ( {
+  existsSync: vi.fn()
+} ) );
+
+vi.mock( '#api/workflow_catalog.js', () => ( {
+  fetchWorkflowCatalog: vi.fn()
+} ) );
+
+function mockCatalog( workflows: Array<{ name: string; path?: string }> ) {
+  vi.mocked( catalog.fetchWorkflowCatalog ).mockResolvedValue( workflows as never );
+}
+
+function mockCatalogFailure() {
+  vi.mocked( catalog.fetchWorkflowCatalog ).mockRejectedValue( new Error( 'API unavailable' ) );
+}
+
+describe( 'resolveWorkflowDir', () => {
+  beforeEach( () => {
+    vi.resetAllMocks();
+  } );
+
+  afterEach( () => {
+    vi.restoreAllMocks();
+  } );
+
+  it( 'resolves a flat layout without querying the catalog', async () => {
+    vi.mocked( fs.existsSync ).mockImplementation( path =>
+      String( path ) === '/project/src/workflows/simple'
+    );
+
+    const result = await resolveWorkflowDir( 'simple', '/project' );
+
+    expect( result ).toBe( '/project/src/workflows/simple' );
+    expect( catalog.fetchWorkflowCatalog ).not.toHaveBeenCalled();
+  } );
+
+  it( 'resolves the workflows/ fallback without querying the catalog', async () => {
+    vi.mocked( fs.existsSync ).mockImplementation( path =>
+      String( path ) === '/project/workflows/simple'
+    );
+
+    const result = await resolveWorkflowDir( 'simple', '/project' );
+
+    expect( result ).toBe( '/project/workflows/simple' );
+    expect( catalog.fetchWorkflowCatalog ).not.toHaveBeenCalled();
+  } );
+
+  it( 'resolves a nested folder via the catalog path', async () => {
+    mockCatalog( [ { name: 'a_b_c', path: '/app/dist/workflows/a/b/c/workflow.js' } ] );
+    vi.mocked( fs.existsSync ).mockImplementation( path =>
+      String( path ) === '/project/src/workflows/a/b/c'
+    );
+
+    const result = await resolveWorkflowDir( 'a_b_c', '/project' );
+
+    expect( result ).toBe( '/project/src/workflows/a/b/c' );
+  } );
+
+  it( 'returns null when the catalog is unavailable and no flat dir exists', async () => {
+    mockCatalogFailure();
+    vi.mocked( fs.existsSync ).mockReturnValue( false );
+
+    const result = await resolveWorkflowDir( 'a_b_c', '/project' );
+
+    expect( result ).toBeNull();
+  } );
+
+  it( 'returns null when the workflow is not in the catalog', async () => {
+    mockCatalog( [ { name: 'other', path: '/app/dist/workflows/other/workflow.js' } ] );
+    vi.mocked( fs.existsSync ).mockReturnValue( false );
+
+    const result = await resolveWorkflowDir( 'a_b_c', '/project' );
+
+    expect( result ).toBeNull();
+  } );
+
+  it( 'uses a provided workflowPath without querying the catalog', async () => {
+    vi.mocked( fs.existsSync ).mockImplementation( path =>
+      String( path ) === '/project/src/workflows/writing/editor'
+    );
+
+    const result = await resolveWorkflowDir(
+      'writing_editor',
+      '/project',
+      '/app/build-output/writing/editor/workflow.js'
+    );
+
+    expect( result ).toBe( '/project/src/workflows/writing/editor' );
+    expect( catalog.fetchWorkflowCatalog ).not.toHaveBeenCalled();
+  } );
+} );

--- a/sdk/cli/src/utils/workflow_dir.ts
+++ b/sdk/cli/src/utils/workflow_dir.ts
@@ -1,0 +1,79 @@
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fetchWorkflowCatalog } from '#api/workflow_catalog.js';
+import { getWorkflowsBasePath } from '#utils/paths.js';
+
+export const WORKFLOWS_PATHS = [ 'src/workflows', 'workflows' ];
+
+export function extractWorkflowRelativePath( path: string ): string | null {
+  const match = path.match( /(?:^|\/)workflows\/(.+)\/workflow\.[jt]s$/ );
+  return match ? match[1] : null;
+}
+
+function unique( values: string[] ): string[] {
+  return [ ...new Set( values ) ];
+}
+
+function workflowPathSuffixes( workflowPath: string ): string[][] {
+  const parts = dirname( workflowPath ).split( /[/\\]+/ ).filter( Boolean );
+  return parts.map( ( _, index ) => parts.slice( index ) );
+}
+
+export function candidateWorkflowDirsFromPath( workflowPath: string, basePath: string ): string[] {
+  return unique(
+    workflowPathSuffixes( workflowPath ).flatMap( suffix =>
+      WORKFLOWS_PATHS.map( workflowsDir => resolve( basePath, workflowsDir, ...suffix ) )
+    )
+  );
+}
+
+export function findWorkflowDirectoryFromPath(
+  workflowPath: string | undefined,
+  basePath: string = getWorkflowsBasePath()
+): string | null {
+  if ( !workflowPath ) {
+    return null;
+  }
+
+  return candidateWorkflowDirsFromPath( workflowPath, basePath ).find( existsSync ) ?? null;
+}
+
+export async function fetchWorkflowPath( workflowName: string ): Promise<string | null> {
+  try {
+    const workflows = await fetchWorkflowCatalog();
+    const workflow = workflows.find( w => w.name === workflowName );
+    return workflow?.path ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the on-disk directory of a registered workflow by name.
+ *
+ * Flat-first so flat-layout projects resolve offline (no catalog round-trip)
+ * exactly as before; nested folders fall through to the worker catalog, whose
+ * `path` is re-rooted under `src/workflows` / `workflows`.
+ */
+export async function resolveWorkflowDir(
+  workflowName: string,
+  basePath: string = getWorkflowsBasePath(),
+  workflowPath?: string
+): Promise<string | null> {
+  for ( const workflowsDir of WORKFLOWS_PATHS ) {
+    const candidate = resolve( basePath, workflowsDir, workflowName );
+    if ( existsSync( candidate ) ) {
+      return candidate;
+    }
+  }
+
+  if ( workflowPath ) {
+    const found = findWorkflowDirectoryFromPath( workflowPath, basePath );
+    if ( found ) {
+      return found;
+    }
+  }
+
+  const catalogPath = await fetchWorkflowPath( workflowName );
+  return findWorkflowDirectoryFromPath( catalogPath ?? undefined, basePath );
+}


### PR DESCRIPTION
## Problem

- `output workflow test` / `dataset generate` / `dataset list` find nothing for workflows in nested folders. `resolveDatasetsDir` assumed a flat path (`src/workflows/<name>/tests/datasets`), so a workflow registered as `context_writing_style_anchor` but living at `src/workflows/context/writing/style_anchor/` resolved to nothing.
- The worker already discovers `workflow.ts` recursively, so nested workflows register fine — only CLI dataset/eval discovery was broken. Converting `_`→`/` is unsafe, and the symlink workaround double-registers the workflow under `npx output dev`.
- Secondary: when `tests/evals/workflow.ts` doesn't compile to `dist` (a tsconfig that excludes `src/**/tests`), `<wf>_eval` never registers and the CLI fails with a generic `WorkflowNotFoundError`.

## Solution

- **Shared resolver** — extracted the catalog-based "find a registered workflow's dir by name" logic (already proven for scenarios) into `sdk/cli/src/utils/workflow_dir.ts`. `resolveWorkflowDir()` tries the flat path first (offline, unchanged for flat layouts), then falls back to the worker catalog for nested folders. `scenario_resolver.ts` now consumes it and re-exports its two public symbols.
- **Datasets** — `resolveDatasetsDir` / `resolveDefaultDatasetsDir` are now catalog-aware; the write path targets the nested `tests/datasets` even on first generation. `dataset list` gets nested support for free.
- **Diagnostic** — `output workflow test` checks the catalog for `<wf>_eval` before running anything; if its source exists but isn't registered, it points at the tsconfig/`dist` fix instead of a bare `WorkflowNotFoundError`.
- **Docs** — nested-folder discovery note, and the `tests/evals` → `dist` tsconfig guidance (exclude `*.spec.ts`/`*.test.ts`, not the whole `tests` tree).

## Test plan

- [x] `eslint` — clean on all changed files
- [x] `tsc --noEmit` (sdk/cli) — clean
- [x] `vitest run` — 689 cli unit tests pass, including new `workflow_dir.spec.ts` and nested read/write cases in `datasets.test.ts`
- [ ] e2e against `./run.sh dev`: `output workflow test <nested>` and `dataset generate <nested> --trace` resolve without a symlink

> Note: 2 `copy_assets.spec.ts` failures in the local run are pre-existing and unrelated — they assert on `sdk/cli/dist` build artifacts not produced in a source-only test run.

## Notes for reviewers

- **Dataset resolution now defaults its base path to `getWorkflowsBasePath()` instead of `process.cwd()`** — this matches scenario resolution and makes datasets resolve correctly under `output dev` (which sets `OUTPUT_WORKFLOWS_DIR`). In-project CLI use is unchanged: `getWorkflowsBasePath()` returns `process.cwd()` when the env var is unset.
- **The eval-registration pre-check is a second catalog fetch** (the nested dataset read may also fetch it). Kept separate for clarity — the catalog GET is cheap and only `test` pays it. The check is best-effort: if the catalog is unreachable it's skipped so the normal run path surfaces the error.

Closes OUT-496