### PR TITLE
chore: Pinning minimum node version 24.15.0 [OUT-512]

### DIFF
--- a/.changeset/fair-buses-doubt.md
+++ b/.changeset/fair-buses-doubt.md
@@ -1,0 +1,12 @@
+---
+"@outputai/credentials": patch
+"@outputai/output": patch
+"@outputai/evals": patch
+"@outputai/core": patch
+"@outputai/http": patch
+"@outputai/cli": patch
+"@outputai/llm": patch
+"output-api": patch
+---
+
+Pinning v24.15.0 as the minimal supported Node version

--- a/.github/workflows/docs_regenerate.yml
+++ b/.github/workflows/docs_regenerate.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24.13'
+          node-version: '24.15.0'
 
       - name: Regenerate MDX
         run: ./ops/regenerate_docs.sh
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '24.13'
+          node-version: '24.15.0'
 
       - name: Regenerate MDX
         run: ./ops/regenerate_docs.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Output.ai is an AI framework for building reliable production-ready LLM workflow
 
 ## Tech Stack Context
 
-- Runtime: Node.js 24.3 with ES modules
+- Runtime: Node.js >=24.15.0
 - Workflow orchestration: Temporal
 - LLM providers: Anthropic, OpenAI (via AI SDK)
 - Testing: Vitest

--- a/api/package.json
+++ b/api/package.json
@@ -4,6 +4,9 @@
   "description": "A simple flow core abstract",
   "type": "module",
   "main": "index.js",
+  "engines": {
+    "node": ">=24.15.0"
+  },
   "scripts": {
     "build": "npm run generate:openapi",
     "generate:openapi": "node ./scripts/generate_openapi.js"

--- a/docs/guides/start-here/getting-started.mdx
+++ b/docs/guides/start-here/getting-started.mdx
@@ -8,8 +8,6 @@ description: "Create your first Output workflow in minutes"
 This is the quick and dirty way to get started – but be sure to read the full guide below.
 
 ```bash
-# Prerequisites: Node.js 20+, Docker Desktop
-
 # Install VS Code Claude Code extension (recommended)
 # https://marketplace.visualstudio.com/items?itemName=anthropics.claude-code
 
@@ -44,7 +42,7 @@ npx output workflow debug <workflow-id>
 
 Before starting, you'll need:
 
-- **Node.js 20+** — [Download here](https://nodejs.org/)
+- **Node.js 24.15.0+** — [Download here](https://nodejs.org/)
 - **Docker Desktop** — [Download here](https://www.docker.com/products/docker-desktop/) we'll need for running some of dependencies (PostgreSQL, Redis, Temporal)
 - **VS Code with Claude Code** — [Install extension](https://marketplace.visualstudio.com/items?itemName=anthropics.claude-code). You can use the CLI directly if you prefer or Claude Code outside of VS Code as well - your choice, but AI assisted is how we recommend you use Output.
 - **Anthropic API key** — [Get one here](https://console.anthropic.com/)

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "description": "The core project that contains the SDK npm modules and the API for the output.ai framework",
   "type": "module",
+  "engines": {
+    "node": ">=24.15.0"
+  },
   "scripts": {
     "prepare": "command -v git > /dev/null && husky || true",
     "lint": "eslint",

--- a/sdk/cli/package.json
+++ b/sdk/cli/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "engines": {
+    "node": ">=24.15.0"
+  },
   "files": [
     "./bin",
     "./dist",

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -3,6 +3,9 @@
   "version": "0.9.1",
   "description": "The core module of the output framework",
   "type": "module",
+  "engines": {
+    "node": ">=24.15.0"
+  },
   "exports": {
     ".": {
       "types": "./src/index.d.ts",

--- a/sdk/credentials/package.json
+++ b/sdk/credentials/package.json
@@ -3,6 +3,9 @@
   "version": "0.9.1",
   "description": "Encrypted credentials management for Output.ai workflows",
   "type": "module",
+  "engines": {
+    "node": ">=24.15.0"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/sdk/evals/package.json
+++ b/sdk/evals/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "engines": {
+    "node": ">=24.15.0"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/sdk/framework/package.json
+++ b/sdk/framework/package.json
@@ -3,6 +3,9 @@
   "version": "0.9.1",
   "description": "The Output.ai Framework",
   "type": "module",
+  "engines": {
+    "node": ">=24.15.0"
+  },
   "dependencies": {
     "@outputai/cli": "workspace:",
     "@outputai/core": "workspace:",

--- a/sdk/http/package.json
+++ b/sdk/http/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "engines": {
+    "node": ">=24.15.0"
+  },
   "files": [
     "dist"
   ],

--- a/sdk/llm/package.json
+++ b/sdk/llm/package.json
@@ -5,6 +5,9 @@
   "type": "module",
   "main": "src/index.js",
   "types": "src/index.d.ts",
+  "engines": {
+    "node": ">=24.15.0"
+  },
   "files": [
     "./src"
   ],

--- a/test_workflows/package.json
+++ b/test_workflows/package.json
@@ -4,6 +4,9 @@
   "description": "A simple output core abstract",
   "type": "module",
   "private": true,
+  "engines": {
+    "node": ">=24.15.0"
+  },
   "scripts": {
     "output:worker:install": "corepack enable && CI=1 pnpm install --frozen-lockfile",
     "output:worker:build": "rm -rf dist/* && tsc && output-copy-assets",


### PR DESCRIPTION
## Summary

Defining the minimum supported node version in the project as 24.15.0, since it matches all dependencies and syntax. So, this PR:
- Updated the docs to explicitly state this is the minimum version;
- Added `engines` section in each `package.json`with `>=24.15.0`;

## Test plan

- [x] Manually tested
