### PR TITLE
feat(core): Add worker tuner options support [OUT-510]

### DIFF
--- a/.changeset/wet-bugs-send.md
+++ b/.changeset/wet-bugs-send.md
@@ -1,0 +1,5 @@
+---
+"@outputai/core": patch
+---
+
+Add support to Temporal worker tuner options. This can be set using a new environment variable `TEMPORAL_WORKER_TUNER` that accepts a JSON value.

--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -101,6 +101,7 @@
               "operations/error-hooks",
               "operations/external-workflow-packages",
               "operations/testing",
+              "operations/worker-tuning",
               "operations/tracing"
             ]
           },

--- a/docs/guides/operations/deployment/railway.mdx
+++ b/docs/guides/operations/deployment/railway.mdx
@@ -273,7 +273,7 @@ TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS=10
 TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS=10
 ```
 
-The defaults work for most workloads. Only tune these if you're seeing task queue backlog in the Temporal UI.
+The defaults work for most workloads. Only tune these if you're seeing task queue backlog in the Temporal UI. See [Worker Tuning](/operations/worker-tuning) for the effect of each setting and Temporal Worker tuner examples.
 
 ## Monitoring
 

--- a/docs/guides/operations/deployment/render.mdx
+++ b/docs/guides/operations/deployment/render.mdx
@@ -366,7 +366,7 @@ For high-throughput workloads, you can tune how aggressively the worker pulls an
   value: 10
 ```
 
-The defaults work for most workloads. Only tune these if you're seeing task queue backlog in the Temporal UI.
+The defaults work for most workloads. Only tune these if you're seeing task queue backlog in the Temporal UI. See [Worker Tuning](/operations/worker-tuning) for the effect of each setting and Temporal Worker tuner examples.
 
 ## Monitoring
 

--- a/docs/guides/operations/worker-tuning.mdx
+++ b/docs/guides/operations/worker-tuning.mdx
@@ -39,6 +39,13 @@ TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS=10
 
 Resource-based auto-tuning is most useful for avoiding out-of-memory failures and absorbing bursts of low-resource work, such as Activities that spend most of their time waiting on external HTTP or I/O. Temporal recommends validating it by monitoring host CPU and memory under full load and confirming they settle near your configured targets. See Temporal's [resource-based auto-tuning announcement](https://temporal.io/blog/resource-based-auto-tuning-for-workers) for the model behind the feature.
 
+Choose exactly one tuner shape:
+
+- **Resource-based tuner:** one set of `tunerOptions`, plus optional `*SlotOptions`.
+- **Mixed slot suppliers:** one `*SlotSupplier` object for each task type.
+
+Do not mix `tunerOptions` / `*SlotOptions` with `*SlotSupplier` fields in the same JSON object.
+
 When `TEMPORAL_WORKER_TUNER` is set, Output passes it to Temporal as `tuner` and does not pass these incompatible execution options:
 
 - `TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS`

--- a/docs/guides/operations/worker-tuning.mdx
+++ b/docs/guides/operations/worker-tuning.mdx
@@ -1,0 +1,163 @@
+---
+title: "Worker Tuning"
+description: "Configure Temporal worker concurrency, polling, cache size, and Worker tuners"
+---
+
+Output workers run workflows and activities through Temporal. These settings control compute, memory, and IO behavior:
+
+- **Compute:** how many Workflow and Activity Tasks can execute concurrently.
+- **Memory:** how many Workflow Executions stay in the sticky cache.
+- **IO:** how many pollers long-poll Temporal for new tasks.
+
+Start with the defaults. Tune only when you see backlog in Temporal, high memory use, underused CPU, or task timeouts.
+
+## Concurrency and Polling
+
+These env vars map to Temporal worker execution slots, cache, and pollers. See Temporal's [Worker performance guide](https://docs.temporal.io/develop/worker-performance), [Worker tuning quick reference](https://docs.temporal.io/develop/worker-tuning-reference), and [`WorkerOptions`](https://typescript.temporal.io/api/interfaces/worker.WorkerOptions).
+
+| Variable | Default | Resource | Effect |
+|----------|---------|----------|--------|
+| `TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS` | `40` | Compute | Maximum Activity Task executions running at once. Each Output step, evaluator, LLM call wrapper, or API call is usually an activity. Raise this to process more activities concurrently; lower it to reduce memory, CPU, or outbound API pressure. |
+| `TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_EXECUTIONS` | `200` | Compute | Maximum Workflow Task executions running at once. Workflow Tasks are usually lightweight state-machine work. Raise this if Workflow Task backlog grows and CPU is low; lower it if Workflow Task timeouts increase. |
+| `TEMPORAL_MAX_CACHED_WORKFLOWS` | `1000` | Memory | Maximum Workflow Executions kept in Temporal's [sticky workflow cache](https://docs.temporal.io/sticky-execution). Higher values reduce workflow replay work; lower values free memory sooner after traffic spikes. |
+| `TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS` | `5` | IO | Number of concurrent Activity Task pollers. Raise this if activity execution slots are available but the worker is not fetching tasks fast enough. Keep it lower than activity execution slots. |
+| `TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS` | `5` | IO | Number of concurrent Workflow Task pollers. Raise this if workflow execution slots are available but polling is the bottleneck. Keep it lower than workflow execution slots. |
+
+Example:
+
+```bash
+TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS=150
+TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_EXECUTIONS=600
+TEMPORAL_MAX_CACHED_WORKFLOWS=50
+TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS=10
+TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS=10
+```
+
+## Worker Tuner
+
+`TEMPORAL_WORKER_TUNER` accepts a JSON-encoded Temporal [`WorkerOptions.tuner`](https://typescript.temporal.io/api/interfaces/worker.WorkerOptions#tuner). Use it when fixed concurrency limits are too rigid and you want Temporal's slot suppliers to control how many tasks the worker accepts.
+
+Resource-based auto-tuning is most useful for avoiding out-of-memory failures and absorbing bursts of low-resource work, such as Activities that spend most of their time waiting on external HTTP or I/O. Temporal recommends validating it by monitoring host CPU and memory under full load and confirming they settle near your configured targets. See Temporal's [resource-based auto-tuning announcement](https://temporal.io/blog/resource-based-auto-tuning-for-workers) for the model behind the feature.
+
+When `TEMPORAL_WORKER_TUNER` is set, Output passes it to Temporal as `tuner` and does not pass these incompatible execution options:
+
+- `TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS`
+- `TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_EXECUTIONS`
+
+Polling and cache settings still apply:
+
+- `TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS`
+- `TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS`
+- `TEMPORAL_MAX_CACHED_WORKFLOWS`
+
+### Resource-Based Tuner
+
+Use a [`ResourceBasedTuner`](https://typescript.temporal.io/api/interfaces/worker.ResourceBasedTuner) to let Temporal adjust slots based on target CPU and memory usage. This is the simpler tuner shape. You can provide only workflow and activity slot options; Temporal applies defaults for local activity and Nexus slots.
+
+```bash
+TEMPORAL_WORKER_TUNER='{
+  "tunerOptions": {
+    "targetMemoryUsage": 0.8,
+    "targetCpuUsage": 0.9
+  },
+  "workflowTaskSlotOptions": {
+    "minimumSlots": 2,
+    "maximumSlots": 1000,
+    "rampThrottle": "10ms"
+  },
+  "activityTaskSlotOptions": {
+    "minimumSlots": 1,
+    "maximumSlots": 100,
+    "rampThrottle": "50ms"
+  }
+}'
+```
+
+Resource-based fields:
+
+| Field | Effect |
+|-------|--------|
+| `targetMemoryUsage` | Target process memory usage as a fraction from `0` to `1`. |
+| `targetCpuUsage` | Target process CPU usage as a fraction from `0` to `1`. |
+| `minimumSlots` | Slots issued regardless of current resource checks. |
+| `maximumSlots` | Upper bound for slots of that task type. |
+| `rampThrottle` | Minimum delay before issuing another slot after `minimumSlots` is reached. |
+
+### Mixed Slot Suppliers
+
+Use a [`TunerHolder`](https://typescript.temporal.io/api/interfaces/worker.TunerHolder) to choose a slot supplier per task type. This is useful when workflow tasks should remain fixed but activities should scale with CPU and memory.
+
+```bash
+TEMPORAL_WORKER_TUNER='{
+  "workflowTaskSlotSupplier": {
+    "type": "fixed-size",
+    "numSlots": 10
+  },
+  "activityTaskSlotSupplier": {
+    "type": "resource-based",
+    "tunerOptions": {
+      "targetMemoryUsage": 0.8,
+      "targetCpuUsage": 0.9
+    },
+    "minimumSlots": 1,
+    "maximumSlots": 100,
+    "rampThrottle": "50ms"
+  },
+  "localActivityTaskSlotSupplier": {
+    "type": "fixed-size",
+    "numSlots": 10
+  },
+  "nexusTaskSlotSupplier": {
+    "type": "fixed-size",
+    "numSlots": 10
+  }
+}'
+```
+
+<Note>
+When using the per-task supplier form, Temporal requires all four supplier fields: `workflowTaskSlotSupplier`, `activityTaskSlotSupplier`, `localActivityTaskSlotSupplier`, and `nexusTaskSlotSupplier`. Omitting local activity or Nexus suppliers can fail worker startup.
+</Note>
+
+Supplier types:
+
+| Type | Fields | Effect |
+|------|--------|--------|
+| `fixed-size` | `numSlots` | Always allows up to a fixed number of slots for that task type. |
+| `resource-based` | `tunerOptions`, `minimumSlots`, `maximumSlots`, `rampThrottle` | Dynamically adjusts slots based on CPU and memory targets. |
+
+Temporal also supports custom slot suppliers in code, but `TEMPORAL_WORKER_TUNER` is JSON and should be used only for fixed-size and resource-based suppliers.
+
+## What to Watch
+
+Use Temporal metrics before changing values. The main question is whether the worker has no execution capacity left, or whether it has capacity but is not polling fast enough. See Temporal's [SDK metrics reference](https://docs.temporal.io/references/sdk-metrics), [Worker health](https://docs.temporal.io/cloud/worker-health), and [performance bottlenecks guide](https://docs.temporal.io/troubleshooting/performance-bottlenecks).
+
+| Signal | Meaning | Tuning response |
+|--------|---------|-----------------|
+| High `temporal_workflow_task_schedule_to_start_latency` or `temporal_activity_schedule_to_start_latency` | Tasks are waiting in the queue before a worker starts them. | Check slots, pollers, worker count, and host CPU/memory. |
+| `temporal_worker_task_slots_available` near zero | Worker execution slots are full. | Increase execution slots, add workers, or use resource-based slots if host resources are available. |
+| High schedule-to-start latency while slots are often available | The worker may not be polling fast enough. | Increase the matching poller count. |
+| High host memory | Worker process or workflow cache is too large for the host. | Lower activity slots, lower `TEMPORAL_MAX_CACHED_WORKFLOWS`, or use a resource-based tuner with a lower `targetMemoryUsage`. |
+| Low CPU/memory with growing backlog | The worker has host capacity but is not accepting enough work. | Raise execution slots, raise pollers, or add resource-based activity slots with a higher `maximumSlots`. |
+
+## Choosing Values
+
+If memory is high, lower activity slots first. Activities usually hold network responses, LLM payloads, browser state, or other heavier objects.
+
+If Temporal shows activity backlog and the worker has spare CPU and memory, raise activity execution slots or use a resource-based tuner with a higher `maximumSlots`.
+
+If workflow task backlog grows while CPU is low, check `temporal_worker_task_slots_available` first. If workflow slots are depleted, raise workflow task execution slots. If slots are available but schedule-to-start latency is high, raise workflow task pollers. If workflow task timeouts increase, lower workflow task execution slots.
+
+If CPU and memory vary heavily by workload, prefer `TEMPORAL_WORKER_TUNER` with resource-based activity slots over a large fixed activity concurrency.
+
+Tune incrementally and load test before applying large production changes. Temporal's [Introduction to Worker Tuning](https://temporal.io/blog/an-introduction-to-worker-tuning) is a good overview of when to scale workers horizontally versus increasing per-worker slots or pollers.
+
+## Useful Links
+
+- [Worker performance](https://docs.temporal.io/develop/worker-performance) — Temporal's main guide for slots, pollers, task queue metrics, and tuning process.
+- [Worker tuning quick reference](https://docs.temporal.io/develop/worker-tuning-reference) — compute, memory, and IO settings by SDK.
+- [Resource-based auto-tuning for Workers](https://temporal.io/blog/resource-based-auto-tuning-for-workers) — explanation of resource-based slot suppliers and when to use them.
+- [An introduction to Worker tuning](https://temporal.io/blog/an-introduction-to-worker-tuning) — conceptual guide to worker capacity, schedule-to-start latency, pollers, and slots.
+- [Worker deployment and performance](https://docs.temporal.io/best-practices/worker) — production worker best practices and monitoring guidance.
+- [Temporal SDK metrics reference](https://docs.temporal.io/references/sdk-metrics) — metric names for slots, pollers, request latency, and schedule-to-start latency.
+- [Performance bottlenecks troubleshooting](https://docs.temporal.io/troubleshooting/performance-bottlenecks) — how to diagnose worker capacity and schedule-to-start issues.
+- [Monitor worker health](https://docs.temporal.io/cloud/worker-health) — Temporal Cloud monitoring signals for workers and task queues.

--- a/docs/guides/packages/core.mdx
+++ b/docs/guides/packages/core.mdx
@@ -270,15 +270,16 @@ The worker reads these environment variables:
 
 ### Worker concurrency and polling
 
-These map to Temporal’s [Worker task slots and pollers](https://docs.temporal.io/develop/worker-performance): they control how many tasks the worker runs at once (executor slots) and how many long-polling connections fetch tasks from the task queue. Tune them for your workload and host resources. Temporal recommends keeping poller count lower than executor slot count.
+These map to Temporal worker slots, pollers, and tuners. See [Worker Tuning](/operations/worker-tuning) for details and examples.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS` | `40` | Max Activity Task executions at once (task slots). Each step (API, LLM, etc.) is one activity; lower to reduce memory under load. |
-| `TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_EXECUTIONS` | `200` | Max Workflow Task executions at once. Workflows are lightweight; this can be high. |
-| `TEMPORAL_MAX_CACHED_WORKFLOWS` | `1000` | Max number of Workflow Executions in the [sticky workflow cache](https://docs.temporal.io/sticky-execution). Lower values free memory sooner after traffic spikes. |
-| `TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS` | `5` | Max concurrent pollers for Activity Task Queues. Increase to ingest work faster when slots are often free. |
+| `TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_EXECUTIONS` | `40` | Max Activity Task executions at once. |
+| `TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_EXECUTIONS` | `200` | Max Workflow Task executions at once. |
+| `TEMPORAL_MAX_CACHED_WORKFLOWS` | `1000` | Max number of Workflow Executions in the sticky workflow cache. |
+| `TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS` | `5` | Max concurrent pollers for Activity Task Queues. |
 | `TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS` | `5` | Max concurrent pollers for Workflow Task Queues. |
+| `TEMPORAL_WORKER_TUNER` | — | JSON-encoded Temporal Worker tuner configuration. |
 
 ### Activity heartbeating
 

--- a/sdk/core/src/worker/configs.js
+++ b/sdk/core/src/worker/configs.js
@@ -1,9 +1,34 @@
 import * as z from 'zod';
 import { isStringboolTrue } from '#helpers/string';
+import { isPlainObject } from '#helpers/object';
 
 class InvalidEnvVarsErrors extends Error { }
 
 const coalesceEmptyString = v => v === '' ? undefined : v;
+
+const jsonObjectEnvSchema = z.preprocess(
+  coalesceEmptyString,
+  /* eslint-disable consistent-return */
+  z.string().optional().transform( ( value, ctx ) => {
+    if ( value === undefined ) {
+      return undefined;
+    }
+
+    try {
+      const parsed = JSON.parse( value );
+      if ( !isPlainObject( parsed ) ) {
+        ctx.addIssue( { code: 'custom', message: 'Expected a JSON representing plain JS object' } );
+        return z.NEVER;
+      }
+
+      return parsed;
+    } catch ( error ) {
+      ctx.addIssue( { code: 'custom', message: `Expected valid JSON: ${error.message}` } );
+      return z.NEVER;
+    }
+  } )
+  /* eslint-enable consistent-return */
+);
 
 const durationSchema = z.preprocess(
   coalesceEmptyString,
@@ -28,6 +53,8 @@ const envVarSchema = z.object( {
   // How aggressively the worker pulls tasks from Temporal.
   TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS: z.preprocess( coalesceEmptyString, z.coerce.number().int().positive().default( 5 ) ),
   TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS: z.preprocess( coalesceEmptyString, z.coerce.number().int().positive().default( 5 ) ),
+  // JSON-encoded Temporal Worker tuner options.
+  TEMPORAL_WORKER_TUNER: jsonObjectEnvSchema,
   // Activity configs
   // How often the worker sends a heartbeat to the Temporal Service during activity execution
   OUTPUT_ACTIVITY_HEARTBEAT_INTERVAL_MS: z.preprocess( coalesceEmptyString, z.coerce.number().int().positive().default( 2 * 60 * 1000 ) ), // 2min
@@ -60,6 +87,7 @@ export const maxConcurrentWorkflowTaskExecutions = envVars.TEMPORAL_MAX_CONCURRE
 export const maxCachedWorkflows = envVars.TEMPORAL_MAX_CACHED_WORKFLOWS;
 export const maxConcurrentActivityTaskPolls = envVars.TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS;
 export const maxConcurrentWorkflowTaskPolls = envVars.TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS;
+export const workerTuner = envVars.TEMPORAL_WORKER_TUNER;
 export const namespace = envVars.TEMPORAL_NAMESPACE;
 export const taskQueue = envVars.OUTPUT_CATALOG_ID;
 export const catalogId = envVars.OUTPUT_CATALOG_ID;

--- a/sdk/core/src/worker/configs.js
+++ b/sdk/core/src/worker/configs.js
@@ -1,34 +1,10 @@
 import * as z from 'zod';
 import { isStringboolTrue } from '#helpers/string';
-import { isPlainObject } from '#helpers/object';
+import { workerTunerEnvSchema } from './configs_tuner_schema.js';
 
 class InvalidEnvVarsErrors extends Error { }
 
 const coalesceEmptyString = v => v === '' ? undefined : v;
-
-const jsonObjectEnvSchema = z.preprocess(
-  coalesceEmptyString,
-  /* eslint-disable consistent-return */
-  z.string().optional().transform( ( value, ctx ) => {
-    if ( value === undefined ) {
-      return undefined;
-    }
-
-    try {
-      const parsed = JSON.parse( value );
-      if ( !isPlainObject( parsed ) ) {
-        ctx.addIssue( { code: 'custom', message: 'Expected a JSON representing plain JS object' } );
-        return z.NEVER;
-      }
-
-      return parsed;
-    } catch ( error ) {
-      ctx.addIssue( { code: 'custom', message: `Expected valid JSON: ${error.message}` } );
-      return z.NEVER;
-    }
-  } )
-  /* eslint-enable consistent-return */
-);
 
 const durationSchema = z.preprocess(
   coalesceEmptyString,
@@ -54,7 +30,7 @@ const envVarSchema = z.object( {
   TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS: z.preprocess( coalesceEmptyString, z.coerce.number().int().positive().default( 5 ) ),
   TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS: z.preprocess( coalesceEmptyString, z.coerce.number().int().positive().default( 5 ) ),
   // JSON-encoded Temporal Worker tuner options.
-  TEMPORAL_WORKER_TUNER: jsonObjectEnvSchema,
+  TEMPORAL_WORKER_TUNER: workerTunerEnvSchema,
   // Activity configs
   // How often the worker sends a heartbeat to the Temporal Service during activity execution
   OUTPUT_ACTIVITY_HEARTBEAT_INTERVAL_MS: z.preprocess( coalesceEmptyString, z.coerce.number().int().positive().default( 2 * 60 * 1000 ) ), // 2min

--- a/sdk/core/src/worker/configs.spec.js
+++ b/sdk/core/src/worker/configs.spec.js
@@ -89,13 +89,6 @@ describe( 'worker/configs', () => {
     expect( configs.workerTelemetryIntervalMs ).toBe( 0 );
   } );
 
-  it( 'treats empty string for worker tuner as unset', async () => {
-    setEnv( { TEMPORAL_WORKER_TUNER: '' } );
-    const configs = await loadConfigs();
-
-    expect( configs.workerTuner ).toBeUndefined();
-  } );
-
   it( 'parses Temporal worker tuner JSON', async () => {
     const workerTuner = {
       tunerOptions: {
@@ -113,20 +106,6 @@ describe( 'worker/configs', () => {
     const configs = await loadConfigs();
 
     expect( configs.workerTuner ).toEqual( workerTuner );
-  } );
-
-  it( 'throws when Temporal worker tuner is not valid JSON', async () => {
-    setEnv( { TEMPORAL_WORKER_TUNER: '{invalid' } );
-    vi.resetModules();
-
-    await expect( import( './configs.js' ) ).rejects.toThrow();
-  } );
-
-  it( 'throws when Temporal worker tuner is not a JSON object', async () => {
-    setEnv( { TEMPORAL_WORKER_TUNER: '[]' } );
-    vi.resetModules();
-
-    await expect( import( './configs.js' ) ).rejects.toThrow();
   } );
 
   it( 'parses custom numeric env vars', async () => {

--- a/sdk/core/src/worker/configs.spec.js
+++ b/sdk/core/src/worker/configs.spec.js
@@ -10,6 +10,7 @@ const CONFIG_KEYS = [
   'TEMPORAL_MAX_CACHED_WORKFLOWS',
   'TEMPORAL_MAX_CONCURRENT_ACTIVITY_TASK_POLLS',
   'TEMPORAL_MAX_CONCURRENT_WORKFLOW_TASK_POLLS',
+  'TEMPORAL_WORKER_TUNER',
   'OUTPUT_WORKER_TELEMETRY_INTERVAL_MS',
   'OUTPUT_ACTIVITY_HEARTBEAT_INTERVAL_MS',
   'OUTPUT_ACTIVITY_HEARTBEAT_ENABLED',
@@ -64,6 +65,7 @@ describe( 'worker/configs', () => {
     expect( configs.maxCachedWorkflows ).toBe( 1000 );
     expect( configs.maxConcurrentActivityTaskPolls ).toBe( 5 );
     expect( configs.maxConcurrentWorkflowTaskPolls ).toBe( 5 );
+    expect( configs.workerTuner ).toBeUndefined();
     expect( configs.workerTelemetryIntervalMs ).toBe( 0 );
     expect( configs.activityHeartbeatIntervalMs ).toBe( 2 * 60 * 1000 );
     expect( configs.activityHeartbeatEnabled ).toBe( true );
@@ -85,6 +87,46 @@ describe( 'worker/configs', () => {
     const configs = await loadConfigs();
 
     expect( configs.workerTelemetryIntervalMs ).toBe( 0 );
+  } );
+
+  it( 'treats empty string for worker tuner as unset', async () => {
+    setEnv( { TEMPORAL_WORKER_TUNER: '' } );
+    const configs = await loadConfigs();
+
+    expect( configs.workerTuner ).toBeUndefined();
+  } );
+
+  it( 'parses Temporal worker tuner JSON', async () => {
+    const workerTuner = {
+      tunerOptions: {
+        targetMemoryUsage: 0.8,
+        targetCpuUsage: 0.9
+      },
+      activityTaskSlotOptions: {
+        minimumSlots: 1,
+        maximumSlots: 100,
+        rampThrottle: '50ms'
+      }
+    };
+
+    setEnv( { TEMPORAL_WORKER_TUNER: JSON.stringify( workerTuner ) } );
+    const configs = await loadConfigs();
+
+    expect( configs.workerTuner ).toEqual( workerTuner );
+  } );
+
+  it( 'throws when Temporal worker tuner is not valid JSON', async () => {
+    setEnv( { TEMPORAL_WORKER_TUNER: '{invalid' } );
+    vi.resetModules();
+
+    await expect( import( './configs.js' ) ).rejects.toThrow();
+  } );
+
+  it( 'throws when Temporal worker tuner is not a JSON object', async () => {
+    setEnv( { TEMPORAL_WORKER_TUNER: '[]' } );
+    vi.resetModules();
+
+    await expect( import( './configs.js' ) ).rejects.toThrow();
   } );
 
   it( 'parses custom numeric env vars', async () => {

--- a/sdk/core/src/worker/configs_tuner_schema.js
+++ b/sdk/core/src/worker/configs_tuner_schema.js
@@ -1,0 +1,81 @@
+import * as z from 'zod';
+
+const coalesceEmptyString = v => v === '' ? undefined : v;
+
+const durationSchema = z.preprocess(
+  coalesceEmptyString,
+  z.string()
+    .regex( /^\d+$|^\d+(\.\d+)?\s?(ms|s|m|h|d)$/i )
+    .optional()
+);
+
+const resourceBasedTunerOptionsSchema = z.strictObject( {
+  targetMemoryUsage: z.number().min( 0 ).max( 1 ),
+  targetCpuUsage: z.number().min( 0 ).max( 1 )
+} );
+
+const resourceBasedSlotOptionsSchema = z.strictObject( {
+  minimumSlots: z.number().int().positive().optional(),
+  maximumSlots: z.number().int().positive().optional(),
+  rampThrottle: durationSchema
+} ).superRefine( ( value, ctx ) => {
+  if ( value.minimumSlots !== undefined && value.maximumSlots !== undefined && value.minimumSlots > value.maximumSlots ) {
+    ctx.addIssue( {
+      code: 'custom',
+      message: 'minimumSlots must be less than or equal to maximumSlots'
+    } );
+  }
+} );
+
+const resourceBasedTunerSchema = z.strictObject( {
+  tunerOptions: resourceBasedTunerOptionsSchema,
+  workflowTaskSlotOptions: resourceBasedSlotOptionsSchema.optional(),
+  activityTaskSlotOptions: resourceBasedSlotOptionsSchema.optional(),
+  localActivityTaskSlotOptions: resourceBasedSlotOptionsSchema.optional(),
+  nexusTaskSlotOptions: resourceBasedSlotOptionsSchema.optional()
+} );
+
+const fixedSizeSlotSupplierSchema = z.strictObject( {
+  type: z.literal( 'fixed-size' ),
+  numSlots: z.number().int().positive()
+} );
+
+const resourceBasedSlotSupplierSchema = resourceBasedSlotOptionsSchema.extend( {
+  type: z.literal( 'resource-based' ),
+  tunerOptions: resourceBasedTunerOptionsSchema
+} );
+
+const slotSupplierSchema = z.union( [
+  fixedSizeSlotSupplierSchema,
+  resourceBasedSlotSupplierSchema
+] );
+
+const tunerHolderSchema = z.strictObject( {
+  workflowTaskSlotSupplier: slotSupplierSchema,
+  activityTaskSlotSupplier: slotSupplierSchema,
+  localActivityTaskSlotSupplier: slotSupplierSchema,
+  nexusTaskSlotSupplier: slotSupplierSchema
+} );
+
+const workerTunerSchema = z.union( [
+  resourceBasedTunerSchema,
+  tunerHolderSchema
+] );
+
+export const workerTunerEnvSchema = z.preprocess(
+  coalesceEmptyString,
+  /* eslint-disable consistent-return */
+  z.string().optional().transform( ( value, ctx ) => {
+    if ( value === undefined ) {
+      return undefined;
+    }
+
+    try {
+      return JSON.parse( value );
+    } catch ( error ) {
+      ctx.addIssue( { code: 'custom', message: `Expected valid JSON: ${error.message}` } );
+      return z.NEVER;
+    }
+  } ).pipe( workerTunerSchema.optional() )
+  /* eslint-enable consistent-return */
+);

--- a/sdk/core/src/worker/configs_tuner_schema.spec.js
+++ b/sdk/core/src/worker/configs_tuner_schema.spec.js
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { workerTunerEnvSchema } from './configs_tuner_schema.js';
+
+const parseWorkerTuner = value => workerTunerEnvSchema.parse( value );
+
+describe( 'worker/configs_tuner_schema', () => {
+  it( 'treats empty string as unset', () => {
+    expect( parseWorkerTuner( '' ) ).toBeUndefined();
+  } );
+
+  it( 'parses resource-based Temporal worker tuner JSON', () => {
+    const workerTuner = {
+      tunerOptions: {
+        targetMemoryUsage: 0.8,
+        targetCpuUsage: 0.9
+      },
+      activityTaskSlotOptions: {
+        minimumSlots: 1,
+        maximumSlots: 100,
+        rampThrottle: '50ms'
+      }
+    };
+
+    expect( parseWorkerTuner( JSON.stringify( workerTuner ) ) ).toEqual( workerTuner );
+  } );
+
+  it( 'parses per-task Temporal worker tuner JSON', () => {
+    const resourceBasedSupplier = {
+      type: 'resource-based',
+      tunerOptions: {
+        targetMemoryUsage: 0.8,
+        targetCpuUsage: 0.9
+      },
+      minimumSlots: 1,
+      maximumSlots: 100,
+      rampThrottle: '50ms'
+    };
+    const workerTuner = {
+      workflowTaskSlotSupplier: {
+        type: 'fixed-size',
+        numSlots: 10
+      },
+      activityTaskSlotSupplier: resourceBasedSupplier,
+      localActivityTaskSlotSupplier: {
+        type: 'fixed-size',
+        numSlots: 10
+      },
+      nexusTaskSlotSupplier: {
+        type: 'fixed-size',
+        numSlots: 10
+      }
+    };
+
+    expect( parseWorkerTuner( JSON.stringify( workerTuner ) ) ).toEqual( workerTuner );
+  } );
+
+  it( 'throws when tuner is not valid JSON', () => {
+    expect( () => parseWorkerTuner( '{invalid' ) ).toThrow();
+  } );
+
+  it( 'throws when tuner is not a JSON object', () => {
+    expect( () => parseWorkerTuner( '[]' ) ).toThrow();
+  } );
+
+  it( 'throws when tuner is missing required per-task suppliers', () => {
+    const workerTuner = {
+      workflowTaskSlotSupplier: {
+        type: 'fixed-size',
+        numSlots: 10
+      },
+      activityTaskSlotSupplier: {
+        type: 'fixed-size',
+        numSlots: 10
+      }
+    };
+
+    expect( () => parseWorkerTuner( JSON.stringify( workerTuner ) ) ).toThrow();
+  } );
+
+  it( 'throws when tuner uses custom suppliers', () => {
+    const workerTuner = {
+      workflowTaskSlotSupplier: {
+        type: 'custom'
+      },
+      activityTaskSlotSupplier: {
+        type: 'fixed-size',
+        numSlots: 10
+      },
+      localActivityTaskSlotSupplier: {
+        type: 'fixed-size',
+        numSlots: 10
+      },
+      nexusTaskSlotSupplier: {
+        type: 'fixed-size',
+        numSlots: 10
+      }
+    };
+
+    expect( () => parseWorkerTuner( JSON.stringify( workerTuner ) ) ).toThrow();
+  } );
+
+  it( 'throws when target usage is outside range', () => {
+    const workerTuner = {
+      tunerOptions: {
+        targetMemoryUsage: 1.5,
+        targetCpuUsage: 0.9
+      }
+    };
+
+    expect( () => parseWorkerTuner( JSON.stringify( workerTuner ) ) ).toThrow();
+  } );
+
+  it( 'throws when minimum slots exceeds maximum slots', () => {
+    const workerTuner = {
+      tunerOptions: {
+        targetMemoryUsage: 0.8,
+        targetCpuUsage: 0.9
+      },
+      activityTaskSlotOptions: {
+        minimumSlots: 10,
+        maximumSlots: 5
+      }
+    };
+
+    expect( () => parseWorkerTuner( JSON.stringify( workerTuner ) ) ).toThrow();
+  } );
+} );

--- a/sdk/core/src/worker/index.js
+++ b/sdk/core/src/worker/index.js
@@ -36,7 +36,8 @@ const {
   maxConcurrentActivityTaskPolls,
   maxConcurrentWorkflowTaskPolls,
   shutdownForceTime,
-  shutdownGraceTime
+  shutdownGraceTime,
+  workerTuner
 } = configs;
 
 const state = {
@@ -88,6 +89,9 @@ const execute = async () => {
   state.catalogJob = new CatalogJob( { connection: state.connection, namespace, catalog, catalogHash } );
 
   log.info( 'Creating worker...' );
+  if ( workerTuner ) {
+    log.info( 'Using worker tuner options', { ...workerTuner } );
+  }
   const worker = await Worker.create( {
     connection: state.connection,
     namespace,
@@ -96,8 +100,13 @@ const execute = async () => {
     activities,
     sinks,
     interceptors: initInterceptors( { activities, workflows } ),
-    maxConcurrentWorkflowTaskExecutions,
-    maxConcurrentActivityTaskExecutions,
+    // tuner isn't compatible with concurrent task executions configs
+    ...( workerTuner ? {
+      tuner: workerTuner
+    } : {
+      maxConcurrentWorkflowTaskExecutions,
+      maxConcurrentActivityTaskExecutions
+    } ),
     maxCachedWorkflows,
     maxConcurrentActivityTaskPolls,
     maxConcurrentWorkflowTaskPolls,

--- a/sdk/core/src/worker/index.spec.js
+++ b/sdk/core/src/worker/index.spec.js
@@ -45,6 +45,7 @@ const {
     maxCachedWorkflows: 1000,
     maxConcurrentActivityTaskPolls: 5,
     maxConcurrentWorkflowTaskPolls: 5,
+    workerTuner: undefined,
     processFailureShutdownDelay: 0,
     shutdownForceTime: undefined,
     shutdownGraceTime: undefined
@@ -185,6 +186,7 @@ describe( 'worker/index', () => {
     resetPromises();
     configValues.apiKey = undefined;
     configValues.grpcProxy = undefined;
+    configValues.workerTuner = undefined;
     configValues.shutdownForceTime = undefined;
     configValues.shutdownGraceTime = undefined;
     catalogJobInstance.error = null;
@@ -261,6 +263,32 @@ describe( 'worker/index', () => {
 
     await settleWorker();
     expect( mockLog.info ).toHaveBeenCalledWith( 'Bye' );
+  } );
+
+  it( 'passes worker tuner instead of incompatible execution concurrency options', async () => {
+    configValues.workerTuner = {
+      tunerOptions: {
+        targetMemoryUsage: 0.8,
+        targetCpuUsage: 0.9
+      }
+    };
+    const { Worker } = await import( '@temporalio/worker' );
+
+    await importWorker();
+
+    await vi.waitFor( () => expect( Worker.create ).toHaveBeenCalled() );
+
+    const workerOptions = Worker.create.mock.calls[0][0];
+    expect( workerOptions ).toEqual( expect.objectContaining( {
+      tuner: configValues.workerTuner,
+      maxCachedWorkflows: configValues.maxCachedWorkflows,
+      maxConcurrentActivityTaskPolls: configValues.maxConcurrentActivityTaskPolls,
+      maxConcurrentWorkflowTaskPolls: configValues.maxConcurrentWorkflowTaskPolls
+    } ) );
+    expect( workerOptions ).not.toHaveProperty( 'maxConcurrentWorkflowTaskExecutions' );
+    expect( workerOptions ).not.toHaveProperty( 'maxConcurrentActivityTaskExecutions' );
+
+    await settleWorker();
   } );
 
   it( 'enables TLS when apiKey is set', async () => {


### PR DESCRIPTION
## Summary

Adding support to Temporal worker `tuner` options (https://docs.temporal.io/develop/worker-tuning-reference). The config is provided using an environment variable `TEMPORAL_WORKER_TUNER` option, its value is parsed as JSON. Example:
```bash
TEMPORAL_WORKER_TUNER='{
  "workflowTaskSlotSupplier": {
    "type": "fixed-size",
    "numSlots": 10
  },
  "activityTaskSlotSupplier": {
    "type": "resource-based",
    "tunerOptions": {
      "targetMemoryUsage": 0.8,
      "targetCpuUsage": 0.9
    },
    "minimumSlots": 1,
    "maximumSlots": 100,
    "rampThrottle": "50ms"
  },
  "localActivityTaskSlotSupplier": {
    "type": "fixed-size",
    "numSlots": 10
  },
  "nexusTaskSlotSupplier": {
    "type": "fixed-size",
    "numSlots": 10
  }
}'
```

## Test plan

- [x] Added unit tests
- [x] Manually tested
