### PR TITLE
chore: add context7 file for integrating with context7

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Output",
+  "description": "Open-source TypeScript framework for building AI workflows and agents, with prompts, evals, tracing, cost tracking, credentials, and durable orchestration built in.",
+  "folders": [
+    "docs/guides"
+  ],
+  "excludeFiles": [
+    "docs/guides/README.md",
+    "docs/guides/CLAUDE.md",
+    "docs/guides/TODO_pages.md"
+  ],
+  "rules": [
+    "Output has two primitives: workflow() for orchestration (no I/O, must be deterministic) and step() for I/O (API calls, LLM calls, database queries). Never call an API or LLM directly inside a workflow function.",
+    "Prompts live in version-controlled .prompt files using LiquidJS templating, not inline strings.",
+    "Output is a framework, not an SDK.",
+    "Temporal powers durable execution under the hood: workflow code may be replayed on failure, which is why workflows must have no direct I/O."
+  ]
+}

--- a/context7.json
+++ b/context7.json
@@ -6,9 +6,12 @@
     "docs/guides"
   ],
   "excludeFiles": [
-    "docs/guides/README.md",
-    "docs/guides/CLAUDE.md",
-    "docs/guides/TODO_pages.md"
+    "CLAUDE.md",
+    "TODO_pages.md",
+    "CODE_OF_CONDUCT.md",
+    "RELEASING.md",
+    "CONTRIBUTING.md",
+    "SECURITY.md"
   ],
   "rules": [
     "Output has two primitives: workflow() for orchestration (no I/O, must be deterministic) and step() for I/O (API calls, LLM calls, database queries). Never call an API or LLM directly inside a workflow function.",

--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,6 @@
 {
+  "url": "https://context7.com/growthxai/output",
+  "public_key": "pk_JkuIXKBz5KSGvCXnTSX00",
   "$schema": "https://context7.com/schema/context7.json",
   "projectTitle": "Output",
   "description": "Open-source TypeScript framework for building AI workflows and agents, with prompts, evals, tracing, cost tracking, credentials, and durable orchestration built in.",


### PR DESCRIPTION
## Summary

Adds configuration to control how Output gets added to [Context7](https://context7.com/), after we [claim ownership](https://context7.com/docs/howto/claiming-libraries). I haven't done the latter because I wanted to put up the config file first
