### PR TITLE
refactor(api): Improving start/run workflow performance [OUT-511]

### DIFF
--- a/.changeset/fair-ways-read.md
+++ b/.changeset/fair-ways-read.md
@@ -1,0 +1,5 @@
+---
+"@outputai/core": patch
+---
+
+Improving catalog startup performance by storing and reading hash from memo. Storing workflow names in memo.

--- a/.changeset/quick-hats-build.md
+++ b/.changeset/quick-hats-build.md
@@ -1,0 +1,5 @@
+---
+"output-api": patch
+---
+
+Improving start/run workflows performance by not querying an workflow to validate `workflowName` argument.

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -21,11 +21,11 @@
     "schemas": {
       "ErrorResponse": {
         "type": "object",
-        "description": "API error body (WorkflowNotFoundError, WorkflowExecutionTimedOutError, WorkflowNotCompletedError, CatalogNotAvailableError, or server error)",
+        "description": "API error body (WorkflowNotFoundError, UnsupportedWorkflowError, WorkflowExecutionTimedOutError, WorkflowNotCompletedError, CatalogNotAvailableError, or server error)",
         "properties": {
           "error": {
             "type": "string",
-            "description": "Error type name (e.g. WorkflowNotFoundError, CatalogNotAvailableError)"
+            "description": "Error type name (e.g. WorkflowNotFoundError, UnsupportedWorkflowError, CatalogNotAvailableError)"
           },
           "message": {
             "type": "string",
@@ -499,7 +499,7 @@
         }
       },
       "FailedDependency": {
-        "description": "Workflow not in a terminal state (still running)",
+        "description": "Workflow dependency failed (e.g. workflow not in a terminal state, or workflow type is unsupported by the selected catalog)",
         "content": {
           "application/json": {
             "schema": {
@@ -629,6 +629,9 @@
           "408": {
             "$ref": "#/components/responses/RequestTimeout"
           },
+          "424": {
+            "$ref": "#/components/responses/FailedDependency"
+          },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
           },
@@ -705,8 +708,14 @@
           "404": {
             "$ref": "#/components/responses/NotFound"
           },
+          "424": {
+            "$ref": "#/components/responses/FailedDependency"
+          },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
           }
         }
       }

--- a/api/src/clients/errors.js
+++ b/api/src/clients/errors.js
@@ -26,10 +26,20 @@ export class WorkflowStreamProtocolError extends Error {
 
 /** Thrown when the catalog workflow is not available (e.g. worker not running). */
 export class CatalogNotAvailableError extends Error {
-  /** @param {number} [retryAfter] - Seconds to suggest in Retry-After header. */
-  constructor( retryAfter ) {
+  /** @param {number} retryAfter - Seconds to suggest in Retry-After header. */
+  /** @param {string} taskQueue - The task queue that the catalog was searched */
+  constructor( retryAfter, taskQueue ) {
     super( 'Catalog workflow is unavailable. This is likely due the worker not running or still starting. Retry in a few seconds.' );
     this.retryAfter = retryAfter;
+    this.taskQueue = taskQueue;
+  }
+}
+
+/** Thrown when the workflow name is not supported by the system. */
+export class UnsupportedWorkflowError extends Error {
+  constructor( workflowName, taskQueue ) {
+    super( `Workflow ${workflowName} is not supported in the task queue ${taskQueue}.` );
+    this.taskQueue = taskQueue;
   }
 }
 

--- a/api/src/clients/temporal/catalog.js
+++ b/api/src/clients/temporal/catalog.js
@@ -1,46 +1,36 @@
-import { WorkflowNotFoundError, CatalogNotAvailableError } from '../errors.js';
+import { CatalogNotAvailableError, UnsupportedWorkflowError, WorkflowNotFoundError } from '../errors.js';
 import { logger } from '#logger';
 
-/**
- * Returns the catalog object from the catalog workflow
- *
- * @param {Client} client
- * @returns {object}
- * @throws {CatalogNotAvailableError}
- * @throws {Error}
- */
-export const getCatalog = async ( { client, taskQueue } ) => {
-  const catalogHandle = client.workflow.getHandle( taskQueue );
+const getAvailableWorkflows = async ( { client, taskQueue } ) => {
+  const handle = client.workflow.getHandle( taskQueue );
+
   try {
-    return await catalogHandle.query( 'get' );
+    const description = await handle.describe();
+    return description.memo?.workflowNames ?? {};
   } catch ( error ) {
     if ( error instanceof WorkflowNotFoundError ) {
-      throw new CatalogNotAvailableError( 3 );
+      throw new CatalogNotAvailableError( 3, taskQueue );
     }
-    // Annotate the catalog/query context (the only place that knows it) so the error_handler can
-    // surface it when it logs the failure centrally.
+    // Annotate the context so the error_handler can surface it when it logs the failure centrally.
     error.taskQueue = taskQueue;
-    error.query = 'get';
     throw error;
   }
 };
 
 /**
- * Resolves a workflow name (or alias) to the canonical workflow name via the catalog.
- *
- * @param {object} catalog - The catalog object
- * @param {string} workflowName - The workflow name or alias
- * @param {string} taskQueue - The task queue (for error messages)
- * @returns {string} The canonical workflow name
- * @throws {WorkflowNotFoundError}
+ * Read the memo of the catalog (same name as the task queue) and return the resolved name.
  */
-export const resolveWorkflowName = ( catalog, workflowName, taskQueue ) => {
-  const resolved = catalog.workflows.find( w => w.name === workflowName || w.aliases?.includes( workflowName ) );
-  if ( !resolved ) {
-    throw new WorkflowNotFoundError( `Workflow "${workflowName}" is not available at worker "${taskQueue}"` );
+export const resolveWorkflowName = async ( { client, workflowName, taskQueue } ) => {
+  const workflowNames = await getAvailableWorkflows( { client, taskQueue } );
+
+  if ( !workflowNames[workflowName] ) {
+    throw new UnsupportedWorkflowError( workflowName, taskQueue );
   }
-  if ( resolved.name !== workflowName ) {
-    logger.info( 'Workflow alias resolved', { alias: workflowName, resolvedName: resolved.name, taskQueue } );
+
+  const resolvedName = workflowNames[workflowName];
+  if ( workflowName !== resolvedName ) {
+    logger.info( 'Workflow alias resolved', { alias: workflowName, resolvedName, taskQueue } );
   }
-  return resolved.name;
+
+  return resolvedName;
 };

--- a/api/src/clients/temporal/catalog.spec.js
+++ b/api/src/clients/temporal/catalog.spec.js
@@ -1,70 +1,94 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { CatalogNotAvailableError, WorkflowNotFoundError } from '../errors.js';
+import { CatalogNotAvailableError, UnsupportedWorkflowError, WorkflowNotFoundError } from '../errors.js';
 
 vi.mock( '#logger', () => ( {
   logger: { info: vi.fn() }
 } ) );
 
-describe( 'getCatalog', () => {
+describe( 'resolveWorkflowName', () => {
   beforeEach( () => {
     vi.clearAllMocks();
   } );
 
-  it( 'queries the catalog workflow named after the task queue', async () => {
-    const catalog = { workflows: [ { name: 'workflow-a' } ] };
-    const query = vi.fn().mockResolvedValue( catalog );
-    const getHandle = vi.fn().mockReturnValue( { query } );
-    const { getCatalog } = await import( './catalog.js' );
+  it( 'describes the catalog workflow named after the task queue', async () => {
+    const describe = vi.fn().mockResolvedValue( { memo: { workflowNames: { 'workflow-a': 'workflow-a' } } } );
+    const getHandle = vi.fn().mockReturnValue( { describe } );
+    const { resolveWorkflowName } = await import( './catalog.js' );
 
-    const result = await getCatalog( { client: { workflow: { getHandle } }, taskQueue: 'queue-a' } );
+    const result = await resolveWorkflowName( {
+      client: { workflow: { getHandle } },
+      workflowName: 'workflow-a',
+      taskQueue: 'queue-a'
+    } );
 
     expect( getHandle ).toHaveBeenCalledWith( 'queue-a' );
-    expect( query ).toHaveBeenCalledWith( 'get' );
-    expect( result ).toBe( catalog );
+    expect( describe ).toHaveBeenCalled();
+    expect( result ).toBe( 'workflow-a' );
   } );
 
   it( 'maps missing catalog workflow errors to CatalogNotAvailableError', async () => {
-    const query = vi.fn().mockRejectedValue( new WorkflowNotFoundError( 'missing catalog' ) );
-    const getHandle = vi.fn().mockReturnValue( { query } );
-    const { getCatalog } = await import( './catalog.js' );
+    const describe = vi.fn().mockRejectedValue( new WorkflowNotFoundError( 'missing catalog' ) );
+    const getHandle = vi.fn().mockReturnValue( { describe } );
+    const { resolveWorkflowName } = await import( './catalog.js' );
 
-    const error = await getCatalog( { client: { workflow: { getHandle } }, taskQueue: 'queue-a' } ).catch( e => e );
+    const error = await resolveWorkflowName( {
+      client: { workflow: { getHandle } },
+      workflowName: 'workflow-a',
+      taskQueue: 'queue-a'
+    } ).catch( e => e );
 
     expect( error ).toBeInstanceOf( CatalogNotAvailableError );
     expect( error.retryAfter ).toBe( 3 );
-  } );
-
-  it( 'annotates and rethrows non-not-found query errors', async () => {
-    const error = new Error( 'unavailable' );
-    const query = vi.fn().mockRejectedValue( error );
-    const getHandle = vi.fn().mockReturnValue( { query } );
-    const { getCatalog } = await import( './catalog.js' );
-
-    await expect( getCatalog( { client: { workflow: { getHandle } }, taskQueue: 'queue-a' } ) ).rejects.toBe( error );
     expect( error.taskQueue ).toBe( 'queue-a' );
-    expect( error.query ).toBe( 'get' );
   } );
-} );
 
-describe( 'resolveWorkflowName', () => {
-  it( 'returns an exact workflow name unchanged', async () => {
+  it( 'annotates and rethrows non-not-found describe errors', async () => {
+    const error = new Error( 'unavailable' );
+    const describe = vi.fn().mockRejectedValue( error );
+    const getHandle = vi.fn().mockReturnValue( { describe } );
     const { resolveWorkflowName } = await import( './catalog.js' );
 
-    expect( resolveWorkflowName( { workflows: [ { name: 'workflow-a' } ] }, 'workflow-a', 'queue-a' ) ).toBe( 'workflow-a' );
+    await expect( resolveWorkflowName( {
+      client: { workflow: { getHandle } },
+      workflowName: 'workflow-a',
+      taskQueue: 'queue-a'
+    } ) ).rejects.toBe( error );
+    expect( error.taskQueue ).toBe( 'queue-a' );
+  } );
+
+  it( 'returns an exact workflow name unchanged', async () => {
+    const describe = vi.fn().mockResolvedValue( { memo: { workflowNames: { 'workflow-a': 'workflow-a' } } } );
+    const getHandle = vi.fn().mockReturnValue( { describe } );
+    const { resolveWorkflowName } = await import( './catalog.js' );
+
+    await expect( resolveWorkflowName( {
+      client: { workflow: { getHandle } },
+      workflowName: 'workflow-a',
+      taskQueue: 'queue-a'
+    } ) ).resolves.toBe( 'workflow-a' );
   } );
 
   it( 'resolves aliases to the canonical workflow name', async () => {
+    const describe = vi.fn().mockResolvedValue( { memo: { workflowNames: { 'workflow-a': 'workflow-a', alias: 'workflow-a' } } } );
+    const getHandle = vi.fn().mockReturnValue( { describe } );
     const { resolveWorkflowName } = await import( './catalog.js' );
 
-    expect( resolveWorkflowName( {
-      workflows: [ { name: 'workflow-a', aliases: [ 'old-workflow-a' ] } ]
-    }, 'old-workflow-a', 'queue-a' ) ).toBe( 'workflow-a' );
+    await expect( resolveWorkflowName( {
+      client: { workflow: { getHandle } },
+      workflowName: 'alias',
+      taskQueue: 'queue-a'
+    } ) ).resolves.toBe( 'workflow-a' );
   } );
 
-  it( 'throws WorkflowNotFoundError when no workflow or alias matches', async () => {
+  it( 'throws UnsupportedWorkflowError when no workflow or alias matches', async () => {
+    const describe = vi.fn().mockResolvedValue( { memo: { workflowNames: { 'workflow-a': 'workflow-a' } } } );
+    const getHandle = vi.fn().mockReturnValue( { describe } );
     const { resolveWorkflowName } = await import( './catalog.js' );
 
-    expect( () => resolveWorkflowName( { workflows: [ { name: 'workflow-a' } ] }, 'missing', 'queue-a' ) )
-      .toThrow( WorkflowNotFoundError );
+    await expect( resolveWorkflowName( {
+      client: { workflow: { getHandle } },
+      workflowName: 'missing',
+      taskQueue: 'queue-a'
+    } ) ).rejects.toBeInstanceOf( UnsupportedWorkflowError );
   } );
 } );

--- a/api/src/clients/temporal/workflow/run.js
+++ b/api/src/clients/temporal/workflow/run.js
@@ -1,6 +1,6 @@
 import { buildWorkflowId, extractErrorDetail } from '#utils';
 import { WorkflowFailedError, WorkflowExecutionTimedOutError } from '../../errors.js';
-import { getCatalog, resolveWorkflowName } from '../catalog.js';
+import { resolveWorkflowName } from '../catalog.js';
 import { temporal as temporalConfig } from '#configs';
 import { buildWorkflowResult } from '../workflow_result.js';
 import { logger } from '#logger';
@@ -25,9 +25,7 @@ const { defaultTaskQueue, workflowExecutionTimeout, workflowExecutionMaxWaiting 
 export const run = async ( { client }, workflowName, input, options = {} ) => {
   const { workflowId: userWorkflowId, taskQueue = defaultTaskQueue, timeout } = options;
 
-  // the catalog worker has the same name of the task queue
-  const catalog = await getCatalog( { client, taskQueue } );
-  const resolvedName = resolveWorkflowName( catalog, workflowName, taskQueue );
+  const resolvedName = await resolveWorkflowName( { client, workflowName, taskQueue } );
 
   const workflowId = userWorkflowId ?? buildWorkflowId();
   const executionTimeout = timeout ?? workflowExecutionMaxWaiting;

--- a/api/src/clients/temporal/workflow/run.spec.js
+++ b/api/src/clients/temporal/workflow/run.spec.js
@@ -5,7 +5,6 @@ const {
   mockBuildWorkflowId,
   mockExtractErrorDetail,
   mockBuildWorkflowResult,
-  mockGetCatalog,
   mockResolveWorkflowName,
   mockLoggerWarn,
   MockWorkflowFailedError
@@ -16,7 +15,6 @@ const {
     mockBuildWorkflowId: vi.fn(),
     mockExtractErrorDetail: vi.fn(),
     mockBuildWorkflowResult: vi.fn(),
-    mockGetCatalog: vi.fn(),
     mockResolveWorkflowName: vi.fn(),
     mockLoggerWarn: vi.fn(),
     MockWorkflowFailedError
@@ -46,7 +44,6 @@ vi.mock( '../../errors.js', async importOriginal => ( {
 } ) );
 
 vi.mock( '../catalog.js', () => ( {
-  getCatalog: mockGetCatalog,
   resolveWorkflowName: mockResolveWorkflowName
 } ) );
 
@@ -60,8 +57,7 @@ describe( 'run', () => {
     vi.useRealTimers();
     mockBuildWorkflowId.mockReturnValue( 'generated-id' );
     mockExtractErrorDetail.mockReturnValue( null );
-    mockGetCatalog.mockResolvedValue( { workflows: [] } );
-    mockResolveWorkflowName.mockReturnValue( 'resolved-workflow' );
+    mockResolveWorkflowName.mockResolvedValue( 'resolved-workflow' );
     mockBuildWorkflowResult.mockImplementation( args => ( { shaped: args } ) );
   } );
 
@@ -78,8 +74,11 @@ describe( 'run', () => {
 
     const result = await run( { client }, 'alias-name', { input: true } );
 
-    expect( mockGetCatalog ).toHaveBeenCalledWith( { client, taskQueue: 'default-queue' } );
-    expect( mockResolveWorkflowName ).toHaveBeenCalledWith( { workflows: [] }, 'alias-name', 'default-queue' );
+    expect( mockResolveWorkflowName ).toHaveBeenCalledWith( {
+      client,
+      workflowName: 'alias-name',
+      taskQueue: 'default-queue'
+    } );
     expect( start ).toHaveBeenCalledWith( 'resolved-workflow', {
       args: [ { input: true } ],
       taskQueue: 'default-queue',
@@ -105,6 +104,11 @@ describe( 'run', () => {
     await run( { client }, 'workflow', 'input', { workflowId: 'provided-id', taskQueue: 'custom-queue', timeout: 1_000 } );
 
     expect( mockBuildWorkflowId ).not.toHaveBeenCalled();
+    expect( mockResolveWorkflowName ).toHaveBeenCalledWith( {
+      client,
+      workflowName: 'workflow',
+      taskQueue: 'custom-queue'
+    } );
     expect( start ).toHaveBeenCalledWith( 'resolved-workflow', expect.objectContaining( {
       taskQueue: 'custom-queue',
       workflowId: 'provided-id'

--- a/api/src/clients/temporal/workflow/start.js
+++ b/api/src/clients/temporal/workflow/start.js
@@ -1,6 +1,6 @@
 import { temporal as temporalConfig } from '#configs';
 import { buildWorkflowId } from '#utils';
-import { getCatalog, resolveWorkflowName } from '../catalog.js';
+import { resolveWorkflowName } from '../catalog.js';
 
 const { defaultTaskQueue, workflowExecutionTimeout } = temporalConfig;
 
@@ -23,8 +23,8 @@ const { defaultTaskQueue, workflowExecutionTimeout } = temporalConfig;
  */
 export const start = async ( { client }, workflowName, input, options = {} ) => {
   const { workflowId: userWorkflowId, taskQueue = defaultTaskQueue } = options;
-  const catalog = await getCatalog( { client, taskQueue } );
-  const resolvedName = resolveWorkflowName( catalog, workflowName, taskQueue );
+
+  const resolvedName = await resolveWorkflowName( { client, workflowName, taskQueue } );
   const workflowId = userWorkflowId ?? buildWorkflowId();
   const handle = await client.workflow.start( resolvedName, { args: [ input ], taskQueue, workflowId, workflowExecutionTimeout } );
   return { workflowId, runId: handle.firstExecutionRunId ?? null };

--- a/api/src/clients/temporal/workflow/start.spec.js
+++ b/api/src/clients/temporal/workflow/start.spec.js
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockBuildWorkflowId, mockGetCatalog, mockResolveWorkflowName } = vi.hoisted( () => ( {
+const { mockBuildWorkflowId, mockResolveWorkflowName } = vi.hoisted( () => ( {
   mockBuildWorkflowId: vi.fn(),
-  mockGetCatalog: vi.fn(),
   mockResolveWorkflowName: vi.fn()
 } ) );
 
@@ -18,7 +17,6 @@ vi.mock( '#utils', () => ( {
 } ) );
 
 vi.mock( '../catalog.js', () => ( {
-  getCatalog: mockGetCatalog,
   resolveWorkflowName: mockResolveWorkflowName
 } ) );
 
@@ -26,8 +24,7 @@ describe( 'start', () => {
   beforeEach( () => {
     vi.clearAllMocks();
     mockBuildWorkflowId.mockReturnValue( 'generated-id' );
-    mockGetCatalog.mockResolvedValue( { workflows: [] } );
-    mockResolveWorkflowName.mockReturnValue( 'resolved-workflow' );
+    mockResolveWorkflowName.mockResolvedValue( 'resolved-workflow' );
   } );
 
   it( 'resolves the workflow against the default task queue and starts it with a generated workflow id', async () => {
@@ -37,8 +34,11 @@ describe( 'start', () => {
 
     const result = await start( { client }, 'alias-name', { value: 1 } );
 
-    expect( mockGetCatalog ).toHaveBeenCalledWith( { client, taskQueue: 'default-queue' } );
-    expect( mockResolveWorkflowName ).toHaveBeenCalledWith( { workflows: [] }, 'alias-name', 'default-queue' );
+    expect( mockResolveWorkflowName ).toHaveBeenCalledWith( {
+      client,
+      workflowName: 'alias-name',
+      taskQueue: 'default-queue'
+    } );
     expect( temporalStart ).toHaveBeenCalledWith( 'resolved-workflow', {
       args: [ { value: 1 } ],
       taskQueue: 'default-queue',
@@ -56,7 +56,11 @@ describe( 'start', () => {
     const result = await start( { client }, 'workflow', null, { workflowId: 'provided-id', taskQueue: 'custom-queue' } );
 
     expect( mockBuildWorkflowId ).not.toHaveBeenCalled();
-    expect( mockGetCatalog ).toHaveBeenCalledWith( { client, taskQueue: 'custom-queue' } );
+    expect( mockResolveWorkflowName ).toHaveBeenCalledWith( {
+      client,
+      workflowName: 'workflow',
+      taskQueue: 'custom-queue'
+    } );
     expect( temporalStart ).toHaveBeenCalledWith( 'resolved-workflow', expect.objectContaining( {
       workflowId: 'provided-id',
       taskQueue: 'custom-queue'
@@ -68,7 +72,7 @@ describe( 'start', () => {
     const error = new Error( 'catalog unavailable' );
     const temporalStart = vi.fn();
     const client = { workflow: { start: temporalStart } };
-    mockGetCatalog.mockRejectedValue( error );
+    mockResolveWorkflowName.mockRejectedValue( error );
     const { start } = await import( './start.js' );
 
     await expect( start( { client }, 'workflow', {} ) ).rejects.toBe( error );

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -141,11 +141,11 @@ app.use( ( req, res, next ) => {
  *   schemas:
  *     ErrorResponse:
  *       type: object
- *       description: API error body (WorkflowNotFoundError, WorkflowExecutionTimedOutError, WorkflowNotCompletedError, CatalogNotAvailableError, or server error)
+ *       description: API error body (WorkflowNotFoundError, UnsupportedWorkflowError, WorkflowExecutionTimedOutError, WorkflowNotCompletedError, CatalogNotAvailableError, or server error)
  *       properties:
  *         error:
  *           type: string
- *           description: Error type name (e.g. WorkflowNotFoundError, CatalogNotAvailableError)
+ *           description: Error type name (e.g. WorkflowNotFoundError, UnsupportedWorkflowError, CatalogNotAvailableError)
  *         message:
  *           type: string
  *           description: Human-readable error message
@@ -453,7 +453,7 @@ app.use( ( req, res, next ) => {
  *           schema:
  *             $ref: '#/components/schemas/ErrorResponse'
  *     FailedDependency:
- *       description: Workflow not in a terminal state (still running)
+ *       description: Workflow dependency failed (e.g. workflow not in a terminal state, or workflow type is unsupported by the selected catalog)
  *       content:
  *         application/json:
  *           schema:
@@ -525,6 +525,8 @@ app.use( ( req, res, next ) => {
  *         $ref: '#/components/responses/NotFound'
  *       408:
  *         $ref: '#/components/responses/RequestTimeout'
+ *       424:
+ *         $ref: '#/components/responses/FailedDependency'
  *       503:
  *         $ref: '#/components/responses/ServiceUnavailable'
  *       500:
@@ -597,6 +599,10 @@ app.post( '/workflow/run', async ( req, res ) => {
  *         $ref: '#/components/responses/BadRequest'
  *       404:
  *         $ref: '#/components/responses/NotFound'
+ *       424:
+ *         $ref: '#/components/responses/FailedDependency'
+ *       503:
+ *         $ref: '#/components/responses/ServiceUnavailable'
  *       500:
  *         $ref: '#/components/responses/InternalServerError'
  */

--- a/api/src/middleware/error_handler.js
+++ b/api/src/middleware/error_handler.js
@@ -1,12 +1,18 @@
-import {
-  CatalogNotAvailableError, WorkflowNotCompletedError, WorkflowNotFoundError,
-  WorkflowExecutionTimedOutError, StepNotFoundError, StepNotCompletedError,
-  TraceNotAvailableError, InvalidPageTokenError
-} from '../clients/errors.js';
 import { isGrpcServiceError } from '@temporalio/client';
 import { logger } from '#logger';
 import { serializeErrorChain } from '#utils';
 import { ZodError } from 'zod';
+import {
+  CatalogNotAvailableError,
+  InvalidPageTokenError,
+  StepNotCompletedError,
+  StepNotFoundError,
+  TraceNotAvailableError,
+  UnsupportedWorkflowError,
+  WorkflowExecutionTimedOutError,
+  WorkflowNotCompletedError,
+  WorkflowNotFoundError
+} from '../clients/errors.js';
 
 // gRPC status codes we surface as HTTP errors. Keeps the lookup numeric so we don't
 // pull @grpc/grpc-js into the API just for the Status enum.
@@ -28,6 +34,7 @@ const NAMED_ERROR_STATUSES = {
   [TraceNotAvailableError.name]: 404,
   [WorkflowExecutionTimedOutError.name]: 408,
   [StepNotCompletedError.name]: 409,
+  [UnsupportedWorkflowError.name]: 424,
   [WorkflowNotCompletedError.name]: 424,
   [CatalogNotAvailableError.name]: 503
 };

--- a/api/src/middleware/error_handler.spec.js
+++ b/api/src/middleware/error_handler.spec.js
@@ -3,7 +3,12 @@ import express from 'express';
 import request from 'supertest';
 import { ZodError } from 'zod';
 
-import { CatalogNotAvailableError, WorkflowNotFoundError, InvalidPageTokenError } from '../clients/errors.js';
+import {
+  CatalogNotAvailableError,
+  InvalidPageTokenError,
+  UnsupportedWorkflowError,
+  WorkflowNotFoundError
+} from '../clients/errors.js';
 
 vi.mock( '#logger', () => ( {
   logger: {
@@ -146,6 +151,19 @@ describe( 'error_handler', () => {
     expect( logger.error ).not.toHaveBeenCalled();
   } );
 
+  it( 'should handle UnsupportedWorkflowError with 424 status', async () => {
+    const error = new UnsupportedWorkflowError( 'missing-workflow', 'queue-a' );
+
+    const { httpRes } = await sendError( error );
+
+    expect( httpRes.status ).toBe( 424 );
+    expect( httpRes.body ).toMatchObject( {
+      error: 'UnsupportedWorkflowError',
+      message: 'Workflow missing-workflow is not supported in the task queue queue-a.'
+    } );
+    expect( logger.error ).not.toHaveBeenCalled();
+  } );
+
   it( 'should include workflowId in response when present on error', async () => {
     const error = new Error( 'Workflow failed' );
     error.workflowId = 'test-workflow-123';
@@ -173,7 +191,7 @@ describe( 'error_handler', () => {
   } );
 
   it( 'should handle CatalogNotAvailableError with 503 and Retry-After header', async () => {
-    const error = new CatalogNotAvailableError( 3 );
+    const error = new CatalogNotAvailableError( 3, 'queue-a' );
 
     const { httpRes } = await sendError( error );
 
@@ -183,6 +201,7 @@ describe( 'error_handler', () => {
       message: 'Catalog workflow is unavailable. This is likely due the worker not running or still starting. Retry in a few seconds.',
       workflowId: undefined
     } );
+    expect( error.taskQueue ).toBe( 'queue-a' );
     expect( httpRes.headers['retry-after'] ).toBe( '3' );
     expect( logger.error ).not.toHaveBeenCalled();
   } );

--- a/docs/guides/openapi.json
+++ b/docs/guides/openapi.json
@@ -21,11 +21,11 @@
     "schemas": {
       "ErrorResponse": {
         "type": "object",
-        "description": "API error body (WorkflowNotFoundError, WorkflowExecutionTimedOutError, WorkflowNotCompletedError, CatalogNotAvailableError, or server error)",
+        "description": "API error body (WorkflowNotFoundError, UnsupportedWorkflowError, WorkflowExecutionTimedOutError, WorkflowNotCompletedError, CatalogNotAvailableError, or server error)",
         "properties": {
           "error": {
             "type": "string",
-            "description": "Error type name (e.g. WorkflowNotFoundError, CatalogNotAvailableError)"
+            "description": "Error type name (e.g. WorkflowNotFoundError, UnsupportedWorkflowError, CatalogNotAvailableError)"
           },
           "message": {
             "type": "string",
@@ -499,7 +499,7 @@
         }
       },
       "FailedDependency": {
-        "description": "Workflow not in a terminal state (still running)",
+        "description": "Workflow dependency failed (e.g. workflow not in a terminal state, or workflow type is unsupported by the selected catalog)",
         "content": {
           "application/json": {
             "schema": {
@@ -629,6 +629,9 @@
           "408": {
             "$ref": "#/components/responses/RequestTimeout"
           },
+          "424": {
+            "$ref": "#/components/responses/FailedDependency"
+          },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
           },
@@ -705,8 +708,14 @@
           "404": {
             "$ref": "#/components/responses/NotFound"
           },
+          "424": {
+            "$ref": "#/components/responses/FailedDependency"
+          },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable"
           }
         }
       }

--- a/sdk/cli/src/api/generated/api.ts
+++ b/sdk/cli/src/api/generated/api.ts
@@ -7,10 +7,10 @@
  */
 import { customFetchInstance, type ApiRequestOptions } from '../http_client.js';
 /**
- * API error body (WorkflowNotFoundError, WorkflowExecutionTimedOutError, WorkflowNotCompletedError, CatalogNotAvailableError, or server error)
+ * API error body (WorkflowNotFoundError, UnsupportedWorkflowError, WorkflowExecutionTimedOutError, WorkflowNotCompletedError, CatalogNotAvailableError, or server error)
  */
 export interface ErrorResponse {
-  /** Error type name (e.g. WorkflowNotFoundError, CatalogNotAvailableError) */
+  /** Error type name (e.g. WorkflowNotFoundError, UnsupportedWorkflowError, CatalogNotAvailableError) */
   error?: string;
   /** Human-readable error message */
   message?: string;
@@ -342,7 +342,7 @@ export type NotFoundResponse = ErrorResponse;
 export type RequestTimeoutResponse = ErrorResponse;
 
 /**
- * Workflow not in a terminal state (still running)
+ * Workflow dependency failed (e.g. workflow not in a terminal state, or workflow type is unsupported by the selected catalog)
  */
 export type FailedDependencyResponse = ErrorResponse;
 
@@ -686,6 +686,11 @@ export type postWorkflowRunResponse408 = {
   status: 408
 }
 
+export type postWorkflowRunResponse424 = {
+  data: FailedDependencyResponse
+  status: 424
+}
+
 export type postWorkflowRunResponse500 = {
   data: InternalServerErrorResponse
   status: 500
@@ -699,7 +704,7 @@ export type postWorkflowRunResponse503 = {
 export type postWorkflowRunResponseSuccess = (postWorkflowRunResponse200) & {
   headers: Headers;
 };
-export type postWorkflowRunResponseError = (postWorkflowRunResponse400 | postWorkflowRunResponse404 | postWorkflowRunResponse408 | postWorkflowRunResponse500 | postWorkflowRunResponse503) & {
+export type postWorkflowRunResponseError = (postWorkflowRunResponse400 | postWorkflowRunResponse404 | postWorkflowRunResponse408 | postWorkflowRunResponse424 | postWorkflowRunResponse500 | postWorkflowRunResponse503) & {
   headers: Headers;
 };
 
@@ -745,15 +750,25 @@ export type postWorkflowStartResponse404 = {
   status: 404
 }
 
+export type postWorkflowStartResponse424 = {
+  data: FailedDependencyResponse
+  status: 424
+}
+
 export type postWorkflowStartResponse500 = {
   data: InternalServerErrorResponse
   status: 500
 }
 
+export type postWorkflowStartResponse503 = {
+  data: ServiceUnavailableResponse
+  status: 503
+}
+
 export type postWorkflowStartResponseSuccess = (postWorkflowStartResponse200) & {
   headers: Headers;
 };
-export type postWorkflowStartResponseError = (postWorkflowStartResponse400 | postWorkflowStartResponse404 | postWorkflowStartResponse500) & {
+export type postWorkflowStartResponseError = (postWorkflowStartResponse400 | postWorkflowStartResponse404 | postWorkflowStartResponse424 | postWorkflowStartResponse500 | postWorkflowStartResponse503) & {
   headers: Headers;
 };
 

--- a/sdk/core/src/worker/catalog_workflow/catalog.js
+++ b/sdk/core/src/worker/catalog_workflow/catalog.js
@@ -8,6 +8,11 @@ export class Catalog {
    */
   workflows;
 
+  /**
+   * Object, where the key is each workflow name and each workflow alias, the value is the resolved workflow name.
+   */
+  workflowNames = {};
+
   constructor() {
     this.workflows = [];
   };
@@ -20,6 +25,11 @@ export class Catalog {
    */
   addWorkflow( workflow ) {
     this.workflows.push( workflow );
+    this.workflowNames[workflow.name] = workflow.name;
+    for ( const alias of workflow.aliases ) {
+      this.workflowNames[alias] = workflow.name;
+    }
+
     return this;
   }
 }

--- a/sdk/core/src/worker/catalog_workflow/catalog_job.js
+++ b/sdk/core/src/worker/catalog_workflow/catalog_job.js
@@ -33,12 +33,12 @@ export class CatalogJob {
   /** Check if the currently running catalog has the same hash as instance. */
   async #checkCatalogIsTheSame( handle ) {
     log.info( 'Checking running catalog hash against worker hash...' );
-    return this.#runCancellable( handle.query( 'get_hash' ) ).then( h => h === this.#catalogHash ).catch( e => {
+    return this.#runCancellable( handle.describe() ).then( d => d.memo?.hash === this.#catalogHash ).catch( e => {
       if ( e instanceof CancellationError ) {
         throw e;
       }
       if ( !( e instanceof WorkflowNotFoundError ) ) {
-        log.warn( 'Error retrieving catalog hash', { error: e } );
+        log.warn( 'Error describing catalog workflow', { error: e } );
       }
       return false;
     } );
@@ -88,7 +88,11 @@ export class CatalogJob {
       taskQueue,
       workflowId: catalogId,
       workflowIdConflictPolicy: WorkflowIdConflictPolicy.FAIL,
-      args: [ this.#catalog, this.#catalogHash ]
+      args: [ this.#catalog ],
+      memo: {
+        workflowNames: this.#catalog.workflowNames,
+        hash: this.#catalogHash
+      }
     };
 
     log.info( 'Starting catalog workflow...' );

--- a/sdk/core/src/worker/catalog_workflow/catalog_job.spec.js
+++ b/sdk/core/src/worker/catalog_workflow/catalog_job.spec.js
@@ -8,7 +8,6 @@ const {
   describeMock,
   executeUpdateMock,
   mockLog,
-  queryMock,
   taskQueue,
   workflowStartMock
 } = vi.hoisted( () => ( {
@@ -16,7 +15,6 @@ const {
   describeMock: vi.fn(),
   executeUpdateMock: vi.fn(),
   mockLog: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-  queryMock: vi.fn(),
   taskQueue: 'test-queue',
   workflowStartMock: vi.fn()
 } ) );
@@ -32,7 +30,7 @@ vi.mock( '@temporalio/client', async importOriginal => {
       return {
         workflow: {
           start: workflowStartMock,
-          getHandle: () => ( { describe: describeMock, query: queryMock, executeUpdate: executeUpdateMock } )
+          getHandle: () => ( { describe: describeMock, executeUpdate: executeUpdateMock } )
         }
       };
     } )
@@ -41,8 +39,18 @@ vi.mock( '@temporalio/client', async importOriginal => {
 
 const mockConnection = {};
 const namespace = 'default';
-const catalog = { workflows: [], activities: {} };
+const catalog = { workflows: [], workflowNames: { workflow: 'workflow', alias: 'workflow' }, activities: {} };
 const catalogHash = 'catalog-hash';
+const startArguments = {
+  taskQueue,
+  workflowId: catalogId,
+  workflowIdConflictPolicy: WorkflowIdConflictPolicy.FAIL,
+  args: [ catalog ],
+  memo: {
+    workflowNames: catalog.workflowNames,
+    hash: catalogHash
+  }
+};
 
 const createJob = () => new CatalogJob( { connection: mockConnection, namespace, catalog, catalogHash } );
 
@@ -55,38 +63,28 @@ describe( 'CatalogJob', () => {
     vi.clearAllMocks();
     describeMock.mockResolvedValue( { closeTime: '2024-01-01T00:00:00Z' } );
     executeUpdateMock.mockResolvedValue( undefined );
-    queryMock.mockResolvedValue( catalogHash );
     workflowStartMock.mockResolvedValue( undefined );
   } );
 
   it( 'completes a previous running stale catalog before starting the new workflow', async () => {
-    describeMock.mockResolvedValue( { closeTime: undefined } );
-    queryMock.mockResolvedValue( 'old-catalog-hash' );
+    describeMock.mockResolvedValue( { closeTime: undefined, memo: { hash: 'old-catalog-hash' } } );
     const job = createJob();
 
     await job.run();
 
     expect( describeMock ).toHaveBeenCalled();
-    expect( queryMock ).toHaveBeenCalledWith( 'get_hash' );
     expect( executeUpdateMock ).toHaveBeenCalledWith( 'complete', { args: [] } );
-    expect( workflowStartMock ).toHaveBeenCalledWith( 'catalog', {
-      taskQueue,
-      workflowId: catalogId,
-      workflowIdConflictPolicy: WorkflowIdConflictPolicy.FAIL,
-      args: [ catalog, catalogHash ]
-    } );
+    expect( workflowStartMock ).toHaveBeenCalledWith( 'catalog', startArguments );
     expect( job.error ).toBeNull();
     expect( job.running ).toBe( false );
   } );
 
   it( 'keeps the existing catalog workflow when the running hash matches', async () => {
-    describeMock.mockResolvedValue( { closeTime: undefined } );
-    queryMock.mockResolvedValue( catalogHash );
+    describeMock.mockResolvedValue( { closeTime: undefined, memo: { hash: catalogHash } } );
     const job = createJob();
 
     await job.run();
 
-    expect( queryMock ).toHaveBeenCalledWith( 'get_hash' );
     expect( executeUpdateMock ).not.toHaveBeenCalled();
     expect( workflowStartMock ).not.toHaveBeenCalled();
     expect( mockLog.info ).toHaveBeenCalledWith( 'Current catalog workflow hash matches worker, restart skipped' );
@@ -100,14 +98,8 @@ describe( 'CatalogJob', () => {
     await job.run();
 
     expect( describeMock ).toHaveBeenCalled();
-    expect( queryMock ).not.toHaveBeenCalled();
     expect( executeUpdateMock ).not.toHaveBeenCalled();
-    expect( workflowStartMock ).toHaveBeenCalledWith( 'catalog', {
-      taskQueue,
-      workflowId: catalogId,
-      workflowIdConflictPolicy: WorkflowIdConflictPolicy.FAIL,
-      args: [ catalog, catalogHash ]
-    } );
+    expect( workflowStartMock ).toHaveBeenCalledWith( 'catalog', startArguments );
     expect( mockLog.warn ).not.toHaveBeenCalled();
   } );
 
@@ -117,20 +109,13 @@ describe( 'CatalogJob', () => {
     await job.run();
 
     expect( describeMock ).toHaveBeenCalled();
-    expect( queryMock ).not.toHaveBeenCalled();
     expect( executeUpdateMock ).not.toHaveBeenCalled();
-    expect( workflowStartMock ).toHaveBeenCalledWith( 'catalog', {
-      taskQueue,
-      workflowId: catalogId,
-      workflowIdConflictPolicy: WorkflowIdConflictPolicy.FAIL,
-      args: [ catalog, catalogHash ]
-    } );
+    expect( workflowStartMock ).toHaveBeenCalledWith( 'catalog', startArguments );
   } );
 
   it( 'warns and continues when describing or completing the previous catalog fails', async () => {
     const completeError = new Error( 'complete failed' );
-    describeMock.mockResolvedValue( { closeTime: undefined } );
-    queryMock.mockResolvedValue( 'old-catalog-hash' );
+    describeMock.mockResolvedValue( { closeTime: undefined, memo: { hash: 'old-catalog-hash' } } );
     executeUpdateMock.mockRejectedValue( completeError );
     const job = createJob();
 
@@ -143,15 +128,15 @@ describe( 'CatalogJob', () => {
 
   it( 'ignores an already-started error when the running catalog hash matches', async () => {
     const alreadyStartedError = new WorkflowExecutionAlreadyStartedError( 'already started', catalogId, 'catalog' );
-    describeMock.mockRejectedValue( new WorkflowNotFoundError( 'not found' ) );
+    describeMock
+      .mockRejectedValueOnce( new WorkflowNotFoundError( 'not found' ) )
+      .mockResolvedValueOnce( { closeTime: undefined, memo: { hash: catalogHash } } );
     workflowStartMock.mockRejectedValue( alreadyStartedError );
-    queryMock.mockResolvedValue( catalogHash );
     const job = createJob();
 
     await job.run();
 
     expect( workflowStartMock ).toHaveBeenCalledWith( 'catalog', expect.any( Object ) );
-    expect( queryMock ).toHaveBeenCalledWith( 'get_hash' );
     expect( mockLog.info ).toHaveBeenCalledWith(
       'Ignoring start error: it failed because execution already started but catalog hash matches worker'
     );
@@ -175,9 +160,10 @@ describe( 'CatalogJob', () => {
   it( 'stores stale already-started errors and calls the error callback', async () => {
     const alreadyStartedError = new WorkflowExecutionAlreadyStartedError( 'already started', catalogId, 'catalog' );
     const onError = vi.fn();
-    describeMock.mockRejectedValue( new WorkflowNotFoundError( 'not found' ) );
+    describeMock
+      .mockRejectedValueOnce( new WorkflowNotFoundError( 'not found' ) )
+      .mockResolvedValueOnce( { closeTime: undefined, memo: { hash: 'old-catalog-hash' } } );
     workflowStartMock.mockRejectedValue( alreadyStartedError );
-    queryMock.mockResolvedValue( 'old-catalog-hash' );
     const job = createJob();
 
     job.onError( onError );

--- a/sdk/core/src/worker/catalog_workflow/index.spec.js
+++ b/sdk/core/src/worker/catalog_workflow/index.spec.js
@@ -212,5 +212,11 @@ describe( 'createCatalog', () => {
 
     expect( catalog.workflows[0].aliases ).toEqual( [ 'flow1_old', 'flow1_legacy' ] );
     expect( catalog.workflows[1].aliases ).toEqual( [] );
+    expect( catalog.workflowNames ).toEqual( {
+      flow1: 'flow1',
+      flow1_old: 'flow1',
+      flow1_legacy: 'flow1',
+      flow2: 'flow2'
+    } );
   } );
 } );

--- a/sdk/core/src/worker/catalog_workflow/workflow.js
+++ b/sdk/core/src/worker/catalog_workflow/workflow.js
@@ -7,14 +7,11 @@ import { defineQuery, setHandler, condition, defineUpdate } from '@temporalio/wo
  *
  * @param {object} catalog - The catalog information
  */
-export default async function catalogWorkflow( catalog, catalogHash ) {
+export default async function catalogWorkflow( catalog ) {
   const state = { canEnd: false };
 
   // Returns the catalog
   setHandler( defineQuery( 'get' ), () => catalog );
-
-  // Returns the catalog hash
-  setHandler( defineQuery( 'get_hash' ), () => catalogHash );
 
   // Politely respond to a ping
   setHandler( defineQuery( 'ping' ), () => 'pong' );


### PR DESCRIPTION
## Summary

When starting a workflow in the API, via `run`/`start` endpoints, it validates the `workflowName`argument by sending a Temporal query to a running workflow called catalog that contains all supported workflows for this task queue.

This have performance drawbacks as, if the workers are already strangled, there might not be an available room to take this processing.

This PR changes that by storing the valid workflows names in a `memo` field in that catalog workflow, so it can be described via Temporal API without the necessity of a worker. Behavior remains the same.

## Test plan

- [x] Add unit tests
- [x] Manually tested
