### PR TITLE
chore(cods): Documented workflow, evaluators and step naming rules (OUT-72)

### DIFF
--- a/docs/guides/evaluators/evaluator-step.mdx
+++ b/docs/guides/evaluators/evaluator-step.mdx
@@ -106,6 +106,8 @@ Evaluators are called from workflows like regular async functions — `await jud
 | `options` | `object` | Optional workflow options (see [Options](#options)) |
 | `fn` | `function` | The evaluator implementation (must return an `EvaluationResult`) |
 
+Evaluator names must start with a letter or underscore, followed by letters, numbers, or underscores. Hyphens, spaces, dots, and other punctuation are not allowed.
+
 ## EvaluationResult Types
 
 Evaluators must return an `EvaluationResult`. Three types are available depending on what you're scoring:

--- a/docs/guides/steps/index.mdx
+++ b/docs/guides/steps/index.mdx
@@ -50,6 +50,8 @@ Steps are called from workflows like regular async functions — `await lookupCo
 | `options` | `object` | Optional workflow options (see [Options](#options)) |
 | `fn` | `function` | The step implementation |
 
+Step names must start with a letter or underscore, followed by letters, numbers, or underscores. Hyphens, spaces, dots, and other punctuation are not allowed.
+
 ## Steps vs Workflows
 
 <CardGroup cols={2}>

--- a/docs/guides/workflows/index.mdx
+++ b/docs/guides/workflows/index.mdx
@@ -53,6 +53,8 @@ The `fn` function is your workflow logic. It calls steps in sequence, and each s
 | `options` | `object` | Optional workflow options (see [Options](#options)) |
 | `aliases` | `string[]` | Optional alternative names for backward-compatible renaming (see [Aliases](#aliases)) |
 
+Workflow names must start with a letter or underscore, followed by letters, numbers, or underscores. Hyphens, spaces, dots, and other punctuation are not allowed.
+
 ## Workflow Rules
 
 Workflows must be **deterministic** — given the same input, they must always follow the same path. This is because Output (via Temporal) replays your workflow code to recover state after failures. If the code produces different results on replay, recovery breaks.
@@ -237,7 +239,7 @@ export default workflow({
 
 Callers using `lead_enrichment` or `enrich_lead` are resolved to `lead_enrichment_v2` before execution. The workflow runs under its canonical name, keeping execution history consistent.
 
-Alias names follow the same naming rules as workflow names (letters, numbers, underscores). Uniqueness is enforced case-insensitively at startup — an alias cannot conflict with any workflow name or another alias.
+Alias names follow the same naming rules as workflow names: start with a letter or underscore, then use only letters, numbers, or underscores. Uniqueness is enforced case-insensitively at startup — an alias cannot conflict with any workflow name or another alias.
 
 ## Workflow Context
 


### PR DESCRIPTION
## Summary

Added missing docs explaining workflow, evaluators and step naming rules.

