### PR TITLE
refactor(core): Drop support for legacy activity/workflow executions [OUT-468]

### DIFF
--- a/.changeset/strong-paws-cheer.md
+++ b/.changeset/strong-paws-cheer.md
@@ -1,0 +1,5 @@
+---
+"@outputai/core": minor
+---
+
+Removing support for non-wrapped activity results and legacy child workflow executions (pre v0.8.0). Workflow executions from those versions can no longer be replayed.

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ agent-os/
 
 # Pnpm publish report
 pnpm-publish-summary.json
+
+docker-compose.remote.yml

--- a/sdk/core/src/interface/workflow.js
+++ b/sdk/core/src/interface/workflow.js
@@ -8,24 +8,11 @@ import { deepMerge } from '#helpers/object';
 import { defaultOptions } from './workflow_activity_options.js';
 import { createWorkflow } from '#helpers/component';
 import {
-  ACTIVITY_WRAPPER_VERSION_FIELD,
   ACTIVITY_GET_TRACE_DESTINATIONS,
   METADATA_ACCESS_SYMBOL,
   SHARED_STEP_PREFIX,
   WORKFLOW_WRAPPER_VERSION_FIELD
 } from '#consts';
-
-/**
- * @temp
- * This is to keep backwards compatibility [OUT-468]
- */
-const parseActivityOutput = p => Object.hasOwn( p ?? {}, ACTIVITY_WRAPPER_VERSION_FIELD ) ? p.output : p;
-
-/**
- * @temp This is a TEMP fallback method to allow workflow child checks on replays without memo. [OUT-468]
- * This workflows for most scenarios, only does not supports recursion with the same name.
- */
-const checkChildFallback = ( { workflowType, name, aliases } ) => workflowType !== name && !aliases.includes( workflowType );
 
 /**
  * Create a new workflow and return a wrapper function around its fn handler
@@ -54,12 +41,11 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
         return output;
       }
 
-      const { workflowId, workflowType, memo, root } = workflowInfo();
+      const { workflowId, memo, root } = workflowInfo();
 
       // if the stack already includes this workflowId, means the workflow() function was called
       // from within a running workflow, meaning it is suppose to start a child workflow
-      const isChild = Array.isArray( memo.stack ) ? memo.stack.includes( workflowId ) :
-        checkChildFallback( { workflowType, aliases, name } );
+      const isChild = Array.isArray( memo.stack ) ? memo.stack.includes( workflowId ) : false;
 
       if ( isChild ) {
         const result = await executeChild( name, {
@@ -87,13 +73,13 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
       }
 
       const steps = proxyActivities( memo.activityOptions );
-      const traceDest = isRoot && parseActivityOutput( await steps[ACTIVITY_GET_TRACE_DESTINATIONS]( memo.traceInfo ) );
+      const traceDest = isRoot && ( await steps[ACTIVITY_GET_TRACE_DESTINATIONS]( memo.traceInfo ) ).output;
 
       try {
         validator.validateInput( input );
 
         // Creates an activity caller based on a prefix
-        const createCaller = prefix => async ( t, ...args ) => parseActivityOutput( await steps[`${prefix}#${t}`]( ...args ) );
+        const createCaller = prefix => async ( t, ...args ) => ( await steps[`${prefix}#${t}`]( ...args ) ).output;
 
         // This are functions used by the AST to replace direct activity (step/evaluator) calls
         const dispatchers = {

--- a/sdk/core/src/interface/workflow.spec.js
+++ b/sdk/core/src/interface/workflow.spec.js
@@ -373,30 +373,6 @@ describe( 'workflow()', () => {
       expect( getTraceDestinations ).toHaveBeenCalledWith( info.memo.traceInfo );
     } );
 
-    it( 'falls back to workflow type matching when replaying an old child call without memo.stack', async () => {
-      const { workflow } = await import( './workflow.js' );
-      const { ParentClosePolicy } = await import( '@temporalio/workflow' );
-      setWorkflowInfo( { workflowType: 'old_parent_wf', memo: { traceInfo: { workflowId: 'root-workflow' } } } );
-      executeChildMock.mockResolvedValueOnce( { output: { child: 'replayed' } } );
-      const fn = vi.fn();
-
-      const wf = workflow( workflowDefinition( {
-        name: 'old_child_wf',
-        inputSchema: z.object( { id: z.number() } ),
-        outputSchema: z.object( { child: z.string() } ),
-        fn
-      } ) );
-
-      await expect( wf( { id: 7 } ) ).resolves.toEqual( { child: 'replayed' } );
-      expect( fn ).not.toHaveBeenCalled();
-      expect( executeChildMock ).toHaveBeenCalledWith( 'old_child_wf', expect.objectContaining( {
-        args: [ { id: 7 } ],
-        parentClosePolicy: ParentClosePolicy.TERMINATE,
-        memo: { traceInfo: { workflowId: 'root-workflow' } }
-      } ) );
-      expect( proxyActivitiesMock ).not.toHaveBeenCalled();
-    } );
-
     it( 'does not fallback to child execution when the replayed workflow type matches an alias', async () => {
       const { workflow } = await import( './workflow.js' );
       setWorkflowInfo( { workflowType: 'old_root_wf', memo: {} } );
@@ -531,43 +507,6 @@ describe( 'workflow()', () => {
       } );
     } );
 
-    it( 'supports old unwrapped trace destination activity results during replay', async () => {
-      const { workflow } = await import( './workflow.js' );
-      setWorkflowInfo( { workflowType: 'old_trace_payload_wf' } );
-      mockActivities( {
-        [ACTIVITY_GET_TRACE_DESTINATIONS]: vi.fn().mockResolvedValue( { local: '/tmp/old-trace' } )
-      } );
-
-      const wf = workflow( workflowDefinition( {
-        name: 'old_trace_payload_wf',
-        outputSchema: z.object( { ok: z.boolean() } ),
-        fn: async () => ( { ok: true } )
-      } ) );
-
-      await expect( wf( {} ) ).resolves.toEqual( {
-        [WORKFLOW_WRAPPER_VERSION_FIELD]: 1,
-        output: { ok: true },
-        trace: { destinations: { local: '/tmp/old-trace' } }
-      } );
-    } );
-
-    it( 'supports old null trace destination activity results during replay', async () => {
-      const { workflow } = await import( './workflow.js' );
-      setWorkflowInfo( { workflowType: 'old_null_trace_payload_wf' } );
-      mockActivities( { [ACTIVITY_GET_TRACE_DESTINATIONS]: vi.fn().mockResolvedValue( null ) } );
-
-      const wf = workflow( workflowDefinition( {
-        name: 'old_null_trace_payload_wf',
-        outputSchema: z.object( { ok: z.boolean() } ),
-        fn: async () => ( { ok: true } )
-      } ) );
-
-      await expect( wf( {} ) ).resolves.toEqual( {
-        [WORKFLOW_WRAPPER_VERSION_FIELD]: 1,
-        output: { ok: true }
-      } );
-    } );
-
     it( 'validates input and output inside workflow context', async () => {
       const { workflow } = await import( './workflow.js' );
       const inputError = new ValidationError( 'invalid workflow input' );
@@ -655,34 +594,6 @@ describe( 'workflow()', () => {
       } );
       expect( sharedStep ).toHaveBeenCalledWith();
       expect( sharedEvaluator ).toHaveBeenCalledWith( { x: 1 } );
-    } );
-
-    it( 'supports old unwrapped step and evaluator activity results during replay', async () => {
-      const { workflow } = await import( './workflow.js' );
-      setWorkflowInfo( { workflowType: 'old_activity_payload_wf' } );
-      const step = vi.fn().mockResolvedValue( 'legacy-step-output' );
-      const evaluator = vi.fn().mockResolvedValue( 'legacy-eval-output' );
-      mockActivities( {
-        [ACTIVITY_GET_TRACE_DESTINATIONS]: vi.fn().mockResolvedValue( activityOutput( null ) ),
-        'old_activity_payload_wf#stepA': step,
-        'old_activity_payload_wf#evalA': evaluator
-      } );
-
-      const wf = workflow( workflowDefinition( {
-        name: 'old_activity_payload_wf',
-        outputSchema: z.object( { stepResult: z.string(), evalResult: z.string() } ),
-        async fn() {
-          return {
-            stepResult: await this.invokeStep( 'stepA' ),
-            evalResult: await this.invokeEvaluator( 'evalA' )
-          };
-        }
-      } ) );
-
-      await expect( wf( {} ) ).resolves.toEqual( {
-        [WORKFLOW_WRAPPER_VERSION_FIELD]: 1,
-        output: { stepResult: 'legacy-step-output', evalResult: 'legacy-eval-output' }
-      } );
     } );
   } );
 


### PR DESCRIPTION
## Summary

- Removing support to execute non response-wrapped activities and legacy `startChildWorkflow()` child workflow executions (<= v0.7.x). Those were kept to allow replay of old workflow executions, but the 30 days agreement on that has expired.

## Test plan

- [x] Refactored unit tests
- [x] Manually tested
