### PR TITLE
chore: Adding docs explain how users should drain fetch responses [OUT-509]

### DIFF
--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-http-client-create/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-http-client-create/SKILL.md
@@ -456,7 +456,25 @@ timeout: 30000
 timeout: 60000
 ```
 
-### 4. Export TypeScript Interfaces
+### 4. Consume or Cancel Response Bodies
+
+`httpClient` follows fetch semantics: callers own returned response bodies. Prefer body readers like `.json()` or `.text()`
+when the payload is needed. If a request only reads metadata such as `response.url`, `response.status`, or headers, cancel the
+unused body in a `finally` block.
+
+```typescript
+const response = await client.get( url );
+
+try {
+  return response.url;
+} finally {
+  await response.body?.cancel();
+}
+```
+
+`HEAD` requests do not have response bodies, so this is only needed for methods that can return one.
+
+### 5. Export TypeScript Interfaces
 
 ```typescript
 // Export interfaces for consumers
@@ -481,6 +499,7 @@ export interface ServiceResponse {
 - [ ] Retry configuration for appropriate status codes
 - [ ] FatalError used for 401, 403, 404 responses
 - [ ] ValidationError used for 429, 5xx responses
+- [ ] Non-HEAD responses are consumed or cancelled when only metadata is used
 - [ ] JSDoc documentation for exported functions
 - [ ] TypeScript interfaces exported for response types
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-step-function/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-step-function/SKILL.md
@@ -244,6 +244,19 @@ const response = await httpClientInstance.head( url );
 const contentType = response.headers.get( 'content-type' );
 ```
 
+When a non-`HEAD` request only uses response metadata, such as `response.url`, `response.status`, or headers, cancel the
+unused body in a `finally` block. Responses read with `.json()`, `.text()`, etc. are already consumed.
+
+```typescript
+const response = await httpClientInstance.get( url );
+
+try {
+  return response.url;
+} finally {
+  await response.body?.cancel();
+}
+```
+
 **Related Skill**: `output-dev-http-client-create` for creating shared clients
 
 ## LLM Operations
@@ -560,6 +573,7 @@ fn: async input => {
 - [ ] Each step has `name`, `description`, `inputSchema`, `outputSchema`, `fn`
 - [ ] FatalError used for non-retryable failures
 - [ ] ValidationError used for retryable failures
+- [ ] Non-HEAD HTTP responses are consumed or cancelled when only metadata is used
 - [ ] No bare try-catch blocks that swallow errors
 - [ ] Steps only import allowed dependencies (local files, shared code)
 - [ ] No imports of other steps, evaluators, or workflows

--- a/coding_assistants/claude/plugins/outputai/skills/output-error-http-client/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-error-http-client/SKILL.md
@@ -152,6 +152,21 @@ const data = await client.get( 'search', {
 } ).json();
 ```
 
+### Metadata-Only Responses
+
+When code only reads metadata from a non-`HEAD` response, such as `response.url`, `response.status`, or headers, cancel the
+unused body. Reading a body with `.json()`, `.text()`, etc. already consumes it.
+
+```typescript
+const response = await client.get( url );
+
+try {
+  return response.url;
+} finally {
+  await response.body?.cancel();
+}
+```
+
 ## Complete Migration Example
 
 ### Before (Wrong - using axios)

--- a/coding_assistants/claude/plugins/outputai/skills/output-meta-pre-flight/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-meta-pre-flight/SKILL.md
@@ -21,6 +21,8 @@ Before proceeding with any workflow operation, verify:
 
 - **ES Modules**: All imports MUST use `.js` extension for ESM modules
 - **HTTP Client**: NEVER use axios directly - always use @outputai/http wrapper
+- **HTTP Bodies**: Consume non-HEAD response bodies with `.json()`/`.text()` or cancel unused bodies with
+  `response.body?.cancel()`
 - **LLM Client**: NEVER use a direct llm call - always use @outputai/llm wrapper
 - **Worker Restarts**: `npx output dev` auto-restarts the worker on file changes; if the worker runs detached, restart it manually with `docker restart <project>-worker-1`
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-meta-project-context/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-meta-project-context/SKILL.md
@@ -82,6 +82,7 @@ src/
 |------|---------|-----------|
 | Zod import | `import { z } from '@outputai/core'` | `import { z } from 'zod'` |
 | HTTP client | `import { httpClient } from '@outputai/http'` | `import axios from 'axios'` |
+| HTTP bodies | Read with `.json()`/`.text()` or cancel unused non-HEAD bodies | Read only `response.url`/`status` and leave body open |
 | Credentials | `import { credentials } from '@outputai/credentials'` | `process.env.SECRET` |
 | LLM calls | `import { generateText, Output } from '@outputai/llm'` | Direct provider SDK |
 | ES imports | `import { fn } from './file.js'` | `import { fn } from './file'` |

--- a/docs/guides/packages/http.mdx
+++ b/docs/guides/packages/http.mdx
@@ -176,6 +176,8 @@ const inputCost = Number( response.headers.get( 'x-cost-input-usd' ) ?? 0 );
 const outputCost = Number( response.headers.get( 'x-cost-output-usd' ) ?? 0 );
 
 addRequestCost( response, inputCost + outputCost );
+
+response.body?.cancel();
 ```
 
 `addRequestCost` accepts the total request cost as a number.

--- a/docs/guides/packages/http.mdx
+++ b/docs/guides/packages/http.mdx
@@ -54,6 +54,26 @@ await client.put('companies/123', {
 await client.delete('companies/123');
 ```
 
+## Response Bodies
+
+`@outputai/http` follows normal `fetch` semantics: callers own the returned response body. Always consume the body with
+`.json()`, `.text()`, `.arrayBuffer()`, or another body reader when you need the payload.
+
+If you only need response metadata from a non-`HEAD` request, such as `response.url`, `response.status`, or headers, cancel
+the unused body so the underlying connection and native buffers can be released:
+
+```typescript
+const response = await client.get('https://example.com', {
+  redirect: 'follow'
+});
+
+try {
+  return response.url;
+} finally {
+  await response.body?.cancel();
+}
+```
+
 ## Using in Steps
 
 Wrap HTTP calls in steps for automatic retry and tracing:

--- a/sdk/http/README.md
+++ b/sdk/http/README.md
@@ -8,4 +8,10 @@ HTTP client with built-in tracing for Output Framework workflows.
 - [README](https://docs.output.ai/packages/http)
 - [API Reference](https://output-ai-reference-code-docs.onrender.com/modules/http_src.html)
 
+## Response Body Ownership
+
+`@outputai/http` follows normal `fetch` semantics: callers must consume returned response bodies or cancel them when unused.
+If a non-`HEAD` request only reads metadata such as `response.url`, `response.status`, or headers, call
+`await response.body?.cancel()` in a `finally` block.
+
 <!-- Internal Dev Note: The documentation for this package is found at docs/guides/packages/http.mdx -->

--- a/test_workflows/src/workflows/http/api_client.ts
+++ b/test_workflows/src/workflows/http/api_client.ts
@@ -1,5 +1,5 @@
 import { httpClient, HttpClientOptions, addRequestCost } from '@outputai/http';
-import type { HttpBinResponse, ClientInput, ContractInput } from './types.js';
+import type { HttpBinResponse, ClientInput, ContractInput, ResponseMetadata } from './types.js';
 
 const httpBinClient = httpClient( {
   prefixUrl: 'https://httpbin.io/anything',
@@ -49,6 +49,26 @@ export async function exportClients(): Promise<HttpBinResponse> {
     headers: {} // This removes inherited headers
   } );
   return response.json() as Promise<HttpBinResponse>;
+}
+
+/**
+ * Get export response metadata without consuming the response body
+ * Drains the unused response body so native buffers can be released
+ */
+export async function getExportMetadata(): Promise<ResponseMetadata> {
+  const response = await clientsClient.get( 'export', {
+    headers: {}
+  } );
+
+  try {
+    return {
+      status: response.status,
+      url: response.url,
+      contentType: response.headers.get( 'content-type' )
+    };
+  } finally {
+    await response.body?.cancel();
+  }
 }
 
 /**

--- a/test_workflows/src/workflows/http/steps.ts
+++ b/test_workflows/src/workflows/http/steps.ts
@@ -1,6 +1,6 @@
 import { step, z } from '@outputai/core';
-import { getClients, createClient, exportClients, getContracts, createContract } from './api_client.js';
-import { ClientInput, ContractInput, httpBinResponseSchema } from './types.js';
+import { getClients, createClient, exportClients, getExportMetadata, getContracts, createContract } from './api_client.js';
+import { ClientInput, ContractInput, httpBinResponseSchema, responseMetadataSchema } from './types.js';
 
 // Test GET request to clients endpoint using API key authentication
 export const listClientsStep = step( {
@@ -35,6 +35,17 @@ export const exportClientsStep = step( {
   outputSchema: httpBinResponseSchema,
   fn: async () => {
     const response = await exportClients();
+    return response;
+  }
+} );
+
+// Test metadata-only response handling and drain the unused response body
+export const exportMetadataStep = step( {
+  name: 'exportMetadataStep',
+  description: 'Test GET request metadata handling with body drain',
+  outputSchema: responseMetadataSchema,
+  fn: async () => {
+    const response = await getExportMetadata();
     return response;
   }
 } );

--- a/test_workflows/src/workflows/http/types.ts
+++ b/test_workflows/src/workflows/http/types.ts
@@ -23,6 +23,12 @@ export interface ContractInput {
   value: number;
 }
 
+export interface ResponseMetadata {
+  status: number;
+  url: string;
+  contentType: string | null;
+}
+
 export const httpBinResponseSchema = z.object( {
   args: z.record( z.string(), z.union( [ z.string(), z.array( z.string() ) ] ) ),
   headers: z.record( z.string(), z.array( z.string() ) ),
@@ -33,4 +39,10 @@ export const httpBinResponseSchema = z.object( {
   files: z.record( z.string(), z.unknown() ),
   form: z.record( z.string(), z.union( [ z.string(), z.array( z.string() ) ] ) ),
   json: z.unknown()
+} );
+
+export const responseMetadataSchema = z.object( {
+  status: z.number(),
+  url: z.string(),
+  contentType: z.string().nullable()
 } );

--- a/test_workflows/src/workflows/http/workflow.ts
+++ b/test_workflows/src/workflows/http/workflow.ts
@@ -1,6 +1,13 @@
 import { workflow, z } from '@outputai/core';
-import { httpBinResponseSchema } from './types.js';
-import { listClientsStep, createClientStep, exportClientsStep, listContractsStep, createContractStep } from './steps.js';
+import { httpBinResponseSchema, responseMetadataSchema } from './types.js';
+import {
+  listClientsStep,
+  createClientStep,
+  exportClientsStep,
+  exportMetadataStep,
+  listContractsStep,
+  createContractStep
+} from './steps.js';
 
 export default workflow( {
   name: 'http',
@@ -9,6 +16,7 @@ export default workflow( {
     clientsListResponse: httpBinResponseSchema,
     createClientResponse: httpBinResponseSchema,
     exportResponse: httpBinResponseSchema,
+    exportMetadataResponse: responseMetadataSchema,
     contractsListResponse: httpBinResponseSchema,
     createContractResponse: httpBinResponseSchema
   } ),
@@ -19,6 +27,7 @@ export default workflow( {
       email: 'test@example.com'
     } );
     const exportResponse = await exportClientsStep();
+    const exportMetadataResponse = await exportMetadataStep();
     const contractsListResponse = await listContractsStep();
     const createContractResponse = await createContractStep( {
       clientId: 'test-client-123',
@@ -30,6 +39,7 @@ export default workflow( {
       clientsListResponse,
       createClientResponse,
       exportResponse,
+      exportMetadataResponse,
       contractsListResponse,
       createContractResponse
     };


### PR DESCRIPTION
## Summary

Fetch responses that doesn't have the body consumed (.text(), .json(), etc) might cause memory problems. This PR add docs explain that users should do that.
