### PR TITLE
feat(core): Added activity lifecycle hooks [OUT-486]

### DIFF
--- a/.changeset/humble-mice-agree.md
+++ b/.changeset/humble-mice-agree.md
@@ -1,0 +1,17 @@
+---
+"@outputai/core": patch
+---
+
+Added activity lifecycle hooks: `onActivityStart`, `onActivityEnd`, `onActivityError`.
+
+Payload:
+```ts
+{
+  eventId: string,
+  eventDate: number,
+  workflowDetails: object, // Serialized and simplified Temporal's workflowInfo() return
+  activityInfo: object, // Temporal's activityInfo() return
+  outputActivityKind: string, // Kind of activity: step, evaluator, etc
+  aggregations: object // Total cost, http calls and tokens used in the activity (only present in End/Error events)
+}
+```

--- a/docs/guides/operations/error-hooks.mdx
+++ b/docs/guides/operations/error-hooks.mdx
@@ -41,19 +41,21 @@ Errors are emitted from three origins. Every payload includes `eventId`, `eventD
 
 | Source | When it fires | Fields besides `eventId`, `eventDate`, `source`, and `error` |
 |--------|----------------|----------------------------------------|
-| `activity` | A step or evaluator fails (after retries are exhausted). | `activityInfo`, `workflowDetails`, `outputActivityKind` |
+| `activity` | A step or evaluator fails (after retries are exhausted). | `activityInfo`, `workflowDetails`, `outputActivityKind`, `aggregations` |
 | `workflow` | The workflow function itself throws (e.g. uncaught step error or logic error). | `workflowDetails` |
 | `runtime` | An error outside workflow/activity scope (e.g. in the worker/runtime). | — |
 
 So:
 
-- **Activity** — `eventId`, `eventDate`, `source: 'activity'`, `activityInfo`, `workflowDetails`, `outputActivityKind`, `error`.
+- **Activity** — `eventId`, `eventDate`, `source: 'activity'`, `activityInfo`, `workflowDetails`, `outputActivityKind`, `aggregations`, `error`.
 - **Workflow** — `eventId`, `eventDate`, `source: 'workflow'`, `workflowDetails`, `error` (no activity fields).
 - **Runtime** — `eventId`, `eventDate`, `source: 'runtime'`, and `error` only.
 
 `activityInfo` is Temporal's Activity execution info object; see Temporal's [`activity.Info`](https://typescript.temporal.io/api/interfaces/activity.Info) reference. `workflowDetails` is Output's serializable subset of Temporal's [`workflow.WorkflowInfo`](https://typescript.temporal.io/api/interfaces/workflow.WorkflowInfo), with fields such as `workflowId`, `runId`, `workflowType`, `parent`, and `root`.
 
 `outputActivityKind` identifies the Output activity type. Possible values are `step`, `evaluator`, and `internal_step`.
+
+`aggregations` contains activity-scoped attribute totals collected before the failure, such as `cost.total`, `tokens.total`, provider-specific token buckets, and `httpRequests.total`. It is `null` when no attributes were collected.
 
 `eventId` is a UUID v4 stamped per emit — use it as a stable idempotency key when forwarding errors to external systems (Sentry, PagerDuty, your own incident pipeline). `eventDate` is the millisecond epoch timestamp for when the event was emitted. Use `source` to branch in one handler, or ignore payload fields that are undefined for that source.
 

--- a/docs/guides/packages/core.mdx
+++ b/docs/guides/packages/core.mdx
@@ -107,6 +107,9 @@ Every hook payload includes an **`eventId`** — a UUID v4 stamped per emit — 
 | `onWorkflowStart` | A user workflow execution starts | `eventId`, `eventDate`, `workflowDetails` |
 | `onWorkflowEnd` | A user workflow execution completes successfully | `eventId`, `eventDate`, `workflowDetails` |
 | `onWorkflowError` | A user workflow execution fails | `eventId`, `eventDate`, `workflowDetails`, `error` |
+| `onActivityStart` | A step or evaluator activity starts | `eventId`, `eventDate`, `activityInfo`, `workflowDetails`, `outputActivityKind` |
+| `onActivityEnd` | A step or evaluator activity completes successfully | `eventId`, `eventDate`, `activityInfo`, `workflowDetails`, `outputActivityKind`, `aggregations` |
+| `onActivityError` | A step or evaluator activity fails | `eventId`, `eventDate`, `activityInfo`, `workflowDetails`, `outputActivityKind`, `aggregations`, `error` |
 | `on(eventName, handler)` | Custom events emitted elsewhere in the stack | Your event payload plus `eventId` and `eventDate`. When emitted from an Output activity, the framework also attaches `activityInfo`, `workflowDetails`, and `outputActivityKind`. |
 
 **Context objects on hook payloads**
@@ -114,6 +117,7 @@ Every hook payload includes an **`eventId`** — a UUID v4 stamped per emit — 
 - `activityInfo` is Temporal's Activity execution info object. See Temporal's [`activity.Info`](https://typescript.temporal.io/api/interfaces/activity.Info) reference for all fields.
 - `workflowDetails` is Output's serializable subset of Temporal's [`workflow.WorkflowInfo`](https://typescript.temporal.io/api/interfaces/workflow.WorkflowInfo). It includes `workflowId`, `runId`, `workflowType`, `parent`, `root`, `firstExecutionRunId`, `continuedFromExecutionRunId`, `startTime`, `runStartTime`, and `attempt`.
 - `outputActivityKind` is Output metadata for activity hooks and custom events emitted from activities. Possible values are `step`, `evaluator`, and `internal_step`.
+- `aggregations` contains activity-scoped attribute totals collected while the step or evaluator ran. It is `null` when no attributes were collected.
 
 ```typescript
 type WorkflowDetails = {
@@ -130,13 +134,24 @@ type WorkflowDetails = {
 };
 ```
 
+```typescript
+type Aggregations = {
+  cost: { total: number };
+  tokens: {
+    total: number;
+    [tokenType: string]: number | undefined;
+  };
+  httpRequests: { total: number };
+};
+```
+
 **`onError` payload by `source`**
 
-- **`activity`** — `eventId`, `eventDate`, `source`, `activityInfo`, `workflowDetails`, `outputActivityKind`, `error`
+- **`activity`** — `eventId`, `eventDate`, `source`, `activityInfo`, `workflowDetails`, `outputActivityKind`, `aggregations`, `error`
 - **`workflow`** — `eventId`, `eventDate`, `source`, `workflowDetails`, `error`
 - **`runtime`** — `eventId`, `eventDate`, `source`, `error`
 
-`onWorkflowStart`, `onWorkflowEnd`, and `onWorkflowError` do **not** run for the internal `$catalog` workflow. `onError` can still report failures from any workflow, including catalog, if you need them.
+`onWorkflowStart`, `onWorkflowEnd`, and `onWorkflowError` do **not** run for the internal `$catalog` workflow. `onActivityStart`, `onActivityEnd`, and `onActivityError` do **not** run for internal activities. `onError` can still report failures from any workflow or activity, including internal ones, if you need them.
 
 ## HTTP from Workflows
 

--- a/sdk/core/src/hooks/index.d.ts
+++ b/sdk/core/src/hooks/index.d.ts
@@ -80,6 +80,47 @@ export interface WorkflowDetails {
 }
 
 /**
+ * Attribute totals collected while an activity executes.
+ */
+export interface Aggregations {
+  /** Cost totals collected from HTTP request cost and LLM usage attributes. */
+  cost: {
+    total: number;
+  };
+  /** Token totals collected from LLM usage attributes. */
+  tokens: {
+    [tokenType: string]: number | undefined;
+    total: number;
+  };
+  /** HTTP request count totals. */
+  httpRequests: {
+    total: number;
+  };
+}
+
+/**
+ * Common lifecycle hook payload fields for events associated with a workflow.
+ */
+export interface HookPayloadBase {
+  /** UUID v4 stamped per emit. Stable per-emit idempotency key. */
+  eventId: string;
+  /** Timestamp of the event */
+  eventDate: number;
+  /** Information about the current workflow execution */
+  workflowDetails: WorkflowDetails;
+}
+
+/**
+ * Common hook payload fields for events associated with an activity.
+ */
+export interface ActivityPayloadBase extends HookPayloadBase {
+  /** Temporal's activityInfo(). */
+  activityInfo: Info;
+  /** Output component kind for the activity, e.g. step or evaluator. */
+  outputActivityKind: string;
+}
+
+/**
  * Payload passed to the onError() handler when a workflow, activity or runtime error occurs.
  */
 export interface ErrorHookPayload {
@@ -95,6 +136,8 @@ export interface ErrorHookPayload {
   activityInfo?: Info;
   /** Output component kind for the activity, e.g. step, evaluator, or internal_step. */
   outputActivityKind?: string;
+  /** Attribute totals collected during the activity execution. */
+  aggregations?: Aggregations | null;
   /** The error thrown. */
   error: Error;
 }
@@ -102,37 +145,45 @@ export interface ErrorHookPayload {
 /**
  * Payload passed to the onWorkflowStart() handler when a workflow run begins.
  */
-export interface WorkflowStartHookPayload {
-  /** UUID v4 stamped per emit. Stable per-emit idempotency key. */
-  eventId: string;
-  /** Timestamp of the event */
-  eventDate: number;
-  /** Information about the current workflow execution */
-  workflowDetails: WorkflowDetails;
-}
+export type WorkflowStartHookPayload = HookPayloadBase;
 
 /**
  * Payload passed to the onWorkflowEnd() handler when a workflow run completes successfully.
  */
-export interface WorkflowEndHookPayload {
-  /** UUID v4 stamped per emit. Stable per-emit idempotency key. */
-  eventId: string;
-  /** Timestamp of the event */
-  eventDate: number;
-  /** Information about the current workflow execution */
-  workflowDetails: WorkflowDetails;
-}
+export type WorkflowEndHookPayload = HookPayloadBase;
 
 /**
  * Payload passed to the onWorkflowError() handler when a workflow run fails.
  */
-export interface WorkflowErrorHookPayload {
-  /** UUID v4 stamped per emit. Stable per-emit idempotency key. */
-  eventId: string;
-  /** Timestamp of the event */
-  eventDate: number;
-  /** Information about the current workflow execution */
-  workflowDetails: WorkflowDetails;
+export interface WorkflowErrorHookPayload extends HookPayloadBase {
+  /** The error thrown. */
+  error: Error;
+}
+
+/**
+ * Common activity lifecycle hook payload fields.
+ */
+export type ActivityHookPayload = ActivityPayloadBase;
+
+/**
+ * Payload passed to the onActivityStart() handler when an activity starts.
+ */
+export type ActivityStartHookPayload = ActivityHookPayload;
+
+/**
+ * Payload passed to the onActivityEnd() handler when an activity completes successfully.
+ */
+export interface ActivityEndHookPayload extends ActivityHookPayload {
+  /** Attribute totals collected during the activity execution. */
+  aggregations: Aggregations | null;
+}
+
+/**
+ * Payload passed to the onActivityError() handler when an activity fails.
+ */
+export interface ActivityErrorHookPayload extends ActivityHookPayload {
+  /** Attribute totals collected during the activity execution. */
+  aggregations: Aggregations | null;
   /** The error thrown. */
   error: Error;
 }
@@ -180,15 +231,36 @@ export declare function onWorkflowEnd( handler: ( payload: WorkflowEndHookPayloa
 export declare function onWorkflowError( handler: ( payload: WorkflowErrorHookPayload ) => void ): void;
 
 /**
+ * Register a handler to be invoked when an activity starts.
+ *
+ * Excludes internal activities.
+ *
+ * @param handler - Function called with the activity start payload.
+ */
+export declare function onActivityStart( handler: ( payload: ActivityStartHookPayload ) => void ): void;
+
+/**
+ * Register a handler to be invoked when an activity completes successfully.
+ *
+ * Excludes internal activities.
+ *
+ * @param handler - Function called with the activity end payload.
+ */
+export declare function onActivityEnd( handler: ( payload: ActivityEndHookPayload ) => void ): void;
+
+/**
+ * Register a handler to be invoked when an activity fails.
+ *
+ * Excludes internal activities.
+ *
+ * @param handler - Function called with the activity error payload.
+ */
+export declare function onActivityError( handler: ( payload: ActivityErrorHookPayload ) => void ): void;
+
+/**
  * Framework-managed envelope added to payloads passed to on() handlers.
  */
-export interface OnHookEnvelope {
-  /** UUID v4 stamped per emit. Stable per-emit idempotency key. */
-  eventId: string;
-  /** Timestamp of the event */
-  eventDate: number;
-  /** Information about the current workflow execution */
-  workflowDetails: WorkflowDetails;
+export interface OnHookEnvelope extends HookPayloadBase {
   /** Temporal's activityInfo(). */
   activityInfo: Info;
   /** Output component kind for the activity, e.g. step, evaluator, or internal_step. */

--- a/sdk/core/src/hooks/index.js
+++ b/sdk/core/src/hooks/index.js
@@ -1,5 +1,5 @@
 import { messageBus } from '#bus';
-import { BusEventType, WORKFLOW_CATALOG } from '#consts';
+import { BusEventType, ComponentType, WORKFLOW_CATALOG } from '#consts';
 import { createChildLogger } from '#logger';
 
 const log = createChildLogger( 'Hooks' );
@@ -47,6 +47,21 @@ export const onWorkflowEnd = handler => messageBus.on( BusEventType.WORKFLOW_END
 /** Listen to workflow error events, excludes catalog workflow */
 export const onWorkflowError = handler => messageBus.on( BusEventType.WORKFLOW_ERROR, ( { workflowDetails, ...eventFields } ) =>
   shouldEmitWorkflowEvent( workflowDetails ) ? safeInvoke( handler, { workflowDetails, ...eventFields }, 'onWorkflowError' ) : null );
+
+/** Internal activities do not trigger hooks */
+const shouldEmitActivityEvent = outputActivityKind => outputActivityKind !== ComponentType.INTERNAL_STEP;
+
+/** Listen to workflow start events, excludes catalog workflow */
+export const onActivityStart = handler => messageBus.on( BusEventType.ACTIVITY_START, ( { outputActivityKind, ...eventFields } ) =>
+  shouldEmitActivityEvent( outputActivityKind ) ? safeInvoke( handler, { outputActivityKind, ...eventFields }, 'onActivityStart' ) : null );
+
+/** Listen to workflow end events, excludes catalog workflow */
+export const onActivityEnd = handler => messageBus.on( BusEventType.ACTIVITY_END, ( { outputActivityKind, ...eventFields } ) =>
+  shouldEmitActivityEvent( outputActivityKind ) ? safeInvoke( handler, { outputActivityKind, ...eventFields }, 'onActivityEnd' ) : null );
+
+/** Listen to workflow error events, excludes catalog workflow */
+export const onActivityError = handler => messageBus.on( BusEventType.ACTIVITY_ERROR, ( { outputActivityKind, ...eventFields } ) =>
+  shouldEmitActivityEvent( outputActivityKind ) ? safeInvoke( handler, { outputActivityKind, ...eventFields }, 'onActivityError' ) : null );
 
 /** Generic listener for events emitted elsewhere (outside core) */
 export const on = ( eventName, handler ) => messageBus.on( `external:${eventName}`, payload =>

--- a/sdk/core/src/hooks/index.spec.js
+++ b/sdk/core/src/hooks/index.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { BusEventType, WORKFLOW_CATALOG } from '#consts';
+import { BusEventType, ComponentType, WORKFLOW_CATALOG } from '#consts';
 
 const logErrorMock = vi.hoisted( () => vi.fn() );
 const createChildLoggerMock = vi.hoisted( () =>
@@ -18,6 +18,9 @@ vi.mock( '#bus', () => ( { messageBus: messageBusMock } ) );
 
 import {
   on,
+  onActivityEnd,
+  onActivityError,
+  onActivityStart,
   onBeforeWorkerStart,
   onError,
   onWorkflowEnd,
@@ -48,6 +51,12 @@ const activityInfo = {
 };
 
 const eventDate = 1710000001234;
+
+const aggregations = {
+  cost: { total: 0 },
+  tokens: { total: 0 },
+  httpRequests: { total: 1 }
+};
 
 describe( 'hooks/index', () => {
   beforeEach( () => {
@@ -194,6 +203,51 @@ describe( 'hooks/index', () => {
       } ) );
       expect( handler ).toHaveBeenCalledWith( {
         eventId: 'evt-err-1', eventDate, workflowDetails, error: err, extra: 'passthrough'
+      } );
+    } );
+  } );
+
+  describe( 'activity lifecycle hooks', () => {
+    const cases = [
+      [ 'onActivityStart', onActivityStart, BusEventType.ACTIVITY_START, undefined ],
+      [ 'onActivityEnd', onActivityEnd, BusEventType.ACTIVITY_END, { aggregations } ],
+      [ 'onActivityError', onActivityError, BusEventType.ACTIVITY_ERROR, { error: new Error( 'activity failed' ) } ]
+    ];
+
+    it.each( cases )( '%s skips internal activities and forwards bus fields', async ( _name, registerHook, eventType, extraFields = {} ) => {
+      const handler = vi.fn().mockResolvedValue( undefined );
+      registerHook( handler );
+
+      expect( messageBusMock.on ).toHaveBeenCalledWith( eventType, expect.any( Function ) );
+
+      await Promise.resolve( onHandlers[eventType]( {
+        eventId: 'evt-ignored',
+        eventDate,
+        activityInfo,
+        workflowDetails,
+        outputActivityKind: ComponentType.INTERNAL_STEP,
+        ...extraFields
+      } ) );
+      expect( handler ).not.toHaveBeenCalled();
+
+      await Promise.resolve( onHandlers[eventType]( {
+        eventId: 'evt-activity-1',
+        eventDate,
+        activityInfo,
+        workflowDetails,
+        outputActivityKind: ComponentType.STEP,
+        extra: 'passthrough',
+        ...extraFields
+      } ) );
+
+      expect( handler ).toHaveBeenCalledWith( {
+        eventId: 'evt-activity-1',
+        eventDate,
+        activityInfo,
+        workflowDetails,
+        outputActivityKind: ComponentType.STEP,
+        extra: 'passthrough',
+        ...extraFields
       } );
     } );
   } );

--- a/sdk/core/src/worker/interceptors/activity.js
+++ b/sdk/core/src/worker/interceptors/activity.js
@@ -77,20 +77,17 @@ export class ActivityExecutionInterceptor {
 
       const output = await Storage.runWithContext( async _ => next( input ), storageContext );
 
-      messageBus.emit( BusEventType.ACTIVITY_END, { activityInfo, workflowDetails, outputActivityKind } );
+      const aggregations = state.attributes.length > 0 ? aggregateAttributes( state.attributes ) : null;
+
+      messageBus.emit( BusEventType.ACTIVITY_END, { activityInfo, aggregations, workflowDetails, outputActivityKind } );
       Tracing.addEventEnd( { id: activityId, details: output, traceInfo } );
 
-      return {
-        [ACTIVITY_WRAPPER_VERSION_FIELD]: 1,
-        output,
-        aggregations: state.attributes.length > 0 ? aggregateAttributes( state.attributes ) : null
-      };
+      return { [ACTIVITY_WRAPPER_VERSION_FIELD]: 1, output, aggregations };
 
     } catch ( error ) {
-      messageBus.emit( BusEventType.ACTIVITY_ERROR, { activityInfo, workflowDetails, outputActivityKind, error } );
-      Tracing.addEventError( { id: activityId, details: error, traceInfo } );
-
       const aggregations = state.attributes.length > 0 ? aggregateAttributes( state.attributes ) : null;
+      messageBus.emit( BusEventType.ACTIVITY_ERROR, { activityInfo, aggregations, workflowDetails, outputActivityKind, error } );
+      Tracing.addEventError( { id: activityId, details: error, traceInfo } );
 
       throw aggregations ? buildApplicationFailureWithDetails( error, { aggregations } ) : error;
     } finally {

--- a/sdk/core/src/worker/interceptors/activity.spec.js
+++ b/sdk/core/src/worker/interceptors/activity.spec.js
@@ -100,6 +100,12 @@ const httpRequestAttribute = {
   requestId: 'req-1'
 };
 
+const httpRequestAggregations = {
+  cost: { total: 0 },
+  tokens: { total: 0 },
+  httpRequests: { total: 1 }
+};
+
 describe( 'ActivityExecutionInterceptor', () => {
   beforeEach( () => {
     vi.clearAllMocks();
@@ -136,7 +142,7 @@ describe( 'ActivityExecutionInterceptor', () => {
     );
     expect( messageBusEmitMock ).toHaveBeenCalledWith(
       BusEventType.ACTIVITY_END,
-      { activityInfo: activityInfoMock, workflowDetails: workflowDetailsMock, outputActivityKind: 'step' }
+      { activityInfo: activityInfoMock, aggregations: null, workflowDetails: workflowDetailsMock, outputActivityKind: 'step' }
     );
     expect( addEventStartMock ).toHaveBeenCalledWith( {
       id: 'act-1',
@@ -189,14 +195,16 @@ describe( 'ActivityExecutionInterceptor', () => {
 
     await expect( interceptor.execute( makeInput(), next ) ).resolves.toEqual( {
       output: { result: 'ok' },
-      aggregations: {
-        cost: { total: 0 },
-        tokens: { total: 0 },
-        httpRequests: { total: 1 }
-      },
+      aggregations: httpRequestAggregations,
       [ACTIVITY_WRAPPER_VERSION_FIELD]: 1
     } );
 
+    expect( messageBusEmitMock ).toHaveBeenCalledWith( BusEventType.ACTIVITY_END, {
+      activityInfo: activityInfoMock,
+      aggregations: httpRequestAggregations,
+      workflowDetails: workflowDetailsMock,
+      outputActivityKind: 'step'
+    } );
   } );
 
   it( 'stores collected aggregations in ApplicationFailure details after failed execution', async () => {
@@ -215,15 +223,17 @@ describe( 'ActivityExecutionInterceptor', () => {
       message: 'step failed',
       type: 'Error',
       details: [ {
-        aggregations: {
-          cost: { total: 0 },
-          tokens: { total: 0 },
-          httpRequests: { total: 1 }
-        }
+        aggregations: httpRequestAggregations
       } ],
       cause: error
     } );
-    expect( messageBusEmitMock ).toHaveBeenCalledWith( BusEventType.ACTIVITY_ERROR, expect.objectContaining( { error } ) );
+    expect( messageBusEmitMock ).toHaveBeenCalledWith( BusEventType.ACTIVITY_ERROR, {
+      activityInfo: activityInfoMock,
+      aggregations: httpRequestAggregations,
+      workflowDetails: workflowDetailsMock,
+      outputActivityKind: 'step',
+      error
+    } );
     expect( addEventErrorMock ).toHaveBeenCalledOnce();
     expect( addEventEndMock ).not.toHaveBeenCalled();
   } );
@@ -243,13 +253,7 @@ describe( 'ActivityExecutionInterceptor', () => {
 
     expect( thrown.details ).toEqual( [
       { domain: { reason: 'bad-input' } },
-      {
-        aggregations: {
-          cost: { total: 0 },
-          tokens: { total: 0 },
-          httpRequests: { total: 1 }
-        }
-      }
+      { aggregations: httpRequestAggregations }
     ] );
   } );
 
@@ -300,13 +304,7 @@ describe( 'ActivityExecutionInterceptor', () => {
       nonRetryable: true,
       details: [
         { domain: { reason: 'bad-input' } },
-        {
-          aggregations: {
-            cost: { total: 0 },
-            tokens: { total: 0 },
-            httpRequests: { total: 1 }
-          }
-        }
+        { aggregations: httpRequestAggregations }
       ]
     } );
   } );
@@ -324,6 +322,7 @@ describe( 'ActivityExecutionInterceptor', () => {
     expect( messageBusEmitMock ).toHaveBeenCalledWith( BusEventType.ACTIVITY_START, expect.any( Object ) );
     expect( messageBusEmitMock ).toHaveBeenCalledWith( BusEventType.ACTIVITY_ERROR, {
       activityInfo: activityInfoMock,
+      aggregations: null,
       workflowDetails: workflowDetailsMock,
       outputActivityKind: 'step',
       error

--- a/test_workflows/src/hooks.js
+++ b/test_workflows/src/hooks.js
@@ -1,4 +1,14 @@
-// import { onError, on, onBeforeWorkerStart, onWorkflowStart, onWorkflowEnd, onWorkflowError } from '@outputai/core/hooks';
+// import {
+//   onError,
+//   on,
+//   onBeforeWorkerStart,
+//   onWorkflowStart,
+//   onWorkflowEnd,
+//   onWorkflowError,
+//   onActivityStart,
+//   onActivityEnd,
+//   onActivityError
+// } from '@outputai/core/hooks';
 
 // const colorize = message => `\x1b[45;30m[HOOK]\x1b[0;35;1m ${message}\x1b[0m`;
 
@@ -17,3 +27,6 @@
 // onWorkflowStart( payload => console.log( colorize( 'onWorkflowStart()' ), payload ) );
 // onWorkflowEnd( payload => console.log( colorize( 'onWorkflowEnd()' ), payload ) );
 // onWorkflowError( payload => console.log( colorize( 'onWorkflowError()' ), payload ) );
+
+// onActivityStart( ( { activityInfo, outputActivityKind } ) => console.log( colorize( 'onActivityStart()' ), { activityInfo, outputActivityKind } ) );
+// onActivityEnd( ( { aggregations } ) => console.log( colorize( 'onActivityStart()' ), { aggregations } ) );


### PR DESCRIPTION
## Summary

Added activity lifecycle hooks: `onActivityStart`, `onActivityEnd`, `onActivityError`.

Payload:
```ts
{
  eventId: string,
  eventDate: number,
  workflowDetails: object, // Serialized and simplified Temporal's workflowInfo() return
  activityInfo: object, // Temporal's activityInfo() return
  outputActivityKind: string, // Kind of activity: step, evaluator, etc
  aggregations: object // Total cost, http calls and tokens used in the activity (only present in End/Error events)
}

## Test plan

- [x] Added unit tests
- [x] Tested via test workflows
- [x] Added docs
