### PR TITLE
refactor(http,llm): Using new Logger module from core [OUT-255]

### DIFF
--- a/docs/guides/packages/core.mdx
+++ b/docs/guides/packages/core.mdx
@@ -351,7 +351,6 @@ Some metadata field names are reserved because Winston, Output log hooks, or log
 - `level`
 - `message`
 - `metadata`
-- `namespace`
 - `runId`
 - `service`
 - `splat`
@@ -361,6 +360,18 @@ Some metadata field names are reserved because Winston, Output log hooks, or log
 - `workflowType`
 
 If you need to include a value with one of those meanings, use a domain-specific name instead, such as `providerMessage`, `errorStack`, or `sourceTimestamp`.
+
+### Namespace
+
+Logs from within workflows have the "Workflow" namespace, while those from activity context have "Activity".
+
+Namespace is a discrete field in the JSON output in production, and a prefix for the string message in development.
+
+The namespace can be customized by setting it in the metadata:
+
+```js
+Logger.warn('My awesome message', { namespace: 'Custom' });
+```
 
 ### Worker output
 

--- a/docs/guides/packages/core.mdx
+++ b/docs/guides/packages/core.mdx
@@ -373,6 +373,23 @@ The namespace can be customized by setting it in the metadata:
 Logger.warn('My awesome message', { namespace: 'Custom' });
 ```
 
+Use `Logger.createLogger()` when several logs should share the same namespace:
+
+```js
+const log = Logger.createLogger('LLM');
+
+log.info('Generating completion', { model: 'claude-sonnet-4' });
+log.warn('Provider request retrying', { attempt: 2 });
+```
+
+Metadata on an individual log call can still override the logger's default namespace:
+
+```js
+const log = Logger.createLogger('LLM');
+
+log.info('Using fallback provider', { namespace: 'LLM Fallback' });
+```
+
 ### Worker output
 
 The worker uses Winston for structured logging.

--- a/sdk/core/src/interface/index.d.ts
+++ b/sdk/core/src/interface/index.d.ts
@@ -7,4 +7,4 @@ export * from './step.js';
 export * from './evaluator.js';
 export * from './workflow.js';
 export * from './evaluation_result.js';
-export * as Logger from './logger.js';
+export * from './logger.js';

--- a/sdk/core/src/interface/index.js
+++ b/sdk/core/src/interface/index.js
@@ -10,7 +10,7 @@ import { step } from './step.js';
 import { workflow } from './workflow.js';
 import { executeInParallel } from './workflow_utils.js';
 import { sendHttpRequest, sendPostRequestAndAwaitWebhook } from './webhook.js';
-import * as Logger from './logger.js';
+import { Logger } from './logger.js';
 
 export {
   evaluator,

--- a/sdk/core/src/interface/logger.d.ts
+++ b/sdk/core/src/interface/logger.d.ts
@@ -1,53 +1,61 @@
-/**
- * Additional structured fields attached to a log record.
- */
-export type LogMetadata = Record<string, unknown>;
+type Logger = {
+  /**
+   * Log an error (level 0)
+   * @param message Log message
+   * @param metadata Additional information to be displayed
+   */
+  error( message: string, metadata?: Record<string, unknown> ) : void,
+
+  /**
+   * Log a warn (level 1)
+   * @param message Log message
+   * @param metadata Additional information to be displayed
+   */
+  warn( message: string, metadata?: Record<string, unknown> ) : void,
+
+  /**
+   * Log an info (level 2)
+   * @param message Log message
+   * @param metadata Additional information to be displayed
+   */
+  info( message: string, metadata?: Record<string, unknown> ) : void,
+
+  /**
+   * Log http (level 3)
+   * @param message Log message
+   * @param metadata Additional information to be displayed
+   */
+  http( message: string, metadata?: Record<string, unknown> ) : void,
+
+  /**
+   * Log verbose (level 4)
+   * @param message Log message
+   * @param metadata Additional information to be displayed
+   */
+  verbose( message: string, metadata?: Record<string, unknown> ) : void,
+
+  /**
+   * Log debug (level 5)
+   * @param message Log message
+   * @param metadata Additional information to be displayed
+   */
+  debug( message: string, metadata?: Record<string, unknown> ) : void,
+
+  /**
+   * Log silly (level 6)
+   * @param message Log message
+   * @param metadata Additional information to be displayed
+   */
+  silly( message: string, metadata?: Record<string, unknown> ) : void,
+
+  /**
+   * Creates a new Logger with a namespace value preset for all emitted logs.
+   * @param namespace
+   */
+  createLogger( namespace: string ) : Logger
+};
 
 /**
- * Log an error (level 0)
- * @param message Log message
- * @param metadata Additional information to be displayed
+ * Logger tool. Can be used in activities or workflows. Logs together with the framework's own logs.
  */
-export declare function error( message: string, metadata?: LogMetadata ) : void;
-
-/**
- * Log a warn (level 1)
- * @param message Log message
- * @param metadata Additional information to be displayed
- */
-export declare function warn( message: string, metadata?: LogMetadata ) : void;
-
-/**
- * Log an info (level 2)
- * @param message Log message
- * @param metadata Additional information to be displayed
- */
-export declare function info( message: string, metadata?: LogMetadata ) : void;
-
-/**
- * Log http (level 3)
- * @param message Log message
- * @param metadata Additional information to be displayed
- */
-export declare function http( message: string, metadata?: LogMetadata ) : void;
-
-/**
- * Log verbose (level 4)
- * @param message Log message
- * @param metadata Additional information to be displayed
- */
-export declare function verbose( message: string, metadata?: LogMetadata ) : void;
-
-/**
- * Log debug (level 5)
- * @param message Log message
- * @param metadata Additional information to be displayed
- */
-export declare function debug( message: string, metadata?: LogMetadata ) : void;
-
-/**
- * Log silly (level 6)
- * @param message Log message
- * @param metadata Additional information to be displayed
- */
-export declare function silly( message: string, metadata?: LogMetadata ) : void;
+export declare const Logger : Logger;

--- a/sdk/core/src/interface/logger.js
+++ b/sdk/core/src/interface/logger.js
@@ -41,6 +41,7 @@ const levels = Object.keys( levelToConsole );
 /** Drops reserved keys from object */
 const removeReservedFields = obj => Object.fromEntries( Object.entries( obj ).filter( ( [ k ] ) => !reservedMetadataFields.has( k ) ) );
 
+/** Dispatch the log message downstream */
 const log = ( level, namespace, message, metadata ) => {
   const baseMetadata = namespace ? { namespace } : {};
   const sanitized = {
@@ -60,11 +61,13 @@ const log = ( level, namespace, message, metadata ) => {
   }
 };
 
+/** Creates a new logger. It uses the npm levels, and for each level, bind the log function */
 const createLogger = namespace => ( {
   ...Object.fromEntries( levels.map( l => [ l, log.bind( null, l, namespace ) ] ) ),
   createLogger
 } );
 
+/** This is the default logger instance */
 const logger = createLogger( null );
 
 export { logger as Logger };

--- a/sdk/core/src/interface/logger.js
+++ b/sdk/core/src/interface/logger.js
@@ -25,6 +25,7 @@ const reservedMetadataFields = new Set( [
 // This is inoffensive and can be used outside workflow sandbox
 const sinks = proxySinks();
 
+// Winston uses npm levels by default: https://github.com/winstonjs/winston#logging-levels
 // Convert npm log levels to console levels
 const levelToConsole = {
   error: 'error',
@@ -35,14 +36,16 @@ const levelToConsole = {
   debug: 'debug',
   silly: 'log'
 };
+const levels = Object.keys( levelToConsole );
 
 /** Drops reserved keys from object */
 const removeReservedFields = obj => Object.fromEntries( Object.entries( obj ).filter( ( [ k ] ) => !reservedMetadataFields.has( k ) ) );
 
-const log = ( level, message, metadata ) => {
+const log = ( level, namespace, message, metadata ) => {
+  const baseMetadata = namespace ? { namespace } : {};
   const sanitized = {
     message: String( message ),
-    ...( isPlainObject( metadata ) && { metadata: removeReservedFields( metadata ) } )
+    metadata: { ...baseMetadata, ...isPlainObject( metadata ) ? removeReservedFields( metadata ) : {} }
   };
 
   // When inside workflow, use sinks to send logs out
@@ -57,11 +60,11 @@ const log = ( level, message, metadata ) => {
   }
 };
 
-// Winston uses npm levels by default: https://github.com/winstonjs/winston#logging-levels
-export const error = log.bind( null, 'error' );
-export const warn = log.bind( null, 'warn' );
-export const info = log.bind( null, 'info' );
-export const http = log.bind( null, 'http' );
-export const verbose = log.bind( null, 'verbose' );
-export const debug = log.bind( null, 'debug' );
-export const silly = log.bind( null, 'silly' );
+const createLogger = namespace => ( {
+  ...Object.fromEntries( levels.map( l => [ l, log.bind( null, l, namespace ) ] ) ),
+  createLogger
+} );
+
+const logger = createLogger( null );
+
+export { logger as Logger };

--- a/sdk/core/src/interface/logger.js
+++ b/sdk/core/src/interface/logger.js
@@ -9,7 +9,6 @@ const reservedMetadataFields = new Set( [
   'level',
   'message',
   'metadata',
-  'namespace',
   'splat',
   'stack',
   'timestamp',

--- a/sdk/core/src/interface/logger.spec.js
+++ b/sdk/core/src/interface/logger.spec.js
@@ -34,7 +34,7 @@ const consoleMethodsByLevel = {
   silly: 'log'
 };
 
-const loadLogger = async () => import( './logger.js' );
+const loadLogger = async () => ( await import( './logger.js' ) ).Logger;
 
 describe( 'interface/logger', () => {
   beforeEach( () => {
@@ -134,5 +134,39 @@ describe( 'interface/logger', () => {
     expect( consoleMocks.debug ).toHaveBeenCalledTimes( 1 );
     expect( consoleMocks.log ).toHaveBeenCalledTimes( 3 );
     expect( workflowLogMock ).not.toHaveBeenCalled();
+  } );
+
+  it( 'creates a logger with a default namespace for every level', async () => {
+    const logger = await loadLogger();
+    inWorkflowContextMock.mockReturnValue( true );
+
+    const namespacedLogger = logger.createLogger( 'Namespace' );
+    logLevels.forEach( level => {
+      namespacedLogger[level]( `${level} message`, { requestId: level } );
+    } );
+
+    logLevels.forEach( ( level, index ) => {
+      expect( workflowLogMock ).toHaveBeenNthCalledWith( index + 1, {
+        level,
+        message: `${level} message`,
+        metadata: {
+          namespace: 'Namespace',
+          requestId: level
+        }
+      } );
+    } );
+  } );
+
+  it( 'lets log metadata override the default namespace', async () => {
+    const logger = await loadLogger();
+    inWorkflowContextMock.mockReturnValue( true );
+
+    logger.createLogger( 'Default namespace' ).info( 'message', { namespace: 'Inline namespace' } );
+
+    expect( workflowLogMock ).toHaveBeenCalledWith( {
+      level: 'info',
+      message: 'message',
+      metadata: { namespace: 'Inline namespace' }
+    } );
   } );
 } );

--- a/sdk/http/src/cost.spec.ts
+++ b/sdk/http/src/cost.spec.ts
@@ -41,7 +41,6 @@ describe( 'addRequestCost', () => {
   beforeEach( () => {
     tracing.addEventAttribute.mockClear();
     event.emit.mockClear();
-    vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
   } );
 
   afterEach( () => {
@@ -54,9 +53,6 @@ describe( 'addRequestCost', () => {
 
     addRequestCost( response, cost );
 
-    expect( console.warn ).toHaveBeenCalledWith(
-      'addRequestCost(): The "response" argument did not originate from @outputai/http, no costs were added.'
-    );
     expect( tracing.addEventAttribute ).not.toHaveBeenCalled();
     expect( event.emit ).not.toHaveBeenCalled();
   } );
@@ -68,7 +64,6 @@ describe( 'addRequestCost', () => {
 
     addRequestCost( response, cost );
 
-    expect( console.warn ).not.toHaveBeenCalled();
     expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
       eventId: 'evt-cost-1',
       attribute: expect.objectContaining( {
@@ -113,7 +108,6 @@ describe( 'addRequestCost', () => {
     const cloned = response.clone();
     addRequestCost( cloned, 4.2 );
 
-    expect( console.warn ).not.toHaveBeenCalled();
     expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
       eventId: 'evt-clone-1',
       attribute: expect.objectContaining( {

--- a/sdk/http/src/cost.ts
+++ b/sdk/http/src/cost.ts
@@ -13,7 +13,7 @@ import { Logger } from '@outputai/core';
 export const addRequestCost = ( response: KyResponse | Response, value: number ) : void => {
   const eventId = Reflect.get( response, requestIdSymbol ) as string;
   if ( !eventId ) {
-    Logger.warn( 'addRequestCost(): The "response" argument did not originate from @outputai/http, no costs were added.' );
+    Logger.warn( 'addRequestCost(): The "response" argument did not originate from @outputai/http, no costs were added.', { namespace: 'HTTP' } );
     return;
   }
 

--- a/sdk/http/src/cost.ts
+++ b/sdk/http/src/cost.ts
@@ -1,6 +1,7 @@
 import { KyResponse } from 'ky';
 import { Tracing, Event } from '@outputai/core/sdk/runtime';
 import { requestIdSymbol } from './consts.js';
+import { Logger } from '@outputai/core';
 
 /**
  * Attach cost information to the trace of an HTTP Request using the response
@@ -12,7 +13,7 @@ import { requestIdSymbol } from './consts.js';
 export const addRequestCost = ( response: KyResponse | Response, value: number ) : void => {
   const eventId = Reflect.get( response, requestIdSymbol ) as string;
   if ( !eventId ) {
-    console.warn( 'addRequestCost(): The "response" argument did not originate from @outputai/http, no costs were added.' );
+    Logger.warn( 'addRequestCost(): The "response" argument did not originate from @outputai/http, no costs were added.' );
     return;
   }
 

--- a/sdk/llm/src/cost/fetch_models_pricing.js
+++ b/sdk/llm/src/cost/fetch_models_pricing.js
@@ -1,3 +1,5 @@
+import { Logger } from '@outputai/core';
+
 const costTableUrl = 'https://models.dev/api.json';
 const cacheTTL = 1000 * 60 * 60 * 24; // 1 day
 
@@ -26,10 +28,10 @@ export const fetchModelsPricing = async () => {
   const res = await fetch( costTableUrl );
   if ( !res.ok ) {
     if ( cache.content ) {
-      console.warn( `Error ${res.status} when fetching models pricing at ${costTableUrl}, falling back to stale cache` );
+      Logger.warn( `Error ${res.status} when fetching models pricing at ${costTableUrl}, falling back to stale cache` );
       return cache.content;
     }
-    console.error( `Error ${res.status} when fetching models pricing at ${costTableUrl}` );
+    Logger.error( `Error ${res.status} when fetching models pricing at ${costTableUrl}` );
     return null;
   }
   cache.content = buildModelMap( await res.json() );

--- a/sdk/llm/src/cost/fetch_models_pricing.js
+++ b/sdk/llm/src/cost/fetch_models_pricing.js
@@ -28,10 +28,10 @@ export const fetchModelsPricing = async () => {
   const res = await fetch( costTableUrl );
   if ( !res.ok ) {
     if ( cache.content ) {
-      Logger.warn( `Error ${res.status} when fetching models pricing at ${costTableUrl}, falling back to stale cache` );
+      Logger.warn( `Error ${res.status} when fetching models pricing at ${costTableUrl}, falling back to stale cache`, { namespace: 'LLM' } );
       return cache.content;
     }
-    Logger.error( `Error ${res.status} when fetching models pricing at ${costTableUrl}` );
+    Logger.error( `Error ${res.status} when fetching models pricing at ${costTableUrl}`, { namespace: 'LLM' } );
     return null;
   }
   cache.content = buildModelMap( await res.json() );

--- a/sdk/llm/src/cost/fetch_models_pricing.spec.js
+++ b/sdk/llm/src/cost/fetch_models_pricing.spec.js
@@ -9,24 +9,29 @@ const fixturePath = join( __dirname, 'fixtures', 'models_api_light.json' );
 const fixture = JSON.parse( readFileSync( fixturePath, 'utf8' ) );
 
 const costTableUrl = 'https://models.dev/api.json';
-const errNoCache = status => `Error ${status} when fetching models pricing at ${costTableUrl}`;
-const warnStaleCache = status => `Error ${status} when fetching models pricing at ${costTableUrl}, falling back to stale cache`;
+const okResponse = data => ( {
+  ok: true,
+  json: () => Promise.resolve( data )
+} );
+const stubFetch = response => {
+  const fetchMock = vi.fn().mockResolvedValue( response );
+  vi.stubGlobal( 'fetch', fetchMock );
+  return fetchMock;
+};
 
 describe( 'fetchModelsPricing', () => {
   beforeEach( () => {
     cache.content = null;
     cache.expiresAt = 0;
-    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   } );
 
   it( 'returns a Map of model costs when fetch succeeds', async () => {
-    vi.stubGlobal( 'fetch', vi.fn().mockResolvedValue( {
-      ok: true,
-      json: () => Promise.resolve( fixture )
-    } ) );
+    const fetchMock = stubFetch( okResponse( fixture ) );
 
     const result = await fetchModelsPricing();
 
+    expect( fetchMock ).toHaveBeenCalledWith( costTableUrl );
     expect( result ).toBeInstanceOf( Map );
     expect( result.size ).toBeGreaterThan( 0 );
     const firstModel = Object.values( fixture )[0];
@@ -37,10 +42,7 @@ describe( 'fetchModelsPricing', () => {
   } );
 
   it( 'includes main providers from fixture (openai, anthropic, google, nvidia, perplexity)', async () => {
-    vi.stubGlobal( 'fetch', vi.fn().mockResolvedValue( {
-      ok: true,
-      json: () => Promise.resolve( fixture )
-    } ) );
+    stubFetch( okResponse( fixture ) );
 
     const result = await fetchModelsPricing();
 
@@ -55,47 +57,35 @@ describe( 'fetchModelsPricing', () => {
 
   it( 'returns null when response is not ok and no cache', async () => {
     const status = 500;
-    const err = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
-    vi.stubGlobal( 'fetch', vi.fn().mockResolvedValue( { ok: false, status } ) );
+    stubFetch( { ok: false, status } );
 
     const result = await fetchModelsPricing();
 
     expect( result ).toBeNull();
-    expect( err ).toHaveBeenCalledWith( errNoCache( status ) );
-    err.mockRestore();
   } );
 
   it( 'returns stale cache when response is not ok but cache exists', async () => {
-    vi.stubGlobal( 'fetch', vi.fn().mockResolvedValue( {
-      ok: true,
-      json: () => Promise.resolve( fixture )
-    } ) );
+    stubFetch( okResponse( fixture ) );
     await fetchModelsPricing();
     cache.expiresAt = 0; // force refetch so we hit the !res.ok path
 
     const status = 404;
-    const warn = vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
-    vi.stubGlobal( 'fetch', vi.fn().mockResolvedValue( { ok: false, status } ) );
+    stubFetch( { ok: false, status } );
 
     const result = await fetchModelsPricing();
 
     expect( result ).toBeInstanceOf( Map );
     expect( result.size ).toBeGreaterThan( 0 );
-    expect( warn ).toHaveBeenCalledWith( warnStaleCache( status ) );
-    warn.mockRestore();
   } );
 
   it( 'returns cached Map when cache is still valid', async () => {
-    vi.stubGlobal( 'fetch', vi.fn().mockResolvedValue( {
-      ok: true,
-      json: () => Promise.resolve( fixture )
-    } ) );
+    const fetchMock = stubFetch( okResponse( fixture ) );
 
     const first = await fetchModelsPricing();
     const second = await fetchModelsPricing();
 
     expect( first ).toBe( second );
-    expect( fetch ).toHaveBeenCalledTimes( 1 );
+    expect( fetchMock ).toHaveBeenCalledTimes( 1 );
   } );
 
   it( 'only stores models that have a cost object', async () => {
@@ -108,10 +98,7 @@ describe( 'fetchModelsPricing', () => {
         }
       }
     };
-    vi.stubGlobal( 'fetch', vi.fn().mockResolvedValue( {
-      ok: true,
-      json: () => Promise.resolve( dataWithMissingCost )
-    } ) );
+    stubFetch( okResponse( dataWithMissingCost ) );
 
     const result = await fetchModelsPricing();
 

--- a/sdk/llm/src/cost/index.js
+++ b/sdk/llm/src/cost/index.js
@@ -1,5 +1,6 @@
 import { fetchModelsPricing } from './fetch_models_pricing.js';
 import { Tracing } from '@outputai/core/sdk/runtime';
+import { Logger } from '@outputai/core';
 
 /**
  * Calculates the cost of an llm call based on the model and usage.
@@ -13,13 +14,13 @@ export const calculateLLMCallCost = async ( { modelId, usage } ) => {
     const models = await fetchModelsPricing();
 
     if ( !models ) {
-      console.warn( 'Failed to fetch models pricing' );
+      Logger.warn( 'Failed to fetch models pricing' );
       return null;
     }
 
     const pricing = models.get( modelId );
     if ( !pricing ) {
-      console.warn( 'Missing cost reference for model' );
+      Logger.warn( 'Missing cost reference for model' );
       return null;
     }
 
@@ -50,7 +51,7 @@ export const calculateLLMCallCost = async ( { modelId, usage } ) => {
 
     return llmUsage;
   } catch ( error ) {
-    console.error( 'Error calculating LLM call costs', error );
+    Logger.error( 'Error calculating LLM call costs', { error: error.message } );
     return null;
   }
 };

--- a/sdk/llm/src/cost/index.js
+++ b/sdk/llm/src/cost/index.js
@@ -14,13 +14,13 @@ export const calculateLLMCallCost = async ( { modelId, usage } ) => {
     const models = await fetchModelsPricing();
 
     if ( !models ) {
-      Logger.warn( 'Failed to fetch models pricing' );
+      Logger.warn( 'Failed to fetch models pricing', { namespace: 'LLM' } );
       return null;
     }
 
     const pricing = models.get( modelId );
     if ( !pricing ) {
-      Logger.warn( 'Missing cost reference for model' );
+      Logger.warn( 'Missing cost reference for model', { namespace: 'LLM' } );
       return null;
     }
 
@@ -51,7 +51,7 @@ export const calculateLLMCallCost = async ( { modelId, usage } ) => {
 
     return llmUsage;
   } catch ( error ) {
-    Logger.error( 'Error calculating LLM call costs', { error: error.message } );
+    Logger.error( 'Error calculating LLM call costs', { error: error.message, namespace: 'LLM' } );
     return null;
   }
 };

--- a/sdk/llm/src/cost/index.spec.js
+++ b/sdk/llm/src/cost/index.spec.js
@@ -61,8 +61,6 @@ const expectLLMUsage = ( result, { modelId, usage, total, tokensUsed } ) => {
 describe( 'calculateLLMCallCost', () => {
   beforeEach( () => {
     vi.clearAllMocks();
-    vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
-    vi.spyOn( console, 'error' ).mockImplementation( () => {} );
   } );
 
   afterEach( () => {
@@ -78,7 +76,6 @@ describe( 'calculateLLMCallCost', () => {
     } );
 
     expect( result ).toBeNull();
-    expect( console.warn ).toHaveBeenCalledWith( 'Failed to fetch models pricing' );
   } );
 
   it( 'returns null when model is missing from cost table', async () => {
@@ -90,7 +87,6 @@ describe( 'calculateLLMCallCost', () => {
     } );
 
     expect( result ).toBeNull();
-    expect( console.warn ).toHaveBeenCalledWith( 'Missing cost reference for model' );
   } );
 
   it( 'calculates input and output usage from model pricing', async () => {
@@ -283,6 +279,5 @@ describe( 'calculateLLMCallCost', () => {
     } );
 
     expect( result ).toBeNull();
-    expect( console.error ).toHaveBeenCalledWith( 'Error calculating LLM call costs', error );
   } );
 } );

--- a/sdk/llm/src/prompt/validations.js
+++ b/sdk/llm/src/prompt/validations.js
@@ -1,5 +1,6 @@
 import { ValidationError, z } from '@outputai/core';
 import { attributesSchema } from './block_options.js';
+import { Logger } from '@outputai/core';
 
 const toolConfigSchema = z.record( z.string(), z.unknown() );
 const toolsConfigSchema = z.record( z.string(), toolConfigSchema );
@@ -70,12 +71,12 @@ const SNAKE_CASE_WARNINGS = {
 function warnSnakeCaseFields( config ) {
   for ( const [ snake, camel ] of Object.entries( SNAKE_CASE_WARNINGS ) ) {
     if ( Object.hasOwn( config, snake ) ) {
-      console.warn( `[output-llm] "${snake}" found in prompt config. Did you mean "${camel}"?` );
+      Logger.warn( `[output-llm] "${snake}" found in prompt config. Did you mean "${camel}"?` );
     }
   }
   const thinking = config.providerOptions?.thinking;
   if ( thinking && Object.hasOwn( thinking, 'budget_tokens' ) ) {
-    console.warn( '[output-llm] "budget_tokens" found in providerOptions.thinking. Did you mean "budgetTokens"?' );
+    Logger.warn( '[output-llm] "budget_tokens" found in providerOptions.thinking. Did you mean "budgetTokens"?' );
   }
 }
 

--- a/sdk/llm/src/prompt/validations.js
+++ b/sdk/llm/src/prompt/validations.js
@@ -1,6 +1,5 @@
-import { ValidationError, z } from '@outputai/core';
+import { Logger, ValidationError, z } from '@outputai/core';
 import { attributesSchema } from './block_options.js';
-import { Logger } from '@outputai/core';
 
 const toolConfigSchema = z.record( z.string(), z.unknown() );
 const toolsConfigSchema = z.record( z.string(), toolConfigSchema );
@@ -71,12 +70,12 @@ const SNAKE_CASE_WARNINGS = {
 function warnSnakeCaseFields( config ) {
   for ( const [ snake, camel ] of Object.entries( SNAKE_CASE_WARNINGS ) ) {
     if ( Object.hasOwn( config, snake ) ) {
-      Logger.warn( `[output-llm] "${snake}" found in prompt config. Did you mean "${camel}"?` );
+      Logger.warn( `[output-llm] "${snake}" found in prompt config. Did you mean "${camel}"?`, { namespace: 'LLM' } );
     }
   }
   const thinking = config.providerOptions?.thinking;
   if ( thinking && Object.hasOwn( thinking, 'budget_tokens' ) ) {
-    Logger.warn( '[output-llm] "budget_tokens" found in providerOptions.thinking. Did you mean "budgetTokens"?' );
+    Logger.warn( '[output-llm] "budget_tokens" found in providerOptions.thinking. Did you mean "budgetTokens"?', { namespace: 'LLM' } );
   }
 }
 

--- a/sdk/llm/src/prompt/validations.spec.js
+++ b/sdk/llm/src/prompt/validations.spec.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { ValidationError } from '@outputai/core';
 import { validatePrompt } from './validations.js';
 
@@ -548,8 +548,6 @@ describe( 'validatePrompt', () => {
   } );
 
   it( 'should pass through budget_tokens in thinking and warn about snake_case', () => {
-    const warnSpy = vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
-
     const promptWithBudgetTokensSnake = {
       name: 'thinking-budget-snake',
       config: {
@@ -571,11 +569,6 @@ describe( 'validatePrompt', () => {
     };
 
     expect( () => validatePrompt( promptWithBudgetTokensSnake ) ).not.toThrow();
-    expect( warnSpy ).toHaveBeenCalledWith(
-      '[output-llm] "budget_tokens" found in providerOptions.thinking. Did you mean "budgetTokens"?'
-    );
-
-    warnSpy.mockRestore();
   } );
 
   it( 'should allow snake_case fields in config via passthrough (no longer strict)', () => {

--- a/test_workflows/src/workflows/logger/steps.ts
+++ b/test_workflows/src/workflows/logger/steps.ts
@@ -15,7 +15,16 @@ export const getWord = step( {
     Logger.verbose( 'Generating a word based on the current date', { date } );
     Logger.debug( 'Generating a word based on the current date', { date } );
     Logger.silly( 'Generating a word based on the current date', { date } );
-    Logger.info( 'drop a reserved word', { message: 'foo' } );
+    Logger.info( 'Inline namespace overwrite', { namespace: 'Inline namespace' } );
+    const l = Logger.createLogger( 'Namespace overwrite' );
+    l.error( 'Generating a word based on the current date', { date } );
+    l.warn( 'Generating a word based on the current date', { date } );
+    l.info( 'Generating a word based on the current date', { date } );
+    l.http( 'Generating a word based on the current date', { date } );
+    l.verbose( 'Generating a word based on the current date', { date } );
+    l.debug( 'Generating a word based on the current date', { date } );
+    l.silly( 'Generating a word based on the current date', { date } );
+    l.info( 'Inline namespace overwrite', { namespace: 'Inline namespace' } );
     const index = Math.floor( date % words.length );
 
     return words[index];


### PR DESCRIPTION
## Summary

- Refactored LLM and HTTP to use new `Logger` from Core module in place of `console.*`.

## Test plan

- [x] Unit tests refactored
- [x] Manually tested
