### PR TITLE
feat(core,api): Handling SIGUSR2 interruptions

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -1494,6 +1494,7 @@ const server = app.listen( apiConfig.port, () => {
 } );
 
 const closeServer = promisify( server.close.bind( server ) );
+const INTERRUPTION_SIGNALS = [ 'SIGTERM', 'SIGINT', 'SIGUSR2' ];
 
 const shutdown = runOnce( async () => {
   logger.info( 'Closing HTTP server...' );
@@ -1516,5 +1517,4 @@ client.onConnectionLost( async e => {
   process.exit( 1 );
 } );
 
-process.on( 'SIGTERM', () => handleInterruption( 'SIGTERM' ) );
-process.on( 'SIGINT', () => handleInterruption( 'SIGINT' ) );
+INTERRUPTION_SIGNALS.forEach( signal => process.on( signal, () => handleInterruption( signal ) ) );

--- a/api/src/index.spec.js
+++ b/api/src/index.spec.js
@@ -78,8 +78,19 @@ vi.mock( '#logger', () => ( { logger: mockLogger } ) );
 const PORT = 3000;
 
 describe( 'API endpoints', () => {
+  const processHandlers = {};
+
   beforeAll( async () => {
+    const originalProcessOn = process.on.bind( process );
+    const processOn = vi.spyOn( process, 'on' ).mockImplementation( ( signal, handler ) => {
+      if ( [ 'SIGTERM', 'SIGINT', 'SIGUSR2' ].includes( signal ) ) {
+        processHandlers[signal] = handler;
+      }
+      return originalProcessOn( signal, handler );
+    } );
+
     await import( './index.js' );
+    processOn.mockRestore();
   } );
 
   beforeEach( () => {
@@ -121,6 +132,14 @@ describe( 'API endpoints', () => {
   it( 'registers a Temporal connection lost handler', () => {
     expect( temporalInitState.options ).toBeUndefined();
     expect( temporalInitState.connectionLostCb ).toEqual( expect.any( Function ) );
+  } );
+
+  it( 'registers interruption handlers', () => {
+    expect( processHandlers ).toEqual( {
+      SIGTERM: expect.any( Function ),
+      SIGINT: expect.any( Function ),
+      SIGUSR2: expect.any( Function )
+    } );
   } );
 
   describe( 'POST /heartbeat', () => {

--- a/sdk/core/src/worker/interruption.js
+++ b/sdk/core/src/worker/interruption.js
@@ -3,6 +3,7 @@ import { createChildLogger } from '#logger';
 const log = createChildLogger( 'Interruption' );
 
 const FORCE_QUIT_GRACE_MS = 1000;
+const INTERRUPTION_SIGNALS = [ 'SIGTERM', 'SIGINT', 'SIGUSR2' ];
 
 export const setupInterruptionHandler = cb => {
   const state = { interruptionReceivedAt: null };
@@ -28,6 +29,5 @@ export const setupInterruptionHandler = cb => {
     cb();
   };
 
-  process.on( 'SIGTERM', () => handle( 'SIGTERM' ) );
-  process.on( 'SIGINT', () => handle( 'SIGINT' ) );
+  INTERRUPTION_SIGNALS.forEach( signal => process.on( signal, () => handle( signal ) ) );
 };

--- a/sdk/core/src/worker/interruption.spec.js
+++ b/sdk/core/src/worker/interruption.spec.js
@@ -29,11 +29,12 @@ describe( 'setupInterruptionHandler', () => {
     process.exit = originalExit;
   } );
 
-  it( 'registers SIGTERM and SIGINT handlers', () => {
+  it( 'registers interruption signal handlers', () => {
     setupInterruptionHandler( callback );
 
     expect( process.on ).toHaveBeenCalledWith( 'SIGTERM', expect.any( Function ) );
     expect( process.on ).toHaveBeenCalledWith( 'SIGINT', expect.any( Function ) );
+    expect( process.on ).toHaveBeenCalledWith( 'SIGUSR2', expect.any( Function ) );
   } );
 
   it( 'logs and invokes callback on first SIGTERM', () => {
@@ -53,6 +54,17 @@ describe( 'setupInterruptionHandler', () => {
     onHandlers.SIGINT();
 
     expect( mockLog.info ).toHaveBeenCalledWith( 'Signal Received', { signal: 'SIGINT' } );
+    expect( mockLog.warn ).toHaveBeenCalledWith( 'Initiating shutdown...' );
+    expect( callback ).toHaveBeenCalledOnce();
+    expect( exitMock ).not.toHaveBeenCalled();
+  } );
+
+  it( 'logs and invokes callback on first SIGUSR2', () => {
+    setupInterruptionHandler( callback );
+
+    onHandlers.SIGUSR2();
+
+    expect( mockLog.info ).toHaveBeenCalledWith( 'Signal Received', { signal: 'SIGUSR2' } );
     expect( mockLog.warn ).toHaveBeenCalledWith( 'Initiating shutdown...' );
     expect( callback ).toHaveBeenCalledOnce();
     expect( exitMock ).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- Nodemon hot reload restarts via ISGUSR2 interruption, causing the workflow to not shutdown properly, leaving old state behind. This PR adds support to it, so proper shutdown is triggered on API/core.

## Test plan

- [x] Manual
- [x] Unit test 
