### PR TITLE
feat(cli): run a workflow with ad-hoc JSON in the dev run pane

### DIFF
--- a/.changeset/out-497-adhoc-json-run.md
+++ b/.changeset/out-497-adhoc-json-run.md
@@ -2,4 +2,4 @@
 "@outputai/cli": patch
 ---
 
-Add a "Run custom JSON" option to the `output dev` run pane. Edit a payload and press ctrl+s to run it as-is without saving, or ctrl+w to save it as a scenario first. Previously every ad-hoc run forced you to name and save a scenario file.
+Add an "Enter input" option to the `output dev` run pane. Edit a payload and press ctrl+r to run it as-is without saving, or ctrl+s to save it as a scenario first. Previously every ad-hoc run forced you to name and save a scenario file.

--- a/.changeset/out-497-adhoc-json-run.md
+++ b/.changeset/out-497-adhoc-json-run.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Add a "Run custom JSON" option to the `output dev` run pane. Edit a payload and press ctrl+s to run it as-is without saving, or ctrl+w to save it as a scenario first. Previously every ad-hoc run forced you to name and save a scenario file.

--- a/sdk/cli/src/views/dev/modals/run_modal.spec.ts
+++ b/sdk/cli/src/views/dev/modals/run_modal.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { buildEntries, validateScenarioName } from './run_modal.js';
+
+describe( 'buildEntries', () => {
+  it( 'lists scenarios then the custom-JSON entry', () => {
+    const entries = buildEntries( [ 'basic', 'edge' ] );
+    expect( entries.map( e => e.label ) ).toEqual( [ 'basic', 'edge', '[Run custom JSON]' ] );
+    expect( entries[0] ).toMatchObject( { kind: 'scenario', scenarioName: 'basic' } );
+    expect( entries.at( -1 ) ).toMatchObject( { kind: 'custom' } );
+  } );
+
+  it( 'offers the custom entry even with no saved scenarios', () => {
+    const entries = buildEntries( [] );
+    expect( entries ).toHaveLength( 1 );
+    expect( entries[0].kind ).toBe( 'custom' );
+  } );
+} );
+
+describe( 'validateScenarioName', () => {
+  it( 'rejects empty or whitespace-only names', () => {
+    expect( validateScenarioName( '', [] ) ).toMatch( /cannot be empty/ );
+    expect( validateScenarioName( '   ', [] ) ).toMatch( /cannot be empty/ );
+  } );
+
+  it( 'rejects names with unsupported characters', () => {
+    expect( validateScenarioName( 'has space', [] ) ).toMatch( /letters, numbers/ );
+    expect( validateScenarioName( 'bad/name', [] ) ).toMatch( /letters, numbers/ );
+  } );
+
+  it( 'rejects names that already exist', () => {
+    expect( validateScenarioName( 'basic', [ 'basic' ] ) ).toMatch( /already exists/ );
+  } );
+
+  it( 'trims before checking for duplicates', () => {
+    expect( validateScenarioName( '  basic  ', [ 'basic' ] ) ).toMatch( /already exists/ );
+  } );
+
+  it( 'accepts a unique name with allowed characters', () => {
+    expect( validateScenarioName( 'edge_case-1', [ 'basic' ] ) ).toBeNull();
+  } );
+} );

--- a/sdk/cli/src/views/dev/modals/run_modal.spec.ts
+++ b/sdk/cli/src/views/dev/modals/run_modal.spec.ts
@@ -4,7 +4,7 @@ import { buildEntries, validateScenarioName } from './run_modal.js';
 describe( 'buildEntries', () => {
   it( 'lists scenarios then the custom-JSON entry', () => {
     const entries = buildEntries( [ 'basic', 'edge' ] );
-    expect( entries.map( e => e.label ) ).toEqual( [ 'basic', 'edge', '[Run custom JSON]' ] );
+    expect( entries.map( e => e.label ) ).toEqual( [ 'basic', 'edge', '[Enter input]' ] );
     expect( entries[0] ).toMatchObject( { kind: 'scenario', scenarioName: 'basic' } );
     expect( entries.at( -1 ) ).toMatchObject( { kind: 'custom' } );
   } );

--- a/sdk/cli/src/views/dev/modals/run_modal.tsx
+++ b/sdk/cli/src/views/dev/modals/run_modal.tsx
@@ -9,7 +9,7 @@ import { readScenario, writeScenario } from '#views/dev/services/scenario_io.js'
 import { JsonEditor } from '#views/dev/utils/json_editor.js';
 import { ModalFrame, type ModalShortcut } from '#views/dev/modals/modal_frame.js';
 
-type Mode = 'select' | 'edit_name' | 'edit_content' | 'submitting' | 'error';
+type Mode = 'select' | 'edit_content' | 'name_for_save' | 'submitting' | 'error';
 
 type EntryKind = 'scenario' | 'custom';
 
@@ -19,17 +19,30 @@ interface Entry {
   scenarioName?: string;
 }
 
-const CUSTOM_SEED: unknown = { '': '' };
 const SCENARIO_NAME_RE = /^[a-zA-Z0-9_-]+$/;
 
-const buildEntries = ( scenarios: string[] ): Entry[] => {
+export const buildEntries = ( scenarios: string[] ): Entry[] => {
   const list: Entry[] = scenarios.map( s => ( {
     kind: 'scenario' as const,
     label: s,
     scenarioName: s
   } ) );
-  list.push( { kind: 'custom', label: '[Create new scenario]' } );
+  list.push( { kind: 'custom', label: '[Run custom JSON]' } );
   return list;
+};
+
+export const validateScenarioName = ( raw: string, existing: string[] ): string | null => {
+  const name = raw.trim();
+  if ( !name ) {
+    return 'Scenario name cannot be empty.';
+  }
+  if ( !SCENARIO_NAME_RE.test( name ) ) {
+    return 'Use letters, numbers, dashes, and underscores only.';
+  }
+  if ( existing.includes( name ) ) {
+    return `A scenario named '${name}' already exists.`;
+  }
+  return null;
 };
 
 const SELECT_SHORTCUTS: ModalShortcut[] = [
@@ -39,9 +52,9 @@ const SELECT_SHORTCUTS: ModalShortcut[] = [
   [ 'esc', 'cancel' ]
 ];
 
-const NAME_SHORTCUTS: ModalShortcut[] = [
-  [ 'enter', 'next' ],
-  [ 'esc', 'back' ]
+const SAVE_SHORTCUTS: ModalShortcut[] = [
+  [ 'enter', 'save & run' ],
+  [ 'esc', 'back to editor' ]
 ];
 
 const ERROR_SHORTCUTS: ModalShortcut[] = [
@@ -67,9 +80,11 @@ export const RunModal: React.FC<{ workflowName: string; workflowPath?: string }>
 
   const [ mode, setMode ] = useState<Mode>( 'select' );
   const [ index, setIndex ] = useState( 0 );
-  const [ editName, setEditName ] = useState( '' );
-  const [ editSeed, setEditSeed ] = useState<unknown>( CUSTOM_SEED );
+  const [ editSeed, setEditSeed ] = useState<unknown>( {} );
   const [ editFrameTitle, setEditFrameTitle ] = useState( '' );
+  const [ defaultSaveName, setDefaultSaveName ] = useState( '' );
+  const [ editName, setEditName ] = useState( '' );
+  const [ pendingValue, setPendingValue ] = useState<unknown>( null );
   const [ nameError, setNameError ] = useState<string | null>( null );
   const [ errorMessage, setErrorMessage ] = useState<string | null>( null );
 
@@ -104,64 +119,56 @@ export const RunModal: React.FC<{ workflowName: string; workflowPath?: string }>
     }
   };
 
+  // Custom + duplicate both open the editor first; saving a scenario is opt-in (ctrl+w).
+  const startCustom = (): void => {
+    setEditSeed( {} );
+    setDefaultSaveName( '' );
+    setEditFrameTitle( 'Run custom JSON' );
+    setMode( 'edit_content' );
+  };
+
   const startDuplicate = async ( scenarioName: string ): Promise<void> => {
     try {
       const sourceContent = await readScenario( workflowName, scenarioName, workflowPath );
-      setEditName( `${scenarioName}_copy` );
       setEditSeed( sourceContent );
+      setDefaultSaveName( `${scenarioName}_copy` );
       setEditFrameTitle( `Duplicate '${scenarioName}'` );
-      setNameError( null );
-      setMode( 'edit_name' );
+      setMode( 'edit_content' );
     } catch ( err ) {
       setErrorMessage( err instanceof Error ? err.message : String( err ) );
       setMode( 'error' );
     }
   };
 
-  const startCustom = (): void => {
-    setEditName( '' );
-    setEditSeed( CUSTOM_SEED );
-    setEditFrameTitle( 'New scenario' );
+  // ctrl+s in the editor: run the payload as-is, nothing written to disk.
+  const runEphemeral = ( value: unknown ): void => {
+    void submit( value, defaultSaveName || 'custom' );
+  };
+
+  // ctrl+w in the editor: keep the payload and ask for a name before saving + running.
+  const beginSave = ( value: unknown ): void => {
+    setPendingValue( value );
+    setEditSeed( value );
+    setEditName( defaultSaveName );
     setNameError( null );
-    setMode( 'edit_name' );
+    setMode( 'name_for_save' );
   };
 
-  const validateName = ( raw: string ): string | null => {
-    const name = raw.trim();
-    if ( !name ) {
-      return 'Scenario name cannot be empty.';
-    }
-    if ( !SCENARIO_NAME_RE.test( name ) ) {
-      return 'Use letters, numbers, dashes, and underscores only.';
-    }
-    if ( scenarios.includes( name ) ) {
-      return `A scenario named '${name}' already exists.`;
-    }
-    return null;
-  };
-
-  const handleEditorSubmit = async ( value: unknown ): Promise<void> => {
-    const name = editName.trim();
-    const writeError = validateName( editName );
-    if ( writeError ) {
-      setNameError( writeError );
-      setMode( 'edit_name' );
+  const confirmSave = async (): Promise<void> => {
+    const validationError = validateScenarioName( editName, scenarios );
+    if ( validationError ) {
+      setNameError( validationError );
       return;
     }
     setMode( 'submitting' );
     try {
-      const writtenPath = await writeScenario( workflowName, name, value, workflowPath );
+      const writtenPath = await writeScenario( workflowName, editName.trim(), pendingValue, workflowPath );
       ui.pushToast( `Saved scenario at ${writtenPath}`, 'info' );
-      await submit( value, name );
+      await submit( pendingValue, editName.trim() );
     } catch ( err ) {
       setErrorMessage( err instanceof Error ? err.message : String( err ) );
       setMode( 'error' );
     }
-  };
-
-  const handleEditorCancel = (): void => {
-    // Bring the user back to the name step so they can adjust it or bail.
-    setMode( 'edit_name' );
   };
 
   useInput( ( input, key ) => {
@@ -198,19 +205,13 @@ export const RunModal: React.FC<{ workflowName: string; workflowPath?: string }>
       }
       return;
     }
-    if ( mode === 'edit_name' ) {
+    if ( mode === 'name_for_save' ) {
       if ( key.escape ) {
-        setMode( 'select' );
+        setMode( 'edit_content' );
         return;
       }
       if ( key.return ) {
-        const err = validateName( editName );
-        if ( err ) {
-          setNameError( err );
-          return;
-        }
-        setNameError( null );
-        setMode( 'edit_content' );
+        void confirmSave();
         return;
       }
       if ( key.backspace || key.delete ) {
@@ -241,20 +242,19 @@ export const RunModal: React.FC<{ workflowName: string; workflowPath?: string }>
       <ModalFrame title={editFrameTitle}>
         <JsonEditor
           seed={editSeed}
-          title={`${editName}.json`}
+          title={defaultSaveName ? `${defaultSaveName}.json` : 'custom input'}
           isActive
-          onSubmit={value => {
-            void handleEditorSubmit( value );
-          }}
-          onCancel={handleEditorCancel}
+          onSubmit={runEphemeral}
+          onSave={beginSave}
+          onCancel={() => setMode( 'select' )}
         />
       </ModalFrame>
     );
   }
 
-  if ( mode === 'edit_name' ) {
+  if ( mode === 'name_for_save' ) {
     return (
-      <ModalFrame title={editFrameTitle} shortcuts={NAME_SHORTCUTS}>
+      <ModalFrame title="Save & run" shortcuts={SAVE_SHORTCUTS}>
         <TextPrompt label="Scenario name:" value={editName} />
         {nameError ? (
           <Box marginTop={1}>
@@ -285,7 +285,7 @@ export const RunModal: React.FC<{ workflowName: string; workflowPath?: string }>
   return (
     <ModalFrame title={`Run ${workflowName}`} shortcuts={SELECT_SHORTCUTS}>
       <Box flexDirection="column" gap={1}>
-        <Text dimColor>{scenarios.length === 0 ? 'No scenarios found. Create a new one:' : 'Select scenarios:'}</Text>
+        <Text dimColor>{scenarios.length === 0 ? 'No saved scenarios. Run with custom JSON:' : 'Select a scenario:'}</Text>
         <Box flexDirection="column">
           {entries.map( ( entry, i ) => (
             <Box key={`${entry.kind}-${entry.scenarioName ?? i}`}>

--- a/sdk/cli/src/views/dev/modals/run_modal.tsx
+++ b/sdk/cli/src/views/dev/modals/run_modal.tsx
@@ -21,13 +21,16 @@ interface Entry {
 
 const SCENARIO_NAME_RE = /^[a-zA-Z0-9_-]+$/;
 
+// Seed for a brand-new input — an empty "": "" pair reads friendlier than a bare {}.
+const CUSTOM_SEED: unknown = { '': '' };
+
 export const buildEntries = ( scenarios: string[] ): Entry[] => {
   const list: Entry[] = scenarios.map( s => ( {
     kind: 'scenario' as const,
     label: s,
     scenarioName: s
   } ) );
-  list.push( { kind: 'custom', label: '[Run custom JSON]' } );
+  list.push( { kind: 'custom', label: '[Enter input]' } );
   return list;
 };
 
@@ -119,11 +122,11 @@ export const RunModal: React.FC<{ workflowName: string; workflowPath?: string }>
     }
   };
 
-  // Custom + duplicate both open the editor first; saving a scenario is opt-in (ctrl+w).
+  // Custom + duplicate both open the editor first; saving a scenario is opt-in (ctrl+s).
   const startCustom = (): void => {
-    setEditSeed( {} );
+    setEditSeed( CUSTOM_SEED );
     setDefaultSaveName( '' );
-    setEditFrameTitle( 'Run custom JSON' );
+    setEditFrameTitle( 'Enter input' );
     setMode( 'edit_content' );
   };
 
@@ -140,12 +143,12 @@ export const RunModal: React.FC<{ workflowName: string; workflowPath?: string }>
     }
   };
 
-  // ctrl+s in the editor: run the payload as-is, nothing written to disk.
+  // ctrl+r in the editor: run the payload as-is, nothing written to disk.
   const runEphemeral = ( value: unknown ): void => {
-    void submit( value, defaultSaveName || 'custom' );
+    void submit( value, defaultSaveName || 'input' );
   };
 
-  // ctrl+w in the editor: keep the payload and ask for a name before saving + running.
+  // ctrl+s in the editor: keep the payload and ask for a name before saving + running.
   const beginSave = ( value: unknown ): void => {
     setPendingValue( value );
     setEditSeed( value );
@@ -242,7 +245,7 @@ export const RunModal: React.FC<{ workflowName: string; workflowPath?: string }>
       <ModalFrame title={editFrameTitle}>
         <JsonEditor
           seed={editSeed}
-          title={defaultSaveName ? `${defaultSaveName}.json` : 'custom input'}
+          title={defaultSaveName ? `${defaultSaveName}.json` : 'input'}
           isActive
           onSubmit={runEphemeral}
           onSave={beginSave}
@@ -285,7 +288,7 @@ export const RunModal: React.FC<{ workflowName: string; workflowPath?: string }>
   return (
     <ModalFrame title={`Run ${workflowName}`} shortcuts={SELECT_SHORTCUTS}>
       <Box flexDirection="column" gap={1}>
-        <Text dimColor>{scenarios.length === 0 ? 'No saved scenarios. Run with custom JSON:' : 'Select a scenario:'}</Text>
+        <Text dimColor>{scenarios.length === 0 ? 'No saved scenarios. Enter input to run:' : 'Select a scenario:'}</Text>
         <Box flexDirection="column">
           {entries.map( ( entry, i ) => (
             <Box key={`${entry.kind}-${entry.scenarioName ?? i}`}>

--- a/sdk/cli/src/views/dev/panels/help_panel.tsx
+++ b/sdk/cli/src/views/dev/panels/help_panel.tsx
@@ -50,7 +50,7 @@ const RunFromCli: React.FC = () => (
     <SubSection title="From the TUI">
       <Text>Open Workflows tab, hover a workflow, press <Text bold>r</Text>.</Text>
       <Text>Pick a saved scenario, or edit JSON with live validation.</Text>
-      <Text>Press <Text bold>ctrl+s</Text> to run as-is, or <Text bold>ctrl+w</Text> to save it as a scenario first.</Text>
+      <Text>Press <Text bold>ctrl+r</Text> to run as-is, or <Text bold>ctrl+s</Text> to save it as a scenario first.</Text>
     </SubSection>
   </Section>
 );

--- a/sdk/cli/src/views/dev/panels/help_panel.tsx
+++ b/sdk/cli/src/views/dev/panels/help_panel.tsx
@@ -49,7 +49,8 @@ const RunFromCli: React.FC = () => (
     </SubSection>
     <SubSection title="From the TUI">
       <Text>Open Workflows tab, hover a workflow, press <Text bold>r</Text>.</Text>
-      <Text>Create a custom input from the TUI using the editor with live JSON validation or select an existing scenario.</Text>
+      <Text>Pick a saved scenario, or edit JSON with live validation.</Text>
+      <Text>Press <Text bold>ctrl+s</Text> to run as-is, or <Text bold>ctrl+w</Text> to save it as a scenario first.</Text>
     </SubSection>
   </Section>
 );

--- a/sdk/cli/src/views/dev/utils/json_editor.spec.ts
+++ b/sdk/cli/src/views/dev/utils/json_editor.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { cursorToPosition, positionToCursor, tryParseJson } from './json_editor.js';
+import { cursorToPosition, initialCursor, positionToCursor, tryParseJson } from './json_editor.js';
 
 describe( 'cursorToPosition', () => {
   it( 'returns line 0 col 0 for an empty buffer', () => {
@@ -66,5 +66,23 @@ describe( 'tryParseJson', () => {
     if ( !result.ok ) {
       expect( result.error.length ).toBeGreaterThan( 0 );
     }
+  } );
+} );
+
+describe( 'initialCursor', () => {
+  it( 'lands inside the first empty "" pair so typing starts there', () => {
+    const buffer = JSON.stringify( { '': '' }, null, 2 ); // {\n  "": ""\n}
+    const cursor = initialCursor( buffer );
+    expect( cursor ).toBe( buffer.indexOf( '""' ) + 1 );
+    expect( buffer[cursor - 1] ).toBe( '"' );
+  } );
+
+  it( 'falls back to the end when there is no empty pair', () => {
+    const buffer = JSON.stringify( { values: [ 1, 2, 3 ] }, null, 2 );
+    expect( initialCursor( buffer ) ).toBe( buffer.length );
+  } );
+
+  it( 'returns 0 for an empty buffer', () => {
+    expect( initialCursor( '' ) ).toBe( 0 );
   } );
 } );

--- a/sdk/cli/src/views/dev/utils/json_editor.tsx
+++ b/sdk/cli/src/views/dev/utils/json_editor.tsx
@@ -32,6 +32,13 @@ export const tryParseJson = ( text: string ): { ok: true } | { ok: false; error:
   }
 };
 
+// Start the cursor inside the first empty "" pair (e.g. the key of a fresh `{ "": "" }`
+// seed) so the user can type immediately; otherwise sit at the end of the buffer.
+export const initialCursor = ( buffer: string ): number => {
+  const emptyPair = buffer.indexOf( '""' );
+  return emptyPair === -1 ? buffer.length : emptyPair + 1;
+};
+
 const VISIBLE_BUFFER = 6;
 
 export const JsonEditor: React.FC<{
@@ -44,7 +51,7 @@ export const JsonEditor: React.FC<{
 }> = ( { seed, title, isActive = true, onSubmit, onSave, onCancel } ) => {
   const initial = JSON.stringify( seed ?? {}, null, 2 );
   const [ buffer, setBuffer ] = useState( initial );
-  const [ cursor, setCursor ] = useState( initial.length );
+  const [ cursor, setCursor ] = useState( () => initialCursor( initial ) );
   const [ status, setStatus ] = useState<{ ok: true } | { ok: false; error: string }>( () => tryParseJson( initial ) );
   const [ submitMessage, setSubmitMessage ] = useState<string | null>( null );
 
@@ -83,11 +90,11 @@ export const JsonEditor: React.FC<{
       onCancel();
       return;
     }
-    if ( key.ctrl && input === 's' ) {
+    if ( key.ctrl && input === 'r' ) {
       commit( onSubmit );
       return;
     }
-    if ( key.ctrl && input === 'w' && onSave ) {
+    if ( key.ctrl && input === 's' && onSave ) {
       commit( onSave );
       return;
     }
@@ -170,9 +177,9 @@ export const JsonEditor: React.FC<{
       )}
 
       <Box marginTop={1} columnGap={2}>
-        <Box columnGap={1}><Text bold>ctrl+s</Text><Text dimColor>run</Text></Box>
+        <Box columnGap={1}><Text bold>ctrl+r</Text><Text dimColor>run</Text></Box>
         {onSave ? (
-          <Box columnGap={1}><Text bold>ctrl+w</Text><Text dimColor>save &amp; run</Text></Box>
+          <Box columnGap={1}><Text bold>ctrl+s</Text><Text dimColor>save &amp; run</Text></Box>
         ) : null}
         <Box columnGap={1}><Text bold>esc</Text><Text dimColor>cancel</Text></Box>
         <Box columnGap={1}><Text bold>↑↓←→</Text><Text dimColor>move</Text></Box>

--- a/sdk/cli/src/views/dev/utils/json_editor.tsx
+++ b/sdk/cli/src/views/dev/utils/json_editor.tsx
@@ -39,8 +39,9 @@ export const JsonEditor: React.FC<{
   title: string;
   isActive?: boolean;
   onSubmit: ( value: unknown ) => void;
+  onSave?: ( value: unknown ) => void;
   onCancel: () => void;
-}> = ( { seed, title, isActive = true, onSubmit, onCancel } ) => {
+}> = ( { seed, title, isActive = true, onSubmit, onSave, onCancel } ) => {
   const initial = JSON.stringify( seed ?? {}, null, 2 );
   const [ buffer, setBuffer ] = useState( initial );
   const [ cursor, setCursor ] = useState( initial.length );
@@ -64,22 +65,30 @@ export const JsonEditor: React.FC<{
     setCursor( c => Math.max( 0, c - 1 ) );
   };
 
+  const commit = ( handler: ( value: unknown ) => void ): void => {
+    const parsed = tryParseJson( buffer );
+    if ( !parsed.ok ) {
+      setSubmitMessage( `Invalid JSON — ${parsed.error}` );
+      return;
+    }
+    try {
+      handler( JSON.parse( buffer ) );
+    } catch ( err ) {
+      setSubmitMessage( err instanceof Error ? err.message : String( err ) );
+    }
+  };
+
   useInput( ( input, key ) => {
     if ( key.escape ) {
       onCancel();
       return;
     }
     if ( key.ctrl && input === 's' ) {
-      const parsed = tryParseJson( buffer );
-      if ( !parsed.ok ) {
-        setSubmitMessage( `Cannot submit — ${parsed.error}` );
-        return;
-      }
-      try {
-        onSubmit( JSON.parse( buffer ) );
-      } catch ( err ) {
-        setSubmitMessage( err instanceof Error ? err.message : String( err ) );
-      }
+      commit( onSubmit );
+      return;
+    }
+    if ( key.ctrl && input === 'w' && onSave ) {
+      commit( onSave );
       return;
     }
     if ( key.return ) {
@@ -161,7 +170,10 @@ export const JsonEditor: React.FC<{
       )}
 
       <Box marginTop={1} columnGap={2}>
-        <Box columnGap={1}><Text bold>ctrl+s</Text><Text dimColor>submit</Text></Box>
+        <Box columnGap={1}><Text bold>ctrl+s</Text><Text dimColor>run</Text></Box>
+        {onSave ? (
+          <Box columnGap={1}><Text bold>ctrl+w</Text><Text dimColor>save &amp; run</Text></Box>
+        ) : null}
         <Box columnGap={1}><Text bold>esc</Text><Text dimColor>cancel</Text></Box>
         <Box columnGap={1}><Text bold>↑↓←→</Text><Text dimColor>move</Text></Box>
         <Box columnGap={1}><Text bold>tab</Text><Text dimColor>indent</Text></Box>


### PR DESCRIPTION
## Problem

In the `output dev` run pane, the only way to run a workflow with a custom payload was `[Create new scenario]` → type a unique name → edit JSON → and on submit it **always** wrote a `scenarios/*.json` file before running. There was no way to fire a one-off payload without persisting it.

(The headless CLI already supports this — `output workflow run|start --input '{...}'` — so the gap was TUI-only.)

## Solution

- **Run pane is editor-first.** `[Enter input]` opens the JSON editor directly — no upfront name step.
- **`ctrl+r` runs the payload as-is** — nothing written to disk (reuses the existing no-write `submit()`).
- **`ctrl+s` saves & runs** — prompts for a name, writes the scenario, then runs.
- **Duplicate (`d`) is editor-first too** — seeds the editor with the source and a `_copy` default name; you only name it if you save.
- The editor opens on a friendly `{ "": "" }` template with the cursor already inside the first quotes.
- `JsonEditor` gained an optional `onSave` and a pure `initialCursor`; `RunModal` extracted pure `buildEntries` / `validateScenarioName` (unit-tested).
- dev TUI Help panel describes the `ctrl+r` / `ctrl+s` split.

## Test plan

- [x] `eslint` clean on the changed files
- [x] `tsc --noEmit -p sdk/cli/tsconfig.json` clean
- [x] `vitest` on `run_modal.spec.ts` + `json_editor.spec.ts` — 23 pass (incl. new `initialCursor` cases); the only suite failures are the known `copy_assets` dist-artifact red herring
- [ ] Manual `./run.sh dev`: `r` → `[Enter input]` → `ctrl+r` runs with **no** file under `scenarios/`; `ctrl+s` → name → saves **and** runs

## Notes for reviewers

- **`ctrl+r` run / `ctrl+s` save & run** — `ctrl+s` reads as "save", so it's the save action; plain keys insert into the JSON buffer, so both actions need a ctrl-chord. (Swapped from the initial `ctrl+s` / `ctrl+w` per review.)
- **Duplicate flow changed order** — the name is requested *after* editing (on save) rather than before. More consistent with editor-first.
- **No Ink render test** — `ink-testing-library` isn't a dependency and the repo unit-tests pure helpers, so I extracted/tested `buildEntries`, `validateScenarioName`, and `initialCursor` instead of driving keystrokes.

Closes OUT-497