### PR TITLE
fix(core): Including /dist when calculating hash for catalog workflow [OUT-500]

### DIFF
--- a/.changeset/true-lies-stare.md
+++ b/.changeset/true-lies-stare.md
@@ -1,0 +1,5 @@
+---
+"@outputai/core": patch
+---
+
+Including /dist when calculating catalog hash to define if catalog workflow needs restart. Excluding /temp.

--- a/sdk/core/src/worker/loader/tools.js
+++ b/sdk/core/src/worker/loader/tools.js
@@ -252,7 +252,7 @@ export const hashSourceCode = async rootDir => {
   try {
     const { hash } = await hashElement( rootDir, {
       folders: {
-        exclude: [ '.*', 'node_modules', 'test_coverage', 'vendor', 'test', 'logs', 'dist' ],
+        exclude: [ '.*', 'node_modules', 'test_coverage', 'vendor', 'test', 'logs', 'temp' ],
         ignoreRootName: true
       },
       files: {

--- a/sdk/core/src/worker/loader/tools.spec.js
+++ b/sdk/core/src/worker/loader/tools.spec.js
@@ -574,7 +574,7 @@ describe( 'hashSourceCode', () => {
 
     // The cruft tree is identical source plus large excluded artifacts that
     // boot must not walk: local trace dumps under logs/ and build output under dist/.
-    for ( const excluded of [ 'logs', 'logs/runs', 'dist', 'node_modules' ] ) {
+    for ( const excluded of [ 'logs', 'logs/runs', 'node_modules' ] ) {
       const dir = join( withCruft, excluded );
       mkdirSync( dir, { recursive: true } );
       writeFileSync( join( dir, 'dump.json' ), JSON.stringify( { blob: 'x'.repeat( 50_000 ) } ) );


### PR DESCRIPTION
## Summary

- Including /dist when calculating catalog hash to define if catalog workflow needs restart. Excluding /temp.

## Test plan

- [x] Updated unit tests
