### PR TITLE
feat: add API endpoint and CLI command to retrieve workflow input

### DIFF
--- a/.changeset/many-paths-fry.md
+++ b/.changeset/many-paths-fry.md
@@ -1,0 +1,6 @@
+---
+"@outputai/cli": minor
+"output-api": minor
+---
+
+Add API endpoint and CLI command to get input from a workflow run

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -405,6 +405,22 @@
           }
         }
       },
+      "WorkflowInputResponse": {
+        "type": "object",
+        "properties": {
+          "workflowId": {
+            "type": "string",
+            "description": "The workflow execution id"
+          },
+          "runId": {
+            "type": "string",
+            "description": "The specific run id the input was read from"
+          },
+          "input": {
+            "description": "The original input passed to the workflow, null if unavailable"
+          }
+        }
+      },
       "StopWorkflowResponse": {
         "type": "object",
         "properties": {
@@ -1192,6 +1208,87 @@
           },
           "424": {
             "$ref": "#/components/responses/FailedDependency"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/workflow/{id}/input": {
+      "get": {
+        "summary": "Return the original input of a workflow (latest run)",
+        "description": "Returns the original input passed to the latest run of the given workflow. Works for workflows in any state, including running. To pin a specific run, use `/workflow/{id}/runs/{rid}/input`.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The id of workflow to retrieve the input"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The workflow input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowInputResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/workflow/{id}/runs/{rid}/input": {
+      "get": {
+        "summary": "Return the original input of a specific workflow run",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "rid",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "The specific run id to target"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The workflow input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowInputResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -407,6 +407,11 @@
       },
       "WorkflowInputResponse": {
         "type": "object",
+        "required": [
+          "workflowId",
+          "runId",
+          "input"
+        ],
         "properties": {
           "workflowId": {
             "type": "string",
@@ -417,7 +422,7 @@
             "description": "The specific run id the input was read from"
           },
           "input": {
-            "description": "The original input passed to the workflow, null if unavailable"
+            "description": "The first input argument the workflow was started with, null if unavailable"
           }
         }
       },
@@ -1260,7 +1265,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "The id of workflow to retrieve the input"
           },
           {
             "in": "path",

--- a/api/src/clients/errors.js
+++ b/api/src/clients/errors.js
@@ -15,6 +15,15 @@ export const workflowNotFoundError = ( workflowId, runId ) => Object.assign(
   { workflowId }
 );
 
+/** Thrown when Temporal reports no runId for a workflow that should have one (describe result). */
+export class WorkflowMissingRunIdError extends Error {
+  /** @param {string} workflowId */
+  constructor( workflowId ) {
+    super( `Temporal did not report a runId for workflow "${workflowId}"` );
+    this.workflowId = workflowId;
+  }
+}
+
 /** Thrown when streamHistory does not yield workflow metadata as its first chunk. */
 export class WorkflowStreamProtocolError extends Error {
   /** @param {string} workflowId */

--- a/api/src/clients/temporal/workflow/fetch_history_page.js
+++ b/api/src/clients/temporal/workflow/fetch_history_page.js
@@ -1,0 +1,48 @@
+import { temporal as temporalConfig } from '#configs';
+import { logger } from '#logger';
+import { workflowNotFoundError } from '../../errors.js';
+import { GrpcStatus } from '../types.js';
+
+const { namespace } = temporalConfig;
+
+/**
+ * Fetch one page of a workflow's history, translating gRPC NOT_FOUND (and, when a mapper is
+ * supplied, INVALID_ARGUMENT for a malformed/expired runId) into a run-aware error, and warning
+ * once when Temporal returns no history field. Shared by get_input and get_result so the
+ * not-found + missing-history handling lives in one place instead of being copy-pasted.
+ *
+ * @param {object} connection - Temporal connection exposing `workflowService`
+ * @param {string} workflowId
+ * @param {string} runId - Resolved run id to fetch
+ * @param {object} [options]
+ * @param {number} [options.maximumPageSize]
+ * @param {Buffer} [options.nextPageToken]
+ * @param {(error: object) => Error} [options.mapInvalidArgument] - Maps a gRPC INVALID_ARGUMENT
+ *   (e.g. a malformed/expired runId) to a domain error; when omitted the raw error propagates.
+ * @returns {Promise<object>} The raw getWorkflowExecutionHistory response
+ */
+export const fetchHistoryPage = async (
+  connection, workflowId, runId,
+  { maximumPageSize, nextPageToken, mapInvalidArgument } = {}
+) => {
+  const response = await connection.workflowService.getWorkflowExecutionHistory( {
+    namespace,
+    execution: { workflowId, runId },
+    maximumPageSize,
+    nextPageToken
+  } ).catch( error => {
+    if ( error?.code === GrpcStatus.NOT_FOUND ) {
+      throw workflowNotFoundError( workflowId, runId );
+    }
+    if ( mapInvalidArgument && error?.code === GrpcStatus.INVALID_ARGUMENT ) {
+      throw mapInvalidArgument( error );
+    }
+    throw error;
+  } );
+
+  if ( !response.history ) {
+    logger.warn( 'Temporal getWorkflowExecutionHistory returned no history field', { workflowId, runId } );
+  }
+
+  return response;
+};

--- a/api/src/clients/temporal/workflow/fetch_history_page.js
+++ b/api/src/clients/temporal/workflow/fetch_history_page.js
@@ -31,10 +31,13 @@ export const fetchHistoryPage = async (
     maximumPageSize,
     nextPageToken
   } ).catch( error => {
-    if ( error?.code === GrpcStatus.NOT_FOUND ) {
+    if ( !error ) {
+      throw new Error( 'Temporal getWorkflowExecutionHistory rejected with no error' );
+    }
+    if ( error.code === GrpcStatus.NOT_FOUND ) {
       throw workflowNotFoundError( workflowId, runId );
     }
-    if ( mapInvalidArgument && error?.code === GrpcStatus.INVALID_ARGUMENT ) {
+    if ( mapInvalidArgument && error.code === GrpcStatus.INVALID_ARGUMENT ) {
       throw mapInvalidArgument( error );
     }
     throw error;

--- a/api/src/clients/temporal/workflow/fetch_history_page.spec.js
+++ b/api/src/clients/temporal/workflow/fetch_history_page.spec.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockWorkflowNotFoundError, mockLoggerWarn } = vi.hoisted( () => ( {
+  mockWorkflowNotFoundError: vi.fn( ( workflowId, runId ) =>
+    Object.assign( new Error( `not found: ${workflowId}/${runId}` ), { name: 'WorkflowNotFoundError' } ) ),
+  mockLoggerWarn: vi.fn()
+} ) );
+
+vi.mock( '#configs', () => ( {
+  temporal: { namespace: 'default' }
+} ) );
+
+vi.mock( '#logger', () => ( {
+  logger: { warn: mockLoggerWarn }
+} ) );
+
+vi.mock( '../../errors.js', () => ( {
+  workflowNotFoundError: mockWorkflowNotFoundError
+} ) );
+
+const { fetchHistoryPage } = await import( './fetch_history_page.js' );
+
+const makeConnection = getWorkflowExecutionHistory => ( { workflowService: { getWorkflowExecutionHistory } } );
+
+describe( 'fetchHistoryPage', () => {
+  beforeEach( () => vi.clearAllMocks() );
+
+  it( 'requests the page with namespace, execution, and paging options', async () => {
+    const getWorkflowExecutionHistory = vi.fn().mockResolvedValue( { history: { events: [] } } );
+
+    await fetchHistoryPage( makeConnection( getWorkflowExecutionHistory ), 'wf-1', 'run-1', {
+      maximumPageSize: 10,
+      nextPageToken: Buffer.from( 'token' )
+    } );
+
+    expect( getWorkflowExecutionHistory ).toHaveBeenCalledWith( {
+      namespace: 'default',
+      execution: { workflowId: 'wf-1', runId: 'run-1' },
+      maximumPageSize: 10,
+      nextPageToken: Buffer.from( 'token' )
+    } );
+  } );
+
+  it( 'returns the raw response on success', async () => {
+    const response = { history: { events: [ { eventId: 1 } ] }, nextPageToken: Buffer.from( 'next' ) };
+    const getWorkflowExecutionHistory = vi.fn().mockResolvedValue( response );
+
+    const result = await fetchHistoryPage( makeConnection( getWorkflowExecutionHistory ), 'wf-1', 'run-1' );
+
+    expect( result ).toBe( response );
+  } );
+
+  it( 'maps NOT_FOUND to a run-aware WorkflowNotFoundError', async () => {
+    const notFound = Object.assign( new Error( 'missing' ), { code: 5 } );
+    const getWorkflowExecutionHistory = vi.fn().mockRejectedValue( notFound );
+
+    await expect( fetchHistoryPage( makeConnection( getWorkflowExecutionHistory ), 'wf-1', 'run-1' ) )
+      .rejects.toMatchObject( { name: 'WorkflowNotFoundError' } );
+    expect( mockWorkflowNotFoundError ).toHaveBeenCalledWith( 'wf-1', 'run-1' );
+  } );
+
+  it( 'maps INVALID_ARGUMENT through the caller-supplied mapper when provided', async () => {
+    const invalidArgument = Object.assign( new Error( 'invalid' ), { code: 3 } );
+    const getWorkflowExecutionHistory = vi.fn().mockRejectedValue( invalidArgument );
+    const mapInvalidArgument = vi.fn().mockReturnValue( new Error( 'mapped' ) );
+
+    await expect( fetchHistoryPage( makeConnection( getWorkflowExecutionHistory ), 'wf-1', 'run-1', { mapInvalidArgument } ) )
+      .rejects.toThrow( 'mapped' );
+    expect( mapInvalidArgument ).toHaveBeenCalledWith( invalidArgument );
+  } );
+
+  it( 'propagates INVALID_ARGUMENT unmapped when no mapper is supplied', async () => {
+    const invalidArgument = Object.assign( new Error( 'invalid' ), { code: 3 } );
+    const getWorkflowExecutionHistory = vi.fn().mockRejectedValue( invalidArgument );
+
+    await expect( fetchHistoryPage( makeConnection( getWorkflowExecutionHistory ), 'wf-1', 'run-1' ) )
+      .rejects.toBe( invalidArgument );
+  } );
+
+  it( 'propagates other errors unchanged', async () => {
+    const unavailable = Object.assign( new Error( 'unavailable' ), { code: 14 } );
+    const getWorkflowExecutionHistory = vi.fn().mockRejectedValue( unavailable );
+
+    await expect( fetchHistoryPage( makeConnection( getWorkflowExecutionHistory ), 'wf-1', 'run-1' ) )
+      .rejects.toBe( unavailable );
+  } );
+
+  it( 'throws a clear error if the RPC rejects without an error object', async () => {
+    const getWorkflowExecutionHistory = vi.fn().mockRejectedValue( null );
+
+    await expect( fetchHistoryPage( makeConnection( getWorkflowExecutionHistory ), 'wf-1', 'run-1' ) )
+      .rejects.toThrow( 'Temporal getWorkflowExecutionHistory rejected with no error' );
+  } );
+
+  it( 'warns once when Temporal returns no history field', async () => {
+    const getWorkflowExecutionHistory = vi.fn().mockResolvedValue( { nextPageToken: Buffer.from( 'would-loop' ) } );
+
+    await fetchHistoryPage( makeConnection( getWorkflowExecutionHistory ), 'wf-1', 'run-1' );
+
+    expect( mockLoggerWarn ).toHaveBeenCalledWith(
+      'Temporal getWorkflowExecutionHistory returned no history field',
+      { workflowId: 'wf-1', runId: 'run-1' }
+    );
+  } );
+
+  it( 'does not warn when the history field is present', async () => {
+    const getWorkflowExecutionHistory = vi.fn().mockResolvedValue( { history: {} } );
+
+    await fetchHistoryPage( makeConnection( getWorkflowExecutionHistory ), 'wf-1', 'run-1' );
+
+    expect( mockLoggerWarn ).not.toHaveBeenCalled();
+  } );
+} );

--- a/api/src/clients/temporal/workflow/get_history.js
+++ b/api/src/clients/temporal/workflow/get_history.js
@@ -1,11 +1,7 @@
-import { temporal as temporalConfig } from '#configs';
-import { logger } from '#logger';
-import { workflowNotFoundError, InvalidPageTokenError } from '../../errors.js';
+import { InvalidPageTokenError } from '../../errors.js';
 import { decodeEventPayloads, serializeEvent } from '../../event_serialization.js';
-import { GrpcStatus } from '../types.js';
 import { describeWorkflow } from './describe_workflow.js';
-
-const { namespace } = temporalConfig;
+import { fetchHistoryPage } from './fetch_history_page.js';
 
 /**
  * Serialized info about a workflow execution
@@ -51,27 +47,11 @@ export const getHistory = async ( { client, connection }, workflowId, options = 
     return { workflow, resolvedRunId: workflow.runId };
   } )() : { workflow: null, resolvedRunId: runId };
 
-  const response = await connection.workflowService.getWorkflowExecutionHistory( {
-    namespace,
-    execution: { workflowId, runId: metadata.resolvedRunId },
+  const response = await fetchHistoryPage( connection, workflowId, metadata.resolvedRunId, {
     maximumPageSize: Math.min( pageSize, 50 ),
-    nextPageToken: pageToken ? Buffer.from( pageToken, 'base64' ) : undefined
-  } ).catch( error => {
-    if ( !error ) {
-      throw new Error( 'Temporal getWorkflowExecutionHistory rejected with no error' );
-    }
-    if ( error.code === GrpcStatus.NOT_FOUND ) {
-      throw workflowNotFoundError( workflowId, runId );
-    }
-    if ( error.code === GrpcStatus.INVALID_ARGUMENT ) {
-      throw new InvalidPageTokenError();
-    }
-    throw error;
+    nextPageToken: pageToken ? Buffer.from( pageToken, 'base64' ) : undefined,
+    mapInvalidArgument: () => new InvalidPageTokenError()
   } );
-
-  if ( !response.history ) {
-    logger.warn( 'Temporal getWorkflowExecutionHistory returned no history field', { workflowId, runId: metadata.resolvedRunId } );
-  }
 
   const events = ( response.history?.events || [] ).map( event => {
     const decoded = includePayloads ? decodeEventPayloads( event ) : event;

--- a/api/src/clients/temporal/workflow/get_history.spec.js
+++ b/api/src/clients/temporal/workflow/get_history.spec.js
@@ -1,15 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { InvalidPageTokenError, WorkflowNotFoundError } from '../../errors.js';
+import { InvalidPageTokenError } from '../../errors.js';
 
-const { mockFormatStatus, mockLoggerWarn, mockDecodeEventPayloads, mockSerializeEvent } = vi.hoisted( () => ( {
+const {
+  mockFormatStatus, mockLoggerWarn, mockDecodeEventPayloads, mockSerializeEvent,
+  mockDescribeWorkflow, mockFetchHistoryPage
+} = vi.hoisted( () => ( {
   mockFormatStatus: vi.fn(),
   mockLoggerWarn: vi.fn(),
   mockDecodeEventPayloads: vi.fn(),
-  mockSerializeEvent: vi.fn()
-} ) );
-
-vi.mock( '#configs', () => ( {
-  temporal: { namespace: 'default' }
+  mockSerializeEvent: vi.fn(),
+  mockDescribeWorkflow: vi.fn(),
+  mockFetchHistoryPage: vi.fn()
 } ) );
 
 vi.mock( '#logger', () => ( {
@@ -26,45 +27,53 @@ vi.mock( '../types.js', async importOriginal => ( {
   formatStatus: mockFormatStatus
 } ) );
 
+vi.mock( './describe_workflow.js', () => ( {
+  describeWorkflow: mockDescribeWorkflow
+} ) );
+
+vi.mock( './fetch_history_page.js', () => ( {
+  fetchHistoryPage: mockFetchHistoryPage
+} ) );
+
+const { getHistory } = await import( './get_history.js' );
+
 describe( 'getHistory', () => {
+  const client = { workflow: {} };
+  const connection = { workflowService: {} };
+
   beforeEach( () => {
     vi.clearAllMocks();
     mockFormatStatus.mockReturnValue( 'formatted-status' );
     mockDecodeEventPayloads.mockImplementation( event => ( { ...event, decoded: true } ) );
     mockSerializeEvent.mockImplementation( ( event, options ) => ( { event, options } ) );
+    mockDescribeWorkflow.mockResolvedValue( {
+      workflow: {
+        workflowId: 'workflow-id',
+        runId: 'resolved-run',
+        status: 'formatted-status',
+        startTime: '2024-01-01T00:00:00.000Z',
+        closeTime: null,
+        historyLength: 10,
+        taskQueue: 'queue-a'
+      }
+    } );
+    mockFetchHistoryPage.mockResolvedValue( { history: { events: [] } } );
   } );
 
   it( 'describes the workflow on the first page and returns serialized events with metadata', async () => {
     const event = { eventId: { toString: () => '1' }, eventType: 1 };
-    const describe = vi.fn().mockResolvedValue( {
-      runId: 'resolved-run',
-      status: { name: 'RUNNING' },
-      startTime: new Date( '2024-01-01T00:00:00.000Z' ),
-      closeTime: null,
-      historyLength: 10,
-      taskQueue: 'queue-a'
-    } );
-    const getHandle = vi.fn().mockReturnValue( { describe } );
-    const getWorkflowExecutionHistory = vi.fn().mockResolvedValue( {
-      history: { events: [ event ] },
-      nextPageToken: Buffer.from( 'next' )
-    } );
-    const client = { workflow: { getHandle } };
-    const connection = { workflowService: { getWorkflowExecutionHistory } };
-    const { getHistory } = await import( './get_history.js' );
+    mockFetchHistoryPage.mockResolvedValue( { history: { events: [ event ] }, nextPageToken: Buffer.from( 'next' ) } );
 
     const result = await getHistory( { client, connection }, 'workflow-id', { pageSize: 30 } );
 
-    expect( getHandle ).toHaveBeenCalledWith( 'workflow-id', undefined );
-    expect( getWorkflowExecutionHistory ).toHaveBeenCalledWith( {
-      namespace: 'default',
-      execution: { workflowId: 'workflow-id', runId: 'resolved-run' },
+    expect( mockDescribeWorkflow ).toHaveBeenCalledWith( { client }, 'workflow-id', { runId: undefined } );
+    expect( mockFetchHistoryPage ).toHaveBeenCalledWith( connection, 'workflow-id', 'resolved-run', {
       maximumPageSize: 30,
-      nextPageToken: undefined
+      nextPageToken: undefined,
+      mapInvalidArgument: expect.any( Function )
     } );
     expect( mockDecodeEventPayloads ).not.toHaveBeenCalled();
     expect( mockSerializeEvent ).toHaveBeenCalledWith( event, { includePayloads: false } );
-    expect( mockFormatStatus ).toHaveBeenCalledWith( 'RUNNING' );
     expect( result ).toEqual( {
       workflow: {
         workflowId: 'workflow-id',
@@ -82,26 +91,17 @@ describe( 'getHistory', () => {
   } );
 
   it( 'requires runId when pageToken is supplied', async () => {
-    const client = { workflow: { getHandle: vi.fn() } };
-    const connection = { workflowService: { getWorkflowExecutionHistory: vi.fn() } };
-    const { getHistory } = await import( './get_history.js' );
-
     await expect( getHistory( { client, connection }, 'workflow-id', { pageToken: 'abc' } ) ).rejects.toBeInstanceOf( InvalidPageTokenError );
+    expect( mockFetchHistoryPage ).not.toHaveBeenCalled();
   } );
 
   it( 'skips describe for later pages and decodes pageToken from base64', async () => {
-    const getHandle = vi.fn();
-    const getWorkflowExecutionHistory = vi.fn().mockResolvedValue( { history: { events: [] }, nextPageToken: null } );
-    const client = { workflow: { getHandle } };
-    const connection = { workflowService: { getWorkflowExecutionHistory } };
-    const { getHistory } = await import( './get_history.js' );
     const pageToken = Buffer.from( 'previous-token' ).toString( 'base64' );
 
     const result = await getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken } );
 
-    expect( getHandle ).not.toHaveBeenCalled();
-    expect( getWorkflowExecutionHistory ).toHaveBeenCalledWith( expect.objectContaining( {
-      execution: { workflowId: 'workflow-id', runId: 'run-id' },
+    expect( mockDescribeWorkflow ).not.toHaveBeenCalled();
+    expect( mockFetchHistoryPage ).toHaveBeenCalledWith( connection, 'workflow-id', 'run-id', expect.objectContaining( {
       nextPageToken: Buffer.from( pageToken, 'base64' )
     } ) );
     expect( result.workflow ).toBeNull();
@@ -112,82 +112,47 @@ describe( 'getHistory', () => {
     const rawEvent = { eventId: { toString: () => '1' }, eventType: 1 };
     const decodedEvent = { eventId: rawEvent.eventId, eventType: 1, decoded: true };
     mockDecodeEventPayloads.mockReturnValue( decodedEvent );
-    const describe = vi.fn().mockResolvedValue( { runId: 'run-id', status: {}, historyLength: 1 } );
-    const getWorkflowExecutionHistory = vi.fn().mockResolvedValue( { history: { events: [ rawEvent ] } } );
-    const client = { workflow: { getHandle: vi.fn().mockReturnValue( { describe } ) } };
-    const connection = { workflowService: { getWorkflowExecutionHistory } };
-    const { getHistory } = await import( './get_history.js' );
+    mockFetchHistoryPage.mockResolvedValue( { history: { events: [ rawEvent ] } } );
 
     await getHistory( { client, connection }, 'workflow-id', { pageSize: 100, includePayloads: true } );
 
-    expect( getWorkflowExecutionHistory ).toHaveBeenCalledWith( expect.objectContaining( { maximumPageSize: 50 } ) );
+    expect( mockFetchHistoryPage ).toHaveBeenCalledWith(
+      connection, 'workflow-id', 'resolved-run', expect.objectContaining( { maximumPageSize: 50 } )
+    );
     expect( mockDecodeEventPayloads ).toHaveBeenCalledWith( rawEvent );
     expect( mockSerializeEvent ).toHaveBeenCalledWith( decodedEvent, { includePayloads: true } );
   } );
 
-  it( 'maps NOT_FOUND from describe and history calls to WorkflowNotFoundError', async () => {
-    const describeNotFound = Object.assign( new Error( 'not found' ), { code: 5 } );
-    const historyNotFound = Object.assign( new Error( 'not found' ), { code: 5 } );
-    const { getHistory } = await import( './get_history.js' );
+  it( 'propagates a NOT_FOUND error surfaced by describeWorkflow', async () => {
+    const notFound = Object.assign( new Error( 'not found' ), { name: 'WorkflowNotFoundError' } );
+    mockDescribeWorkflow.mockRejectedValue( notFound );
 
-    const missingDescribeClient = { workflow: { getHandle: vi.fn().mockReturnValue( { describe: vi.fn().mockRejectedValue( describeNotFound ) } ) } };
-    const missingDescribeConnection = { workflowService: { getWorkflowExecutionHistory: vi.fn() } };
-    await expect( getHistory( { client: missingDescribeClient, connection: missingDescribeConnection }, 'workflow-id' ) )
-      .rejects.toBeInstanceOf( WorkflowNotFoundError );
-
-    const missingPageClient = { workflow: { getHandle: vi.fn() } };
-    const missingPageConnection = { workflowService: { getWorkflowExecutionHistory: vi.fn().mockRejectedValue( historyNotFound ) } };
-    await expect( getHistory(
-      { client: missingPageClient, connection: missingPageConnection },
-      'workflow-id',
-      { runId: 'run-id', pageToken: 'abc' }
-    ) )
-      .rejects.toBeInstanceOf( WorkflowNotFoundError );
+    await expect( getHistory( { client, connection }, 'workflow-id' ) ).rejects.toBe( notFound );
+    expect( mockFetchHistoryPage ).not.toHaveBeenCalled();
   } );
 
-  it( 'maps INVALID_ARGUMENT history errors to InvalidPageTokenError and propagates other errors', async () => {
-    const invalidArgument = Object.assign( new Error( 'invalid' ), { code: 3 } );
-    const unavailable = Object.assign( new Error( 'unavailable' ), { code: 14 } );
-    const { getHistory } = await import( './get_history.js' );
+  it( 'maps a malformed/expired pageToken (INVALID_ARGUMENT) to InvalidPageTokenError via mapInvalidArgument', async () => {
+    mockFetchHistoryPage.mockImplementation( ( _connection, _workflowId, _runId, { mapInvalidArgument } ) =>
+      Promise.reject( mapInvalidArgument( new Error( 'invalid' ) ) ) );
 
-    const invalidTokenClient = { workflow: { getHandle: vi.fn() } };
-    const invalidTokenConnection = { workflowService: { getWorkflowExecutionHistory: vi.fn().mockRejectedValue( invalidArgument ) } };
-    await expect( getHistory(
-      { client: invalidTokenClient, connection: invalidTokenConnection },
-      'workflow-id',
-      { runId: 'run-id', pageToken: 'abc' }
-    ) )
-      .rejects.toBeInstanceOf( InvalidPageTokenError );
-
-    const outageClient = { workflow: { getHandle: vi.fn() } };
-    const outageConnection = { workflowService: { getWorkflowExecutionHistory: vi.fn().mockRejectedValue( unavailable ) } };
-    await expect( getHistory( { client: outageClient, connection: outageConnection }, 'workflow-id', { runId: 'run-id', pageToken: 'abc' } ) )
-      .rejects.toBe( unavailable );
+    await expect(
+      getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken: 'abc' } )
+    ).rejects.toBeInstanceOf( InvalidPageTokenError );
   } );
 
-  it( 'warns and suppresses pagination when Temporal returns no history field', async () => {
-    const describe = vi.fn().mockResolvedValue( { runId: 'run-id', status: {}, historyLength: 0 } );
-    const getWorkflowExecutionHistory = vi.fn().mockResolvedValue( { nextPageToken: Buffer.from( 'would-loop' ) } );
-    const client = { workflow: { getHandle: vi.fn().mockReturnValue( { describe } ) } };
-    const connection = { workflowService: { getWorkflowExecutionHistory } };
-    const { getHistory } = await import( './get_history.js' );
+  it( 'propagates other errors from fetchHistoryPage unchanged', async () => {
+    const unavailable = new Error( 'unavailable' );
+    mockFetchHistoryPage.mockRejectedValue( unavailable );
+
+    await expect( getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken: 'abc' } ) ).rejects.toBe( unavailable );
+  } );
+
+  it( 'suppresses pagination when Temporal returns no history field', async () => {
+    mockFetchHistoryPage.mockResolvedValue( { nextPageToken: Buffer.from( 'would-loop' ) } );
 
     const result = await getHistory( { client, connection }, 'workflow-id' );
 
-    expect( mockLoggerWarn ).toHaveBeenCalledWith(
-      'Temporal getWorkflowExecutionHistory returned no history field',
-      { workflowId: 'workflow-id', runId: 'run-id' }
-    );
     expect( result.events ).toEqual( [] );
     expect( result.nextPageToken ).toBeNull();
-  } );
-
-  it( 'throws a clear error if the history RPC rejects without an error object', async () => {
-    const client = { workflow: { getHandle: vi.fn() } };
-    const connection = { workflowService: { getWorkflowExecutionHistory: vi.fn().mockRejectedValue( null ) } };
-    const { getHistory } = await import( './get_history.js' );
-
-    await expect( getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken: 'abc' } ) )
-      .rejects.toThrow( 'Temporal getWorkflowExecutionHistory rejected with no error' );
   } );
 } );

--- a/api/src/clients/temporal/workflow/get_input.js
+++ b/api/src/clients/temporal/workflow/get_input.js
@@ -1,4 +1,4 @@
-import { workflowNotFoundError } from '../../errors.js';
+import { workflowNotFoundError, WorkflowMissingRunIdError } from '../../errors.js';
 import { describeWorkflow } from './describe_workflow.js';
 import { extractWorkflowInput } from './get_result.js';
 import { fetchHistoryPage } from './fetch_history_page.js';
@@ -17,6 +17,7 @@ import { fetchHistoryPage } from './fetch_history_page.js';
  * @param {string} [runId] - Optional specific run id; defaults to the original run of the chain
  * @returns {Promise<{ workflowId: string, runId: string, input: any }>}
  * @throws {WorkflowNotFoundError}
+ * @throws {WorkflowMissingRunIdError}
  */
 export const getInput = async ( { client, connection }, workflowId, runId ) => {
   // For a pinned runId the run is already known, so skip the describe round-trip; the history
@@ -27,7 +28,7 @@ export const getInput = async ( { client, connection }, workflowId, runId ) => {
     if ( !description.runId ) {
       // Temporal should always report a runId; fail loudly rather than silently fall back to an
       // unpinned (latest-run) read, which would race continueAsNew and drop the runId field.
-      throw new Error( `Temporal did not report a runId for workflow "${workflowId}"` );
+      throw new WorkflowMissingRunIdError( workflowId );
     }
     return description.runId;
   } )();

--- a/api/src/clients/temporal/workflow/get_input.js
+++ b/api/src/clients/temporal/workflow/get_input.js
@@ -1,50 +1,50 @@
-import { temporal as temporalConfig } from '#configs';
 import { workflowNotFoundError } from '../../errors.js';
-import { GrpcStatus } from '../types.js';
 import { describeWorkflow } from './describe_workflow.js';
 import { extractWorkflowInput } from './get_result.js';
-import { logger } from '#logger';
-
-const { namespace } = temporalConfig;
+import { fetchHistoryPage } from './fetch_history_page.js';
 
 /**
- * Returns the first input argument a workflow execution was started with.
+ * Returns the first input argument a workflow execution was *originally* started with.
  *
- * Unlike getResult, this works for workflows in any state (including running): the input
- * lives in the first history event (WorkflowExecutionStarted), available the moment the
- * workflow starts. Fetching a single-event page keeps the call cheap. Only the first start
- * argument is decoded (extractWorkflowInput reads payloads[0]).
+ * Unlike getResult, this works for workflows in any state (including running): the input lives
+ * in the first history event (WorkflowExecutionStarted), available the moment the workflow
+ * starts. For a continue-as-new chain an unpinned (latest-run) read lands on a continuation
+ * whose start event holds the continuation args, so we follow firstExecutionRunId back to the
+ * chain's first run to return the truly-original input. A pinned runId is returned verbatim.
+ * Fetching a single-event page keeps each call cheap (extractWorkflowInput reads payloads[0]).
  *
  * @param {string} workflowId - The workflow execution id
- * @param {string} [runId] - Optional specific run id; defaults to the latest run
+ * @param {string} [runId] - Optional specific run id; defaults to the original run of the chain
  * @returns {Promise<{ workflowId: string, runId: string, input: any }>}
  * @throws {WorkflowNotFoundError}
  */
 export const getInput = async ( { client, connection }, workflowId, runId ) => {
-  // Resolve (and validate) the run via describe, whether or not a runId was pinned. For a
-  // pinned-but-missing/expired run this surfaces a clean WorkflowNotFoundError (404), matching
-  // the latest-run path, instead of the raw INVALID_ARGUMENT the history RPC would return.
-  const { description } = await describeWorkflow( { client }, workflowId, { runId } );
-  const resolvedRunId = description.runId;
-  if ( !resolvedRunId ) {
-    // Temporal should always report a runId; fail loudly rather than silently fall back to an
-    // unpinned (latest-run) read, which would race continueAsNew and drop the runId field.
-    throw new Error( `Temporal did not report a runId for workflow "${workflowId}"` );
-  }
-
-  const firstPage = await connection.workflowService.getWorkflowExecutionHistory( {
-    namespace,
-    execution: { workflowId, runId: resolvedRunId },
-    maximumPageSize: 1
-  } ).catch( error => {
-    if ( error?.code === GrpcStatus.NOT_FOUND ) {
-      throw workflowNotFoundError( workflowId, resolvedRunId );
+  // For a pinned runId the run is already known, so skip the describe round-trip; the history
+  // fetch's NOT_FOUND/INVALID_ARGUMENT handling surfaces a clean 404 for a missing, expired, or
+  // malformed run. Only the unpinned path needs describe to resolve a concrete run.
+  const resolvedRunId = runId ?? await ( async () => {
+    const { description } = await describeWorkflow( { client }, workflowId );
+    if ( !description.runId ) {
+      // Temporal should always report a runId; fail loudly rather than silently fall back to an
+      // unpinned (latest-run) read, which would race continueAsNew and drop the runId field.
+      throw new Error( `Temporal did not report a runId for workflow "${workflowId}"` );
     }
-    throw error;
+    return description.runId;
+  } )();
+
+  const firstPage = await fetchHistoryPage( connection, workflowId, resolvedRunId, {
+    maximumPageSize: 1,
+    mapInvalidArgument: () => workflowNotFoundError( workflowId, resolvedRunId )
   } );
 
-  if ( !firstPage.history ) {
-    logger.warn( 'Temporal getWorkflowExecutionHistory returned no history field', { workflowId, runId: resolvedRunId } );
+  // An unpinned read resolves the *latest* run; for a continue-as-new chain that run's start
+  // event holds the continuation args, not the input the workflow was originally started with.
+  // firstExecutionRunId points at the chain's first run, so re-fetch it to honor "original".
+  const firstExecutionRunId = firstPage.history?.events?.[0]
+    ?.workflowExecutionStartedEventAttributes?.firstExecutionRunId;
+  if ( !runId && firstExecutionRunId && firstExecutionRunId !== resolvedRunId ) {
+    const originalPage = await fetchHistoryPage( connection, workflowId, firstExecutionRunId, { maximumPageSize: 1 } );
+    return { workflowId, runId: firstExecutionRunId, input: extractWorkflowInput( originalPage.history ) };
   }
 
   return { workflowId, runId: resolvedRunId, input: extractWorkflowInput( firstPage.history ) };

--- a/api/src/clients/temporal/workflow/get_input.js
+++ b/api/src/clients/temporal/workflow/get_input.js
@@ -1,0 +1,37 @@
+import { temporal as temporalConfig } from '#configs';
+import { workflowNotFoundError } from '../../errors.js';
+import { GrpcStatus } from '../types.js';
+import { describeWorkflow } from './describe_workflow.js';
+import { extractWorkflowInput } from './get_result.js';
+
+const { namespace } = temporalConfig;
+
+/**
+ * Returns the original input of a workflow execution.
+ *
+ * Unlike getResult, this works for workflows in any state (including running): the input
+ * lives in the first history event (WorkflowExecutionStarted), available the moment the
+ * workflow starts. Fetching a single-event page keeps the call cheap.
+ *
+ * @param {string} workflowId - The workflow execution id
+ * @param {string} [runId] - Optional specific run id; defaults to the latest run
+ * @returns {Promise<{ workflowId: string, runId: string, input: any }>}
+ * @throws {WorkflowNotFoundError}
+ */
+export const getInput = async ( { client, connection }, workflowId, runId ) => {
+  const { description } = await describeWorkflow( { client }, workflowId, { runId } );
+  const resolvedRunId = description.runId;
+
+  const firstPage = await connection.workflowService.getWorkflowExecutionHistory( {
+    namespace,
+    execution: { workflowId, runId: resolvedRunId },
+    maximumPageSize: 1
+  } ).catch( error => {
+    if ( error?.code === GrpcStatus.NOT_FOUND ) {
+      throw workflowNotFoundError( workflowId, resolvedRunId );
+    }
+    throw error;
+  } );
+
+  return { workflowId, runId: resolvedRunId, input: extractWorkflowInput( firstPage.history ) };
+};

--- a/api/src/clients/temporal/workflow/get_input.js
+++ b/api/src/clients/temporal/workflow/get_input.js
@@ -19,8 +19,9 @@ const { namespace } = temporalConfig;
  * @throws {WorkflowNotFoundError}
  */
 export const getInput = async ( { client, connection }, workflowId, runId ) => {
-  const { description } = await describeWorkflow( { client }, workflowId, { runId } );
-  const resolvedRunId = description.runId;
+  // A caller-supplied runId is already the run to read; only resolve the latest run via
+  // describe when none was pinned, avoiding a needless DescribeWorkflowExecution RPC.
+  const resolvedRunId = runId ?? ( await describeWorkflow( { client }, workflowId ) ).description.runId;
 
   const firstPage = await connection.workflowService.getWorkflowExecutionHistory( {
     namespace,

--- a/api/src/clients/temporal/workflow/get_input.js
+++ b/api/src/clients/temporal/workflow/get_input.js
@@ -3,15 +3,17 @@ import { workflowNotFoundError } from '../../errors.js';
 import { GrpcStatus } from '../types.js';
 import { describeWorkflow } from './describe_workflow.js';
 import { extractWorkflowInput } from './get_result.js';
+import { logger } from '#logger';
 
 const { namespace } = temporalConfig;
 
 /**
- * Returns the original input of a workflow execution.
+ * Returns the first input argument a workflow execution was started with.
  *
  * Unlike getResult, this works for workflows in any state (including running): the input
  * lives in the first history event (WorkflowExecutionStarted), available the moment the
- * workflow starts. Fetching a single-event page keeps the call cheap.
+ * workflow starts. Fetching a single-event page keeps the call cheap. Only the first start
+ * argument is decoded (extractWorkflowInput reads payloads[0]).
  *
  * @param {string} workflowId - The workflow execution id
  * @param {string} [runId] - Optional specific run id; defaults to the latest run
@@ -22,6 +24,11 @@ export const getInput = async ( { client, connection }, workflowId, runId ) => {
   // A caller-supplied runId is already the run to read; only resolve the latest run via
   // describe when none was pinned, avoiding a needless DescribeWorkflowExecution RPC.
   const resolvedRunId = runId ?? ( await describeWorkflow( { client }, workflowId ) ).description.runId;
+  if ( !resolvedRunId ) {
+    // Temporal should always report a runId; fail loudly rather than silently fall back to an
+    // unpinned (latest-run) read, which would race continueAsNew and drop the runId field.
+    throw new Error( `Temporal did not report a runId for workflow "${workflowId}"` );
+  }
 
   const firstPage = await connection.workflowService.getWorkflowExecutionHistory( {
     namespace,
@@ -33,6 +40,10 @@ export const getInput = async ( { client, connection }, workflowId, runId ) => {
     }
     throw error;
   } );
+
+  if ( !firstPage.history ) {
+    logger.warn( 'Temporal getWorkflowExecutionHistory returned no history field', { workflowId, runId: resolvedRunId } );
+  }
 
   return { workflowId, runId: resolvedRunId, input: extractWorkflowInput( firstPage.history ) };
 };

--- a/api/src/clients/temporal/workflow/get_input.js
+++ b/api/src/clients/temporal/workflow/get_input.js
@@ -21,9 +21,11 @@ const { namespace } = temporalConfig;
  * @throws {WorkflowNotFoundError}
  */
 export const getInput = async ( { client, connection }, workflowId, runId ) => {
-  // A caller-supplied runId is already the run to read; only resolve the latest run via
-  // describe when none was pinned, avoiding a needless DescribeWorkflowExecution RPC.
-  const resolvedRunId = runId ?? ( await describeWorkflow( { client }, workflowId ) ).description.runId;
+  // Resolve (and validate) the run via describe, whether or not a runId was pinned. For a
+  // pinned-but-missing/expired run this surfaces a clean WorkflowNotFoundError (404), matching
+  // the latest-run path, instead of the raw INVALID_ARGUMENT the history RPC would return.
+  const { description } = await describeWorkflow( { client }, workflowId, { runId } );
+  const resolvedRunId = description.runId;
   if ( !resolvedRunId ) {
     // Temporal should always report a runId; fail loudly rather than silently fall back to an
     // unpinned (latest-run) read, which would race continueAsNew and drop the runId field.

--- a/api/src/clients/temporal/workflow/get_input.spec.js
+++ b/api/src/clients/temporal/workflow/get_input.spec.js
@@ -30,14 +30,14 @@ describe( 'getInput', () => {
     mockExtractWorkflowInput.mockReturnValue( { values: [ 1, 2, 3 ] } );
   } );
 
-  const makeFixtures = ( { historyResponse, getHistoryError } = {} ) => {
+  const makeFixtures = ( { getHistoryError } = {} ) => {
     const getWorkflowExecutionHistory = vi.fn();
     if ( getHistoryError !== undefined ) {
       getWorkflowExecutionHistory.mockRejectedValue( getHistoryError );
     } else {
-      getWorkflowExecutionHistory.mockResolvedValue( historyResponse ?? {
-        history: { events: [ { workflowExecutionStartedEventAttributes: { input: { payloads: [ { p: 1 } ] } } } ] }
-      } );
+      // History content is irrelevant: extractWorkflowInput is mocked, so getInput's
+      // return comes from the mock, not from decoding this object.
+      getWorkflowExecutionHistory.mockResolvedValue( { history: {} } );
     }
     return {
       getWorkflowExecutionHistory,
@@ -46,13 +46,13 @@ describe( 'getInput', () => {
     };
   };
 
-  it( 'returns the decoded input for the resolved latest run', async () => {
+  it( 'resolves the latest run via describe and returns the decoded input', async () => {
     const fixtures = makeFixtures();
     const { getInput } = await import( './get_input.js' );
 
     const result = await getInput( fixtures, 'workflow-id' );
 
-    expect( mockDescribeWorkflow ).toHaveBeenCalledWith( { client: fixtures.client }, 'workflow-id', { runId: undefined } );
+    expect( mockDescribeWorkflow ).toHaveBeenCalledWith( { client: fixtures.client }, 'workflow-id' );
     expect( fixtures.getWorkflowExecutionHistory ).toHaveBeenCalledWith( {
       namespace: 'default',
       execution: { workflowId: 'workflow-id', runId: 'resolved-run' },
@@ -61,14 +61,13 @@ describe( 'getInput', () => {
     expect( result ).toEqual( { workflowId: 'workflow-id', runId: 'resolved-run', input: { values: [ 1, 2, 3 ] } } );
   } );
 
-  it( 'targets the pinned run when a runId is given', async () => {
-    mockDescribeWorkflow.mockResolvedValue( { description: { runId: 'pinned-run' } } );
+  it( 'skips describe and targets the pinned run when a runId is given', async () => {
     const fixtures = makeFixtures();
     const { getInput } = await import( './get_input.js' );
 
     await getInput( fixtures, 'workflow-id', 'pinned-run' );
 
-    expect( mockDescribeWorkflow ).toHaveBeenCalledWith( { client: fixtures.client }, 'workflow-id', { runId: 'pinned-run' } );
+    expect( mockDescribeWorkflow ).not.toHaveBeenCalled();
     expect( fixtures.getWorkflowExecutionHistory ).toHaveBeenCalledWith(
       expect.objectContaining( { execution: { workflowId: 'workflow-id', runId: 'pinned-run' } } )
     );
@@ -76,7 +75,7 @@ describe( 'getInput', () => {
 
   it( 'returns null input when no payloads exist (e.g. a running workflow with empty start input)', async () => {
     mockExtractWorkflowInput.mockReturnValue( null );
-    const fixtures = makeFixtures( { historyResponse: { history: { events: [] } } } );
+    const fixtures = makeFixtures();
     const { getInput } = await import( './get_input.js' );
 
     const result = await getInput( fixtures, 'workflow-id' );

--- a/api/src/clients/temporal/workflow/get_input.spec.js
+++ b/api/src/clients/temporal/workflow/get_input.spec.js
@@ -1,23 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WorkflowMissingRunIdError } from '../../errors.js';
 
-const { mockDescribeWorkflow, mockExtractWorkflowInput, mockWorkflowNotFoundError, mockLoggerWarn } = vi.hoisted( () => ( {
+const { mockDescribeWorkflow, mockExtractWorkflowInput, mockFetchHistoryPage } = vi.hoisted( () => ( {
   mockDescribeWorkflow: vi.fn(),
   mockExtractWorkflowInput: vi.fn(),
-  mockWorkflowNotFoundError: vi.fn( ( workflowId, runId ) =>
-    Object.assign( new Error( `not found: ${workflowId}/${runId}` ), { name: 'WorkflowNotFoundError' } ) ),
-  mockLoggerWarn: vi.fn()
-} ) );
-
-vi.mock( '#configs', () => ( {
-  temporal: { namespace: 'default' }
-} ) );
-
-vi.mock( '#logger', () => ( {
-  logger: { warn: mockLoggerWarn }
-} ) );
-
-vi.mock( '../../errors.js', () => ( {
-  workflowNotFoundError: mockWorkflowNotFoundError
+  mockFetchHistoryPage: vi.fn()
 } ) );
 
 vi.mock( './describe_workflow.js', () => ( {
@@ -28,40 +15,31 @@ vi.mock( './get_result.js', () => ( {
   extractWorkflowInput: mockExtractWorkflowInput
 } ) );
 
+vi.mock( './fetch_history_page.js', () => ( {
+  fetchHistoryPage: mockFetchHistoryPage
+} ) );
+
+const { getInput } = await import( './get_input.js' );
+
 describe( 'getInput', () => {
+  const fixtures = { client: { workflow: {} }, connection: { workflowService: {} } };
+
   beforeEach( () => {
     vi.clearAllMocks();
     mockDescribeWorkflow.mockResolvedValue( { description: { runId: 'resolved-run' } } );
     mockExtractWorkflowInput.mockReturnValue( { values: [ 1, 2, 3 ] } );
+    // History content is irrelevant: extractWorkflowInput is mocked, so getInput's return
+    // comes from the mock, not from decoding this object.
+    mockFetchHistoryPage.mockResolvedValue( { history: {} } );
   } );
 
-  const makeFixtures = ( { historyResponse, getHistoryError } = {} ) => {
-    const getWorkflowExecutionHistory = vi.fn();
-    if ( getHistoryError !== undefined ) {
-      getWorkflowExecutionHistory.mockRejectedValue( getHistoryError );
-    } else {
-      // History content is irrelevant: extractWorkflowInput is mocked, so getInput's
-      // return comes from the mock, not from decoding this object.
-      getWorkflowExecutionHistory.mockResolvedValue( historyResponse ?? { history: {} } );
-    }
-    return {
-      getWorkflowExecutionHistory,
-      client: { workflow: {} },
-      connection: { workflowService: { getWorkflowExecutionHistory } }
-    };
-  };
-
   it( 'resolves the latest run via describe and returns the decoded input', async () => {
-    const fixtures = makeFixtures();
-    const { getInput } = await import( './get_input.js' );
-
     const result = await getInput( fixtures, 'workflow-id' );
 
     expect( mockDescribeWorkflow ).toHaveBeenCalledWith( { client: fixtures.client }, 'workflow-id' );
-    expect( fixtures.getWorkflowExecutionHistory ).toHaveBeenCalledWith( {
-      namespace: 'default',
-      execution: { workflowId: 'workflow-id', runId: 'resolved-run' },
-      maximumPageSize: 1
+    expect( mockFetchHistoryPage ).toHaveBeenCalledWith( fixtures.connection, 'workflow-id', 'resolved-run', {
+      maximumPageSize: 1,
+      mapInvalidArgument: expect.any( Function )
     } );
     // Pin the wiring: the resolved history object is what gets decoded, not the whole page.
     expect( mockExtractWorkflowInput ).toHaveBeenCalledWith( {} );
@@ -70,88 +48,68 @@ describe( 'getInput', () => {
 
   it( 'throws when describe reports no runId rather than reading the unpinned latest run', async () => {
     mockDescribeWorkflow.mockResolvedValue( { description: {} } );
-    const fixtures = makeFixtures();
-    const { getInput } = await import( './get_input.js' );
 
-    await expect( getInput( fixtures, 'workflow-id' ) ).rejects.toThrow( /did not report a runId/ );
-    expect( fixtures.getWorkflowExecutionHistory ).not.toHaveBeenCalled();
-  } );
-
-  it( 'warns when the history response has no history field', async () => {
-    const fixtures = makeFixtures( { historyResponse: {} } );
-    const { getInput } = await import( './get_input.js' );
-
-    await getInput( fixtures, 'workflow-id' );
-
-    expect( mockLoggerWarn ).toHaveBeenCalledWith(
-      'Temporal getWorkflowExecutionHistory returned no history field',
-      { workflowId: 'workflow-id', runId: 'resolved-run' }
-    );
+    await expect( getInput( fixtures, 'workflow-id' ) ).rejects.toBeInstanceOf( WorkflowMissingRunIdError );
+    expect( mockFetchHistoryPage ).not.toHaveBeenCalled();
   } );
 
   it( 'reads a pinned run directly without describing it', async () => {
-    const fixtures = makeFixtures();
-    const { getInput } = await import( './get_input.js' );
-
     const result = await getInput( fixtures, 'workflow-id', 'pinned-run' );
 
     // A pinned run is already known, so describe is skipped to save a round-trip.
     expect( mockDescribeWorkflow ).not.toHaveBeenCalled();
-    expect( fixtures.getWorkflowExecutionHistory ).toHaveBeenCalledWith(
-      expect.objectContaining( { execution: { workflowId: 'workflow-id', runId: 'pinned-run' } } )
+    expect( mockFetchHistoryPage ).toHaveBeenCalledWith(
+      fixtures.connection, 'workflow-id', 'pinned-run', expect.objectContaining( { maximumPageSize: 1 } )
     );
     expect( result ).toEqual( { workflowId: 'workflow-id', runId: 'pinned-run', input: { values: [ 1, 2, 3 ] } } );
   } );
 
-  it( 'maps a malformed/expired pinned run (INVALID_ARGUMENT) to a 404 without describing', async () => {
-    const invalidArg = Object.assign( new Error( 'invalid runId' ), { code: 3 } );
-    const fixtures = makeFixtures( { getHistoryError: invalidArg } );
-    const { getInput } = await import( './get_input.js' );
+  it( 'wires mapInvalidArgument to translate a malformed/expired pinned run into a WorkflowNotFoundError', async () => {
+    mockFetchHistoryPage.mockImplementation( ( _connection, _workflowId, _runId, { mapInvalidArgument } ) =>
+      Promise.reject( mapInvalidArgument( new Error( 'invalid runId' ) ) ) );
 
     await expect( getInput( fixtures, 'workflow-id', 'pinned-run' ) ).rejects.toMatchObject( { name: 'WorkflowNotFoundError' } );
-    expect( mockDescribeWorkflow ).not.toHaveBeenCalled();
   } );
 
   it( 'follows firstExecutionRunId back to the original run for a continue-as-new chain', async () => {
-    const getWorkflowExecutionHistory = vi.fn()
+    mockFetchHistoryPage
       .mockResolvedValueOnce( { history: { events: [ { workflowExecutionStartedEventAttributes: { firstExecutionRunId: 'first-run' } } ] } } )
       .mockResolvedValueOnce( { history: {} } );
-    const fixtures = {
-      getWorkflowExecutionHistory,
-      client: { workflow: {} },
-      connection: { workflowService: { getWorkflowExecutionHistory } }
-    };
     mockExtractWorkflowInput.mockReturnValue( { values: [ 9 ] } );
-    const { getInput } = await import( './get_input.js' );
 
     const result = await getInput( fixtures, 'workflow-id' );
 
     // Latest run resolved to 'resolved-run', but its start event points at 'first-run', so the
     // original input is re-fetched from the chain's first run.
-    expect( getWorkflowExecutionHistory ).toHaveBeenNthCalledWith(
-      2, expect.objectContaining( { execution: { workflowId: 'workflow-id', runId: 'first-run' } } )
+    expect( mockFetchHistoryPage ).toHaveBeenNthCalledWith(
+      2, fixtures.connection, 'workflow-id', 'first-run', { maximumPageSize: 1 }
     );
     expect( result ).toEqual( { workflowId: 'workflow-id', runId: 'first-run', input: { values: [ 9 ] } } );
   } );
 
+  it( 'does not follow firstExecutionRunId when the caller pinned a runId', async () => {
+    mockFetchHistoryPage.mockResolvedValue( {
+      history: { events: [ { workflowExecutionStartedEventAttributes: { firstExecutionRunId: 'first-run' } } ] }
+    } );
+
+    const result = await getInput( fixtures, 'workflow-id', 'pinned-run' );
+
+    expect( mockFetchHistoryPage ).toHaveBeenCalledTimes( 1 );
+    expect( result.runId ).toBe( 'pinned-run' );
+  } );
+
   it( 'returns null input when no payloads exist (e.g. a running workflow with empty start input)', async () => {
     mockExtractWorkflowInput.mockReturnValue( null );
-    const fixtures = makeFixtures();
-    const { getInput } = await import( './get_input.js' );
 
     const result = await getInput( fixtures, 'workflow-id' );
 
     expect( result ).toEqual( { workflowId: 'workflow-id', runId: 'resolved-run', input: null } );
   } );
 
-  it( 'maps NOT_FOUND history errors to WorkflowNotFoundError and propagates other errors', async () => {
-    const notFound = Object.assign( new Error( 'missing' ), { code: 5 } );
-    const unavailable = Object.assign( new Error( 'unavailable' ), { code: 14 } );
-    const { getInput } = await import( './get_input.js' );
+  it( 'propagates errors from fetchHistoryPage unchanged', async () => {
+    const unavailable = new Error( 'unavailable' );
+    mockFetchHistoryPage.mockRejectedValue( unavailable );
 
-    await expect( getInput( makeFixtures( { getHistoryError: notFound } ), 'workflow-id' ) )
-      .rejects.toMatchObject( { name: 'WorkflowNotFoundError' } );
-    await expect( getInput( makeFixtures( { getHistoryError: unavailable } ), 'workflow-id' ) )
-      .rejects.toBe( unavailable );
+    await expect( getInput( fixtures, 'workflow-id' ) ).rejects.toBe( unavailable );
   } );
 } );

--- a/api/src/clients/temporal/workflow/get_input.spec.js
+++ b/api/src/clients/temporal/workflow/get_input.spec.js
@@ -57,7 +57,7 @@ describe( 'getInput', () => {
 
     const result = await getInput( fixtures, 'workflow-id' );
 
-    expect( mockDescribeWorkflow ).toHaveBeenCalledWith( { client: fixtures.client }, 'workflow-id', { runId: undefined } );
+    expect( mockDescribeWorkflow ).toHaveBeenCalledWith( { client: fixtures.client }, 'workflow-id' );
     expect( fixtures.getWorkflowExecutionHistory ).toHaveBeenCalledWith( {
       namespace: 'default',
       execution: { workflowId: 'workflow-id', runId: 'resolved-run' },
@@ -89,27 +89,49 @@ describe( 'getInput', () => {
     );
   } );
 
-  it( 'resolves a pinned run via describe and reads its history', async () => {
-    mockDescribeWorkflow.mockResolvedValue( { description: { runId: 'pinned-run' } } );
+  it( 'reads a pinned run directly without describing it', async () => {
     const fixtures = makeFixtures();
     const { getInput } = await import( './get_input.js' );
 
-    await getInput( fixtures, 'workflow-id', 'pinned-run' );
+    const result = await getInput( fixtures, 'workflow-id', 'pinned-run' );
 
-    expect( mockDescribeWorkflow ).toHaveBeenCalledWith( { client: fixtures.client }, 'workflow-id', { runId: 'pinned-run' } );
+    // A pinned run is already known, so describe is skipped to save a round-trip.
+    expect( mockDescribeWorkflow ).not.toHaveBeenCalled();
     expect( fixtures.getWorkflowExecutionHistory ).toHaveBeenCalledWith(
       expect.objectContaining( { execution: { workflowId: 'workflow-id', runId: 'pinned-run' } } )
     );
+    expect( result ).toEqual( { workflowId: 'workflow-id', runId: 'pinned-run', input: { values: [ 1, 2, 3 ] } } );
   } );
 
-  it( 'propagates a not-found from describe so a missing pinned run becomes a 404', async () => {
-    const notFound = mockWorkflowNotFoundError( 'workflow-id', 'pinned-run' );
-    mockDescribeWorkflow.mockRejectedValue( notFound );
-    const fixtures = makeFixtures();
+  it( 'maps a malformed/expired pinned run (INVALID_ARGUMENT) to a 404 without describing', async () => {
+    const invalidArg = Object.assign( new Error( 'invalid runId' ), { code: 3 } );
+    const fixtures = makeFixtures( { getHistoryError: invalidArg } );
     const { getInput } = await import( './get_input.js' );
 
-    await expect( getInput( fixtures, 'workflow-id', 'pinned-run' ) ).rejects.toBe( notFound );
-    expect( fixtures.getWorkflowExecutionHistory ).not.toHaveBeenCalled();
+    await expect( getInput( fixtures, 'workflow-id', 'pinned-run' ) ).rejects.toMatchObject( { name: 'WorkflowNotFoundError' } );
+    expect( mockDescribeWorkflow ).not.toHaveBeenCalled();
+  } );
+
+  it( 'follows firstExecutionRunId back to the original run for a continue-as-new chain', async () => {
+    const getWorkflowExecutionHistory = vi.fn()
+      .mockResolvedValueOnce( { history: { events: [ { workflowExecutionStartedEventAttributes: { firstExecutionRunId: 'first-run' } } ] } } )
+      .mockResolvedValueOnce( { history: {} } );
+    const fixtures = {
+      getWorkflowExecutionHistory,
+      client: { workflow: {} },
+      connection: { workflowService: { getWorkflowExecutionHistory } }
+    };
+    mockExtractWorkflowInput.mockReturnValue( { values: [ 9 ] } );
+    const { getInput } = await import( './get_input.js' );
+
+    const result = await getInput( fixtures, 'workflow-id' );
+
+    // Latest run resolved to 'resolved-run', but its start event points at 'first-run', so the
+    // original input is re-fetched from the chain's first run.
+    expect( getWorkflowExecutionHistory ).toHaveBeenNthCalledWith(
+      2, expect.objectContaining( { execution: { workflowId: 'workflow-id', runId: 'first-run' } } )
+    );
+    expect( result ).toEqual( { workflowId: 'workflow-id', runId: 'first-run', input: { values: [ 9 ] } } );
   } );
 
   it( 'returns null input when no payloads exist (e.g. a running workflow with empty start input)', async () => {

--- a/api/src/clients/temporal/workflow/get_input.spec.js
+++ b/api/src/clients/temporal/workflow/get_input.spec.js
@@ -57,7 +57,7 @@ describe( 'getInput', () => {
 
     const result = await getInput( fixtures, 'workflow-id' );
 
-    expect( mockDescribeWorkflow ).toHaveBeenCalledWith( { client: fixtures.client }, 'workflow-id' );
+    expect( mockDescribeWorkflow ).toHaveBeenCalledWith( { client: fixtures.client }, 'workflow-id', { runId: undefined } );
     expect( fixtures.getWorkflowExecutionHistory ).toHaveBeenCalledWith( {
       namespace: 'default',
       execution: { workflowId: 'workflow-id', runId: 'resolved-run' },
@@ -89,16 +89,27 @@ describe( 'getInput', () => {
     );
   } );
 
-  it( 'skips describe and targets the pinned run when a runId is given', async () => {
+  it( 'resolves a pinned run via describe and reads its history', async () => {
+    mockDescribeWorkflow.mockResolvedValue( { description: { runId: 'pinned-run' } } );
     const fixtures = makeFixtures();
     const { getInput } = await import( './get_input.js' );
 
     await getInput( fixtures, 'workflow-id', 'pinned-run' );
 
-    expect( mockDescribeWorkflow ).not.toHaveBeenCalled();
+    expect( mockDescribeWorkflow ).toHaveBeenCalledWith( { client: fixtures.client }, 'workflow-id', { runId: 'pinned-run' } );
     expect( fixtures.getWorkflowExecutionHistory ).toHaveBeenCalledWith(
       expect.objectContaining( { execution: { workflowId: 'workflow-id', runId: 'pinned-run' } } )
     );
+  } );
+
+  it( 'propagates a not-found from describe so a missing pinned run becomes a 404', async () => {
+    const notFound = mockWorkflowNotFoundError( 'workflow-id', 'pinned-run' );
+    mockDescribeWorkflow.mockRejectedValue( notFound );
+    const fixtures = makeFixtures();
+    const { getInput } = await import( './get_input.js' );
+
+    await expect( getInput( fixtures, 'workflow-id', 'pinned-run' ) ).rejects.toBe( notFound );
+    expect( fixtures.getWorkflowExecutionHistory ).not.toHaveBeenCalled();
   } );
 
   it( 'returns null input when no payloads exist (e.g. a running workflow with empty start input)', async () => {

--- a/api/src/clients/temporal/workflow/get_input.spec.js
+++ b/api/src/clients/temporal/workflow/get_input.spec.js
@@ -1,14 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockDescribeWorkflow, mockExtractWorkflowInput, mockWorkflowNotFoundError } = vi.hoisted( () => ( {
+const { mockDescribeWorkflow, mockExtractWorkflowInput, mockWorkflowNotFoundError, mockLoggerWarn } = vi.hoisted( () => ( {
   mockDescribeWorkflow: vi.fn(),
   mockExtractWorkflowInput: vi.fn(),
   mockWorkflowNotFoundError: vi.fn( ( workflowId, runId ) =>
-    Object.assign( new Error( `not found: ${workflowId}/${runId}` ), { name: 'WorkflowNotFoundError' } ) )
+    Object.assign( new Error( `not found: ${workflowId}/${runId}` ), { name: 'WorkflowNotFoundError' } ) ),
+  mockLoggerWarn: vi.fn()
 } ) );
 
 vi.mock( '#configs', () => ( {
   temporal: { namespace: 'default' }
+} ) );
+
+vi.mock( '#logger', () => ( {
+  logger: { warn: mockLoggerWarn }
 } ) );
 
 vi.mock( '../../errors.js', () => ( {
@@ -30,14 +35,14 @@ describe( 'getInput', () => {
     mockExtractWorkflowInput.mockReturnValue( { values: [ 1, 2, 3 ] } );
   } );
 
-  const makeFixtures = ( { getHistoryError } = {} ) => {
+  const makeFixtures = ( { historyResponse, getHistoryError } = {} ) => {
     const getWorkflowExecutionHistory = vi.fn();
     if ( getHistoryError !== undefined ) {
       getWorkflowExecutionHistory.mockRejectedValue( getHistoryError );
     } else {
       // History content is irrelevant: extractWorkflowInput is mocked, so getInput's
       // return comes from the mock, not from decoding this object.
-      getWorkflowExecutionHistory.mockResolvedValue( { history: {} } );
+      getWorkflowExecutionHistory.mockResolvedValue( historyResponse ?? { history: {} } );
     }
     return {
       getWorkflowExecutionHistory,
@@ -58,7 +63,30 @@ describe( 'getInput', () => {
       execution: { workflowId: 'workflow-id', runId: 'resolved-run' },
       maximumPageSize: 1
     } );
+    // Pin the wiring: the resolved history object is what gets decoded, not the whole page.
+    expect( mockExtractWorkflowInput ).toHaveBeenCalledWith( {} );
     expect( result ).toEqual( { workflowId: 'workflow-id', runId: 'resolved-run', input: { values: [ 1, 2, 3 ] } } );
+  } );
+
+  it( 'throws when describe reports no runId rather than reading the unpinned latest run', async () => {
+    mockDescribeWorkflow.mockResolvedValue( { description: {} } );
+    const fixtures = makeFixtures();
+    const { getInput } = await import( './get_input.js' );
+
+    await expect( getInput( fixtures, 'workflow-id' ) ).rejects.toThrow( /did not report a runId/ );
+    expect( fixtures.getWorkflowExecutionHistory ).not.toHaveBeenCalled();
+  } );
+
+  it( 'warns when the history response has no history field', async () => {
+    const fixtures = makeFixtures( { historyResponse: {} } );
+    const { getInput } = await import( './get_input.js' );
+
+    await getInput( fixtures, 'workflow-id' );
+
+    expect( mockLoggerWarn ).toHaveBeenCalledWith(
+      'Temporal getWorkflowExecutionHistory returned no history field',
+      { workflowId: 'workflow-id', runId: 'resolved-run' }
+    );
   } );
 
   it( 'skips describe and targets the pinned run when a runId is given', async () => {

--- a/api/src/clients/temporal/workflow/get_input.spec.js
+++ b/api/src/clients/temporal/workflow/get_input.spec.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockDescribeWorkflow, mockExtractWorkflowInput, mockWorkflowNotFoundError } = vi.hoisted( () => ( {
+  mockDescribeWorkflow: vi.fn(),
+  mockExtractWorkflowInput: vi.fn(),
+  mockWorkflowNotFoundError: vi.fn( ( workflowId, runId ) =>
+    Object.assign( new Error( `not found: ${workflowId}/${runId}` ), { name: 'WorkflowNotFoundError' } ) )
+} ) );
+
+vi.mock( '#configs', () => ( {
+  temporal: { namespace: 'default' }
+} ) );
+
+vi.mock( '../../errors.js', () => ( {
+  workflowNotFoundError: mockWorkflowNotFoundError
+} ) );
+
+vi.mock( './describe_workflow.js', () => ( {
+  describeWorkflow: mockDescribeWorkflow
+} ) );
+
+vi.mock( './get_result.js', () => ( {
+  extractWorkflowInput: mockExtractWorkflowInput
+} ) );
+
+describe( 'getInput', () => {
+  beforeEach( () => {
+    vi.clearAllMocks();
+    mockDescribeWorkflow.mockResolvedValue( { description: { runId: 'resolved-run' } } );
+    mockExtractWorkflowInput.mockReturnValue( { values: [ 1, 2, 3 ] } );
+  } );
+
+  const makeFixtures = ( { historyResponse, getHistoryError } = {} ) => {
+    const getWorkflowExecutionHistory = vi.fn();
+    if ( getHistoryError !== undefined ) {
+      getWorkflowExecutionHistory.mockRejectedValue( getHistoryError );
+    } else {
+      getWorkflowExecutionHistory.mockResolvedValue( historyResponse ?? {
+        history: { events: [ { workflowExecutionStartedEventAttributes: { input: { payloads: [ { p: 1 } ] } } } ] }
+      } );
+    }
+    return {
+      getWorkflowExecutionHistory,
+      client: { workflow: {} },
+      connection: { workflowService: { getWorkflowExecutionHistory } }
+    };
+  };
+
+  it( 'returns the decoded input for the resolved latest run', async () => {
+    const fixtures = makeFixtures();
+    const { getInput } = await import( './get_input.js' );
+
+    const result = await getInput( fixtures, 'workflow-id' );
+
+    expect( mockDescribeWorkflow ).toHaveBeenCalledWith( { client: fixtures.client }, 'workflow-id', { runId: undefined } );
+    expect( fixtures.getWorkflowExecutionHistory ).toHaveBeenCalledWith( {
+      namespace: 'default',
+      execution: { workflowId: 'workflow-id', runId: 'resolved-run' },
+      maximumPageSize: 1
+    } );
+    expect( result ).toEqual( { workflowId: 'workflow-id', runId: 'resolved-run', input: { values: [ 1, 2, 3 ] } } );
+  } );
+
+  it( 'targets the pinned run when a runId is given', async () => {
+    mockDescribeWorkflow.mockResolvedValue( { description: { runId: 'pinned-run' } } );
+    const fixtures = makeFixtures();
+    const { getInput } = await import( './get_input.js' );
+
+    await getInput( fixtures, 'workflow-id', 'pinned-run' );
+
+    expect( mockDescribeWorkflow ).toHaveBeenCalledWith( { client: fixtures.client }, 'workflow-id', { runId: 'pinned-run' } );
+    expect( fixtures.getWorkflowExecutionHistory ).toHaveBeenCalledWith(
+      expect.objectContaining( { execution: { workflowId: 'workflow-id', runId: 'pinned-run' } } )
+    );
+  } );
+
+  it( 'returns null input when no payloads exist (e.g. a running workflow with empty start input)', async () => {
+    mockExtractWorkflowInput.mockReturnValue( null );
+    const fixtures = makeFixtures( { historyResponse: { history: { events: [] } } } );
+    const { getInput } = await import( './get_input.js' );
+
+    const result = await getInput( fixtures, 'workflow-id' );
+
+    expect( result ).toEqual( { workflowId: 'workflow-id', runId: 'resolved-run', input: null } );
+  } );
+
+  it( 'maps NOT_FOUND history errors to WorkflowNotFoundError and propagates other errors', async () => {
+    const notFound = Object.assign( new Error( 'missing' ), { code: 5 } );
+    const unavailable = Object.assign( new Error( 'unavailable' ), { code: 14 } );
+    const { getInput } = await import( './get_input.js' );
+
+    await expect( getInput( makeFixtures( { getHistoryError: notFound } ), 'workflow-id' ) )
+      .rejects.toMatchObject( { name: 'WorkflowNotFoundError' } );
+    await expect( getInput( makeFixtures( { getHistoryError: unavailable } ), 'workflow-id' ) )
+      .rejects.toBe( unavailable );
+  } );
+} );

--- a/api/src/clients/temporal/workflow/get_result.js
+++ b/api/src/clients/temporal/workflow/get_result.js
@@ -1,10 +1,9 @@
 import { defaultPayloadConverter } from '@temporalio/client';
-import { temporal as temporalConfig } from '#configs';
-import { WorkflowNotFoundError, WorkflowFailedError, WorkflowNotCompletedError } from '../../errors.js';
-import { WorkflowStatus, isWorkflowClosed, GrpcStatus, formatStatus } from '../types.js';
+import { WorkflowFailedError, WorkflowNotCompletedError } from '../../errors.js';
+import { WorkflowStatus, isWorkflowClosed, formatStatus } from '../types.js';
 import { buildWorkflowResult } from '../workflow_result.js';
+import { fetchHistoryPage } from './fetch_history_page.js';
 import { logger } from '#logger';
-const { namespace } = temporalConfig;
 
 /**
  * Extracts the workflow input from a Temporal history object.
@@ -46,22 +45,9 @@ export const getResult = async ( { client, connection }, workflowId, runId ) => 
   }
   // Pin a handle to the resolved run so subsequent RPCs can't race against continueAsNew
   const pinnedHandle = runId ? handle : client.workflow.getHandle( workflowId, resolvedRunId );
-  // The input lives in the first event (WorkflowExecutionStarted), so a
-  // single-event page suffices instead of paging through the full history
-  const firstPage = await connection.workflowService.getWorkflowExecutionHistory( {
-    namespace,
-    execution: { workflowId, runId: resolvedRunId },
-    maximumPageSize: 1
-  } ).catch( error => {
-    if ( error?.code === GrpcStatus.NOT_FOUND ) {
-      throw new WorkflowNotFoundError( `Run "${resolvedRunId}" not found for workflow "${workflowId}"` );
-    }
-    throw error;
-  } );
-
-  if ( !firstPage.history ) {
-    logger.warn( 'Temporal getWorkflowExecutionHistory returned no history field', { workflowId, runId: resolvedRunId } );
-  }
+  // The input lives in the first event (WorkflowExecutionStarted), so a single-event page
+  // suffices instead of paging through the full history.
+  const firstPage = await fetchHistoryPage( connection, workflowId, resolvedRunId, { maximumPageSize: 1 } );
 
   const status = formatStatus( description.status.name );
   const input = extractWorkflowInput( firstPage.history );

--- a/api/src/clients/temporal/workflow/get_result.spec.js
+++ b/api/src/clients/temporal/workflow/get_result.spec.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { WorkflowNotCompletedError, WorkflowNotFoundError } from '../../errors.js';
+import { WorkflowNotCompletedError } from '../../errors.js';
 import { WorkflowStatus } from '../types.js';
 
 const {
@@ -7,30 +7,24 @@ const {
   mockFormatStatus,
   mockBuildWorkflowResult,
   mockLoggerWarn,
-  MockWorkflowFailedError,
-  MockWorkflowNotFoundError
+  mockFetchHistoryPage,
+  MockWorkflowFailedError
 } = vi.hoisted( () => {
   class MockWorkflowFailedError extends Error {}
-  class MockWorkflowNotFoundError extends Error {}
 
   return {
     mockFromPayload: vi.fn(),
     mockFormatStatus: vi.fn(),
     mockBuildWorkflowResult: vi.fn(),
     mockLoggerWarn: vi.fn(),
-    MockWorkflowFailedError,
-    MockWorkflowNotFoundError
+    mockFetchHistoryPage: vi.fn(),
+    MockWorkflowFailedError
   };
 } );
 
 vi.mock( '@temporalio/client', () => ( {
   defaultPayloadConverter: { fromPayload: mockFromPayload },
-  WorkflowFailedError: MockWorkflowFailedError,
-  WorkflowNotFoundError: MockWorkflowNotFoundError
-} ) );
-
-vi.mock( '#configs', () => ( {
-  temporal: { namespace: 'default' }
+  WorkflowFailedError: MockWorkflowFailedError
 } ) );
 
 vi.mock( '#logger', () => ( {
@@ -44,6 +38,10 @@ vi.mock( '../workflow_result.js', () => ( {
 vi.mock( '../types.js', async importOriginal => ( {
   ...( await importOriginal() ),
   formatStatus: mockFormatStatus
+} ) );
+
+vi.mock( './fetch_history_page.js', () => ( {
+  fetchHistoryPage: mockFetchHistoryPage
 } ) );
 
 describe( 'extractWorkflowInput', () => {
@@ -79,7 +77,7 @@ describe( 'getResult', () => {
     mockBuildWorkflowResult.mockImplementation( args => ( { shaped: args } ) );
   } );
 
-  const makeGetResult = ( { describe, result, historyResponse, getHistoryError } = {} ) => {
+  const makeGetResult = ( { describe, result, historyResponse, historyError } = {} ) => {
     const latestHandle = {
       describe: vi.fn().mockResolvedValue( describe ?? {
         runId: 'resolved-run',
@@ -93,12 +91,11 @@ describe( 'getResult', () => {
     const getHandle = vi.fn()
       .mockReturnValueOnce( latestHandle )
       .mockReturnValue( pinnedHandle );
-    const getWorkflowExecutionHistory = vi.fn();
 
-    if ( getHistoryError !== undefined ) {
-      getWorkflowExecutionHistory.mockRejectedValue( getHistoryError );
+    if ( historyError !== undefined ) {
+      mockFetchHistoryPage.mockRejectedValue( historyError );
     } else {
-      getWorkflowExecutionHistory.mockResolvedValue( historyResponse ?? {
+      mockFetchHistoryPage.mockResolvedValue( historyResponse ?? {
         history: {
           events: [ {
             workflowExecutionStartedEventAttributes: { input: { payloads: [ { input: true } ] } }
@@ -111,9 +108,8 @@ describe( 'getResult', () => {
       latestHandle,
       pinnedHandle,
       getHandle,
-      getWorkflowExecutionHistory,
       client: { workflow: { getHandle } },
-      connection: { workflowService: { getWorkflowExecutionHistory } }
+      connection: { workflowService: {} }
     };
   };
 
@@ -124,7 +120,7 @@ describe( 'getResult', () => {
     const { getResult } = await import( './get_result.js' );
 
     await expect( getResult( fixtures, 'workflow-id' ) ).rejects.toBeInstanceOf( WorkflowNotCompletedError );
-    expect( fixtures.getWorkflowExecutionHistory ).not.toHaveBeenCalled();
+    expect( mockFetchHistoryPage ).not.toHaveBeenCalled();
   } );
 
   it( 'throws before history fetch when a terminal describe has no runId', async () => {
@@ -134,7 +130,7 @@ describe( 'getResult', () => {
     const { getResult } = await import( './get_result.js' );
 
     await expect( getResult( fixtures, 'workflow-id' ) ).rejects.toThrow( /did not report a runId/ );
-    expect( fixtures.getWorkflowExecutionHistory ).not.toHaveBeenCalled();
+    expect( mockFetchHistoryPage ).not.toHaveBeenCalled();
   } );
 
   it( 'pins latest-run result reads to the described runId and returns completed output', async () => {
@@ -146,11 +142,7 @@ describe( 'getResult', () => {
 
     expect( fixtures.getHandle ).toHaveBeenNthCalledWith( 1, 'workflow-id', undefined );
     expect( fixtures.getHandle ).toHaveBeenNthCalledWith( 2, 'workflow-id', 'resolved-run' );
-    expect( fixtures.getWorkflowExecutionHistory ).toHaveBeenCalledWith( {
-      namespace: 'default',
-      execution: { workflowId: 'workflow-id', runId: 'resolved-run' },
-      maximumPageSize: 1
-    } );
+    expect( mockFetchHistoryPage ).toHaveBeenCalledWith( fixtures.connection, 'workflow-id', 'resolved-run', { maximumPageSize: 1 } );
     expect( mockFormatStatus ).toHaveBeenCalledWith( 'COMPLETED' );
     expect( mockBuildWorkflowResult ).toHaveBeenCalledWith( {
       workflowId: 'workflow-id',
@@ -171,11 +163,11 @@ describe( 'getResult', () => {
       result: vi.fn().mockResolvedValue( { output: null } )
     };
     const getHandle = vi.fn().mockReturnValue( explicitHandle );
-    const getWorkflowExecutionHistory = vi.fn().mockResolvedValue( { history: { events: [] } } );
+    mockFetchHistoryPage.mockResolvedValue( { history: { events: [] } } );
     const { getResult } = await import( './get_result.js' );
     const internals = {
       client: { workflow: { getHandle } },
-      connection: { workflowService: { getWorkflowExecutionHistory } }
+      connection: { workflowService: {} }
     };
 
     await getResult( internals, 'workflow-id', 'explicit-run' );
@@ -247,27 +239,20 @@ describe( 'getResult', () => {
     } );
   } );
 
-  it( 'maps NOT_FOUND history errors to WorkflowNotFoundError and propagates other history errors', async () => {
-    const notFound = Object.assign( new Error( 'missing' ), { code: 5 } );
-    const unavailable = Object.assign( new Error( 'unavailable' ), { code: 14 } );
+  it( 'propagates errors from fetchHistoryPage unchanged', async () => {
+    const unavailable = new Error( 'unavailable' );
+    const fixtures = makeGetResult( { historyError: unavailable } );
     const { getResult } = await import( './get_result.js' );
 
-    await expect( getResult( makeGetResult( { getHistoryError: notFound } ), 'workflow-id' ) )
-      .rejects.toBeInstanceOf( WorkflowNotFoundError );
-    await expect( getResult( makeGetResult( { getHistoryError: unavailable } ), 'workflow-id' ) )
-      .rejects.toBe( unavailable );
+    await expect( getResult( fixtures, 'workflow-id' ) ).rejects.toBe( unavailable );
   } );
 
-  it( 'warns and returns null input when the history response has no history field', async () => {
+  it( 'returns null input when the history response has no history field', async () => {
     const fixtures = makeGetResult( { historyResponse: {} } );
     const { getResult } = await import( './get_result.js' );
 
     await getResult( fixtures, 'workflow-id' );
 
-    expect( mockLoggerWarn ).toHaveBeenCalledWith(
-      'Temporal getWorkflowExecutionHistory returned no history field',
-      { workflowId: 'workflow-id', runId: 'resolved-run' }
-    );
     expect( mockBuildWorkflowResult ).toHaveBeenCalledWith( expect.objectContaining( { input: null } ) );
   } );
 } );

--- a/api/src/clients/temporal/workflow/index.js
+++ b/api/src/clients/temporal/workflow/index.js
@@ -1,4 +1,5 @@
 import { getHistory } from './get_history.js';
+import { getInput } from './get_input.js';
 import { getResult } from './get_result.js';
 import { getStatus } from './get_status.js';
 import { listRuns } from './list_runs.js';
@@ -14,6 +15,7 @@ export const getWorkflowMethods = context => Object.fromEntries(
   Object.entries( {
     executeUpdate,
     getHistory,
+    getInput,
     getResult,
     getStatus,
     listRuns,

--- a/api/src/handlers/workflow_run.js
+++ b/api/src/handlers/workflow_run.js
@@ -22,3 +22,9 @@ export function createResultHandler( client ) {
     res.json( await client.workflow.getResult( req.params.id, readPinnedRunId( req ) ) );
   };
 }
+
+export function createInputHandler( client ) {
+  return async ( req, res ) => {
+    res.json( await client.workflow.getInput( req.params.id, readPinnedRunId( req ) ) );
+  };
+}

--- a/api/src/handlers/workflow_run.spec.js
+++ b/api/src/handlers/workflow_run.spec.js
@@ -9,18 +9,20 @@ vi.mock( '#logger', () => ( {
   logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), http: vi.fn() }
 } ) );
 
-import { createStopHandler, createTerminateHandler, createResultHandler } from './workflow_run.js';
+import { createStopHandler, createTerminateHandler, createResultHandler, createInputHandler } from './workflow_run.js';
 import errorHandler from '../middleware/error_handler.js';
 
 describe( 'workflow_run handlers', () => {
   const mockStopWorkflow = vi.fn();
   const mockTerminateWorkflow = vi.fn();
   const mockGetWorkflowResult = vi.fn();
+  const mockGetWorkflowInput = vi.fn();
   const mockClient = {
     workflow: {
       stop: mockStopWorkflow,
       terminate: mockTerminateWorkflow,
-      getResult: mockGetWorkflowResult
+      getResult: mockGetWorkflowResult,
+      getInput: mockGetWorkflowInput
     }
   };
 
@@ -131,6 +133,39 @@ describe( 'workflow_run handlers', () => {
     it( 'returns 400 for an invalid rid', async () => {
       await request( app() ).get( '/workflow/w1/runs/not-a-uuid/result' ).expect( 400 );
       expect( mockGetWorkflowResult ).not.toHaveBeenCalled();
+    } );
+  } );
+
+  describe( 'createInputHandler', () => {
+    const app = () => {
+      const handler = createInputHandler( mockClient );
+      const a = express();
+      a.get( '/workflow/:id/input', handler );
+      a.get( '/workflow/:id/runs/:rid/input', handler );
+      a.use( errorHandler );
+      return a;
+    };
+
+    it( 'returns the workflow input', async () => {
+      mockGetWorkflowInput.mockResolvedValue( { workflowId: 'w1', runId: RID, input: { values: [ 1, 2 ] } } );
+
+      const res = await request( app() ).get( '/workflow/w1/input' ).expect( 200 );
+
+      expect( res.body ).toEqual( { workflowId: 'w1', runId: RID, input: { values: [ 1, 2 ] } } );
+      expect( mockGetWorkflowInput ).toHaveBeenCalledWith( 'w1', undefined );
+    } );
+
+    it( 'forwards the pinned rid', async () => {
+      mockGetWorkflowInput.mockResolvedValue( {} );
+
+      await request( app() ).get( `/workflow/w1/runs/${RID}/input` ).expect( 200 );
+
+      expect( mockGetWorkflowInput ).toHaveBeenCalledWith( 'w1', RID );
+    } );
+
+    it( 'returns 400 for an invalid rid', async () => {
+      await request( app() ).get( '/workflow/w1/runs/not-a-uuid/input' ).expect( 400 );
+      expect( mockGetWorkflowInput ).not.toHaveBeenCalled();
     } );
   } );
 } );

--- a/api/src/handlers/workflow_run.spec.js
+++ b/api/src/handlers/workflow_run.spec.js
@@ -10,6 +10,7 @@ vi.mock( '#logger', () => ( {
 } ) );
 
 import { createStopHandler, createTerminateHandler, createResultHandler, createInputHandler } from './workflow_run.js';
+import { workflowNotFoundError } from '../clients/errors.js';
 import errorHandler from '../middleware/error_handler.js';
 
 describe( 'workflow_run handlers', () => {
@@ -166,6 +167,16 @@ describe( 'workflow_run handlers', () => {
     it( 'returns 400 for an invalid rid', async () => {
       await request( app() ).get( '/workflow/w1/runs/not-a-uuid/input' ).expect( 400 );
       expect( mockGetWorkflowInput ).not.toHaveBeenCalled();
+    } );
+
+    it( 'maps a WorkflowNotFoundError to a 404', async () => {
+      mockGetWorkflowInput.mockRejectedValue( workflowNotFoundError( 'w1' ) );
+
+      await request( app() ).get( '/workflow/w1/input' ).expect( 404, {
+        error: 'WorkflowNotFoundError',
+        message: 'Workflow "w1" not found',
+        workflowId: 'w1'
+      } );
     } );
   } );
 } );

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -399,6 +399,7 @@ app.use( ( req, res, next ) => {
  *               description: Sanitized error cause chain (name/message per level, no stack)
  *     WorkflowInputResponse:
  *       type: object
+ *       required: [workflowId, runId, input]
  *       properties:
  *         workflowId:
  *           type: string
@@ -407,7 +408,7 @@ app.use( ( req, res, next ) => {
  *           type: string
  *           description: The specific run id the input was read from
  *         input:
- *           description: The original input passed to the workflow, null if unavailable
+ *           description: The first input argument the workflow was started with, null if unavailable
  *     StopWorkflowResponse:
  *       type: object
  *       properties:
@@ -1024,6 +1025,7 @@ app.get( '/workflow/:id/runs/:rid/result', resultHandler );
  *        required: true
  *        schema:
  *          type: string
+ *        description: The id of workflow to retrieve the input
  *      - in: path
  *        name: rid
  *        required: true

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -8,7 +8,7 @@ import { createHttpLoggingMiddleware } from './middleware/http_logger.js';
 import errorHandler from './middleware/error_handler.js';
 import deprecated from './middleware/deprecated.js';
 import { createTraceLogHandler } from './handlers/trace_log.js';
-import { createStopHandler, createTerminateHandler, createResultHandler } from './handlers/workflow_run.js';
+import { createStopHandler, createTerminateHandler, createResultHandler, createInputHandler } from './handlers/workflow_run.js';
 import { createWorkflowHistoryHandler } from './handlers/workflow_history.js';
 import { createWorkflowHistoryStreamHandler } from './handlers/workflow_history_stream.js';
 import { readPinnedRunId } from './handlers/utils.js';
@@ -53,6 +53,7 @@ const client = await temporalClient.init().catch( e => {
 const stopHandler = createStopHandler( client );
 const terminateHandler = createTerminateHandler( client );
 const resultHandler = createResultHandler( client );
+const inputHandler = createInputHandler( client );
 const traceLogHandler = createTraceLogHandler( client );
 
 // Sets payload limit for POST in application/json format. Some workflow have very large payloads
@@ -396,6 +397,17 @@ app.use( ( req, res, next ) => {
  *               nullable: true
  *               additionalProperties: true
  *               description: Sanitized error cause chain (name/message per level, no stack)
+ *     WorkflowInputResponse:
+ *       type: object
+ *       properties:
+ *         workflowId:
+ *           type: string
+ *           description: The workflow execution id
+ *         runId:
+ *           type: string
+ *           description: The specific run id the input was read from
+ *         input:
+ *           description: The original input passed to the workflow, null if unavailable
  *     StopWorkflowResponse:
  *       type: object
  *       properties:
@@ -977,6 +989,64 @@ app.post(
  */
 app.get( '/workflow/:id/result', resultHandler );
 app.get( '/workflow/:id/runs/:rid/result', resultHandler );
+
+/**
+ * @swagger
+ * /workflow/{id}/input:
+ *   get:
+ *     summary: Return the original input of a workflow (latest run)
+ *     description: Returns the original input passed to the latest run of the given workflow. Works for workflows in any state, including running. To pin a specific run, use `/workflow/{id}/runs/{rid}/input`.
+ *     parameters:
+ *      - in: path
+ *        name: id
+ *        required: true
+ *        schema:
+ *          type: string
+ *        description: The id of workflow to retrieve the input
+ *     responses:
+ *       200:
+ *         description: The workflow input
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WorkflowInputResponse'
+ *       404:
+ *         $ref: '#/components/responses/NotFound'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ *
+ * /workflow/{id}/runs/{rid}/input:
+ *   get:
+ *     summary: Return the original input of a specific workflow run
+ *     parameters:
+ *      - in: path
+ *        name: id
+ *        required: true
+ *        schema:
+ *          type: string
+ *      - in: path
+ *        name: rid
+ *        required: true
+ *        schema:
+ *          type: string
+ *          format: uuid
+ *        description: The specific run id to target
+ *     responses:
+ *       200:
+ *         description: The workflow input
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/WorkflowInputResponse'
+ *       400:
+ *         $ref: '#/components/responses/BadRequest'
+ *       404:
+ *         $ref: '#/components/responses/NotFound'
+ *       500:
+ *         $ref: '#/components/responses/InternalServerError'
+ */
+app.get( '/workflow/:id/input', inputHandler );
+app.get( '/workflow/:id/runs/:rid/input', inputHandler );
 
 /**
  * @swagger

--- a/docs/guides/openapi.json
+++ b/docs/guides/openapi.json
@@ -405,6 +405,22 @@
           }
         }
       },
+      "WorkflowInputResponse": {
+        "type": "object",
+        "properties": {
+          "workflowId": {
+            "type": "string",
+            "description": "The workflow execution id"
+          },
+          "runId": {
+            "type": "string",
+            "description": "The specific run id the input was read from"
+          },
+          "input": {
+            "description": "The original input passed to the workflow, null if unavailable"
+          }
+        }
+      },
       "StopWorkflowResponse": {
         "type": "object",
         "properties": {
@@ -1192,6 +1208,87 @@
           },
           "424": {
             "$ref": "#/components/responses/FailedDependency"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/workflow/{id}/input": {
+      "get": {
+        "summary": "Return the original input of a workflow (latest run)",
+        "description": "Returns the original input passed to the latest run of the given workflow. Works for workflows in any state, including running. To pin a specific run, use `/workflow/{id}/runs/{rid}/input`.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The id of workflow to retrieve the input"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The workflow input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowInputResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/workflow/{id}/runs/{rid}/input": {
+      "get": {
+        "summary": "Return the original input of a specific workflow run",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "rid",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "description": "The specific run id to target"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The workflow input",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowInputResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"

--- a/docs/guides/openapi.json
+++ b/docs/guides/openapi.json
@@ -407,6 +407,11 @@
       },
       "WorkflowInputResponse": {
         "type": "object",
+        "required": [
+          "workflowId",
+          "runId",
+          "input"
+        ],
         "properties": {
           "workflowId": {
             "type": "string",
@@ -417,7 +422,7 @@
             "description": "The specific run id the input was read from"
           },
           "input": {
-            "description": "The original input passed to the workflow, null if unavailable"
+            "description": "The first input argument the workflow was started with, null if unavailable"
           }
         }
       },
@@ -1260,7 +1265,8 @@
             "required": true,
             "schema": {
               "type": "string"
-            }
+            },
+            "description": "The id of workflow to retrieve the input"
           },
           {
             "in": "path",

--- a/sdk/cli/src/api/generated/api.ts
+++ b/sdk/cli/src/api/generated/api.ts
@@ -303,11 +303,11 @@ export interface WorkflowResultResponse {
 
 export interface WorkflowInputResponse {
   /** The workflow execution id */
-  workflowId?: string;
+  workflowId: string;
   /** The specific run id the input was read from */
-  runId?: string;
-  /** The original input passed to the workflow, null if unavailable */
-  input?: unknown;
+  runId: string;
+  /** The first input argument the workflow was started with, null if unavailable */
+  input: unknown;
 }
 
 export interface StopWorkflowResponse {

--- a/sdk/cli/src/api/generated/api.ts
+++ b/sdk/cli/src/api/generated/api.ts
@@ -301,6 +301,15 @@ export interface WorkflowResultResponse {
   errorDetails?: WorkflowResultResponseErrorDetails;
 }
 
+export interface WorkflowInputResponse {
+  /** The workflow execution id */
+  workflowId?: string;
+  /** The specific run id the input was read from */
+  runId?: string;
+  /** The original input passed to the workflow, null if unavailable */
+  input?: unknown;
+}
+
 export interface StopWorkflowResponse {
   workflowId?: string;
   runId?: string;
@@ -1354,6 +1363,110 @@ export const getWorkflowIdRunsRidResult = async (id: string,
     rid: string, options?: ApiRequestOptions): Promise<getWorkflowIdRunsRidResultResponse> => {
 
   return customFetchInstance<getWorkflowIdRunsRidResultResponse>(getGetWorkflowIdRunsRidResultUrl(id,rid),
+  {
+    ...options,
+    method: 'GET'
+
+
+  }
+);}
+
+
+
+/**
+ * Returns the original input passed to the latest run of the given workflow. Works for workflows in any state, including running. To pin a specific run, use `/workflow/{id}/runs/{rid}/input`.
+ * @summary Return the original input of a workflow (latest run)
+ */
+export type getWorkflowIdInputResponse200 = {
+  data: WorkflowInputResponse
+  status: 200
+}
+
+export type getWorkflowIdInputResponse404 = {
+  data: NotFoundResponse
+  status: 404
+}
+
+export type getWorkflowIdInputResponse500 = {
+  data: InternalServerErrorResponse
+  status: 500
+}
+
+export type getWorkflowIdInputResponseSuccess = (getWorkflowIdInputResponse200) & {
+  headers: Headers;
+};
+export type getWorkflowIdInputResponseError = (getWorkflowIdInputResponse404 | getWorkflowIdInputResponse500) & {
+  headers: Headers;
+};
+
+export type getWorkflowIdInputResponse = (getWorkflowIdInputResponseSuccess | getWorkflowIdInputResponseError)
+
+export const getGetWorkflowIdInputUrl = (id: string,) => {
+
+
+
+
+  return `/workflow/${id}/input`
+}
+
+export const getWorkflowIdInput = async (id: string, options?: ApiRequestOptions): Promise<getWorkflowIdInputResponse> => {
+
+  return customFetchInstance<getWorkflowIdInputResponse>(getGetWorkflowIdInputUrl(id),
+  {
+    ...options,
+    method: 'GET'
+
+
+  }
+);}
+
+
+
+/**
+ * @summary Return the original input of a specific workflow run
+ */
+export type getWorkflowIdRunsRidInputResponse200 = {
+  data: WorkflowInputResponse
+  status: 200
+}
+
+export type getWorkflowIdRunsRidInputResponse400 = {
+  data: BadRequestResponse
+  status: 400
+}
+
+export type getWorkflowIdRunsRidInputResponse404 = {
+  data: NotFoundResponse
+  status: 404
+}
+
+export type getWorkflowIdRunsRidInputResponse500 = {
+  data: InternalServerErrorResponse
+  status: 500
+}
+
+export type getWorkflowIdRunsRidInputResponseSuccess = (getWorkflowIdRunsRidInputResponse200) & {
+  headers: Headers;
+};
+export type getWorkflowIdRunsRidInputResponseError = (getWorkflowIdRunsRidInputResponse400 | getWorkflowIdRunsRidInputResponse404 | getWorkflowIdRunsRidInputResponse500) & {
+  headers: Headers;
+};
+
+export type getWorkflowIdRunsRidInputResponse = (getWorkflowIdRunsRidInputResponseSuccess | getWorkflowIdRunsRidInputResponseError)
+
+export const getGetWorkflowIdRunsRidInputUrl = (id: string,
+    rid: string,) => {
+
+
+
+
+  return `/workflow/${id}/runs/${rid}/input`
+}
+
+export const getWorkflowIdRunsRidInput = async (id: string,
+    rid: string, options?: ApiRequestOptions): Promise<getWorkflowIdRunsRidInputResponse> => {
+
+  return customFetchInstance<getWorkflowIdRunsRidInputResponse>(getGetWorkflowIdRunsRidInputUrl(id,rid),
   {
     ...options,
     method: 'GET'

--- a/sdk/cli/src/commands/workflow/input.spec.ts
+++ b/sdk/cli/src/commands/workflow/input.spec.ts
@@ -1,0 +1,136 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs/promises';
+import { getWorkflowIdInput, getWorkflowIdRunsRidInput } from '#api/generated/api.js';
+import WorkflowInput from './input.js';
+
+vi.mock( 'node:fs/promises' );
+vi.mock( '#api/generated/api.js', () => ( {
+  getWorkflowIdInput: vi.fn(),
+  getWorkflowIdRunsRidInput: vi.fn()
+} ) );
+
+const RID = '11111111-2222-4333-8444-555555555555';
+const INPUT = { values: [ 1, 2, 3 ] };
+
+const makeCmd = ( argv: string[] ) => {
+  const config = { runHook: vi.fn().mockResolvedValue( { failures: [], successes: [] } ) } as any;
+  const cmd = new WorkflowInput( argv, config );
+  cmd.log = vi.fn() as any;
+  cmd.logToStderr = vi.fn() as any;
+  cmd.error = vi.fn().mockImplementation( ( msg: string ) => {
+    throw new Error( msg );
+  } ) as any;
+  cmd.jsonEnabled = vi.fn().mockReturnValue( false ) as any;
+  return cmd;
+};
+
+describe( 'workflow input command', () => {
+  beforeEach( () => vi.clearAllMocks() );
+  afterEach( () => vi.restoreAllMocks() );
+
+  describe( 'command definition', () => {
+    it( 'exports a valid OCLIF command', () => {
+      expect( WorkflowInput.description ).toContain( 'input' );
+      expect( WorkflowInput.args ).toHaveProperty( 'workflowId' );
+      expect( WorkflowInput.enableJsonFlag ).toBe( true );
+    } );
+
+    it( 'defines run-id, output-file and force flags', () => {
+      expect( WorkflowInput.flags['run-id'] ).toBeDefined();
+      expect( WorkflowInput.flags['output-file'].char ).toBe( 'o' );
+      expect( WorkflowInput.flags.force.char ).toBe( 'f' );
+      expect( WorkflowInput.flags.force.default ).toBe( false );
+    } );
+  } );
+
+  describe( 'fetching input', () => {
+    it( 'prints the input JSON to stdout for the latest run', async () => {
+      vi.mocked( getWorkflowIdInput ).mockResolvedValue(
+        { data: { workflowId: 'wf-1', runId: RID, input: INPUT } } as any
+      );
+
+      const cmd = makeCmd( [ 'wf-1' ] );
+      await cmd.run();
+
+      expect( getWorkflowIdInput ).toHaveBeenCalledWith( 'wf-1' );
+      expect( getWorkflowIdRunsRidInput ).not.toHaveBeenCalled();
+      expect( cmd.log ).toHaveBeenCalledWith( JSON.stringify( INPUT, null, 2 ) );
+    } );
+
+    it( 'uses the run-pinned endpoint when --run-id is given', async () => {
+      vi.mocked( getWorkflowIdRunsRidInput ).mockResolvedValue(
+        { data: { workflowId: 'wf-1', runId: RID, input: INPUT } } as any
+      );
+
+      const cmd = makeCmd( [ 'wf-1', '--run-id', RID ] );
+      await cmd.run();
+
+      expect( getWorkflowIdRunsRidInput ).toHaveBeenCalledWith( 'wf-1', RID );
+      expect( getWorkflowIdInput ).not.toHaveBeenCalled();
+    } );
+
+    it( 'prints null when no input is available', async () => {
+      vi.mocked( getWorkflowIdInput ).mockResolvedValue(
+        { data: { workflowId: 'wf-1', runId: RID, input: null } } as any
+      );
+
+      const cmd = makeCmd( [ 'wf-1' ] );
+      await cmd.run();
+
+      expect( cmd.log ).toHaveBeenCalledWith( 'null' );
+    } );
+  } );
+
+  describe( 'writing to a file', () => {
+    beforeEach( () => {
+      vi.mocked( getWorkflowIdInput ).mockResolvedValue(
+        { data: { workflowId: 'wf-1', runId: RID, input: INPUT } } as any
+      );
+    } );
+
+    it( 'writes the input JSON to the output file', async () => {
+      vi.mocked( fs.access ).mockRejectedValue( new Error( 'not found' ) );
+      vi.mocked( fs.writeFile ).mockResolvedValue();
+
+      const cmd = makeCmd( [ 'wf-1', '-o', 'out.json' ] );
+      await cmd.run();
+
+      expect( fs.writeFile ).toHaveBeenCalledWith(
+        expect.stringContaining( 'out.json' ),
+        `${JSON.stringify( INPUT, null, 2 )}\n`,
+        'utf-8'
+      );
+      expect( cmd.log ).not.toHaveBeenCalled();
+      expect( cmd.logToStderr ).toHaveBeenCalledWith( expect.stringContaining( 'out.json' ) );
+    } );
+
+    it( 'refuses to overwrite an existing file without --force', async () => {
+      vi.mocked( fs.access ).mockResolvedValue();
+
+      const cmd = makeCmd( [ 'wf-1', '-o', 'out.json' ] );
+
+      await expect( cmd.run() ).rejects.toThrow( 'File already exists' );
+      expect( fs.writeFile ).not.toHaveBeenCalled();
+    } );
+
+    it( 'overwrites an existing file when --force is set', async () => {
+      vi.mocked( fs.access ).mockResolvedValue();
+      vi.mocked( fs.writeFile ).mockResolvedValue();
+
+      const cmd = makeCmd( [ 'wf-1', '-o', 'out.json', '--force' ] );
+      await cmd.run();
+
+      expect( fs.writeFile ).toHaveBeenCalled();
+    } );
+  } );
+
+  describe( 'error handling', () => {
+    it( 'maps a 404 to a friendly message', async () => {
+      const cmd = makeCmd( [ 'wf-1' ] );
+      const apiError = Object.assign( new Error( 'Not Found' ), { response: { status: 404 } } );
+
+      await expect( cmd.catch( apiError ) ).rejects.toThrow( 'Workflow not found' );
+    } );
+  } );
+} );

--- a/sdk/cli/src/commands/workflow/input.spec.ts
+++ b/sdk/cli/src/commands/workflow/input.spec.ts
@@ -35,13 +35,6 @@ describe( 'workflow input command', () => {
       expect( WorkflowInput.args ).toHaveProperty( 'workflowId' );
       expect( WorkflowInput.enableJsonFlag ).toBe( true );
     } );
-
-    it( 'defines run-id, output-file and force flags', () => {
-      expect( WorkflowInput.flags['run-id'] ).toBeDefined();
-      expect( WorkflowInput.flags['output-file'].char ).toBe( 'o' );
-      expect( WorkflowInput.flags.force.char ).toBe( 'f' );
-      expect( WorkflowInput.flags.force.default ).toBe( false );
-    } );
   } );
 
   describe( 'fetching input', () => {

--- a/sdk/cli/src/commands/workflow/input.spec.ts
+++ b/sdk/cli/src/commands/workflow/input.spec.ts
@@ -38,17 +38,32 @@ describe( 'workflow input command', () => {
   } );
 
   describe( 'fetching input', () => {
-    it( 'prints the input JSON to stdout for the latest run', async () => {
+    it( 'prints the bare input JSON to stdout and returns it for the latest run', async () => {
       vi.mocked( getWorkflowIdInput ).mockResolvedValue(
         { data: { workflowId: 'wf-1', runId: RID, input: INPUT } } as any
       );
 
       const cmd = makeCmd( [ 'wf-1' ] );
-      await cmd.run();
+      const result = await cmd.run();
 
       expect( getWorkflowIdInput ).toHaveBeenCalledWith( 'wf-1' );
       expect( getWorkflowIdRunsRidInput ).not.toHaveBeenCalled();
       expect( cmd.log ).toHaveBeenCalledWith( JSON.stringify( INPUT, null, 2 ) );
+      // run() returns the bare input (not the envelope), so --json emits the same shape.
+      expect( result ).toEqual( INPUT );
+    } );
+
+    it( 'returns the bare input and skips manual logging in --json mode', async () => {
+      vi.mocked( getWorkflowIdInput ).mockResolvedValue(
+        { data: { workflowId: 'wf-1', runId: RID, input: INPUT } } as any
+      );
+
+      const cmd = makeCmd( [ 'wf-1', '--json' ] );
+      ( cmd.jsonEnabled as any ).mockReturnValue( true );
+      const result = await cmd.run();
+
+      expect( cmd.log ).not.toHaveBeenCalled();
+      expect( result ).toEqual( INPUT );
     } );
 
     it( 'uses the run-pinned endpoint when --run-id is given', async () => {

--- a/sdk/cli/src/commands/workflow/input.spec.ts
+++ b/sdk/cli/src/commands/workflow/input.spec.ts
@@ -113,6 +113,19 @@ describe( 'workflow input command', () => {
       expect( cmd.logToStderr ).toHaveBeenCalledWith( expect.stringContaining( 'out.json' ) );
     } );
 
+    it( 'does not return the bare input in file mode, so --json never duplicates it to stdout', async () => {
+      vi.mocked( fs.access ).mockRejectedValue( new Error( 'not found' ) );
+      vi.mocked( fs.writeFile ).mockResolvedValue();
+
+      const cmd = makeCmd( [ 'wf-1', '-o', 'out.json', '--json' ] );
+      ( cmd.jsonEnabled as any ).mockReturnValue( true );
+      const result = await cmd.run();
+
+      // The input went to the file; --json must emit a confirmation, not the input again.
+      expect( result ).not.toEqual( INPUT );
+      expect( result ).toMatchObject( { outputFile: expect.stringContaining( 'out.json' ) } );
+    } );
+
     it( 'refuses to overwrite an existing file without --force', async () => {
       vi.mocked( fs.access ).mockResolvedValue();
 
@@ -139,6 +152,16 @@ describe( 'workflow input command', () => {
       const apiError = Object.assign( new Error( 'Not Found' ), { response: { status: 404 } } );
 
       await expect( cmd.catch( apiError ) ).rejects.toThrow( 'Workflow not found' );
+    } );
+
+    it( 'shows the friendly 404 even when the API body carries error/message', async () => {
+      const cmd = makeCmd( [ 'wf-1' ] );
+      // Real API 404 shape: the override must win over this body, not be shadowed by it.
+      const apiError = Object.assign( new Error( 'Not Found' ), {
+        response: { status: 404, data: { error: 'WorkflowNotFoundError', message: 'Workflow "wf-1" not found' } }
+      } );
+
+      await expect( cmd.catch( apiError ) ).rejects.toThrow( 'Workflow not found. Check the workflow ID.' );
     } );
   } );
 } );

--- a/sdk/cli/src/commands/workflow/input.ts
+++ b/sdk/cli/src/commands/workflow/input.ts
@@ -72,7 +72,10 @@ export default class WorkflowInput extends Command {
 
       await fs.writeFile( destPath, `${json}\n`, 'utf-8' );
       this.logToStderr( `Wrote workflow input to ${destPath}` );
-      return input;
+      // Don't return the bare input here: under --json oclif serializes run()'s return value to
+      // stdout, which would duplicate the input we just wrote to the file. Return a status object
+      // so --json emits a confirmation instead, and non-json mode keeps stdout empty.
+      return { outputFile: destPath };
     }
 
     // Emit only the bare input (never the response envelope) so every mode yields the same

--- a/sdk/cli/src/commands/workflow/input.ts
+++ b/sdk/cli/src/commands/workflow/input.ts
@@ -42,7 +42,7 @@ export default class WorkflowInput extends Command {
     } )
   };
 
-  async run(): Promise<WorkflowInputResponse> {
+  async run(): Promise<unknown> {
     const { args, flags } = await this.parse( WorkflowInput );
     const runId = flags['run-id'];
     const outputFile = flags['output-file'];
@@ -56,7 +56,8 @@ export default class WorkflowInput extends Command {
     }
 
     const data = response.data as WorkflowInputResponse;
-    const json = JSON.stringify( data.input ?? null, null, 2 );
+    const input = data.input;
+    const json = JSON.stringify( input, null, 2 );
 
     if ( outputFile ) {
       const destPath = path.resolve( process.cwd(), outputFile );
@@ -71,16 +72,17 @@ export default class WorkflowInput extends Command {
 
       await fs.writeFile( destPath, `${json}\n`, 'utf-8' );
       this.logToStderr( `Wrote workflow input to ${destPath}` );
-      return data;
+      return input;
     }
 
-    // Keep stdout pure JSON so it can be piped (e.g. `output workflow input <id> | jq .`).
-    // oclif serializes the returned object itself when --json is set, so skip the manual log.
+    // Emit only the bare input (never the response envelope) so every mode yields the same
+    // pipeable value (e.g. `output workflow input <id> | jq .`). Under --json oclif serializes
+    // run()'s return value, which is also the bare input, so skip the manual log here.
     if ( !this.jsonEnabled() ) {
       this.log( json );
     }
 
-    return data;
+    return input;
   }
 
   async catch( error: Error ): Promise<void> {

--- a/sdk/cli/src/commands/workflow/input.ts
+++ b/sdk/cli/src/commands/workflow/input.ts
@@ -1,0 +1,91 @@
+import { Args, Command, Flags } from '@oclif/core';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {
+  getWorkflowIdInput,
+  getWorkflowIdRunsRidInput,
+  type WorkflowInputResponse
+} from '#api/generated/api.js';
+import { handleApiError } from '#utils/error_handler.js';
+
+export default class WorkflowInput extends Command {
+  static override description = 'Get the original input a workflow run was started with';
+
+  static override enableJsonFlag = true;
+
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> wf-12345',
+    '<%= config.bin %> <%= command.id %> wf-12345 --run-id 11111111-2222-4333-8444-555555555555',
+    '<%= config.bin %> <%= command.id %> wf-12345 -o w_input.json',
+    '<%= config.bin %> <%= command.id %> wf-12345 --output-file w_input.json --force'
+  ];
+
+  static override args = {
+    workflowId: Args.string( {
+      description: 'The workflow ID to get the input for',
+      required: true
+    } )
+  };
+
+  static override flags = {
+    'run-id': Flags.string( {
+      description: 'Specific run id to target (defaults to the latest run)'
+    } ),
+    'output-file': Flags.string( {
+      char: 'o',
+      description: 'Write the input JSON to this file instead of stdout'
+    } ),
+    force: Flags.boolean( {
+      char: 'f',
+      default: false,
+      description: 'Overwrite the output file if it already exists'
+    } )
+  };
+
+  async run(): Promise<WorkflowInputResponse> {
+    const { args, flags } = await this.parse( WorkflowInput );
+    const runId = flags['run-id'];
+    const outputFile = flags['output-file'];
+
+    const response = runId ?
+      await getWorkflowIdRunsRidInput( args.workflowId, runId ) :
+      await getWorkflowIdInput( args.workflowId );
+
+    if ( !response || !response.data ) {
+      this.error( 'API returned invalid response', { exit: 1 } );
+    }
+
+    const data = response.data as WorkflowInputResponse;
+    const json = JSON.stringify( data.input ?? null, null, 2 );
+
+    if ( outputFile ) {
+      const destPath = path.resolve( process.cwd(), outputFile );
+      const fileExists = await fs.access( destPath ).then( () => true ).catch( () => false );
+
+      if ( fileExists && !flags.force ) {
+        this.error(
+          `File already exists at ${destPath}. Use --force to overwrite or choose a different --output-file.`,
+          { exit: 1 }
+        );
+      }
+
+      await fs.writeFile( destPath, `${json}\n`, 'utf-8' );
+      this.logToStderr( `Wrote workflow input to ${destPath}` );
+      return data;
+    }
+
+    // Keep stdout pure JSON so it can be piped (e.g. `output workflow input <id> | jq .`).
+    // oclif serializes the returned object itself when --json is set, so skip the manual log.
+    if ( !this.jsonEnabled() ) {
+      this.log( json );
+    }
+
+    return data;
+  }
+
+  async catch( error: Error ): Promise<void> {
+    return handleApiError( error, ( ...args ) => this.error( ...args ), {
+      404: 'Workflow not found. Check the workflow ID.'
+    } );
+  }
+}

--- a/sdk/cli/src/utils/error_handler.ts
+++ b/sdk/cli/src/utils/error_handler.ts
@@ -97,6 +97,15 @@ export function handleApiError(
   if ( apiError.response?.status ) {
     const status = apiError.response.status;
 
+    // A caller-supplied override for this exact status wins over the raw server body. The API's
+    // 404 body is a bare "WorkflowNotFoundError: ..." that the friendly override is meant to
+    // replace; without this, extractApiErrorDetails consumes the body first and every command's
+    // per-status override is dead code. Defaults are not consulted here, so commands that pass no
+    // override still get the rich server detail below.
+    if ( status in overrides ) {
+      errorFn( overrides[status as keyof ErrorOverrides] as string, { exit: 1 } );
+    }
+
     // Extract error details from response body
     const apiErrorDetails = extractApiErrorDetails( apiError.response.data );
     if ( apiErrorDetails ) {


### PR DESCRIPTION
Adds API/CLI to get the input used from a workflow. 

Example usage:

```
❯ output workflow input 5n0pcHLKGXb7HwAJ8-KZo
{
  "urls": [
    "https://a.com",
    "https://b.com",
    "https://c.com",
    "https://d.com"
  ],
  "delayMs": 5000
}
```

Write to file:

```
❯ output workflow input 5n0pcHLKGXb7HwAJ8-KZo -o file.json
Wrote workflow input to /Users/clint/go/github.com/growthxai/output/.claude/worktrees/cli_workflow_input/file.json

❯ cat file.json
{
  "urls": [
    "https://a.com",
    "https://b.com",
    "https://c.com",
    "https://d.com"
  ],
  "delayMs": 5000
}
```

Note: at time of writing, the `--json` flag actually provides more information, including the workflow and run ids. I'm not sure if we should keep that, or invert it (`--json` omits that, but by default we include it):

```
❯ output workflow input 5n0pcHLKGXb7HwAJ8-KZo --json
{
  "workflowId": "5n0pcHLKGXb7HwAJ8-KZo",
  "runId": "019f0081-835b-7812-9872-897cbc4c01fc",
  "input": {
    "urls": [
      "https://a.com",
      "https://b.com",
      "https://c.com",
      "https://d.com"
    ],
    "delayMs": 5000
  }
}
```

Also accepts `runId`: 

```
❯ output workflow input 5n0pcHLKGXb7HwAJ8-KZo --run-id 019f0081-835b-7812-9872-897cbc4c01fc
{
  "urls": [
    "https://a.com",
    "https://b.com",
    "https://c.com",
    "https://d.com"
  ],
  "delayMs": 5000
}
```