### PR TITLE
feat: Workflow Monitor CLI command

### DIFF
--- a/.changeset/fancy-wombats-buy.md
+++ b/.changeset/fancy-wombats-buy.md
@@ -1,0 +1,6 @@
+---
+"@outputai/cli": minor
+"output-api": minor
+---
+
+Add workflow monitor command, update workflow history API to be resumable

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1459,21 +1459,12 @@
           },
           {
             "in": "query",
-            "name": "wait",
-            "schema": {
-              "type": "boolean",
-              "default": false
-            },
-            "description": "Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.\n"
-          },
-          {
-            "in": "query",
-            "name": "waitMs",
+            "name": "longPollTimeoutMs",
             "schema": {
               "type": "integer",
               "minimum": 1
             },
-            "description": "Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes effect when `wait` is true, and only ever shortens the server's configured long-poll deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval) keep the block roughly aligned with its own cadence.\n"
+            "description": "When set, long-poll for a new event once caught up to the end of history instead of returning immediately, bounding the block by this many milliseconds. Clamped to the server's configured maximum — a caller can shorten the wait but never exceed it. Omit for an immediate response; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry. Lets a poller keep the block roughly aligned with its own tick interval.\n"
           }
         ],
         "responses": {
@@ -1573,21 +1564,12 @@
           },
           {
             "in": "query",
-            "name": "wait",
-            "schema": {
-              "type": "boolean",
-              "default": false
-            },
-            "description": "Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.\n"
-          },
-          {
-            "in": "query",
-            "name": "waitMs",
+            "name": "longPollTimeoutMs",
             "schema": {
               "type": "integer",
               "minimum": 1
             },
-            "description": "Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes effect when `wait` is true, and only ever shortens the server's configured long-poll deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval) keep the block roughly aligned with its own cadence.\n"
+            "description": "When set, long-poll for a new event once caught up to the end of history instead of returning immediately, bounding the block by this many milliseconds. Clamped to the server's configured maximum — a caller can shorten the wait but never exceed it. Omit for an immediate response; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry. Lets a poller keep the block roughly aligned with its own tick interval.\n"
           }
         ],
         "responses": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1465,6 +1465,15 @@
               "default": false
             },
             "description": "Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.\n"
+          },
+          {
+            "in": "query",
+            "name": "waitMs",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes effect when `wait` is true, and only ever shortens the server's configured long-poll deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval) keep the block roughly aligned with its own cadence.\n"
           }
         ],
         "responses": {
@@ -1570,6 +1579,15 @@
               "default": false
             },
             "description": "Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.\n"
+          },
+          {
+            "in": "query",
+            "name": "waitMs",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes effect when `wait` is true, and only ever shortens the server's configured long-poll deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval) keep the block roughly aligned with its own cadence.\n"
           }
         ],
         "responses": {

--- a/api/openapi.json
+++ b/api/openapi.json
@@ -1456,6 +1456,15 @@
               "default": false
             },
             "description": "Include decoded input/output payloads in events"
+          },
+          {
+            "in": "query",
+            "name": "wait",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.\n"
           }
         ],
         "responses": {
@@ -1552,6 +1561,15 @@
               "default": false
             },
             "description": "Include decoded input/output payloads in events"
+          },
+          {
+            "in": "query",
+            "name": "wait",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.\n"
           }
         ],
         "responses": {

--- a/api/src/clients/temporal/workflow/fetch_history_page.js
+++ b/api/src/clients/temporal/workflow/fetch_history_page.js
@@ -1,3 +1,4 @@
+import { isGrpcDeadlineError } from '@temporalio/client';
 import { temporal as temporalConfig } from '#configs';
 import { logger } from '#logger';
 import { workflowNotFoundError } from '../../errors.js';
@@ -11,7 +12,7 @@ const { namespace } = temporalConfig;
  * once when Temporal returns no history field. Shared by get_input and get_result so the
  * not-found + missing-history handling lives in one place instead of being copy-pasted.
  *
- * @param {object} connection - Temporal connection exposing `workflowService`
+ * @param {object} connection - Temporal connection exposing `workflowService` and `withDeadline`
  * @param {string} workflowId
  * @param {string} runId - Resolved run id to fetch
  * @param {object} [options]
@@ -19,29 +20,46 @@ const { namespace } = temporalConfig;
  * @param {Buffer} [options.nextPageToken]
  * @param {(error: object) => Error} [options.mapInvalidArgument] - Maps a gRPC INVALID_ARGUMENT
  *   (e.g. a malformed/expired runId) to a domain error; when omitted the raw error propagates.
- * @returns {Promise<object>} The raw getWorkflowExecutionHistory response
+ * @param {boolean} [options.waitNewEvent] - Long-poll: block server-side until a new event
+ *   exists past this page, up to `deadlineMs`. Only blocks when this page is already at the
+ *   current end of history; returns immediately if more is already buffered.
+ * @param {number} [options.deadlineMs] - Bounds how long a `waitNewEvent` call may block.
+ *   Required when `waitNewEvent` is true.
+ * @returns {Promise<object|null>} The raw getWorkflowExecutionHistory response, or `null` if
+ *   `waitNewEvent` was requested and the deadline elapsed with no new event.
  */
 export const fetchHistoryPage = async (
   connection, workflowId, runId,
-  { maximumPageSize, nextPageToken, mapInvalidArgument } = {}
+  { maximumPageSize, nextPageToken, mapInvalidArgument, waitNewEvent, deadlineMs } = {}
 ) => {
-  const response = await connection.workflowService.getWorkflowExecutionHistory( {
+  const call = () => connection.workflowService.getWorkflowExecutionHistory( {
     namespace,
     execution: { workflowId, runId },
     maximumPageSize,
-    nextPageToken
-  } ).catch( error => {
-    if ( !error ) {
-      throw new Error( 'Temporal getWorkflowExecutionHistory rejected with no error' );
-    }
-    if ( error.code === GrpcStatus.NOT_FOUND ) {
-      throw workflowNotFoundError( workflowId, runId );
-    }
-    if ( mapInvalidArgument && error.code === GrpcStatus.INVALID_ARGUMENT ) {
-      throw mapInvalidArgument( error );
-    }
-    throw error;
+    nextPageToken,
+    ...( waitNewEvent ? { waitNewEvent: true } : {} )
   } );
+
+  const response = await ( waitNewEvent ? connection.withDeadline( Date.now() + deadlineMs, call ) : call() )
+    .catch( error => {
+      if ( !error ) {
+        throw new Error( 'Temporal getWorkflowExecutionHistory rejected with no error' );
+      }
+      if ( waitNewEvent && isGrpcDeadlineError( error ) ) {
+        return null;
+      }
+      if ( error.code === GrpcStatus.NOT_FOUND ) {
+        throw workflowNotFoundError( workflowId, runId );
+      }
+      if ( mapInvalidArgument && error.code === GrpcStatus.INVALID_ARGUMENT ) {
+        throw mapInvalidArgument( error );
+      }
+      throw error;
+    } );
+
+  if ( response === null ) {
+    return null;
+  }
 
   if ( !response.history ) {
     logger.warn( 'Temporal getWorkflowExecutionHistory returned no history field', { workflowId, runId } );

--- a/api/src/clients/temporal/workflow/fetch_history_page.spec.js
+++ b/api/src/clients/temporal/workflow/fetch_history_page.spec.js
@@ -1,9 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockWorkflowNotFoundError, mockLoggerWarn } = vi.hoisted( () => ( {
+const { mockWorkflowNotFoundError, mockLoggerWarn, mockIsGrpcDeadlineError } = vi.hoisted( () => ( {
   mockWorkflowNotFoundError: vi.fn( ( workflowId, runId ) =>
     Object.assign( new Error( `not found: ${workflowId}/${runId}` ), { name: 'WorkflowNotFoundError' } ) ),
-  mockLoggerWarn: vi.fn()
+  mockLoggerWarn: vi.fn(),
+  mockIsGrpcDeadlineError: vi.fn( err => err?.code === 4 )
+} ) );
+
+vi.mock( '@temporalio/client', () => ( {
+  isGrpcDeadlineError: mockIsGrpcDeadlineError
 } ) );
 
 vi.mock( '#configs', () => ( {
@@ -20,7 +25,10 @@ vi.mock( '../../errors.js', () => ( {
 
 const { fetchHistoryPage } = await import( './fetch_history_page.js' );
 
-const makeConnection = getWorkflowExecutionHistory => ( { workflowService: { getWorkflowExecutionHistory } } );
+const makeConnection = ( getWorkflowExecutionHistory, withDeadline ) => ( {
+  workflowService: { getWorkflowExecutionHistory },
+  withDeadline: withDeadline ?? vi.fn( ( _deadline, fn ) => fn() )
+} );
 
 describe( 'fetchHistoryPage', () => {
   beforeEach( () => vi.clearAllMocks() );
@@ -109,5 +117,61 @@ describe( 'fetchHistoryPage', () => {
     await fetchHistoryPage( makeConnection( getWorkflowExecutionHistory ), 'wf-1', 'run-1' );
 
     expect( mockLoggerWarn ).not.toHaveBeenCalled();
+  } );
+
+  it( 'passes waitNewEvent and applies a deadline when requested', async () => {
+    const response = { history: { events: [] } };
+    const getWorkflowExecutionHistory = vi.fn().mockResolvedValue( response );
+    const withDeadline = vi.fn( ( _deadline, fn ) => fn() );
+
+    const result = await fetchHistoryPage(
+      makeConnection( getWorkflowExecutionHistory, withDeadline ), 'wf-1', 'run-1',
+      { maximumPageSize: 10, waitNewEvent: true, deadlineMs: 15_000 }
+    );
+
+    expect( withDeadline ).toHaveBeenCalledWith( expect.any( Number ), expect.any( Function ) );
+    expect( getWorkflowExecutionHistory ).toHaveBeenCalledWith( {
+      namespace: 'default',
+      execution: { workflowId: 'wf-1', runId: 'run-1' },
+      maximumPageSize: 10,
+      nextPageToken: undefined,
+      waitNewEvent: true
+    } );
+    expect( result ).toBe( response );
+  } );
+
+  it( 'does not apply a deadline or waitNewEvent when not requested', async () => {
+    const getWorkflowExecutionHistory = vi.fn().mockResolvedValue( { history: { events: [] } } );
+    const withDeadline = vi.fn( ( _deadline, fn ) => fn() );
+
+    await fetchHistoryPage( makeConnection( getWorkflowExecutionHistory, withDeadline ), 'wf-1', 'run-1' );
+
+    expect( withDeadline ).not.toHaveBeenCalled();
+    expect( getWorkflowExecutionHistory ).toHaveBeenCalledWith( {
+      namespace: 'default',
+      execution: { workflowId: 'wf-1', runId: 'run-1' },
+      maximumPageSize: undefined,
+      nextPageToken: undefined
+    } );
+  } );
+
+  it( 'returns null when a waitNewEvent call hits its deadline with no new events', async () => {
+    const deadlineError = Object.assign( new Error( 'deadline exceeded' ), { code: 4 } );
+    const getWorkflowExecutionHistory = vi.fn().mockRejectedValue( deadlineError );
+
+    const result = await fetchHistoryPage(
+      makeConnection( getWorkflowExecutionHistory ), 'wf-1', 'run-1',
+      { waitNewEvent: true, deadlineMs: 15_000 }
+    );
+
+    expect( result ).toBeNull();
+  } );
+
+  it( 'propagates a deadline error unchanged when waitNewEvent was not requested', async () => {
+    const deadlineError = Object.assign( new Error( 'deadline exceeded' ), { code: 4 } );
+    const getWorkflowExecutionHistory = vi.fn().mockRejectedValue( deadlineError );
+
+    await expect( fetchHistoryPage( makeConnection( getWorkflowExecutionHistory ), 'wf-1', 'run-1' ) )
+      .rejects.toBe( deadlineError );
   } );
 } );

--- a/api/src/clients/temporal/workflow/get_history.js
+++ b/api/src/clients/temporal/workflow/get_history.js
@@ -46,8 +46,12 @@ export const getHistory = async ( { client, connection }, workflowId, options = 
     throw new InvalidPageTokenError();
   }
 
-  const isFirstPage = !pageToken;
-  const metadata = isFirstPage ? await ( async () => {
+  // Re-describe on every `wait` call, not just the first page: a resumable poller
+  // (`workflow monitor`) never requests the first page again, so if metadata were only
+  // fetched there, `workflow.status` would freeze at whatever it was on the very first
+  // poll and the caller could never observe the run finishing.
+  const shouldDescribe = !pageToken || wait;
+  const metadata = shouldDescribe ? await ( async () => {
     const { workflow } = await describeWorkflow( { client }, workflowId, { runId } );
     return { workflow, resolvedRunId: workflow.runId };
   } )() : { workflow: null, resolvedRunId: runId };

--- a/api/src/clients/temporal/workflow/get_history.js
+++ b/api/src/clients/temporal/workflow/get_history.js
@@ -1,3 +1,4 @@
+import { temporal as temporalConfig } from '#configs';
 import { InvalidPageTokenError } from '../../errors.js';
 import { decodeEventPayloads, serializeEvent } from '../../event_serialization.js';
 import { describeWorkflow } from './describe_workflow.js';
@@ -32,10 +33,14 @@ import { fetchHistoryPage } from './fetch_history_page.js';
  * @param {object} options.pageSize - Amount of results default=20
  * @param {object} options.pageToken - Used to retrieve next page, must be used together with runId
  * @param {object} options.includePayloads - Omit/display payloads, default=false
+ * @param {boolean} [options.wait] - Long-poll for a new event when already caught up to the
+ *   end of history, bounded by `temporal.historyWaitTimeoutMs`, instead of returning
+ *   immediately. Lets a resumable poller (`workflow monitor`) avoid restarting from page 1
+ *   on every tick.
  * @returns {WorkflowHistoryResults}
  */
 export const getHistory = async ( { client, connection }, workflowId, options = {} ) => {
-  const { runId, pageSize = 20, pageToken, includePayloads = false } = options ?? {};
+  const { runId, pageSize = 20, pageToken, includePayloads = false, wait = false } = options ?? {};
 
   if ( pageToken && !runId ) {
     throw new InvalidPageTokenError();
@@ -50,8 +55,20 @@ export const getHistory = async ( { client, connection }, workflowId, options = 
   const response = await fetchHistoryPage( connection, workflowId, metadata.resolvedRunId, {
     maximumPageSize: Math.min( pageSize, 50 ),
     nextPageToken: pageToken ? Buffer.from( pageToken, 'base64' ) : undefined,
-    mapInvalidArgument: () => new InvalidPageTokenError()
+    mapInvalidArgument: () => new InvalidPageTokenError(),
+    ...( wait ? { waitNewEvent: true, deadlineMs: temporalConfig.historyWaitTimeoutMs } : {} )
   } );
+
+  if ( response === null ) {
+    // Long-poll deadline elapsed with no new events. Return the cursor unchanged so the
+    // caller can retry from the same position instead of losing its place.
+    return {
+      workflow: metadata.workflow,
+      events: [],
+      runId: metadata.resolvedRunId,
+      nextPageToken: pageToken ?? null
+    };
+  }
 
   const events = ( response.history?.events || [] ).map( event => {
     const decoded = includePayloads ? decodeEventPayloads( event ) : event;

--- a/api/src/clients/temporal/workflow/get_history.js
+++ b/api/src/clients/temporal/workflow/get_history.js
@@ -37,10 +37,14 @@ import { fetchHistoryPage } from './fetch_history_page.js';
  *   end of history, bounded by `temporal.historyWaitTimeoutMs`, instead of returning
  *   immediately. Lets a resumable poller (`workflow monitor`) avoid restarting from page 1
  *   on every tick.
+ * @param {number} [options.waitMs] - Caller-requested upper bound (ms) for a `wait` long-poll,
+ *   letting a poller keep the block roughly aligned with its own poll cadence instead of
+ *   always blocking for the full `temporal.historyWaitTimeoutMs`. Clamped to that value —
+ *   callers can shorten the long-poll, never lengthen it past the server's configured cap.
  * @returns {WorkflowHistoryResults}
  */
 export const getHistory = async ( { client, connection }, workflowId, options = {} ) => {
-  const { runId, pageSize = 20, pageToken, includePayloads = false, wait = false } = options ?? {};
+  const { runId, pageSize = 20, pageToken, includePayloads = false, wait = false, waitMs } = options ?? {};
 
   if ( pageToken && !runId ) {
     throw new InvalidPageTokenError();
@@ -60,7 +64,10 @@ export const getHistory = async ( { client, connection }, workflowId, options = 
     maximumPageSize: Math.min( pageSize, 50 ),
     nextPageToken: pageToken ? Buffer.from( pageToken, 'base64' ) : undefined,
     mapInvalidArgument: () => new InvalidPageTokenError(),
-    ...( wait ? { waitNewEvent: true, deadlineMs: temporalConfig.historyWaitTimeoutMs } : {} )
+    ...( wait ? {
+      waitNewEvent: true,
+      deadlineMs: waitMs ? Math.min( waitMs, temporalConfig.historyWaitTimeoutMs ) : temporalConfig.historyWaitTimeoutMs
+    } : {} )
   } );
 
   if ( response === null ) {

--- a/api/src/clients/temporal/workflow/get_history.js
+++ b/api/src/clients/temporal/workflow/get_history.js
@@ -33,27 +33,25 @@ import { fetchHistoryPage } from './fetch_history_page.js';
  * @param {object} options.pageSize - Amount of results default=20
  * @param {object} options.pageToken - Used to retrieve next page, must be used together with runId
  * @param {object} options.includePayloads - Omit/display payloads, default=false
- * @param {boolean} [options.wait] - Long-poll for a new event when already caught up to the
- *   end of history, bounded by `temporal.historyWaitTimeoutMs`, instead of returning
- *   immediately. Lets a resumable poller (`workflow monitor`) avoid restarting from page 1
- *   on every tick.
- * @param {number} [options.waitMs] - Caller-requested upper bound (ms) for a `wait` long-poll,
- *   letting a poller keep the block roughly aligned with its own poll cadence instead of
- *   always blocking for the full `temporal.historyWaitTimeoutMs`. Clamped to that value —
- *   callers can shorten the long-poll, never lengthen it past the server's configured cap.
+ * @param {number} [options.longPollTimeoutMs] - When set (and positive), long-poll for a new
+ *   event once caught up to the end of history instead of returning immediately, bounding the
+ *   block by this many milliseconds. Clamped to `temporal.historyMaxWaitTimeoutMs` — a caller
+ *   can shorten the wait but never exceed the server-configured ceiling. Omit for an immediate
+ *   response. Lets a resumable poller avoid restarting its history fetch from page 1 each tick.
  * @returns {WorkflowHistoryResults}
  */
 export const getHistory = async ( { client, connection }, workflowId, options = {} ) => {
-  const { runId, pageSize = 20, pageToken, includePayloads = false, wait = false, waitMs } = options ?? {};
+  const { runId, pageSize = 20, pageToken, includePayloads = false, longPollTimeoutMs } = options ?? {};
+  const wait = longPollTimeoutMs !== undefined && longPollTimeoutMs > 0;
 
   if ( pageToken && !runId ) {
     throw new InvalidPageTokenError();
   }
 
-  // Re-describe on every `wait` call, not just the first page: a resumable poller
-  // (`workflow monitor`) never requests the first page again, so if metadata were only
-  // fetched there, `workflow.status` would freeze at whatever it was on the very first
-  // poll and the caller could never observe the run finishing.
+  // Re-describe on every long-poll call, not just the first page: a resumable poller
+  // never requests the first page again, so if metadata were only fetched there,
+  // `workflow.status` would freeze at whatever it was on the very first poll and the
+  // caller could never observe the run finishing.
   const shouldDescribe = !pageToken || wait;
   const metadata = shouldDescribe ? await ( async () => {
     const { workflow } = await describeWorkflow( { client }, workflowId, { runId } );
@@ -66,7 +64,7 @@ export const getHistory = async ( { client, connection }, workflowId, options = 
     mapInvalidArgument: () => new InvalidPageTokenError(),
     ...( wait ? {
       waitNewEvent: true,
-      deadlineMs: waitMs ? Math.min( waitMs, temporalConfig.historyWaitTimeoutMs ) : temporalConfig.historyWaitTimeoutMs
+      deadlineMs: Math.min( longPollTimeoutMs, temporalConfig.historyMaxWaitTimeoutMs )
     } : {} )
   } );
 

--- a/api/src/clients/temporal/workflow/get_history.spec.js
+++ b/api/src/clients/temporal/workflow/get_history.spec.js
@@ -18,7 +18,7 @@ vi.mock( '#logger', () => ( {
 } ) );
 
 vi.mock( '#configs', () => ( {
-  temporal: { historyWaitTimeoutMs: 15_000 }
+  temporal: { historyMaxWaitTimeoutMs: 15_000 }
 } ) );
 
 vi.mock( '../../event_serialization.js', () => ( {
@@ -160,12 +160,12 @@ describe( 'getHistory', () => {
     expect( result.nextPageToken ).toBeNull();
   } );
 
-  it( 'passes waitNewEvent and the configured deadline through when wait is requested', async () => {
+  it( 'passes waitNewEvent and the configured deadline through when a long-poll timeout is requested', async () => {
     const pageToken = Buffer.from( 'previous-token' ).toString( 'base64' );
 
-    await getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken, wait: true } );
+    await getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken, longPollTimeoutMs: 15_000 } );
 
-    // wait:true re-describes even on a later page (resolving to 'resolved-run', the fixture's
+    // A long-poll re-describes even on a later page (resolving to 'resolved-run', the fixture's
     // describeWorkflow stub), so status stays live across a resumed poll — see the next test.
     expect( mockFetchHistoryPage ).toHaveBeenCalledWith( connection, 'workflow-id', 'resolved-run', {
       maximumPageSize: 20,
@@ -176,8 +176,8 @@ describe( 'getHistory', () => {
     } );
   } );
 
-  it( 'clamps deadlineMs to the configured max when waitMs requests a shorter wait', async () => {
-    await getHistory( { client, connection }, 'workflow-id', { wait: true, waitMs: 2_500 } );
+  it( 'clamps deadlineMs to the configured max when longPollTimeoutMs requests a shorter wait', async () => {
+    await getHistory( { client, connection }, 'workflow-id', { longPollTimeoutMs: 2_500 } );
 
     expect( mockFetchHistoryPage ).toHaveBeenCalledWith( connection, 'workflow-id', 'resolved-run', {
       maximumPageSize: 20,
@@ -188,15 +188,15 @@ describe( 'getHistory', () => {
     } );
   } );
 
-  it( 'ignores a waitMs longer than the configured max, capping at historyWaitTimeoutMs', async () => {
-    await getHistory( { client, connection }, 'workflow-id', { wait: true, waitMs: 60_000 } );
+  it( 'ignores a longPollTimeoutMs longer than the configured max, capping at historyMaxWaitTimeoutMs', async () => {
+    await getHistory( { client, connection }, 'workflow-id', { longPollTimeoutMs: 60_000 } );
 
     expect( mockFetchHistoryPage ).toHaveBeenCalledWith( connection, 'workflow-id', 'resolved-run', expect.objectContaining( {
       deadlineMs: 15_000
     } ) );
   } );
 
-  it( 'does not pass waitNewEvent/deadlineMs when wait is not requested', async () => {
+  it( 'does not pass waitNewEvent/deadlineMs when no long-poll timeout is requested', async () => {
     await getHistory( { client, connection }, 'workflow-id', { pageSize: 30 } );
 
     expect( mockFetchHistoryPage ).toHaveBeenCalledWith( connection, 'workflow-id', 'resolved-run', {
@@ -206,15 +206,15 @@ describe( 'getHistory', () => {
     } );
   } );
 
-  it( 're-describes on a later page when wait is requested, so a resumed poll sees a status change', async () => {
+  it( 're-describes on a later page when a long-poll timeout is requested, so a resumed poll sees a status change', async () => {
     const pageToken = Buffer.from( 'previous-token' ).toString( 'base64' );
 
-    await getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken, wait: true } );
+    await getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken, longPollTimeoutMs: 15_000 } );
 
     expect( mockDescribeWorkflow ).toHaveBeenCalledWith( { client }, 'workflow-id', { runId: 'run-id' } );
   } );
 
-  it( 'skips the describe call on a later page when wait is not requested', async () => {
+  it( 'skips the describe call on a later page when no long-poll timeout is requested', async () => {
     const pageToken = Buffer.from( 'previous-token' ).toString( 'base64' );
 
     await getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken } );
@@ -226,7 +226,7 @@ describe( 'getHistory', () => {
     const pageToken = Buffer.from( 'previous-token' ).toString( 'base64' );
     mockFetchHistoryPage.mockResolvedValue( null );
 
-    const result = await getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken, wait: true } );
+    const result = await getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken, longPollTimeoutMs: 15_000 } );
 
     expect( result ).toEqual( {
       workflow: expect.objectContaining( { workflowId: 'workflow-id' } ),
@@ -240,7 +240,7 @@ describe( 'getHistory', () => {
   it( 'returns a null nextPageToken when a first-page wait call times out', async () => {
     mockFetchHistoryPage.mockResolvedValue( null );
 
-    const result = await getHistory( { client, connection }, 'workflow-id', { wait: true } );
+    const result = await getHistory( { client, connection }, 'workflow-id', { longPollTimeoutMs: 15_000 } );
 
     expect( result.nextPageToken ).toBeNull();
     expect( result.workflow ).toEqual( expect.objectContaining( { workflowId: 'workflow-id' } ) );

--- a/api/src/clients/temporal/workflow/get_history.spec.js
+++ b/api/src/clients/temporal/workflow/get_history.spec.js
@@ -17,6 +17,10 @@ vi.mock( '#logger', () => ( {
   logger: { warn: mockLoggerWarn }
 } ) );
 
+vi.mock( '#configs', () => ( {
+  temporal: { historyWaitTimeoutMs: 15_000 }
+} ) );
+
 vi.mock( '../../event_serialization.js', () => ( {
   decodeEventPayloads: mockDecodeEventPayloads,
   serializeEvent: mockSerializeEvent
@@ -154,5 +158,53 @@ describe( 'getHistory', () => {
 
     expect( result.events ).toEqual( [] );
     expect( result.nextPageToken ).toBeNull();
+  } );
+
+  it( 'passes waitNewEvent and the configured deadline through when wait is requested', async () => {
+    const pageToken = Buffer.from( 'previous-token' ).toString( 'base64' );
+
+    await getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken, wait: true } );
+
+    expect( mockFetchHistoryPage ).toHaveBeenCalledWith( connection, 'workflow-id', 'run-id', {
+      maximumPageSize: 20,
+      nextPageToken: Buffer.from( pageToken, 'base64' ),
+      mapInvalidArgument: expect.any( Function ),
+      waitNewEvent: true,
+      deadlineMs: 15_000
+    } );
+  } );
+
+  it( 'does not pass waitNewEvent/deadlineMs when wait is not requested', async () => {
+    await getHistory( { client, connection }, 'workflow-id', { pageSize: 30 } );
+
+    expect( mockFetchHistoryPage ).toHaveBeenCalledWith( connection, 'workflow-id', 'resolved-run', {
+      maximumPageSize: 30,
+      nextPageToken: undefined,
+      mapInvalidArgument: expect.any( Function )
+    } );
+  } );
+
+  it( 'returns the unchanged cursor and empty events when a wait call times out', async () => {
+    const pageToken = Buffer.from( 'previous-token' ).toString( 'base64' );
+    mockFetchHistoryPage.mockResolvedValue( null );
+
+    const result = await getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken, wait: true } );
+
+    expect( result ).toEqual( {
+      workflow: null,
+      events: [],
+      runId: 'run-id',
+      nextPageToken: pageToken
+    } );
+    expect( mockSerializeEvent ).not.toHaveBeenCalled();
+  } );
+
+  it( 'returns a null nextPageToken when a first-page wait call times out', async () => {
+    mockFetchHistoryPage.mockResolvedValue( null );
+
+    const result = await getHistory( { client, connection }, 'workflow-id', { wait: true } );
+
+    expect( result.nextPageToken ).toBeNull();
+    expect( result.workflow ).toEqual( expect.objectContaining( { workflowId: 'workflow-id' } ) );
   } );
 } );

--- a/api/src/clients/temporal/workflow/get_history.spec.js
+++ b/api/src/clients/temporal/workflow/get_history.spec.js
@@ -165,7 +165,9 @@ describe( 'getHistory', () => {
 
     await getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken, wait: true } );
 
-    expect( mockFetchHistoryPage ).toHaveBeenCalledWith( connection, 'workflow-id', 'run-id', {
+    // wait:true re-describes even on a later page (resolving to 'resolved-run', the fixture's
+    // describeWorkflow stub), so status stays live across a resumed poll — see the next test.
+    expect( mockFetchHistoryPage ).toHaveBeenCalledWith( connection, 'workflow-id', 'resolved-run', {
       maximumPageSize: 20,
       nextPageToken: Buffer.from( pageToken, 'base64' ),
       mapInvalidArgument: expect.any( Function ),
@@ -184,16 +186,32 @@ describe( 'getHistory', () => {
     } );
   } );
 
-  it( 'returns the unchanged cursor and empty events when a wait call times out', async () => {
+  it( 're-describes on a later page when wait is requested, so a resumed poll sees a status change', async () => {
+    const pageToken = Buffer.from( 'previous-token' ).toString( 'base64' );
+
+    await getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken, wait: true } );
+
+    expect( mockDescribeWorkflow ).toHaveBeenCalledWith( { client }, 'workflow-id', { runId: 'run-id' } );
+  } );
+
+  it( 'skips the describe call on a later page when wait is not requested', async () => {
+    const pageToken = Buffer.from( 'previous-token' ).toString( 'base64' );
+
+    await getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken } );
+
+    expect( mockDescribeWorkflow ).not.toHaveBeenCalled();
+  } );
+
+  it( 'returns the unchanged cursor and fresh workflow metadata when a wait call times out', async () => {
     const pageToken = Buffer.from( 'previous-token' ).toString( 'base64' );
     mockFetchHistoryPage.mockResolvedValue( null );
 
     const result = await getHistory( { client, connection }, 'workflow-id', { runId: 'run-id', pageToken, wait: true } );
 
     expect( result ).toEqual( {
-      workflow: null,
+      workflow: expect.objectContaining( { workflowId: 'workflow-id' } ),
       events: [],
-      runId: 'run-id',
+      runId: 'resolved-run',
       nextPageToken: pageToken
     } );
     expect( mockSerializeEvent ).not.toHaveBeenCalled();

--- a/api/src/clients/temporal/workflow/get_history.spec.js
+++ b/api/src/clients/temporal/workflow/get_history.spec.js
@@ -176,6 +176,26 @@ describe( 'getHistory', () => {
     } );
   } );
 
+  it( 'clamps deadlineMs to the configured max when waitMs requests a shorter wait', async () => {
+    await getHistory( { client, connection }, 'workflow-id', { wait: true, waitMs: 2_500 } );
+
+    expect( mockFetchHistoryPage ).toHaveBeenCalledWith( connection, 'workflow-id', 'resolved-run', {
+      maximumPageSize: 20,
+      nextPageToken: undefined,
+      mapInvalidArgument: expect.any( Function ),
+      waitNewEvent: true,
+      deadlineMs: 2_500
+    } );
+  } );
+
+  it( 'ignores a waitMs longer than the configured max, capping at historyWaitTimeoutMs', async () => {
+    await getHistory( { client, connection }, 'workflow-id', { wait: true, waitMs: 60_000 } );
+
+    expect( mockFetchHistoryPage ).toHaveBeenCalledWith( connection, 'workflow-id', 'resolved-run', expect.objectContaining( {
+      deadlineMs: 15_000
+    } ) );
+  } );
+
   it( 'does not pass waitNewEvent/deadlineMs when wait is not requested', async () => {
     await getHistory( { client, connection }, 'workflow-id', { pageSize: 30 } );
 

--- a/api/src/configs.js
+++ b/api/src/configs.js
@@ -12,10 +12,11 @@ const envSchema = z.object( {
   TEMPORAL_NAMESPACE: z.string().optional().default( 'default' ),
   TEMPORAL_WORKFLOW_EXECUTION_TIMEOUT: z.string().optional().default( '24h' ),
   TEMPORAL_WORKFLOW_EXECUTION_MAX_WAITING: z.coerce.number().optional().default( 300_000 ), // 5minutes
-  // Bounds a single long-poll (waitNewEvent) call on GET /workflow/:id/history so a resumable
-  // poller (e.g. `workflow monitor`) gets a fast, incremental response instead of restarting
-  // its history fetch from page 1 on every tick.
-  TEMPORAL_HISTORY_WAIT_TIMEOUT_MS: z.coerce.number().optional().default( 15_000 ),
+  // Upper bound (ceiling) for a single long-poll (waitNewEvent) call on GET /workflow/:id/history.
+  // A caller opts into long-polling via the `longPollTimeoutMs` query parameter; any value above
+  // this cap is clamped down to it, so a client can shorten the block but never exceed the
+  // server-configured maximum.
+  TEMPORAL_HISTORY_MAX_WAIT_TIMEOUT_MS: z.coerce.number().optional().default( 15_000 ),
   TEMPORAL_API_KEY: z.string().optional(),
   // gRPC max message size for the Temporal client connection (send + receive).
   // gRPC's default receive cap is 4 MiB; some workflow result exceed it.
@@ -44,7 +45,7 @@ export const temporal = {
   namespace: safeEnvVar.TEMPORAL_NAMESPACE,
   workflowExecutionTimeout: safeEnvVar.TEMPORAL_WORKFLOW_EXECUTION_TIMEOUT,
   workflowExecutionMaxWaiting: safeEnvVar.TEMPORAL_WORKFLOW_EXECUTION_MAX_WAITING,
-  historyWaitTimeoutMs: safeEnvVar.TEMPORAL_HISTORY_WAIT_TIMEOUT_MS,
+  historyMaxWaitTimeoutMs: safeEnvVar.TEMPORAL_HISTORY_MAX_WAIT_TIMEOUT_MS,
   grpcMaxMessageSizeBytes: safeEnvVar.TEMPORAL_GRPC_MAX_MESSAGE_SIZE_BYTES
 };
 

--- a/api/src/configs.js
+++ b/api/src/configs.js
@@ -12,6 +12,10 @@ const envSchema = z.object( {
   TEMPORAL_NAMESPACE: z.string().optional().default( 'default' ),
   TEMPORAL_WORKFLOW_EXECUTION_TIMEOUT: z.string().optional().default( '24h' ),
   TEMPORAL_WORKFLOW_EXECUTION_MAX_WAITING: z.coerce.number().optional().default( 300_000 ), // 5minutes
+  // Bounds a single long-poll (waitNewEvent) call on GET /workflow/:id/history so a resumable
+  // poller (e.g. `workflow monitor`) gets a fast, incremental response instead of restarting
+  // its history fetch from page 1 on every tick.
+  TEMPORAL_HISTORY_WAIT_TIMEOUT_MS: z.coerce.number().optional().default( 15_000 ),
   TEMPORAL_API_KEY: z.string().optional(),
   // gRPC max message size for the Temporal client connection (send + receive).
   // gRPC's default receive cap is 4 MiB; some workflow result exceed it.
@@ -40,6 +44,7 @@ export const temporal = {
   namespace: safeEnvVar.TEMPORAL_NAMESPACE,
   workflowExecutionTimeout: safeEnvVar.TEMPORAL_WORKFLOW_EXECUTION_TIMEOUT,
   workflowExecutionMaxWaiting: safeEnvVar.TEMPORAL_WORKFLOW_EXECUTION_MAX_WAITING,
+  historyWaitTimeoutMs: safeEnvVar.TEMPORAL_HISTORY_WAIT_TIMEOUT_MS,
   grpcMaxMessageSizeBytes: safeEnvVar.TEMPORAL_GRPC_MAX_MESSAGE_SIZE_BYTES
 };
 

--- a/api/src/configs.spec.js
+++ b/api/src/configs.spec.js
@@ -6,7 +6,7 @@ const CONFIG_KEYS = [
   'TEMPORAL_NAMESPACE',
   'TEMPORAL_WORKFLOW_EXECUTION_TIMEOUT',
   'TEMPORAL_WORKFLOW_EXECUTION_MAX_WAITING',
-  'TEMPORAL_HISTORY_WAIT_TIMEOUT_MS',
+  'TEMPORAL_HISTORY_MAX_WAIT_TIMEOUT_MS',
   'TEMPORAL_API_KEY',
   'TEMPORAL_GRPC_MAX_MESSAGE_SIZE_BYTES',
   'OUTPUT_API_PORT',
@@ -65,7 +65,7 @@ describe( 'configs', () => {
       namespace: 'default',
       workflowExecutionTimeout: '24h',
       workflowExecutionMaxWaiting: 300_000,
-      historyWaitTimeoutMs: 15_000,
+      historyMaxWaitTimeoutMs: 15_000,
       grpcMaxMessageSizeBytes: 32 * 1024 * 1024
     } );
     expect( configs.api ).toEqual( {
@@ -115,11 +115,11 @@ describe( 'configs', () => {
     expect( configs.temporal.workflowExecutionMaxWaiting ).toBe( 600_000 );
   } );
 
-  it( 'coerces TEMPORAL_HISTORY_WAIT_TIMEOUT_MS from string', async () => {
-    setEnv( { TEMPORAL_HISTORY_WAIT_TIMEOUT_MS: '20000' } );
+  it( 'coerces TEMPORAL_HISTORY_MAX_WAIT_TIMEOUT_MS from string', async () => {
+    setEnv( { TEMPORAL_HISTORY_MAX_WAIT_TIMEOUT_MS: '20000' } );
     const configs = await loadConfigs();
 
-    expect( configs.temporal.historyWaitTimeoutMs ).toBe( 20_000 );
+    expect( configs.temporal.historyMaxWaitTimeoutMs ).toBe( 20_000 );
   } );
 
   it( 'coerces TEMPORAL_GRPC_MAX_MESSAGE_SIZE_BYTES from string', async () => {

--- a/api/src/configs.spec.js
+++ b/api/src/configs.spec.js
@@ -6,6 +6,7 @@ const CONFIG_KEYS = [
   'TEMPORAL_NAMESPACE',
   'TEMPORAL_WORKFLOW_EXECUTION_TIMEOUT',
   'TEMPORAL_WORKFLOW_EXECUTION_MAX_WAITING',
+  'TEMPORAL_HISTORY_WAIT_TIMEOUT_MS',
   'TEMPORAL_API_KEY',
   'TEMPORAL_GRPC_MAX_MESSAGE_SIZE_BYTES',
   'OUTPUT_API_PORT',
@@ -64,6 +65,7 @@ describe( 'configs', () => {
       namespace: 'default',
       workflowExecutionTimeout: '24h',
       workflowExecutionMaxWaiting: 300_000,
+      historyWaitTimeoutMs: 15_000,
       grpcMaxMessageSizeBytes: 32 * 1024 * 1024
     } );
     expect( configs.api ).toEqual( {
@@ -111,6 +113,13 @@ describe( 'configs', () => {
     const configs = await loadConfigs();
 
     expect( configs.temporal.workflowExecutionMaxWaiting ).toBe( 600_000 );
+  } );
+
+  it( 'coerces TEMPORAL_HISTORY_WAIT_TIMEOUT_MS from string', async () => {
+    setEnv( { TEMPORAL_HISTORY_WAIT_TIMEOUT_MS: '20000' } );
+    const configs = await loadConfigs();
+
+    expect( configs.temporal.historyWaitTimeoutMs ).toBe( 20_000 );
   } );
 
   it( 'coerces TEMPORAL_GRPC_MAX_MESSAGE_SIZE_BYTES from string', async () => {

--- a/api/src/handlers/workflow_history.js
+++ b/api/src/handlers/workflow_history.js
@@ -11,12 +11,11 @@ export function createWorkflowHistoryHandler( client ) {
       z.string().max( 4096 ).regex( /^[A-Za-z0-9+/]+={0,2}$/, 'Invalid pageToken format' ).optional()
     ),
     includePayloads: z.union( [ z.literal( 'true' ), z.literal( 'false' ) ] ).default( 'false' ).transform( v => v === 'true' ),
-    // Long-poll for a new event when already caught up to the end of history, instead of
-    // returning immediately. Lets a resumable poller avoid restarting from page 1 every tick.
-    wait: z.union( [ z.literal( 'true' ), z.literal( 'false' ) ] ).default( 'false' ).transform( v => v === 'true' ),
-    // Caller-requested upper bound for a `wait` long-poll; only ever shortens the
-    // server-configured deadline (see getHistory), never lengthens it.
-    waitMs: z.coerce.number().int().positive().optional()
+    // When set (and positive), long-poll for a new event once caught up to the end of history
+    // instead of returning immediately, bounding the block by this many milliseconds (clamped to
+    // the server ceiling; see getHistory). Omit for an immediate response. Lets a resumable poller
+    // avoid restarting from page 1 every tick.
+    longPollTimeoutMs: z.coerce.number().int().positive().optional()
   } ).refine(
     data => !data.pageToken || data.runId,
     { message: 'runId is required when using pageToken', path: [ 'runId' ] }
@@ -25,7 +24,7 @@ export function createWorkflowHistoryHandler( client ) {
   return async ( req, res ) => {
     const workflowId = req.params.id;
     const pathRunId = readPinnedRunId( req );
-    const { runId, pageSize, pageToken, includePayloads, wait, waitMs } = querySchema.parse(
+    const { runId, pageSize, pageToken, includePayloads, longPollTimeoutMs } = querySchema.parse(
       pathRunId ? { ...req.query, runId: pathRunId } : req.query
     );
 
@@ -34,8 +33,7 @@ export function createWorkflowHistoryHandler( client ) {
       pageSize,
       pageToken,
       includePayloads,
-      wait,
-      waitMs
+      longPollTimeoutMs
     } );
 
     res.json( result );

--- a/api/src/handlers/workflow_history.js
+++ b/api/src/handlers/workflow_history.js
@@ -10,7 +10,10 @@ export function createWorkflowHistoryHandler( client ) {
       // pageToken is a base64-encoded Temporal pagination cursor
       z.string().max( 4096 ).regex( /^[A-Za-z0-9+/]+={0,2}$/, 'Invalid pageToken format' ).optional()
     ),
-    includePayloads: z.union( [ z.literal( 'true' ), z.literal( 'false' ) ] ).default( 'false' ).transform( v => v === 'true' )
+    includePayloads: z.union( [ z.literal( 'true' ), z.literal( 'false' ) ] ).default( 'false' ).transform( v => v === 'true' ),
+    // Long-poll for a new event when already caught up to the end of history, instead of
+    // returning immediately. Lets a resumable poller avoid restarting from page 1 every tick.
+    wait: z.union( [ z.literal( 'true' ), z.literal( 'false' ) ] ).default( 'false' ).transform( v => v === 'true' )
   } ).refine(
     data => !data.pageToken || data.runId,
     { message: 'runId is required when using pageToken', path: [ 'runId' ] }
@@ -19,7 +22,7 @@ export function createWorkflowHistoryHandler( client ) {
   return async ( req, res ) => {
     const workflowId = req.params.id;
     const pathRunId = readPinnedRunId( req );
-    const { runId, pageSize, pageToken, includePayloads } = querySchema.parse(
+    const { runId, pageSize, pageToken, includePayloads, wait } = querySchema.parse(
       pathRunId ? { ...req.query, runId: pathRunId } : req.query
     );
 
@@ -27,7 +30,8 @@ export function createWorkflowHistoryHandler( client ) {
       runId,
       pageSize,
       pageToken,
-      includePayloads
+      includePayloads,
+      wait
     } );
 
     res.json( result );

--- a/api/src/handlers/workflow_history.js
+++ b/api/src/handlers/workflow_history.js
@@ -13,7 +13,10 @@ export function createWorkflowHistoryHandler( client ) {
     includePayloads: z.union( [ z.literal( 'true' ), z.literal( 'false' ) ] ).default( 'false' ).transform( v => v === 'true' ),
     // Long-poll for a new event when already caught up to the end of history, instead of
     // returning immediately. Lets a resumable poller avoid restarting from page 1 every tick.
-    wait: z.union( [ z.literal( 'true' ), z.literal( 'false' ) ] ).default( 'false' ).transform( v => v === 'true' )
+    wait: z.union( [ z.literal( 'true' ), z.literal( 'false' ) ] ).default( 'false' ).transform( v => v === 'true' ),
+    // Caller-requested upper bound for a `wait` long-poll; only ever shortens the
+    // server-configured deadline (see getHistory), never lengthens it.
+    waitMs: z.coerce.number().int().positive().optional()
   } ).refine(
     data => !data.pageToken || data.runId,
     { message: 'runId is required when using pageToken', path: [ 'runId' ] }
@@ -22,7 +25,7 @@ export function createWorkflowHistoryHandler( client ) {
   return async ( req, res ) => {
     const workflowId = req.params.id;
     const pathRunId = readPinnedRunId( req );
-    const { runId, pageSize, pageToken, includePayloads, wait } = querySchema.parse(
+    const { runId, pageSize, pageToken, includePayloads, wait, waitMs } = querySchema.parse(
       pathRunId ? { ...req.query, runId: pathRunId } : req.query
     );
 
@@ -31,7 +34,8 @@ export function createWorkflowHistoryHandler( client ) {
       pageSize,
       pageToken,
       includePayloads,
-      wait
+      wait,
+      waitMs
     } );
 
     res.json( result );

--- a/api/src/handlers/workflow_history.spec.js
+++ b/api/src/handlers/workflow_history.spec.js
@@ -52,7 +52,7 @@ describe( 'workflow_history handler', () => {
       pageSize: 20,
       pageToken: undefined,
       includePayloads: false,
-      wait: false
+      longPollTimeoutMs: undefined
     } );
   } );
 
@@ -61,7 +61,7 @@ describe( 'workflow_history handler', () => {
     const token = Buffer.from( 'page-data' ).toString( 'base64' );
 
     await request( createApp() )
-      .get( `/workflow/wf-123/history?runId=run-abc&pageSize=30&pageToken=${token}&includePayloads=true&wait=true` )
+      .get( `/workflow/wf-123/history?runId=run-abc&pageSize=30&pageToken=${token}&includePayloads=true&longPollTimeoutMs=2500` )
       .expect( 200 );
 
     expect( mockGetWorkflowHistory ).toHaveBeenCalledWith( 'wf-123', {
@@ -69,45 +69,29 @@ describe( 'workflow_history handler', () => {
       pageSize: 30,
       pageToken: token,
       includePayloads: true,
-      wait: true
+      longPollTimeoutMs: 2500
     } );
   } );
 
-  it( 'defaults wait to false', async () => {
+  it( 'omits longPollTimeoutMs when not provided', async () => {
     mockGetWorkflowHistory.mockResolvedValue( { workflow: null, events: [], nextPageToken: null } );
 
     await request( createApp() )
       .get( '/workflow/wf-123/history' )
       .expect( 200 );
 
-    expect( mockGetWorkflowHistory ).toHaveBeenCalledWith( 'wf-123', expect.objectContaining( { wait: false } ) );
+    expect( mockGetWorkflowHistory ).toHaveBeenCalledWith( 'wf-123', expect.objectContaining( { longPollTimeoutMs: undefined } ) );
   } );
 
-  it( 'rejects non-boolean wait values', async () => {
+  it( 'rejects a non-positive longPollTimeoutMs', async () => {
     await request( createApp() )
-      .get( '/workflow/wf-123/history?wait=yes' )
+      .get( '/workflow/wf-123/history?longPollTimeoutMs=0' )
       .expect( 400 );
   } );
 
-  it( 'passes waitMs through to the client', async () => {
-    mockGetWorkflowHistory.mockResolvedValue( { workflow: null, events: [], nextPageToken: null } );
-
+  it( 'rejects a non-numeric longPollTimeoutMs', async () => {
     await request( createApp() )
-      .get( '/workflow/wf-123/history?wait=true&waitMs=2500' )
-      .expect( 200 );
-
-    expect( mockGetWorkflowHistory ).toHaveBeenCalledWith( 'wf-123', expect.objectContaining( { waitMs: 2500 } ) );
-  } );
-
-  it( 'rejects a non-positive waitMs', async () => {
-    await request( createApp() )
-      .get( '/workflow/wf-123/history?wait=true&waitMs=0' )
-      .expect( 400 );
-  } );
-
-  it( 'rejects a non-numeric waitMs', async () => {
-    await request( createApp() )
-      .get( '/workflow/wf-123/history?wait=true&waitMs=soon' )
+      .get( '/workflow/wf-123/history?longPollTimeoutMs=soon' )
       .expect( 400 );
   } );
 

--- a/api/src/handlers/workflow_history.spec.js
+++ b/api/src/handlers/workflow_history.spec.js
@@ -89,6 +89,28 @@ describe( 'workflow_history handler', () => {
       .expect( 400 );
   } );
 
+  it( 'passes waitMs through to the client', async () => {
+    mockGetWorkflowHistory.mockResolvedValue( { workflow: null, events: [], nextPageToken: null } );
+
+    await request( createApp() )
+      .get( '/workflow/wf-123/history?wait=true&waitMs=2500' )
+      .expect( 200 );
+
+    expect( mockGetWorkflowHistory ).toHaveBeenCalledWith( 'wf-123', expect.objectContaining( { waitMs: 2500 } ) );
+  } );
+
+  it( 'rejects a non-positive waitMs', async () => {
+    await request( createApp() )
+      .get( '/workflow/wf-123/history?wait=true&waitMs=0' )
+      .expect( 400 );
+  } );
+
+  it( 'rejects a non-numeric waitMs', async () => {
+    await request( createApp() )
+      .get( '/workflow/wf-123/history?wait=true&waitMs=soon' )
+      .expect( 400 );
+  } );
+
   it( 'defaults pageSize to 20 and includePayloads to false', async () => {
     mockGetWorkflowHistory.mockResolvedValue( { workflow: null, events: [], nextPageToken: null } );
 

--- a/api/src/handlers/workflow_history.spec.js
+++ b/api/src/handlers/workflow_history.spec.js
@@ -51,7 +51,8 @@ describe( 'workflow_history handler', () => {
       runId: undefined,
       pageSize: 20,
       pageToken: undefined,
-      includePayloads: false
+      includePayloads: false,
+      wait: false
     } );
   } );
 
@@ -60,15 +61,32 @@ describe( 'workflow_history handler', () => {
     const token = Buffer.from( 'page-data' ).toString( 'base64' );
 
     await request( createApp() )
-      .get( `/workflow/wf-123/history?runId=run-abc&pageSize=30&pageToken=${token}&includePayloads=true` )
+      .get( `/workflow/wf-123/history?runId=run-abc&pageSize=30&pageToken=${token}&includePayloads=true&wait=true` )
       .expect( 200 );
 
     expect( mockGetWorkflowHistory ).toHaveBeenCalledWith( 'wf-123', {
       runId: 'run-abc',
       pageSize: 30,
       pageToken: token,
-      includePayloads: true
+      includePayloads: true,
+      wait: true
     } );
+  } );
+
+  it( 'defaults wait to false', async () => {
+    mockGetWorkflowHistory.mockResolvedValue( { workflow: null, events: [], nextPageToken: null } );
+
+    await request( createApp() )
+      .get( '/workflow/wf-123/history' )
+      .expect( 200 );
+
+    expect( mockGetWorkflowHistory ).toHaveBeenCalledWith( 'wf-123', expect.objectContaining( { wait: false } ) );
+  } );
+
+  it( 'rejects non-boolean wait values', async () => {
+    await request( createApp() )
+      .get( '/workflow/wf-123/history?wait=yes' )
+      .expect( 400 );
   } );
 
   it( 'defaults pageSize to 20 and includePayloads to false', async () => {

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -1164,6 +1164,16 @@ app.get( '/workflow/:id/runs/:rid/trace-log', traceLogHandler );
  *           Long-poll for a new event when already caught up to the end of history, instead of
  *           returning immediately. Bounded server-side; on timeout returns the same page's
  *           cursor unchanged with an empty events array so the caller can retry.
+ *       - in: query
+ *         name: waitMs
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: >
+ *           Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes
+ *           effect when `wait` is true, and only ever shortens the server's configured long-poll
+ *           deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval)
+ *           keep the block roughly aligned with its own cadence.
  *     responses:
  *       200:
  *         description: Paginated history events
@@ -1238,6 +1248,16 @@ app.get( '/workflow/:id/runs/:rid/trace-log', traceLogHandler );
  *           Long-poll for a new event when already caught up to the end of history, instead of
  *           returning immediately. Bounded server-side; on timeout returns the same page's
  *           cursor unchanged with an empty events array so the caller can retry.
+ *       - in: query
+ *         name: waitMs
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *         description: >
+ *           Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes
+ *           effect when `wait` is true, and only ever shortens the server's configured long-poll
+ *           deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval)
+ *           keep the block roughly aligned with its own cadence.
  *     responses:
  *       200:
  *         description: Paginated history events

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -1155,6 +1155,15 @@ app.get( '/workflow/:id/runs/:rid/trace-log', traceLogHandler );
  *           type: boolean
  *           default: false
  *         description: Include decoded input/output payloads in events
+ *       - in: query
+ *         name: wait
+ *         schema:
+ *           type: boolean
+ *           default: false
+ *         description: >
+ *           Long-poll for a new event when already caught up to the end of history, instead of
+ *           returning immediately. Bounded server-side; on timeout returns the same page's
+ *           cursor unchanged with an empty events array so the caller can retry.
  *     responses:
  *       200:
  *         description: Paginated history events
@@ -1220,6 +1229,15 @@ app.get( '/workflow/:id/runs/:rid/trace-log', traceLogHandler );
  *           type: boolean
  *           default: false
  *         description: Include decoded input/output payloads in events
+ *       - in: query
+ *         name: wait
+ *         schema:
+ *           type: boolean
+ *           default: false
+ *         description: >
+ *           Long-poll for a new event when already caught up to the end of history, instead of
+ *           returning immediately. Bounded server-side; on timeout returns the same page's
+ *           cursor unchanged with an empty events array so the caller can retry.
  *     responses:
  *       200:
  *         description: Paginated history events

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -1156,24 +1156,17 @@ app.get( '/workflow/:id/runs/:rid/trace-log', traceLogHandler );
  *           default: false
  *         description: Include decoded input/output payloads in events
  *       - in: query
- *         name: wait
- *         schema:
- *           type: boolean
- *           default: false
- *         description: >
- *           Long-poll for a new event when already caught up to the end of history, instead of
- *           returning immediately. Bounded server-side; on timeout returns the same page's
- *           cursor unchanged with an empty events array so the caller can retry.
- *       - in: query
- *         name: waitMs
+ *         name: longPollTimeoutMs
  *         schema:
  *           type: integer
  *           minimum: 1
  *         description: >
- *           Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes
- *           effect when `wait` is true, and only ever shortens the server's configured long-poll
- *           deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval)
- *           keep the block roughly aligned with its own cadence.
+ *           When set, long-poll for a new event once caught up to the end of history instead of
+ *           returning immediately, bounding the block by this many milliseconds. Clamped to the
+ *           server's configured maximum — a caller can shorten the wait but never exceed it. Omit
+ *           for an immediate response; on timeout returns the same page's cursor unchanged with an
+ *           empty events array so the caller can retry. Lets a poller keep the block roughly
+ *           aligned with its own tick interval.
  *     responses:
  *       200:
  *         description: Paginated history events
@@ -1240,24 +1233,17 @@ app.get( '/workflow/:id/runs/:rid/trace-log', traceLogHandler );
  *           default: false
  *         description: Include decoded input/output payloads in events
  *       - in: query
- *         name: wait
- *         schema:
- *           type: boolean
- *           default: false
- *         description: >
- *           Long-poll for a new event when already caught up to the end of history, instead of
- *           returning immediately. Bounded server-side; on timeout returns the same page's
- *           cursor unchanged with an empty events array so the caller can retry.
- *       - in: query
- *         name: waitMs
+ *         name: longPollTimeoutMs
  *         schema:
  *           type: integer
  *           minimum: 1
  *         description: >
- *           Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes
- *           effect when `wait` is true, and only ever shortens the server's configured long-poll
- *           deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval)
- *           keep the block roughly aligned with its own cadence.
+ *           When set, long-poll for a new event once caught up to the end of history instead of
+ *           returning immediately, bounding the block by this many milliseconds. Clamped to the
+ *           server's configured maximum — a caller can shorten the wait but never exceed it. Omit
+ *           for an immediate response; on timeout returns the same page's cursor unchanged with an
+ *           empty events array so the caller can retry. Lets a poller keep the block roughly
+ *           aligned with its own tick interval.
  *     responses:
  *       200:
  *         description: Paginated history events

--- a/api/src/index.spec.js
+++ b/api/src/index.spec.js
@@ -446,7 +446,8 @@ describe( 'API endpoints', () => {
         runId: undefined,
         pageSize: 20,
         pageToken: undefined,
-        includePayloads: false
+        includePayloads: false,
+        wait: false
       } );
     } );
 

--- a/api/src/index.spec.js
+++ b/api/src/index.spec.js
@@ -447,7 +447,7 @@ describe( 'API endpoints', () => {
         pageSize: 20,
         pageToken: undefined,
         includePayloads: false,
-        wait: false
+        longPollTimeoutMs: undefined
       } );
     } );
 

--- a/docs/guides/openapi.json
+++ b/docs/guides/openapi.json
@@ -1459,21 +1459,12 @@
           },
           {
             "in": "query",
-            "name": "wait",
-            "schema": {
-              "type": "boolean",
-              "default": false
-            },
-            "description": "Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.\n"
-          },
-          {
-            "in": "query",
-            "name": "waitMs",
+            "name": "longPollTimeoutMs",
             "schema": {
               "type": "integer",
               "minimum": 1
             },
-            "description": "Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes effect when `wait` is true, and only ever shortens the server's configured long-poll deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval) keep the block roughly aligned with its own cadence.\n"
+            "description": "When set, long-poll for a new event once caught up to the end of history instead of returning immediately, bounding the block by this many milliseconds. Clamped to the server's configured maximum — a caller can shorten the wait but never exceed it. Omit for an immediate response; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry. Lets a poller keep the block roughly aligned with its own tick interval.\n"
           }
         ],
         "responses": {
@@ -1573,21 +1564,12 @@
           },
           {
             "in": "query",
-            "name": "wait",
-            "schema": {
-              "type": "boolean",
-              "default": false
-            },
-            "description": "Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.\n"
-          },
-          {
-            "in": "query",
-            "name": "waitMs",
+            "name": "longPollTimeoutMs",
             "schema": {
               "type": "integer",
               "minimum": 1
             },
-            "description": "Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes effect when `wait` is true, and only ever shortens the server's configured long-poll deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval) keep the block roughly aligned with its own cadence.\n"
+            "description": "When set, long-poll for a new event once caught up to the end of history instead of returning immediately, bounding the block by this many milliseconds. Clamped to the server's configured maximum — a caller can shorten the wait but never exceed it. Omit for an immediate response; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry. Lets a poller keep the block roughly aligned with its own tick interval.\n"
           }
         ],
         "responses": {

--- a/docs/guides/openapi.json
+++ b/docs/guides/openapi.json
@@ -1465,6 +1465,15 @@
               "default": false
             },
             "description": "Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.\n"
+          },
+          {
+            "in": "query",
+            "name": "waitMs",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes effect when `wait` is true, and only ever shortens the server's configured long-poll deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval) keep the block roughly aligned with its own cadence.\n"
           }
         ],
         "responses": {
@@ -1570,6 +1579,15 @@
               "default": false
             },
             "description": "Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.\n"
+          },
+          {
+            "in": "query",
+            "name": "waitMs",
+            "schema": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "description": "Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes effect when `wait` is true, and only ever shortens the server's configured long-poll deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval) keep the block roughly aligned with its own cadence.\n"
           }
         ],
         "responses": {

--- a/docs/guides/openapi.json
+++ b/docs/guides/openapi.json
@@ -1456,6 +1456,15 @@
               "default": false
             },
             "description": "Include decoded input/output payloads in events"
+          },
+          {
+            "in": "query",
+            "name": "wait",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.\n"
           }
         ],
         "responses": {
@@ -1552,6 +1561,15 @@
               "default": false
             },
             "description": "Include decoded input/output payloads in events"
+          },
+          {
+            "in": "query",
+            "name": "wait",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.\n"
           }
         ],
         "responses": {

--- a/docs/guides/packages/cli.mdx
+++ b/docs/guides/packages/cli.mdx
@@ -303,7 +303,7 @@ output workflow monitor <workflowId>
 | `--run-id, -r` | latest run | Monitor a specific run (continue-as-new chains are followed regardless of this flag) |
 | `--format, -f` | text | Output format: json, text |
 | `--include-payloads` | false | Include decoded step input/output payloads |
-| `--interval` | 2500 | Poll interval in milliseconds |
+| `--interval` | 2500 | Poll interval in milliseconds. Also bounds the resumed long-poll's server-side wait, so an idle workflow's update cadence is roughly twice this value, not a longer separate server default. |
 | `--color` | true | Colorize status output (`--no-color` to disable) |
 
 Exits `0` when the workflow completes, `1` when it fails, is canceled,

--- a/docs/guides/packages/cli.mdx
+++ b/docs/guides/packages/cli.mdx
@@ -308,7 +308,10 @@ output workflow monitor <workflowId>
 
 Exits `0` when the workflow completes, `1` when it fails, is canceled,
 terminated, or times out, and `130` if you detach with Ctrl+C — detaching
-never stops the workflow itself.
+never stops the workflow itself. `monitor` also exits `1` after 5 consecutive
+transient poll failures (network errors, 5xx/408/429 responses), printing a
+warning before each retry — this is API/network trouble, not a workflow
+outcome, but shares the same exit code.
 
 ```bash
 output workflow monitor wf-12345

--- a/docs/guides/packages/cli.mdx
+++ b/docs/guides/packages/cli.mdx
@@ -33,6 +33,7 @@ npx output workflow run lead_enrichment acme
 | `output workflow run` | Run a workflow and wait for the result |
 | `output workflow start` | Start a workflow without waiting |
 | `output workflow status` | Check workflow execution status |
+| `output workflow monitor` | Attach to a run and stream status updates until it ends |
 | `output workflow result` | Get a completed workflow's result |
 | `output workflow stop` | Stop a workflow gracefully |
 | `output workflow terminate` | Force-stop a workflow |
@@ -282,6 +283,42 @@ output workflow status <workflowId>
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--format, -f` | text | Output format: json, text |
+
+### output workflow monitor
+
+Attach to a workflow run and stream status updates until it ends — a step
+starts, completes, or fails is printed as it happens, so you don't have to
+re-run `workflow status` in a loop to watch a long-running workflow:
+
+```bash
+output workflow monitor <workflowId>
+```
+
+<ParamField path="workflowId" type="string" required>
+  The workflow execution ID
+</ParamField>
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--run-id, -r` | latest run | Monitor a specific run (continue-as-new chains are followed regardless of this flag) |
+| `--format, -f` | text | Output format: json, text |
+| `--include-payloads` | false | Include decoded step input/output payloads |
+| `--interval` | 2500 | Poll interval in milliseconds |
+| `--color` | true | Colorize status output (`--no-color` to disable) |
+
+Exits `0` when the workflow completes, `1` when it fails, is canceled,
+terminated, or times out, and `130` if you detach with Ctrl+C — detaching
+never stops the workflow itself.
+
+```bash
+output workflow monitor wf-12345
+output workflow monitor wf-12345 --run-id 2fe0b36b-...
+output workflow monitor wf-12345 --format json
+```
+
+<Note>
+  `--format json` here is **not** the same thing as the native `--json` flag used by `workflow run`, `workflow status`, and other commands migrated in OUT-419 (see the [changelog](/changelog)). Native `--json` suppresses all in-progress log output and prints a single JSON object once the command finishes. `monitor` has no single final result to print — it's a long-running command that emits a stream of discrete events (a step starting or finishing, a continue-as-new notice, a final summary) while the workflow is still running. `--format json` prints each event as its own line of newline-delimited JSON as it happens, so the output can be piped into `jq` or read incrementally by another process — often another automated or agent process rather than a person, which is the primary reason this command keeps its own JSON mode instead of adopting `--json`.
+</Note>
 
 ### output workflow result
 

--- a/sdk/cli/src/api/generated/api.ts
+++ b/sdk/cli/src/api/generated/api.ts
@@ -436,6 +436,11 @@ pageToken?: string;
  * Include decoded input/output payloads in events
  */
 includePayloads?: boolean;
+/**
+ * Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.
+
+ */
+wait?: boolean;
 };
 
 /**
@@ -474,6 +479,11 @@ pageToken?: string;
  * Include decoded input/output payloads in events
  */
 includePayloads?: boolean;
+/**
+ * Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.
+
+ */
+wait?: boolean;
 };
 
 /**

--- a/sdk/cli/src/api/generated/api.ts
+++ b/sdk/cli/src/api/generated/api.ts
@@ -441,6 +441,12 @@ includePayloads?: boolean;
 
  */
 wait?: boolean;
+/**
+ * Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes effect when `wait` is true, and only ever shortens the server's configured long-poll deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval) keep the block roughly aligned with its own cadence.
+
+ * @minimum 1
+ */
+waitMs?: number;
 };
 
 /**
@@ -484,6 +490,12 @@ includePayloads?: boolean;
 
  */
 wait?: boolean;
+/**
+ * Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes effect when `wait` is true, and only ever shortens the server's configured long-poll deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval) keep the block roughly aligned with its own cadence.
+
+ * @minimum 1
+ */
+waitMs?: number;
 };
 
 /**

--- a/sdk/cli/src/api/generated/api.ts
+++ b/sdk/cli/src/api/generated/api.ts
@@ -437,16 +437,11 @@ pageToken?: string;
  */
 includePayloads?: boolean;
 /**
- * Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.
-
- */
-wait?: boolean;
-/**
- * Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes effect when `wait` is true, and only ever shortens the server's configured long-poll deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval) keep the block roughly aligned with its own cadence.
+ * When set, long-poll for a new event once caught up to the end of history instead of returning immediately, bounding the block by this many milliseconds. Clamped to the server's configured maximum — a caller can shorten the wait but never exceed it. Omit for an immediate response; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry. Lets a poller keep the block roughly aligned with its own tick interval.
 
  * @minimum 1
  */
-waitMs?: number;
+longPollTimeoutMs?: number;
 };
 
 /**
@@ -486,16 +481,11 @@ pageToken?: string;
  */
 includePayloads?: boolean;
 /**
- * Long-poll for a new event when already caught up to the end of history, instead of returning immediately. Bounded server-side; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry.
-
- */
-wait?: boolean;
-/**
- * Upper bound in milliseconds for how long a `wait` long-poll may block. Only takes effect when `wait` is true, and only ever shortens the server's configured long-poll deadline, never lengthens it. Lets a caller (e.g. a poller with its own tick interval) keep the block roughly aligned with its own cadence.
+ * When set, long-poll for a new event once caught up to the end of history instead of returning immediately, bounding the block by this many milliseconds. Clamped to the server's configured maximum — a caller can shorten the wait but never exceed it. Omit for an immediate response; on timeout returns the same page's cursor unchanged with an empty events array so the caller can retry. Lets a poller keep the block roughly aligned with its own tick interval.
 
  * @minimum 1
  */
-waitMs?: number;
+longPollTimeoutMs?: number;
 };
 
 /**

--- a/sdk/cli/src/commands/workflow/history.spec.ts
+++ b/sdk/cli/src/commands/workflow/history.spec.ts
@@ -1,7 +1,10 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi } from 'vitest';
 
-// Isolate the command module from the API/service layer at import time.
-vi.mock( '../../services/workflow_history.js', () => ( {
+// Isolate the command module from the API/service layer at import time. Must use the
+// `#`-aliased specifier — history.ts imports via that alias, and a relative specifier here
+// resolves to a different module id, so the mock silently never intercepts the real import.
+vi.mock( '#services/workflow_history.js', () => ( {
   fetchWorkflowHistory: vi.fn()
 } ) );
 
@@ -27,5 +30,36 @@ describe( 'workflow history command', () => {
     expect( flags.format.options ).toEqual( [ 'text', 'json' ] );
     expect( flags.format.default ).toBe( 'text' );
     expect( flags.raw.default ).toBe( false );
+  } );
+
+  describe( 'run() --raw', () => {
+    it( 'prints the server\'s literal status, not the client-normalized one', async () => {
+      const WorkflowHistory = ( await import( './history.js' ) ).default;
+      const { fetchWorkflowHistory } = await import( '#services/workflow_history.js' );
+
+      // `workflow` carries the normalized status (what monitor/waterfall consume);
+      // `rawWorkflow` is the untouched server value — `--raw` must use the latter.
+      vi.mocked( fetchWorkflowHistory ).mockResolvedValueOnce( {
+        workflow: { workflowId: 'wf-1', runId: 'run-1', status: 'continued_as_new' },
+        rawWorkflow: { workflowId: 'wf-1', runId: 'run-1', status: 'continued' },
+        runId: 'run-1',
+        events: [],
+        spans: [],
+        totalDurationMs: 0,
+        continuedAsNewRunId: null
+      } as any );
+
+      const cmd = new WorkflowHistory( [ 'wf-1', '--raw' ], {} as any );
+      cmd.log = vi.fn();
+      ( cmd as any ).parse = vi.fn().mockResolvedValue( {
+        args: { workflowId: 'wf-1' },
+        flags: { 'run-id': undefined, format: 'text', raw: true, 'include-payloads': false, width: undefined, color: false }
+      } );
+
+      await cmd.run();
+
+      const printed = JSON.parse( ( cmd.log as ReturnType<typeof vi.fn> ).mock.calls[0][0] as string );
+      expect( printed.workflow.status ).toBe( 'continued' );
+    } );
   } );
 } );

--- a/sdk/cli/src/commands/workflow/history.ts
+++ b/sdk/cli/src/commands/workflow/history.ts
@@ -65,7 +65,7 @@ export default class WorkflowHistory extends Command {
 
     if ( flags.raw ) {
       this.log( JSON.stringify( {
-        workflow: result.workflow,
+        workflow: result.rawWorkflow,
         runId: result.runId,
         events: result.events
       }, null, 2 ) );

--- a/sdk/cli/src/commands/workflow/history.ts
+++ b/sdk/cli/src/commands/workflow/history.ts
@@ -3,6 +3,7 @@ import { fetchWorkflowHistory } from '#services/workflow_history.js';
 import buildSpanLabels from '#utils/span_labels.js';
 import renderWaterfall, { formatDurationLabel } from '#utils/waterfall.js';
 import { handleApiError } from '#utils/error_handler.js';
+import { shouldColorize } from '#utils/color.js';
 
 const DEFAULT_WIDTH = 80;
 const OUTPUT_FORMAT = { JSON: 'json', TEXT: 'text' } as const;
@@ -83,8 +84,7 @@ export default class WorkflowHistory extends Command {
 
     const labels = buildSpanLabels( result.spans );
     const width = flags.width ?? process.stdout.columns ?? DEFAULT_WIDTH;
-    const color = flags.color && !process.env.NO_COLOR &&
-      ( !!process.env.FORCE_COLOR || process.stdout.isTTY === true );
+    const color = shouldColorize( flags.color );
 
     this.log( renderWaterfall( result.spans, result.totalDurationMs, {
       width,

--- a/sdk/cli/src/commands/workflow/monitor.spec.ts
+++ b/sdk/cli/src/commands/workflow/monitor.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-vi.mock( '#services/workflow_history.js', () => ( { fetchWorkflowHistory: vi.fn() } ) );
+vi.mock( '#services/workflow_history.js', () => ( { fetchWorkflowHistory: vi.fn(), fetchWorkflowHistoryUpdates: vi.fn() } ) );
 vi.mock( '#utils/sleep.js', () => ( { sleep: vi.fn().mockResolvedValue( undefined ) } ) );
 
 const span = ( id: string, status: string, overrides: Record<string, unknown> = {} ): Record<string, unknown> => ( {
@@ -29,7 +29,17 @@ const history = ( status: string, overrides: Record<string, unknown> = {} ): Rec
   spans: [],
   totalDurationMs: 0,
   continuedAsNewRunId: null,
+  // Every result carries a cursor now (see workflow_history.ts) — `poll()` uses its
+  // presence to decide fetchWorkflowHistory vs. fetchWorkflowHistoryUpdates on the next tick.
+  cursor: { pageToken: 'token', lastEventId: 1, meta: null, runId: 'run-1', events: [] },
   ...overrides
+} );
+
+// `fetchWorkflowHistoryUpdates` (used from the second poll onward) wraps the same result
+// shape with a resume cursor; tests don't care about cursor contents, only that it's threaded.
+const update = ( status: string, overrides: Record<string, unknown> = {} ): Record<string, unknown> => ( {
+  result: history( status, overrides ),
+  cursor: { pageToken: 'token', lastEventId: 1, meta: null, runId: 'run-1', events: [] }
 } );
 
 describe( 'workflow monitor command', () => {
@@ -64,7 +74,7 @@ describe( 'workflow monitor command', () => {
   describe( 'run()', () => {
     const createCommand = async ( flagOverrides: Record<string, unknown> = {} ) => {
       const WorkflowMonitor = ( await import( './monitor.js' ) ).default;
-      const { fetchWorkflowHistory } = await import( '#services/workflow_history.js' );
+      const { fetchWorkflowHistory, fetchWorkflowHistoryUpdates } = await import( '#services/workflow_history.js' );
 
       const cmd = new WorkflowMonitor( [ 'wf-1' ], {} as any );
       cmd.log = vi.fn();
@@ -84,7 +94,11 @@ describe( 'workflow monitor command', () => {
         }
       } );
 
-      return { cmd, fetchWorkflowHistory: vi.mocked( fetchWorkflowHistory ) };
+      return {
+        cmd,
+        fetchWorkflowHistory: vi.mocked( fetchWorkflowHistory ),
+        fetchWorkflowHistoryUpdates: vi.mocked( fetchWorkflowHistoryUpdates )
+      };
     };
 
     it( 'prints span updates and exits cleanly when the workflow is already completed on the first poll', async () => {
@@ -113,28 +127,53 @@ describe( 'workflow monitor command', () => {
     } );
 
     it( 'polls again while the workflow is running, then stops once it completes', async () => {
-      const { cmd, fetchWorkflowHistory } = await createCommand();
-      fetchWorkflowHistory
-        .mockResolvedValueOnce( history( 'running', { spans: [ span( '1', 'running' ) ] } ) as any )
-        .mockResolvedValueOnce( history( 'completed', {
-          spans: [ span( '1', 'completed' ) ], totalDurationMs: 2000
-        } ) as any );
+      const { cmd, fetchWorkflowHistory, fetchWorkflowHistoryUpdates } = await createCommand();
+      fetchWorkflowHistory.mockResolvedValueOnce( history( 'running', { spans: [ span( '1', 'running' ) ] } ) as any );
+      fetchWorkflowHistoryUpdates.mockResolvedValueOnce( update( 'completed', {
+        spans: [ span( '1', 'completed' ) ], totalDurationMs: 2000
+      } ) as any );
 
       await cmd.run();
 
-      expect( fetchWorkflowHistory ).toHaveBeenCalledTimes( 2 );
+      expect( fetchWorkflowHistory ).toHaveBeenCalledTimes( 1 );
+      expect( fetchWorkflowHistoryUpdates ).toHaveBeenCalledTimes( 1 );
       expect( cmd.log ).toHaveBeenCalledWith( expect.stringContaining( 'running' ) );
       expect( cmd.log ).toHaveBeenCalledWith( expect.stringContaining( '1s' ) );
       expect( process.exitCode ).toBeUndefined();
     } );
 
+    it( 'keeps a span label stable once printed, even when a same-named span appears on a later poll', async () => {
+      const { cmd, fetchWorkflowHistory, fetchWorkflowHistoryUpdates } = await createCommand();
+      fetchWorkflowHistory.mockResolvedValueOnce(
+        history( 'running', { spans: [ span( '1', 'running', { name: 'Scrape Page' } ) ] } ) as any
+      );
+      // Span 2 shares span 1's name, only showing up on the second poll — buildSpanLabels
+      // would number both "#1"/"#2" if recomputed fresh, retroactively relabeling span 1's
+      // already-printed "running" line.
+      fetchWorkflowHistoryUpdates.mockResolvedValueOnce( update( 'completed', {
+        spans: [
+          span( '1', 'completed', { name: 'Scrape Page' } ),
+          span( '2', 'completed', { name: 'Scrape Page' } )
+        ]
+      } ) as any );
+
+      await cmd.run();
+
+      const lines: string[] = ( cmd.log as any ).mock.calls.map( ( [ line ]: [ string ] ) => line );
+      expect( lines.some( ( line: string ) => line.includes( 'Scrape Page running' ) ) ).toBe( true );
+      // Span 1's completion line keeps its original unnumbered label...
+      expect( lines.some( ( line: string ) => line.includes( 'Scrape Page  ' ) ) ).toBe( true );
+      expect( lines.some( ( line: string ) => line.includes( 'Scrape Page #1' ) ) ).toBe( false );
+      // ...while span 2, new this tick, is free to be numbered.
+      expect( lines.some( ( line: string ) => line.includes( 'Scrape Page #2' ) ) ).toBe( true );
+    } );
+
     it( 'does not re-print a span whose status has not changed between polls', async () => {
-      const { cmd, fetchWorkflowHistory } = await createCommand();
-      fetchWorkflowHistory
-        .mockResolvedValueOnce( history( 'running', { spans: [ span( '1', 'running' ) ] } ) as any )
-        .mockResolvedValueOnce( history( 'completed', {
-          spans: [ span( '1', 'running' ), span( '2', 'completed' ) ], totalDurationMs: 1000
-        } ) as any );
+      const { cmd, fetchWorkflowHistory, fetchWorkflowHistoryUpdates } = await createCommand();
+      fetchWorkflowHistory.mockResolvedValueOnce( history( 'running', { spans: [ span( '1', 'running' ) ] } ) as any );
+      fetchWorkflowHistoryUpdates.mockResolvedValueOnce( update( 'completed', {
+        spans: [ span( '1', 'running' ), span( '2', 'completed' ) ], totalDurationMs: 1000
+      } ) as any );
 
       await cmd.run();
 
@@ -143,15 +182,18 @@ describe( 'workflow monitor command', () => {
     } );
 
     it( 'follows a continue-as-new chain by re-polling with the new run id', async () => {
-      const { cmd, fetchWorkflowHistory } = await createCommand();
+      const { cmd, fetchWorkflowHistory, fetchWorkflowHistoryUpdates } = await createCommand();
       fetchWorkflowHistory
         .mockResolvedValueOnce( history( 'continued_as_new', { continuedAsNewRunId: 'run-2' } ) as any )
+        // The new run's cursor was reset, so its first poll takes the same fast,
+        // non-waiting path as the very first poll of the command — not a resumed one.
         .mockResolvedValueOnce( history( 'completed', { runId: 'run-2', totalDurationMs: 500 } ) as any );
 
       await cmd.run();
 
       expect( fetchWorkflowHistory ).toHaveBeenCalledTimes( 2 );
       expect( fetchWorkflowHistory ).toHaveBeenNthCalledWith( 2, expect.objectContaining( { runId: 'run-2' } ) );
+      expect( fetchWorkflowHistoryUpdates ).not.toHaveBeenCalled();
       expect( cmd.log ).toHaveBeenCalledWith( expect.stringContaining( 'continued as new run run-2' ) );
       expect( process.exitCode ).toBeUndefined();
     } );
@@ -172,15 +214,16 @@ describe( 'workflow monitor command', () => {
     } );
 
     it( 'retries a transient failure after the first successful poll instead of crashing', async () => {
-      const { cmd, fetchWorkflowHistory } = await createCommand();
-      fetchWorkflowHistory
-        .mockResolvedValueOnce( history( 'running' ) as any )
+      const { cmd, fetchWorkflowHistory, fetchWorkflowHistoryUpdates } = await createCommand();
+      fetchWorkflowHistory.mockResolvedValueOnce( history( 'running' ) as any );
+      fetchWorkflowHistoryUpdates
         .mockRejectedValueOnce( new Error( 'blip' ) )
-        .mockResolvedValueOnce( history( 'completed', { totalDurationMs: 1000 } ) as any );
+        .mockResolvedValueOnce( update( 'completed', { totalDurationMs: 1000 } ) as any );
 
       await cmd.run();
 
-      expect( fetchWorkflowHistory ).toHaveBeenCalledTimes( 3 );
+      expect( fetchWorkflowHistory ).toHaveBeenCalledTimes( 1 );
+      expect( fetchWorkflowHistoryUpdates ).toHaveBeenCalledTimes( 2 );
       expect( cmd.warn ).toHaveBeenCalledWith( expect.stringContaining( '(1/5)' ) );
       expect( process.exitCode ).toBeUndefined();
     } );

--- a/sdk/cli/src/commands/workflow/monitor.spec.ts
+++ b/sdk/cli/src/commands/workflow/monitor.spec.ts
@@ -1,0 +1,228 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock( '#services/workflow_history.js', () => ( { fetchWorkflowHistory: vi.fn() } ) );
+vi.mock( '#utils/sleep.js', () => ( { sleep: vi.fn().mockResolvedValue( undefined ) } ) );
+
+const span = ( id: string, status: string, overrides: Record<string, unknown> = {} ): Record<string, unknown> => ( {
+  id,
+  name: `Step ${id}`,
+  technicalName: `wf#step${id}`,
+  description: null,
+  status,
+  kind: 'activity',
+  attempt: 1,
+  startedAt: null,
+  scheduledAt: null,
+  completedAt: null,
+  startOffsetMs: 0,
+  endOffsetMs: 0,
+  durationMs: 1000,
+  failureMessage: null,
+  ...overrides
+} );
+
+const history = ( status: string, overrides: Record<string, unknown> = {} ): Record<string, unknown> => ( {
+  workflow: { status },
+  runId: 'run-1',
+  events: [],
+  spans: [],
+  totalDurationMs: 0,
+  continuedAsNewRunId: null,
+  ...overrides
+} );
+
+describe( 'workflow monitor command', () => {
+  beforeEach( () => {
+    vi.clearAllMocks();
+    process.exitCode = undefined;
+  } );
+
+  describe( 'command definition', () => {
+    it( 'exports a valid OCLIF command with a required workflowId arg', async () => {
+      const WorkflowMonitor = ( await import( './monitor.js' ) ).default;
+      expect( WorkflowMonitor ).toBeDefined();
+      expect( WorkflowMonitor.args ).toHaveProperty( 'workflowId' );
+      expect( WorkflowMonitor.args.workflowId.required ).toBe( true );
+    } );
+
+    it( 'declares the expected flags and defaults', async () => {
+      const WorkflowMonitor = ( await import( './monitor.js' ) ).default;
+      const flags = WorkflowMonitor.flags;
+
+      expect( flags ).toHaveProperty( 'run-id' );
+      expect( flags ).toHaveProperty( 'include-payloads' );
+      expect( flags ).toHaveProperty( 'interval' );
+      expect( flags ).toHaveProperty( 'color' );
+      expect( flags.format.options ).toEqual( [ 'text', 'json' ] );
+      expect( flags.format.default ).toBe( 'text' );
+      expect( flags.interval.default ).toBe( 2500 );
+      expect( flags.color.default ).toBe( true );
+    } );
+  } );
+
+  describe( 'run()', () => {
+    const createCommand = async ( flagOverrides: Record<string, unknown> = {} ) => {
+      const WorkflowMonitor = ( await import( './monitor.js' ) ).default;
+      const { fetchWorkflowHistory } = await import( '#services/workflow_history.js' );
+
+      const cmd = new WorkflowMonitor( [ 'wf-1' ], {} as any );
+      cmd.log = vi.fn();
+      cmd.warn = vi.fn() as any;
+      cmd.error = vi.fn( ( message: string ) => {
+        throw new Error( message );
+      } ) as any;
+      ( cmd as any ).parse = vi.fn().mockResolvedValue( {
+        args: { workflowId: 'wf-1' },
+        flags: {
+          'run-id': undefined,
+          format: 'text',
+          'include-payloads': false,
+          interval: 1,
+          color: false,
+          ...flagOverrides
+        }
+      } );
+
+      return { cmd, fetchWorkflowHistory: vi.mocked( fetchWorkflowHistory ) };
+    };
+
+    it( 'prints span updates and exits cleanly when the workflow is already completed on the first poll', async () => {
+      const { cmd, fetchWorkflowHistory } = await createCommand();
+      fetchWorkflowHistory.mockResolvedValueOnce(
+        history( 'completed', { spans: [ span( '1', 'completed' ) ], totalDurationMs: 5000 } ) as any
+      );
+
+      await cmd.run();
+
+      expect( fetchWorkflowHistory ).toHaveBeenCalledTimes( 1 );
+      expect( cmd.log ).toHaveBeenCalledWith( expect.stringContaining( 'Step 1' ) );
+      expect( cmd.log ).toHaveBeenCalledWith( expect.stringContaining( 'workflow completed' ) );
+      expect( process.exitCode ).toBeUndefined();
+    } );
+
+    it( 'sets exit code 1 when the workflow ends in a failed status', async () => {
+      const { cmd, fetchWorkflowHistory } = await createCommand();
+      fetchWorkflowHistory.mockResolvedValueOnce( history( 'failed', {
+        spans: [ span( '1', 'failed', { failureMessage: 'boom' } ) ], totalDurationMs: 1000
+      } ) as any );
+
+      await cmd.run();
+
+      expect( process.exitCode ).toBe( 1 );
+    } );
+
+    it( 'polls again while the workflow is running, then stops once it completes', async () => {
+      const { cmd, fetchWorkflowHistory } = await createCommand();
+      fetchWorkflowHistory
+        .mockResolvedValueOnce( history( 'running', { spans: [ span( '1', 'running' ) ] } ) as any )
+        .mockResolvedValueOnce( history( 'completed', {
+          spans: [ span( '1', 'completed' ) ], totalDurationMs: 2000
+        } ) as any );
+
+      await cmd.run();
+
+      expect( fetchWorkflowHistory ).toHaveBeenCalledTimes( 2 );
+      expect( cmd.log ).toHaveBeenCalledWith( expect.stringContaining( 'running' ) );
+      expect( cmd.log ).toHaveBeenCalledWith( expect.stringContaining( '1s' ) );
+      expect( process.exitCode ).toBeUndefined();
+    } );
+
+    it( 'does not re-print a span whose status has not changed between polls', async () => {
+      const { cmd, fetchWorkflowHistory } = await createCommand();
+      fetchWorkflowHistory
+        .mockResolvedValueOnce( history( 'running', { spans: [ span( '1', 'running' ) ] } ) as any )
+        .mockResolvedValueOnce( history( 'completed', {
+          spans: [ span( '1', 'running' ), span( '2', 'completed' ) ], totalDurationMs: 1000
+        } ) as any );
+
+      await cmd.run();
+
+      const runningLines = ( cmd.log as any ).mock.calls.filter( ( [ line ]: [ string ] ) => line.includes( 'Step 1' ) );
+      expect( runningLines ).toHaveLength( 1 ); // span 1 only reported once, not again on the second poll
+    } );
+
+    it( 'follows a continue-as-new chain by re-polling with the new run id', async () => {
+      const { cmd, fetchWorkflowHistory } = await createCommand();
+      fetchWorkflowHistory
+        .mockResolvedValueOnce( history( 'continued_as_new', { continuedAsNewRunId: 'run-2' } ) as any )
+        .mockResolvedValueOnce( history( 'completed', { runId: 'run-2', totalDurationMs: 500 } ) as any );
+
+      await cmd.run();
+
+      expect( fetchWorkflowHistory ).toHaveBeenCalledTimes( 2 );
+      expect( fetchWorkflowHistory ).toHaveBeenNthCalledWith( 2, expect.objectContaining( { runId: 'run-2' } ) );
+      expect( cmd.log ).toHaveBeenCalledWith( expect.stringContaining( 'continued as new run run-2' ) );
+      expect( process.exitCode ).toBeUndefined();
+    } );
+
+    it( 'errors when the workflow continues as new but no new run id can be determined', async () => {
+      const { cmd, fetchWorkflowHistory } = await createCommand();
+      fetchWorkflowHistory.mockResolvedValueOnce( history( 'continued_as_new' ) as any );
+
+      await expect( cmd.run() ).rejects.toThrow( /new run ID could not be determined/ );
+    } );
+
+    it( 'propagates a failure on the very first poll', async () => {
+      const { cmd, fetchWorkflowHistory } = await createCommand();
+      fetchWorkflowHistory.mockRejectedValue( new Error( 'network down' ) );
+
+      await expect( cmd.run() ).rejects.toThrow( 'network down' );
+      expect( fetchWorkflowHistory ).toHaveBeenCalledTimes( 1 );
+    } );
+
+    it( 'retries a transient failure after the first successful poll instead of crashing', async () => {
+      const { cmd, fetchWorkflowHistory } = await createCommand();
+      fetchWorkflowHistory
+        .mockResolvedValueOnce( history( 'running' ) as any )
+        .mockRejectedValueOnce( new Error( 'blip' ) )
+        .mockResolvedValueOnce( history( 'completed', { totalDurationMs: 1000 } ) as any );
+
+      await cmd.run();
+
+      expect( fetchWorkflowHistory ).toHaveBeenCalledTimes( 3 );
+      expect( cmd.warn ).toHaveBeenCalledWith( expect.stringContaining( '(1/5)' ) );
+      expect( process.exitCode ).toBeUndefined();
+    } );
+
+    it( 'registers a SIGINT handler that detaches and exits 130 without affecting the workflow', async () => {
+      const { cmd, fetchWorkflowHistory } = await createCommand();
+      fetchWorkflowHistory.mockResolvedValueOnce( history( 'completed' ) as any );
+
+      const onSpy = vi.spyOn( process, 'on' );
+      const exitSpy = vi.spyOn( process, 'exit' ).mockImplementation( ( () => undefined ) as any );
+
+      await cmd.run();
+
+      const sigintCall = onSpy.mock.calls.find( ( [ event ] ) => event === 'SIGINT' );
+      expect( sigintCall ).toBeDefined();
+      const handler = sigintCall![1] as () => void;
+
+      handler();
+
+      expect( exitSpy ).toHaveBeenCalledWith( 130 );
+      expect( cmd.log ).toHaveBeenCalledWith( expect.stringContaining( 'Detached' ) );
+
+      onSpy.mockRestore();
+      exitSpy.mockRestore();
+    } );
+
+    it( 'emits NDJSON lines under --format json', async () => {
+      const { cmd, fetchWorkflowHistory } = await createCommand( { format: 'json' } );
+      fetchWorkflowHistory.mockResolvedValueOnce(
+        history( 'completed', { spans: [ span( '1', 'completed' ) ], totalDurationMs: 1000 } ) as any
+      );
+
+      await cmd.run();
+
+      const lines = ( cmd.log as any ).mock.calls.map( ( [ line ]: [ string ] ) => line );
+      expect( lines.some( ( line: string ) => {
+        try {
+          return JSON.parse( line ).span?.id === '1';
+        } catch {
+          return false;
+        }
+      } ) ).toBe( true );
+    } );
+  } );
+} );

--- a/sdk/cli/src/commands/workflow/monitor.spec.ts
+++ b/sdk/cli/src/commands/workflow/monitor.spec.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HttpError } from '#api/http_client.js';
 
 vi.mock( '#services/workflow_history.js', () => ( { fetchWorkflowHistory: vi.fn(), fetchWorkflowHistoryUpdates: vi.fn() } ) );
 vi.mock( '#utils/sleep.js', () => ( { sleep: vi.fn().mockResolvedValue( undefined ) } ) );
@@ -213,11 +214,11 @@ describe( 'workflow monitor command', () => {
       expect( fetchWorkflowHistory ).toHaveBeenCalledTimes( 1 );
     } );
 
-    it( 'retries a transient failure after the first successful poll instead of crashing', async () => {
+    it( 'retries a transient network failure after the first successful poll instead of crashing', async () => {
       const { cmd, fetchWorkflowHistory, fetchWorkflowHistoryUpdates } = await createCommand();
       fetchWorkflowHistory.mockResolvedValueOnce( history( 'running' ) as any );
       fetchWorkflowHistoryUpdates
-        .mockRejectedValueOnce( new Error( 'blip' ) )
+        .mockRejectedValueOnce( Object.assign( new Error( 'blip' ), { code: 'ECONNRESET' } ) )
         .mockResolvedValueOnce( update( 'completed', { totalDurationMs: 1000 } ) as any );
 
       await cmd.run();
@@ -226,6 +227,33 @@ describe( 'workflow monitor command', () => {
       expect( fetchWorkflowHistoryUpdates ).toHaveBeenCalledTimes( 2 );
       expect( cmd.warn ).toHaveBeenCalledWith( expect.stringContaining( '(1/5)' ) );
       expect( process.exitCode ).toBeUndefined();
+    } );
+
+    it( 'retries a transient 503 HttpError after the first successful poll', async () => {
+      const { cmd, fetchWorkflowHistory, fetchWorkflowHistoryUpdates } = await createCommand();
+      fetchWorkflowHistory.mockResolvedValueOnce( history( 'running' ) as any );
+      fetchWorkflowHistoryUpdates
+        .mockRejectedValueOnce( new HttpError( 'Service unavailable', { status: 503 } ) )
+        .mockResolvedValueOnce( update( 'completed', { totalDurationMs: 1000 } ) as any );
+
+      await cmd.run();
+
+      expect( fetchWorkflowHistoryUpdates ).toHaveBeenCalledTimes( 2 );
+      expect( cmd.warn ).toHaveBeenCalledWith( expect.stringContaining( '(1/5)' ) );
+      expect( process.exitCode ).toBeUndefined();
+    } );
+
+    it( 'immediately rethrows a non-transient error (e.g. a stale resume cursor) without retrying', async () => {
+      const { cmd, fetchWorkflowHistory, fetchWorkflowHistoryUpdates } = await createCommand();
+      fetchWorkflowHistory.mockResolvedValueOnce( history( 'running' ) as any );
+      fetchWorkflowHistoryUpdates.mockRejectedValueOnce(
+        new HttpError( 'Invalid page token', { status: 400 } )
+      );
+
+      await expect( cmd.run() ).rejects.toThrow( 'Invalid page token' );
+
+      expect( fetchWorkflowHistoryUpdates ).toHaveBeenCalledTimes( 1 );
+      expect( cmd.warn ).not.toHaveBeenCalled();
     } );
 
     it( 'registers a SIGINT handler that detaches and exits 130 without affecting the workflow', async () => {
@@ -259,13 +287,16 @@ describe( 'workflow monitor command', () => {
       await cmd.run();
 
       const lines = ( cmd.log as any ).mock.calls.map( ( [ line ]: [ string ] ) => line );
-      expect( lines.some( ( line: string ) => {
+      expect( lines.every( ( line: string ) => {
         try {
-          return JSON.parse( line ).span?.id === '1';
+          JSON.parse( line );
+          return true;
         } catch {
           return false;
         }
       } ) ).toBe( true );
+      expect( lines.some( ( line: string ) => JSON.parse( line ).span?.id === '1' ) ).toBe( true );
+      expect( lines.some( ( line: string ) => JSON.parse( line ).monitoring === true ) ).toBe( true );
     } );
   } );
 } );

--- a/sdk/cli/src/commands/workflow/monitor.ts
+++ b/sdk/cli/src/commands/workflow/monitor.ts
@@ -12,11 +12,36 @@ import { ERROR_STATUSES, TERMINAL_STATUSES } from '#utils/format_workflow_result
 import { handleApiError } from '#utils/error_handler.js';
 import { sleep } from '#utils/sleep.js';
 import { shouldColorize } from '#utils/color.js';
+import { HttpError } from '#api/http_client.js';
 
 const DEFAULT_INTERVAL_MS = 2500;
 const MAX_CONSECUTIVE_ERRORS = 5;
 const OUTPUT_FORMAT = { JSON: 'json', TEXT: 'text' } as const;
 const SIGINT_EXIT_CODE = 130;
+const TRANSIENT_ERROR_CODES = new Set( [ 'ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN', 'ENOTFOUND' ] );
+
+/**
+ * Distinguishes blips worth retrying from errors that will fail identically on
+ * every attempt: network hiccups, a client-side request timeout, and 5xx/408/429
+ * responses are transient. Everything else — a 4xx like a stale/invalid resume
+ * cursor (`InvalidPageTokenError`, surfaced as 400), or a bug in correlate()/
+ * buildResult() re-throwing the same exception — can't self-resolve by waiting,
+ * so it should surface immediately instead of burning the retry budget.
+ */
+function isTransientPollError( error: unknown ): boolean {
+  if ( error instanceof HttpError ) {
+    const status = error.response.status;
+    return status >= 500 || status === 408 || status === 429;
+  }
+  const err = error as { name?: string; code?: string; cause?: { code?: string } };
+  if ( err.name === 'TimeoutError' ) {
+    return true;
+  }
+  return Boolean(
+    ( err.code && TRANSIENT_ERROR_CODES.has( err.code ) ) ||
+    ( err.cause?.code && TRANSIENT_ERROR_CODES.has( err.cause.code ) )
+  );
+}
 
 /**
  * Unlike `run`/`status`/`result` (migrated to oclif's native `--json` in
@@ -106,10 +131,13 @@ export default class WorkflowMonitor extends Command {
         text );
     };
 
-    this.log( `Monitoring ${args.workflowId}${state.runId ? ` (run ${state.runId})` : ''}... (Ctrl+C to detach)` );
+    emit(
+      { monitoring: true },
+      `Monitoring ${args.workflowId}${state.runId ? ` (run ${state.runId})` : ''}... (Ctrl+C to detach)`
+    );
 
     const sigintHandler = (): void => {
-      this.log( '\nDetached (the workflow keeps running).' );
+      emit( { detached: true }, '\nDetached (the workflow keeps running).' );
       process.exit( SIGINT_EXIT_CODE );
     };
     process.on( 'SIGINT', sigintHandler );
@@ -173,10 +201,13 @@ export default class WorkflowMonitor extends Command {
 
   /**
    * Wraps a single poll: a failure on the very first tick propagates (there's
-   * nothing to fall back on), but a blip after we've already been monitoring
-   * successfully just returns `null` so the loop can retry — matching the dev
-   * TUI's `useStepGraph` behavior of keeping the last good state on a poll
-   * hiccup. `MAX_CONSECUTIVE_ERRORS` bounds how long we'll retry silently.
+   * nothing to fall back on), but a transient blip (see `isTransientPollError`)
+   * after we've already been monitoring successfully just returns `null` so the
+   * loop can retry — matching the dev TUI's `useStepGraph` behavior of keeping
+   * the last good state on a poll hiccup. A non-transient error (e.g. a stale
+   * resume cursor, or a bug in the parsing pipeline) rethrows immediately since
+   * retrying it cannot succeed. `MAX_CONSECUTIVE_ERRORS` bounds how long we'll
+   * retry transient failures before giving up.
    *
    * Fetch strategy is driven by `state.cursor`, not tick count: no cursor yet
    * (the very first poll, or the first poll of a run chained via continue-as-new)
@@ -198,7 +229,7 @@ export default class WorkflowMonitor extends Command {
       }
       return await fetchWorkflowHistoryUpdates( options, state.cursor );
     } catch ( error ) {
-      if ( state.firstTick || state.consecutiveErrors + 1 >= MAX_CONSECUTIVE_ERRORS ) {
+      if ( state.firstTick || !isTransientPollError( error ) || state.consecutiveErrors + 1 >= MAX_CONSECUTIVE_ERRORS ) {
         throw error;
       }
       this.warn( `Poll failed (${state.consecutiveErrors + 1}/${MAX_CONSECUTIVE_ERRORS}), retrying: ${( error as Error ).message}` );
@@ -208,7 +239,8 @@ export default class WorkflowMonitor extends Command {
 
   async catch( error: Error ): Promise<void> {
     return handleApiError( error, ( ...args ) => this.error( ...args ), {
-      404: 'Workflow not found. Check the workflow ID.'
+      404: 'Workflow not found. Check the workflow ID.',
+      400: 'Resume cursor is no longer valid for this workflow; restart the monitor.'
     } );
   }
 }

--- a/sdk/cli/src/commands/workflow/monitor.ts
+++ b/sdk/cli/src/commands/workflow/monitor.ts
@@ -7,7 +7,7 @@ import type { SpanStatus } from '#services/workflow_history/correlator.js';
 import type { WorkflowResultResponseStatus } from '#api/generated/api.js';
 import buildSpanLabels from '#utils/span_labels.js';
 import { formatDurationLabel } from '#utils/waterfall.js';
-import { diffSpanUpdates, formatSpanUpdate } from '#utils/monitor_log.js';
+import { diffSpanUpdates, formatContinuedAsNew, formatSpanUpdate } from '#utils/monitor_log.js';
 import { ERROR_STATUSES, TERMINAL_STATUSES } from '#utils/format_workflow_result.js';
 import { handleApiError } from '#utils/error_handler.js';
 import { getErrorMessage } from '#utils/error_utils.js';
@@ -149,7 +149,7 @@ export default class WorkflowMonitor extends Command {
     process.on( 'SIGINT', sigintHandler );
 
     try {
-      for ( ; ; ) {
+      while ( true ) {
         const outcome = await this.poll( args.workflowId, flags, state );
         if ( outcome === null ) {
           state.consecutiveErrors += 1;
@@ -179,7 +179,7 @@ export default class WorkflowMonitor extends Command {
           }
           emit(
             { continuedAsNewRunId: result.continuedAsNewRunId },
-            `↻ continued as new run ${result.continuedAsNewRunId}`
+            formatContinuedAsNew( result.continuedAsNewRunId )
           );
           state.runId = result.continuedAsNewRunId;
           state.cursor = undefined;
@@ -231,8 +231,9 @@ export default class WorkflowMonitor extends Command {
       // Keeps the resumed long-poll's server-side block roughly aligned with `--interval`
       // instead of always blocking for the server's full configured deadline regardless of
       // it (see `plan_workflow_monitor_history.md`'s "Known tradeoff" note). Only takes
-      // effect once `wait: true` is sent, i.e. from the second tick onward.
-      const options = { workflowId, runId: state.runId, includePayloads: flags['include-payloads'], waitMs: flags.interval };
+      // effect once resuming (i.e. from the second tick onward); `fetchWorkflowHistory`
+      // ignores it on the initial full walk.
+      const options = { workflowId, runId: state.runId, includePayloads: flags['include-payloads'], longPollTimeoutMs: flags.interval };
       if ( !state.cursor ) {
         const result = await fetchWorkflowHistory( options );
         return { result, cursor: result.cursor };
@@ -249,7 +250,7 @@ export default class WorkflowMonitor extends Command {
 
   async catch( error: Error ): Promise<void> {
     // A 400 is the generic status for several distinct causes (invalid pageToken, a
-    // missing runId, an out-of-range waitMs) — only override it with the stale-cursor
+    // missing runId, an out-of-range longPollTimeoutMs) — only override it with the stale-cursor
     // message when the server actually identifies that specific cause; otherwise let
     // the real validation error surface instead of misdiagnosing an unrelated 400.
     const response = ( error as { response?: { status?: number; data?: { error?: string } } } ).response;

--- a/sdk/cli/src/commands/workflow/monitor.ts
+++ b/sdk/cli/src/commands/workflow/monitor.ts
@@ -94,7 +94,8 @@ export default class WorkflowMonitor extends Command {
         'at the server\'s configured max), so an idle workflow\'s update cadence is roughly ' +
         'twice this value (the long-poll bound, then this sleep) rather than a much longer, ' +
         'separate server default.',
-      default: DEFAULT_INTERVAL_MS
+      default: DEFAULT_INTERVAL_MS,
+      min: 1
     } ),
     color: Flags.boolean( {
       description: 'Colorize status output (use --no-color to disable)',
@@ -246,9 +247,18 @@ export default class WorkflowMonitor extends Command {
   }
 
   async catch( error: Error ): Promise<void> {
-    return handleApiError( error, ( ...args ) => this.error( ...args ), {
-      404: 'Workflow not found. Check the workflow ID.',
-      400: 'Resume cursor is no longer valid for this workflow; restart the monitor.'
-    } );
+    // A 400 is the generic status for several distinct causes (invalid pageToken, a
+    // missing runId, an out-of-range waitMs) — only override it with the stale-cursor
+    // message when the server actually identifies that specific cause; otherwise let
+    // the real validation error surface instead of misdiagnosing an unrelated 400.
+    const response = ( error as { response?: { status?: number; data?: { error?: string } } } ).response;
+    const isStaleCursor = response?.status === 400 && response.data?.error === 'InvalidPageTokenError';
+
+    const overrides: Record<number, string> = { 404: 'Workflow not found. Check the workflow ID.' };
+    if ( isStaleCursor ) {
+      overrides[400] = 'Resume cursor is no longer valid for this workflow; restart the monitor.';
+    }
+
+    return handleApiError( error, ( ...args ) => this.error( ...args ), overrides );
   }
 }

--- a/sdk/cli/src/commands/workflow/monitor.ts
+++ b/sdk/cli/src/commands/workflow/monitor.ts
@@ -10,6 +10,7 @@ import { formatDurationLabel } from '#utils/waterfall.js';
 import { diffSpanUpdates, formatSpanUpdate } from '#utils/monitor_log.js';
 import { ERROR_STATUSES, TERMINAL_STATUSES } from '#utils/format_workflow_result.js';
 import { handleApiError } from '#utils/error_handler.js';
+import { getErrorMessage } from '#utils/error_utils.js';
 import { sleep } from '#utils/sleep.js';
 import { shouldColorize } from '#utils/color.js';
 import { HttpError } from '#api/http_client.js';
@@ -241,7 +242,7 @@ export default class WorkflowMonitor extends Command {
       if ( state.firstTick || !isTransientPollError( error ) || state.consecutiveErrors + 1 >= MAX_CONSECUTIVE_ERRORS ) {
         throw error;
       }
-      this.warn( `Poll failed (${state.consecutiveErrors + 1}/${MAX_CONSECUTIVE_ERRORS}), retrying: ${( error as Error ).message}` );
+      this.warn( `Poll failed (${state.consecutiveErrors + 1}/${MAX_CONSECUTIVE_ERRORS}), retrying: ${getErrorMessage( error )}` );
       return null;
     }
   }

--- a/sdk/cli/src/commands/workflow/monitor.ts
+++ b/sdk/cli/src/commands/workflow/monitor.ts
@@ -1,0 +1,186 @@
+import { Args, Command, Flags } from '@oclif/core';
+import { fetchWorkflowHistory } from '#services/workflow_history.js';
+import type { SpanStatus } from '#services/workflow_history/correlator.js';
+import type { WorkflowResultResponseStatus } from '#api/generated/api.js';
+import buildSpanLabels from '#utils/span_labels.js';
+import { formatDurationLabel } from '#utils/waterfall.js';
+import { diffSpanUpdates, formatSpanUpdate } from '#utils/monitor_log.js';
+import { ERROR_STATUSES } from '#utils/format_workflow_result.js';
+import { handleApiError } from '#utils/error_handler.js';
+import { sleep } from '#utils/sleep.js';
+import { shouldColorize } from '#utils/color.js';
+
+const DEFAULT_INTERVAL_MS = 2500;
+const MAX_CONSECUTIVE_ERRORS = 5;
+// "Terminal" is every error status plus the one success status — derived so
+// the two sets can't silently drift apart as error statuses evolve.
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set( [ 'completed', ...( Array.from( ERROR_STATUSES ) as string[] ) ] );
+const OUTPUT_FORMAT = { JSON: 'json', TEXT: 'text' } as const;
+const SIGINT_EXIT_CODE = 130;
+
+/**
+ * Unlike `run`/`status`/`result` (migrated to oclif's native `--json` in
+ * OUT-419, #281), this command deliberately keeps a custom `--format json`
+ * instead of `enableJsonFlag`. Native `--json` suppresses all `this.log()`
+ * calls and prints exactly one JSON object — the command's return value —
+ * after `run()` resolves. `monitor` has no single "return value": it emits a
+ * live stream of discrete events (span status changes, a continue-as-new
+ * notice, a final summary) while the workflow is still in progress, and
+ * `--format json` prints each as its own NDJSON line as it happens. That's
+ * the point — a caller (often another automated/agent process, not a human)
+ * can tail and parse the stream incrementally, which native `--json`'s
+ * "one object at the end" model can't do. See docs/guides/packages/cli.mdx
+ * ("output workflow monitor") for the same rationale written up for users.
+ */
+export default class WorkflowMonitor extends Command {
+  static override description = 'Attach to a workflow run and stream status updates until it ends';
+
+  static override examples = [
+    '<%= config.bin %> <%= command.id %> wf-12345',
+    '<%= config.bin %> <%= command.id %> wf-12345 --run-id 2fe0b36b-...',
+    '<%= config.bin %> <%= command.id %> wf-12345 --format json'
+  ];
+
+  static override args = {
+    workflowId: Args.string( {
+      description: 'The workflow ID to monitor',
+      required: true
+    } )
+  };
+
+  static override flags = {
+    'run-id': Flags.string( {
+      char: 'r',
+      description: 'Monitor a specific run (defaults to the latest run; continue-as-new chains are followed regardless)'
+    } ),
+    format: Flags.string( {
+      char: 'f',
+      description: 'Output format',
+      options: [ OUTPUT_FORMAT.TEXT, OUTPUT_FORMAT.JSON ],
+      default: OUTPUT_FORMAT.TEXT
+    } ),
+    'include-payloads': Flags.boolean( {
+      description: 'Include decoded step input/output payloads',
+      default: false
+    } ),
+    interval: Flags.integer( {
+      description: 'Poll interval in milliseconds',
+      default: DEFAULT_INTERVAL_MS
+    } ),
+    color: Flags.boolean( {
+      description: 'Colorize status output (use --no-color to disable)',
+      default: true,
+      allowNo: true
+    } )
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = await this.parse( WorkflowMonitor );
+    const color = shouldColorize( flags.color );
+    const json = flags.format === OUTPUT_FORMAT.JSON;
+
+    // Threaded via mutable properties (not `let` reassignment) so state
+    // persists across polls without local variable reassignment.
+    const state = {
+      runId: flags['run-id'],
+      consecutiveErrors: 0,
+      firstTick: true
+    };
+    const seen = new Map<string, SpanStatus>();
+
+    // One emit point for both output formats: json mode wraps `fields` (plus
+    // the ambient workflow/run id) as a line of NDJSON, text mode prints `text`.
+    const emit = ( fields: Record<string, unknown>, text: string ): void => {
+      this.log( json ?
+        JSON.stringify( { workflowId: args.workflowId, runId: state.runId, ...fields } ) :
+        text );
+    };
+
+    this.log( `Monitoring ${args.workflowId}${state.runId ? ` (run ${state.runId})` : ''}... (Ctrl+C to detach)` );
+
+    const sigintHandler = (): void => {
+      this.log( '\nDetached (the workflow keeps running).' );
+      process.exit( SIGINT_EXIT_CODE );
+    };
+    process.on( 'SIGINT', sigintHandler );
+
+    try {
+      for ( ; ; ) {
+        const result = await this.poll( args.workflowId, state.runId, flags, state.firstTick, state.consecutiveErrors );
+        if ( result === null ) {
+          state.consecutiveErrors += 1;
+          await sleep( flags.interval );
+          continue;
+        }
+        state.consecutiveErrors = 0;
+        state.firstTick = false;
+
+        state.runId = result.runId ?? state.runId;
+        const labels = buildSpanLabels( result.spans );
+        for ( const update of diffSpanUpdates( result.spans, labels, seen ) ) {
+          emit( { span: update.span }, formatSpanUpdate( update, color ) );
+        }
+
+        const status = result.workflow?.status;
+
+        if ( status === 'continued_as_new' ) {
+          if ( !result.continuedAsNewRunId ) {
+            this.error( 'Workflow continued as a new run, but the new run ID could not be determined.', { exit: 1 } );
+          }
+          emit(
+            { continuedAsNewRunId: result.continuedAsNewRunId },
+            `↻ continued as new run ${result.continuedAsNewRunId}`
+          );
+          state.runId = result.continuedAsNewRunId;
+          seen.clear();
+          await sleep( flags.interval );
+          continue;
+        }
+
+        if ( status && TERMINAL_STATUSES.has( status ) ) {
+          const summary = `${status === 'completed' ? '✓' : '✗'} workflow ${status} · ${formatDurationLabel( result.totalDurationMs )}`;
+          emit( { status }, summary );
+          if ( ERROR_STATUSES.has( status as WorkflowResultResponseStatus ) ) {
+            process.exitCode = 1;
+          }
+          return;
+        }
+
+        await sleep( flags.interval );
+      }
+    } finally {
+      process.removeListener( 'SIGINT', sigintHandler );
+    }
+  }
+
+  /**
+   * Wraps a single poll: a failure on the very first tick propagates (there's
+   * nothing to fall back on), but a blip after we've already been monitoring
+   * successfully just returns `null` so the loop can retry — matching the dev
+   * TUI's `useStepGraph` behavior of keeping the last good state on a poll
+   * hiccup. `MAX_CONSECUTIVE_ERRORS` bounds how long we'll retry silently.
+   */
+  private async poll(
+    workflowId: string,
+    runId: string | undefined,
+    flags: { 'include-payloads': boolean },
+    firstTick: boolean,
+    consecutiveErrors: number
+  ): Promise<Awaited<ReturnType<typeof fetchWorkflowHistory>> | null> {
+    try {
+      return await fetchWorkflowHistory( { workflowId, runId, includePayloads: flags['include-payloads'] } );
+    } catch ( error ) {
+      if ( firstTick || consecutiveErrors + 1 >= MAX_CONSECUTIVE_ERRORS ) {
+        throw error;
+      }
+      this.warn( `Poll failed (${consecutiveErrors + 1}/${MAX_CONSECUTIVE_ERRORS}), retrying: ${( error as Error ).message}` );
+      return null;
+    }
+  }
+
+  async catch( error: Error ): Promise<void> {
+    return handleApiError( error, ( ...args ) => this.error( ...args ), {
+      404: 'Workflow not found. Check the workflow ID.'
+    } );
+  }
+}

--- a/sdk/cli/src/commands/workflow/monitor.ts
+++ b/sdk/cli/src/commands/workflow/monitor.ts
@@ -89,7 +89,11 @@ export default class WorkflowMonitor extends Command {
       default: false
     } ),
     interval: Flags.integer( {
-      description: 'Poll interval in milliseconds',
+      description: 'Poll interval in milliseconds. Once a resumed poll is long-polling ' +
+        'server-side for new events, this also bounds how long that block may last (capped ' +
+        'at the server\'s configured max), so an idle workflow\'s update cadence is roughly ' +
+        'twice this value (the long-poll bound, then this sleep) rather than a much longer, ' +
+        'separate server default.',
       default: DEFAULT_INTERVAL_MS
     } ),
     color: Flags.boolean( {
@@ -218,11 +222,15 @@ export default class WorkflowMonitor extends Command {
    */
   private async poll(
     workflowId: string,
-    flags: { 'include-payloads': boolean },
+    flags: { 'include-payloads': boolean; interval: number },
     state: { runId: string | undefined; firstTick: boolean; consecutiveErrors: number; cursor: WorkflowHistoryCursor | undefined }
   ): Promise<{ result: WorkflowHistoryResult; cursor: WorkflowHistoryCursor } | null> {
     try {
-      const options = { workflowId, runId: state.runId, includePayloads: flags['include-payloads'] };
+      // Keeps the resumed long-poll's server-side block roughly aligned with `--interval`
+      // instead of always blocking for the server's full configured deadline regardless of
+      // it (see `plan_workflow_monitor_history.md`'s "Known tradeoff" note). Only takes
+      // effect once `wait: true` is sent, i.e. from the second tick onward.
+      const options = { workflowId, runId: state.runId, includePayloads: flags['include-payloads'], waitMs: flags.interval };
       if ( !state.cursor ) {
         const result = await fetchWorkflowHistory( options );
         return { result, cursor: result.cursor };

--- a/sdk/cli/src/commands/workflow/monitor.ts
+++ b/sdk/cli/src/commands/workflow/monitor.ts
@@ -1,20 +1,20 @@
 import { Args, Command, Flags } from '@oclif/core';
-import { fetchWorkflowHistory } from '#services/workflow_history.js';
+import {
+  fetchWorkflowHistory, fetchWorkflowHistoryUpdates,
+  type WorkflowHistoryCursor, type WorkflowHistoryResult
+} from '#services/workflow_history.js';
 import type { SpanStatus } from '#services/workflow_history/correlator.js';
 import type { WorkflowResultResponseStatus } from '#api/generated/api.js';
 import buildSpanLabels from '#utils/span_labels.js';
 import { formatDurationLabel } from '#utils/waterfall.js';
 import { diffSpanUpdates, formatSpanUpdate } from '#utils/monitor_log.js';
-import { ERROR_STATUSES } from '#utils/format_workflow_result.js';
+import { ERROR_STATUSES, TERMINAL_STATUSES } from '#utils/format_workflow_result.js';
 import { handleApiError } from '#utils/error_handler.js';
 import { sleep } from '#utils/sleep.js';
 import { shouldColorize } from '#utils/color.js';
 
 const DEFAULT_INTERVAL_MS = 2500;
 const MAX_CONSECUTIVE_ERRORS = 5;
-// "Terminal" is every error status plus the one success status — derived so
-// the two sets can't silently drift apart as error statuses evolve.
-const TERMINAL_STATUSES: ReadonlySet<string> = new Set( [ 'completed', ...( Array.from( ERROR_STATUSES ) as string[] ) ] );
 const OUTPUT_FORMAT = { JSON: 'json', TEXT: 'text' } as const;
 const SIGINT_EXIT_CODE = 130;
 
@@ -84,9 +84,19 @@ export default class WorkflowMonitor extends Command {
     const state = {
       runId: flags['run-id'],
       consecutiveErrors: 0,
-      firstTick: true
+      firstTick: true,
+      // Undefined until a resumable cursor is established (see `poll` and
+      // `fetchWorkflowHistoryUpdates`); reset on continue-as-new since a new run's
+      // cursor position is meaningless carried over from the old one.
+      cursor: undefined as WorkflowHistoryCursor | undefined
     };
     const seen = new Map<string, SpanStatus>();
+    // Assigned once per span id and never overwritten: `buildSpanLabels` numbers
+    // same-named spans by how many are in the array *at call time*, so recomputing
+    // it fresh every poll could retroactively change a label already printed to
+    // the user (e.g. an unnumbered "Scrape Page" becoming "Scrape Page #1" once a
+    // second instance appears). Freezing on first sight keeps printed labels stable.
+    const labels = new Map<string, string>();
 
     // One emit point for both output formats: json mode wraps `fields` (plus
     // the ambient workflow/run id) as a line of NDJSON, text mode prints `text`.
@@ -106,17 +116,23 @@ export default class WorkflowMonitor extends Command {
 
     try {
       for ( ; ; ) {
-        const result = await this.poll( args.workflowId, state.runId, flags, state.firstTick, state.consecutiveErrors );
-        if ( result === null ) {
+        const outcome = await this.poll( args.workflowId, flags, state );
+        if ( outcome === null ) {
           state.consecutiveErrors += 1;
           await sleep( flags.interval );
           continue;
         }
         state.consecutiveErrors = 0;
         state.firstTick = false;
+        state.cursor = outcome.cursor;
 
+        const result = outcome.result;
         state.runId = result.runId ?? state.runId;
-        const labels = buildSpanLabels( result.spans );
+        for ( const [ id, label ] of buildSpanLabels( result.spans ) ) {
+          if ( !labels.has( id ) ) {
+            labels.set( id, label );
+          }
+        }
         for ( const update of diffSpanUpdates( result.spans, labels, seen ) ) {
           emit( { span: update.span }, formatSpanUpdate( update, color ) );
         }
@@ -132,7 +148,9 @@ export default class WorkflowMonitor extends Command {
             `↻ continued as new run ${result.continuedAsNewRunId}`
           );
           state.runId = result.continuedAsNewRunId;
+          state.cursor = undefined;
           seen.clear();
+          labels.clear();
           await sleep( flags.interval );
           continue;
         }
@@ -159,21 +177,31 @@ export default class WorkflowMonitor extends Command {
    * successfully just returns `null` so the loop can retry — matching the dev
    * TUI's `useStepGraph` behavior of keeping the last good state on a poll
    * hiccup. `MAX_CONSECUTIVE_ERRORS` bounds how long we'll retry silently.
+   *
+   * Fetch strategy is driven by `state.cursor`, not tick count: no cursor yet
+   * (the very first poll, or the first poll of a run chained via continue-as-new)
+   * uses `fetchWorkflowHistory` (fast, no long-poll) so that render isn't delayed;
+   * once a cursor exists, every poll resumes via `fetchWorkflowHistoryUpdates`
+   * instead of re-paging the whole history — see `plan_workflow_monitor_history.md`
+   * for why a full re-fetch every tick is expensive for long-running workflows.
    */
   private async poll(
     workflowId: string,
-    runId: string | undefined,
     flags: { 'include-payloads': boolean },
-    firstTick: boolean,
-    consecutiveErrors: number
-  ): Promise<Awaited<ReturnType<typeof fetchWorkflowHistory>> | null> {
+    state: { runId: string | undefined; firstTick: boolean; consecutiveErrors: number; cursor: WorkflowHistoryCursor | undefined }
+  ): Promise<{ result: WorkflowHistoryResult; cursor: WorkflowHistoryCursor } | null> {
     try {
-      return await fetchWorkflowHistory( { workflowId, runId, includePayloads: flags['include-payloads'] } );
+      const options = { workflowId, runId: state.runId, includePayloads: flags['include-payloads'] };
+      if ( !state.cursor ) {
+        const result = await fetchWorkflowHistory( options );
+        return { result, cursor: result.cursor };
+      }
+      return await fetchWorkflowHistoryUpdates( options, state.cursor );
     } catch ( error ) {
-      if ( firstTick || consecutiveErrors + 1 >= MAX_CONSECUTIVE_ERRORS ) {
+      if ( state.firstTick || state.consecutiveErrors + 1 >= MAX_CONSECUTIVE_ERRORS ) {
         throw error;
       }
-      this.warn( `Poll failed (${consecutiveErrors + 1}/${MAX_CONSECUTIVE_ERRORS}), retrying: ${( error as Error ).message}` );
+      this.warn( `Poll failed (${state.consecutiveErrors + 1}/${MAX_CONSECUTIVE_ERRORS}), retrying: ${( error as Error ).message}` );
       return null;
     }
   }

--- a/sdk/cli/src/services/workflow_history.spec.ts
+++ b/sdk/cli/src/services/workflow_history.spec.ts
@@ -172,36 +172,46 @@ describe( 'fetchWorkflowHistory', () => {
 } );
 
 describe( 'fetchWorkflowHistoryUpdates', () => {
-  it( 'starts a fresh long-poll walk when no cursor is given, and stops once the deadline echoes the sent token', async () => {
-    mockGet
-      .mockResolvedValueOnce( page( {
-        workflow: { workflowId: 'wf-7', runId: 'run-7', status: 'running', startTime: at( 0 ) },
-        runId: 'run-7',
-        events: [ workflowStarted( 0 ) ],
-        nextPageToken: 'tip-token'
-      } ) )
-      .mockResolvedValueOnce( page( {
-        workflow: null,
-        runId: 'run-7',
-        events: [],
-        nextPageToken: 'tip-token'
-      } ) );
+  it( 'stops as soon as the first hop finds new events, without draining further buffered pages', async () => {
+    // Two pages already exist beyond the resume point; the old behavior kept paging until a
+    // timeout, which could silently merge several transitions (even a terminal one) into a
+    // single delayed render. A poller needs each batch back as soon as it has something new.
+    mockGet.mockResolvedValueOnce( page( {
+      workflow: { workflowId: 'wf-7', runId: 'run-7', status: 'running', startTime: at( 0 ) },
+      runId: 'run-7',
+      events: [ workflowStarted( 0 ) ],
+      nextPageToken: 'page-2'
+    } ) );
 
     const { result, cursor } = await fetchWorkflowHistoryUpdates( { workflowId: 'wf-7', runId: 'run-7' } );
 
-    expect( mockGet ).toHaveBeenCalledTimes( 2 );
-    expect( mockGet ).toHaveBeenNthCalledWith( 1, 'wf-7', {
+    expect( mockGet ).toHaveBeenCalledTimes( 1 );
+    expect( mockGet ).toHaveBeenCalledWith( 'wf-7', {
       runId: 'run-7', pageSize: 50, pageToken: undefined, includePayloads: false, wait: true
     } );
-    expect( mockGet ).toHaveBeenNthCalledWith( 2, 'wf-7', {
-      runId: 'run-7', pageSize: 50, pageToken: 'tip-token', includePayloads: false, wait: true
-    } );
     expect( result.events ).toHaveLength( 1 );
-    expect( cursor.pageToken ).toBe( 'tip-token' );
+    expect( result.workflow?.status ).toBe( 'running' );
+    // Resumes from the still-unfetched page 2 next time, not from the start.
+    expect( cursor.pageToken ).toBe( 'page-2' );
     expect( cursor.lastEventId ).toBe( 1 );
   } );
 
-  it( 'resumes from a prior cursor, fetching only new events until the deadline echoes the token back', async () => {
+  it( 'times out with the sent token echoed back when there is genuinely nothing new', async () => {
+    mockGet.mockResolvedValueOnce( page( {
+      workflow: { workflowId: 'wf-7', runId: 'run-7', status: 'running', startTime: at( 0 ) },
+      runId: 'run-7',
+      events: [],
+      nextPageToken: null
+    } ) );
+
+    const { result, cursor } = await fetchWorkflowHistoryUpdates( { workflowId: 'wf-7', runId: 'run-7' } );
+
+    expect( mockGet ).toHaveBeenCalledTimes( 1 );
+    expect( result.events ).toHaveLength( 0 );
+    expect( cursor.pageToken ).toBeUndefined();
+  } );
+
+  it( 'resumes from a prior cursor and picks up the workflow status finishing, not the status frozen on the cursor', async () => {
     const cursor: WorkflowHistoryCursor = {
       pageToken: 'token-2',
       lastEventId: 2,
@@ -210,23 +220,25 @@ describe( 'fetchWorkflowHistoryUpdates', () => {
       events: [ workflowStarted( 0 ), scheduled( '2', 'wf#step', 0 ) ]
     };
 
-    mockGet.mockResolvedValue( page( {
-      workflow: null,
+    mockGet.mockResolvedValueOnce( page( {
+      // The server re-describes on every `wait` call specifically so a resumed poll can see
+      // status changes — this must win over the (now-stale) status carried on the cursor.
+      workflow: { workflowId: 'wf-6', runId: 'run-6', status: 'completed', startTime: at( 0 ), closeTime: at( 5 ) },
       runId: 'run-6',
-      events: [ started( '3', '2', 1 ) ],
-      nextPageToken: 'token-2'
+      events: [ started( '3', '2', 1 ), completed( '4', '2', 5 ) ],
+      nextPageToken: null
     } ) );
 
     const { result, cursor: nextCursor } = await fetchWorkflowHistoryUpdates( { workflowId: 'wf-6', runId: 'run-6' }, cursor );
 
-    expect( mockGet ).toHaveBeenCalledTimes( 2 );
-    expect( mockGet ).toHaveBeenNthCalledWith( 1, 'wf-6', {
+    expect( mockGet ).toHaveBeenCalledTimes( 1 );
+    expect( mockGet ).toHaveBeenCalledWith( 'wf-6', {
       runId: 'run-6', pageSize: 50, pageToken: 'token-2', includePayloads: false, wait: true
     } );
-    // The events already carried on the cursor (2) plus the one genuinely new event (1) — the
-    // replayed duplicate on the second call must not be double-counted.
-    expect( result.events ).toHaveLength( 3 );
+    expect( result.workflow?.status ).toBe( 'completed' );
+    // The events already carried on the cursor (2) plus the genuinely new ones (2).
+    expect( result.events ).toHaveLength( 4 );
     expect( nextCursor.pageToken ).toBe( 'token-2' );
-    expect( nextCursor.lastEventId ).toBe( 3 );
+    expect( nextCursor.lastEventId ).toBe( 4 );
   } );
 } );

--- a/sdk/cli/src/services/workflow_history.spec.ts
+++ b/sdk/cli/src/services/workflow_history.spec.ts
@@ -89,11 +89,11 @@ describe( 'fetchWorkflowHistory', () => {
       workflow: null, runId: 'run-456', events: [], nextPageToken: 'token-2'
     } ) );
 
-    const { result, cursor } = await fetchWorkflowHistoryUpdates( { workflowId: 'wf-123', runId: 'run-456' }, first.cursor );
+    const { result, cursor } = await fetchWorkflowHistoryUpdates( { workflowId: 'wf-123', runId: 'run-456', longPollTimeoutMs: 2500 }, first.cursor );
 
     expect( mockGet ).toHaveBeenCalledTimes( 3 );
     expect( mockGet ).toHaveBeenNthCalledWith( 3, 'wf-123', {
-      runId: 'run-456', pageSize: 50, pageToken: 'token-2', includePayloads: false, wait: true
+      runId: 'run-456', pageSize: 50, pageToken: 'token-2', includePayloads: false, longPollTimeoutMs: 2500
     } );
     expect( result.events ).toHaveLength( 3 );
     expect( cursor.pageToken ).toBe( 'token-2' );
@@ -183,11 +183,11 @@ describe( 'fetchWorkflowHistoryUpdates', () => {
       nextPageToken: 'page-2'
     } ) );
 
-    const { result, cursor } = await fetchWorkflowHistoryUpdates( { workflowId: 'wf-7', runId: 'run-7' } );
+    const { result, cursor } = await fetchWorkflowHistoryUpdates( { workflowId: 'wf-7', runId: 'run-7', longPollTimeoutMs: 2500 } );
 
     expect( mockGet ).toHaveBeenCalledTimes( 1 );
     expect( mockGet ).toHaveBeenCalledWith( 'wf-7', {
-      runId: 'run-7', pageSize: 50, pageToken: undefined, includePayloads: false, wait: true
+      runId: 'run-7', pageSize: 50, pageToken: undefined, includePayloads: false, longPollTimeoutMs: 2500
     } );
     expect( result.events ).toHaveLength( 1 );
     expect( result.workflow?.status ).toBe( 'running' );
@@ -247,20 +247,20 @@ describe( 'fetchWorkflowHistoryUpdates', () => {
     expect( result.continuedAsNewRunId ).toBe( 'run-10' );
   } );
 
-  it( 'forwards waitMs to the API on a resumed poll', async () => {
+  it( 'forwards longPollTimeoutMs to the API on a resumed poll', async () => {
     mockGet.mockResolvedValueOnce( page( {
       workflow: { workflowId: 'wf-7', runId: 'run-7', status: 'running', startTime: at( 0 ) },
       runId: 'run-7', events: [], nextPageToken: null
     } ) );
 
-    await fetchWorkflowHistoryUpdates( { workflowId: 'wf-7', runId: 'run-7', waitMs: 2500 } );
+    await fetchWorkflowHistoryUpdates( { workflowId: 'wf-7', runId: 'run-7', longPollTimeoutMs: 2500 } );
 
     expect( mockGet ).toHaveBeenCalledWith( 'wf-7', {
-      runId: 'run-7', pageSize: 50, pageToken: undefined, includePayloads: false, wait: true, waitMs: 2500
+      runId: 'run-7', pageSize: 50, pageToken: undefined, includePayloads: false, longPollTimeoutMs: 2500
     } );
   } );
 
-  it( 'omits waitMs when not provided', async () => {
+  it( 'sends no long-poll param when longPollTimeoutMs is not provided', async () => {
     mockGet.mockResolvedValueOnce( page( {
       workflow: { workflowId: 'wf-7', runId: 'run-7', status: 'running', startTime: at( 0 ) },
       runId: 'run-7', events: [], nextPageToken: null
@@ -268,7 +268,7 @@ describe( 'fetchWorkflowHistoryUpdates', () => {
 
     await fetchWorkflowHistoryUpdates( { workflowId: 'wf-7', runId: 'run-7' } );
 
-    expect( mockGet ).toHaveBeenCalledWith( 'wf-7', expect.not.objectContaining( { waitMs: expect.anything() } ) );
+    expect( mockGet ).toHaveBeenCalledWith( 'wf-7', expect.not.objectContaining( { longPollTimeoutMs: expect.anything() } ) );
   } );
 
   it( 'times out with the sent token echoed back when there is genuinely nothing new', async () => {
@@ -304,11 +304,13 @@ describe( 'fetchWorkflowHistoryUpdates', () => {
       nextPageToken: null
     } ) );
 
-    const { result, cursor: nextCursor } = await fetchWorkflowHistoryUpdates( { workflowId: 'wf-6', runId: 'run-6' }, cursor );
+    const { result, cursor: nextCursor } = await fetchWorkflowHistoryUpdates(
+      { workflowId: 'wf-6', runId: 'run-6', longPollTimeoutMs: 2500 }, cursor
+    );
 
     expect( mockGet ).toHaveBeenCalledTimes( 1 );
     expect( mockGet ).toHaveBeenCalledWith( 'wf-6', {
-      runId: 'run-6', pageSize: 50, pageToken: 'token-2', includePayloads: false, wait: true
+      runId: 'run-6', pageSize: 50, pageToken: 'token-2', includePayloads: false, longPollTimeoutMs: 2500
     } );
     expect( result.workflow?.status ).toBe( 'completed' );
     // The events already carried on the cursor (2) plus the genuinely new ones (2).

--- a/sdk/cli/src/services/workflow_history.spec.ts
+++ b/sdk/cli/src/services/workflow_history.spec.ts
@@ -196,6 +196,30 @@ describe( 'fetchWorkflowHistoryUpdates', () => {
     expect( cursor.lastEventId ).toBe( 1 );
   } );
 
+  it( 'forwards waitMs to the API on a resumed poll', async () => {
+    mockGet.mockResolvedValueOnce( page( {
+      workflow: { workflowId: 'wf-7', runId: 'run-7', status: 'running', startTime: at( 0 ) },
+      runId: 'run-7', events: [], nextPageToken: null
+    } ) );
+
+    await fetchWorkflowHistoryUpdates( { workflowId: 'wf-7', runId: 'run-7', waitMs: 2500 } );
+
+    expect( mockGet ).toHaveBeenCalledWith( 'wf-7', {
+      runId: 'run-7', pageSize: 50, pageToken: undefined, includePayloads: false, wait: true, waitMs: 2500
+    } );
+  } );
+
+  it( 'omits waitMs when not provided', async () => {
+    mockGet.mockResolvedValueOnce( page( {
+      workflow: { workflowId: 'wf-7', runId: 'run-7', status: 'running', startTime: at( 0 ) },
+      runId: 'run-7', events: [], nextPageToken: null
+    } ) );
+
+    await fetchWorkflowHistoryUpdates( { workflowId: 'wf-7', runId: 'run-7' } );
+
+    expect( mockGet ).toHaveBeenCalledWith( 'wf-7', expect.not.objectContaining( { waitMs: expect.anything() } ) );
+  } );
+
   it( 'times out with the sent token echoed back when there is genuinely nothing new', async () => {
     mockGet.mockResolvedValueOnce( page( {
       workflow: { workflowId: 'wf-7', runId: 'run-7', status: 'running', startTime: at( 0 ) },

--- a/sdk/cli/src/services/workflow_history.spec.ts
+++ b/sdk/cli/src/services/workflow_history.spec.ts
@@ -196,6 +196,57 @@ describe( 'fetchWorkflowHistoryUpdates', () => {
     expect( cursor.lastEventId ).toBe( 1 );
   } );
 
+  it( 'drains buffered pages when the describe already reports the run closed, so the terminal events are not stranded', async () => {
+    // >1 page of events accumulated between polls, then the run completed: the fresh
+    // describe says 'completed' before the closing events have been paged in. Stopping
+    // after the first batch would make the poller act on the terminal status with the
+    // final steps' events unfetched.
+    mockGet
+      .mockResolvedValueOnce( page( {
+        workflow: { workflowId: 'wf-8', runId: 'run-8', status: 'completed', startTime: at( 0 ), closeTime: at( 30 ) },
+        runId: 'run-8',
+        events: [ workflowStarted( 0 ), scheduled( '2', 'wf#step', 0 ) ],
+        nextPageToken: 'page-2'
+      } ) )
+      .mockResolvedValueOnce( page( {
+        workflow: null,
+        runId: 'run-8',
+        events: [ started( '3', '2', 1 ), completed( '4', '2', 30 ) ],
+        nextPageToken: null
+      } ) );
+
+    const { result } = await fetchWorkflowHistoryUpdates( { workflowId: 'wf-8', runId: 'run-8' } );
+
+    expect( mockGet ).toHaveBeenCalledTimes( 2 );
+    expect( result.events ).toHaveLength( 4 );
+    expect( result.spans ).toHaveLength( 1 );
+    expect( result.spans[0].status ).toBe( 'completed' );
+  } );
+
+  it( 'drains to the CONTINUED_AS_NEW event on a later page when the describe already reports continued_as_new', async () => {
+    mockGet
+      .mockResolvedValueOnce( page( {
+        workflow: { workflowId: 'wf-9', runId: 'run-9', status: 'continued_as_new', startTime: at( 0 ) },
+        runId: 'run-9',
+        events: [ workflowStarted( 0 ) ],
+        nextPageToken: 'page-2'
+      } ) )
+      .mockResolvedValueOnce( page( {
+        workflow: null,
+        runId: 'run-9',
+        events: [ {
+          eventId: '2', eventTypeName: 'WORKFLOW_EXECUTION_CONTINUED_AS_NEW', eventTime: at( 60 ),
+          workflowExecutionContinuedAsNewEventAttributes: { newExecutionRunId: 'run-10' }
+        } ],
+        nextPageToken: null
+      } ) );
+
+    const { result } = await fetchWorkflowHistoryUpdates( { workflowId: 'wf-9', runId: 'run-9' } );
+
+    expect( mockGet ).toHaveBeenCalledTimes( 2 );
+    expect( result.continuedAsNewRunId ).toBe( 'run-10' );
+  } );
+
   it( 'forwards waitMs to the API on a resumed poll', async () => {
     mockGet.mockResolvedValueOnce( page( {
       workflow: { workflowId: 'wf-7', runId: 'run-7', status: 'running', startTime: at( 0 ) },

--- a/sdk/cli/src/services/workflow_history.spec.ts
+++ b/sdk/cli/src/services/workflow_history.spec.ts
@@ -103,4 +103,32 @@ describe( 'fetchWorkflowHistory', () => {
     mockGet.mockResolvedValueOnce( { status: 200 } );
     await expect( fetchWorkflowHistory( { workflowId: 'wf-x' } ) ).rejects.toThrow( /invalid response/ );
   } );
+
+  it( 'extracts the chained run id from a WORKFLOW_EXECUTION_CONTINUED_AS_NEW event', async () => {
+    mockGet.mockResolvedValueOnce( page( {
+      workflow: { workflowId: 'wf-4', runId: 'run-4', status: 'continued_as_new', startTime: at( 0 ) },
+      runId: 'run-4',
+      events: [
+        workflowStarted( 0 ),
+        {
+          eventId: '9', eventTypeName: 'WORKFLOW_EXECUTION_CONTINUED_AS_NEW', eventTime: at( 60 ),
+          workflowExecutionContinuedAsNewEventAttributes: { newExecutionRunId: 'run-5' }
+        }
+      ],
+      nextPageToken: null
+    } ) );
+
+    const result = await fetchWorkflowHistory( { workflowId: 'wf-4' } );
+    expect( result.continuedAsNewRunId ).toBe( 'run-5' );
+  } );
+
+  it( 'returns null continuedAsNewRunId when there is no continue-as-new event', async () => {
+    mockGet.mockResolvedValueOnce( page( {
+      workflow: { workflowId: 'wf-5', runId: 'run-5', status: 'completed', startTime: at( 0 ), closeTime: at( 1 ) },
+      runId: 'run-5', events: [ workflowStarted( 0 ) ], nextPageToken: null
+    } ) );
+
+    const result = await fetchWorkflowHistory( { workflowId: 'wf-5' } );
+    expect( result.continuedAsNewRunId ).toBeNull();
+  } );
 } );

--- a/sdk/cli/src/services/workflow_history.spec.ts
+++ b/sdk/cli/src/services/workflow_history.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getWorkflowIdHistory } from '#api/generated/api.js';
-import { fetchWorkflowHistory } from '#services/workflow_history.js';
+import { fetchWorkflowHistory, fetchWorkflowHistoryUpdates, type WorkflowHistoryCursor } from '#services/workflow_history.js';
 
 vi.mock( '#api/generated/api.js', () => ( { getWorkflowIdHistory: vi.fn() } ) );
 
@@ -59,6 +59,44 @@ describe( 'fetchWorkflowHistory', () => {
     expect( result.totalDurationMs ).toBe( 300_000 ); // closeTime - startTime
     expect( result.spans ).toHaveLength( 1 );
     expect( result.spans[0].durationMs ).toBe( 27_000 );
+    // Even though the server's own nextPageToken for the final page is empty (nothing more
+    // buffered), the cursor keeps the *request* token that reached it — a genuinely resumable
+    // position for a follow-up fetchWorkflowHistoryUpdates call. See fetchPages.
+    expect( result.cursor.pageToken ).toBe( 'token-2' );
+  } );
+
+  it( 'a follow-up fetchWorkflowHistoryUpdates call resumes from fetchWorkflowHistory\'s cursor instead of re-paging from page 1', async () => {
+    mockGet
+      .mockResolvedValueOnce( page( {
+        workflow: { workflowId: 'wf-123', runId: 'run-456', status: 'running', startTime: at( 0 ) },
+        runId: 'run-456',
+        events: [ workflowStarted( 0 ), scheduled( '2', 'wf#step', 0 ) ],
+        nextPageToken: 'token-2'
+      } ) )
+      .mockResolvedValueOnce( page( {
+        workflow: null,
+        runId: 'run-456',
+        events: [ started( '3', '2', 0 ) ],
+        nextPageToken: null
+      } ) );
+
+    const first = await fetchWorkflowHistory( { workflowId: 'wf-123' } );
+    expect( mockGet ).toHaveBeenCalledTimes( 2 );
+
+    // The next tick replays the last page (deduped) then finds nothing new and times out —
+    // one call, not a full re-walk from page 1 through both prior pages again.
+    mockGet.mockResolvedValueOnce( page( {
+      workflow: null, runId: 'run-456', events: [], nextPageToken: 'token-2'
+    } ) );
+
+    const { result, cursor } = await fetchWorkflowHistoryUpdates( { workflowId: 'wf-123', runId: 'run-456' }, first.cursor );
+
+    expect( mockGet ).toHaveBeenCalledTimes( 3 );
+    expect( mockGet ).toHaveBeenNthCalledWith( 3, 'wf-123', {
+      runId: 'run-456', pageSize: 50, pageToken: 'token-2', includePayloads: false, wait: true
+    } );
+    expect( result.events ).toHaveLength( 3 );
+    expect( cursor.pageToken ).toBe( 'token-2' );
   } );
 
   it( 'forwards an explicit runId and includePayloads, stopping after a single page', async () => {
@@ -130,5 +168,65 @@ describe( 'fetchWorkflowHistory', () => {
 
     const result = await fetchWorkflowHistory( { workflowId: 'wf-5' } );
     expect( result.continuedAsNewRunId ).toBeNull();
+  } );
+} );
+
+describe( 'fetchWorkflowHistoryUpdates', () => {
+  it( 'starts a fresh long-poll walk when no cursor is given, and stops once the deadline echoes the sent token', async () => {
+    mockGet
+      .mockResolvedValueOnce( page( {
+        workflow: { workflowId: 'wf-7', runId: 'run-7', status: 'running', startTime: at( 0 ) },
+        runId: 'run-7',
+        events: [ workflowStarted( 0 ) ],
+        nextPageToken: 'tip-token'
+      } ) )
+      .mockResolvedValueOnce( page( {
+        workflow: null,
+        runId: 'run-7',
+        events: [],
+        nextPageToken: 'tip-token'
+      } ) );
+
+    const { result, cursor } = await fetchWorkflowHistoryUpdates( { workflowId: 'wf-7', runId: 'run-7' } );
+
+    expect( mockGet ).toHaveBeenCalledTimes( 2 );
+    expect( mockGet ).toHaveBeenNthCalledWith( 1, 'wf-7', {
+      runId: 'run-7', pageSize: 50, pageToken: undefined, includePayloads: false, wait: true
+    } );
+    expect( mockGet ).toHaveBeenNthCalledWith( 2, 'wf-7', {
+      runId: 'run-7', pageSize: 50, pageToken: 'tip-token', includePayloads: false, wait: true
+    } );
+    expect( result.events ).toHaveLength( 1 );
+    expect( cursor.pageToken ).toBe( 'tip-token' );
+    expect( cursor.lastEventId ).toBe( 1 );
+  } );
+
+  it( 'resumes from a prior cursor, fetching only new events until the deadline echoes the token back', async () => {
+    const cursor: WorkflowHistoryCursor = {
+      pageToken: 'token-2',
+      lastEventId: 2,
+      meta: { workflowId: 'wf-6', runId: 'run-6', status: 'running', startTime: at( 0 ) },
+      runId: 'run-6',
+      events: [ workflowStarted( 0 ), scheduled( '2', 'wf#step', 0 ) ]
+    };
+
+    mockGet.mockResolvedValue( page( {
+      workflow: null,
+      runId: 'run-6',
+      events: [ started( '3', '2', 1 ) ],
+      nextPageToken: 'token-2'
+    } ) );
+
+    const { result, cursor: nextCursor } = await fetchWorkflowHistoryUpdates( { workflowId: 'wf-6', runId: 'run-6' }, cursor );
+
+    expect( mockGet ).toHaveBeenCalledTimes( 2 );
+    expect( mockGet ).toHaveBeenNthCalledWith( 1, 'wf-6', {
+      runId: 'run-6', pageSize: 50, pageToken: 'token-2', includePayloads: false, wait: true
+    } );
+    // The events already carried on the cursor (2) plus the one genuinely new event (1) — the
+    // replayed duplicate on the second call must not be double-counted.
+    expect( result.events ).toHaveLength( 3 );
+    expect( nextCursor.pageToken ).toBe( 'token-2' );
+    expect( nextCursor.lastEventId ).toBe( 3 );
   } );
 } );

--- a/sdk/cli/src/services/workflow_history.ts
+++ b/sdk/cli/src/services/workflow_history.ts
@@ -9,6 +9,7 @@
  */
 import { getWorkflowIdHistory, type GetWorkflowIdHistory200 } from '#api/generated/api.js';
 import { correlate, eventAttributes, eventTypeName, type HistoryEvent, type Span } from '#services/workflow_history/correlator.js';
+import { normalizeWorkflowStatus } from '#utils/normalize_workflow_status.js';
 
 const PAGE_SIZE = 50;
 
@@ -108,9 +109,9 @@ async function fetchAllPages(
   // the server, mirroring Atlas's metadata shape).
   const meta = acc.meta ?? ( data.workflow as unknown as WorkflowMeta | null ) ?? null;
   const resolvedRunId = runId ?? data.runId ?? acc.runId;
-  const events = [ ...acc.events, ...( ( data.events as HistoryEvent[] | undefined ) ?? [] ) ];
+  acc.events.push( ...( ( data.events as HistoryEvent[] | undefined ) ?? [] ) );
   const nextToken = data.nextPageToken ?? undefined;
-  const nextAcc: PageAccumulator = { meta, runId: resolvedRunId, events };
+  const nextAcc: PageAccumulator = { meta, runId: resolvedRunId, events: acc.events };
 
   if ( nextToken ) {
     return fetchAllPages( workflowId, includePayloads, resolvedRunId, nextToken, nextAcc );
@@ -121,9 +122,14 @@ async function fetchAllPages(
 export async function fetchWorkflowHistory( options: FetchWorkflowHistoryOptions ): Promise<WorkflowHistoryResult> {
   const { workflowId, runId, includePayloads = false } = options;
 
-  const { meta, runId: resolvedRunId, events } = await fetchAllPages(
+  const { meta: rawMeta, runId: resolvedRunId, events } = await fetchAllPages(
     workflowId, includePayloads, runId, undefined, { meta: null, runId, events: [] }
   );
+
+  // Normalize once here so every consumer (monitor, history, etc.) sees the
+  // same status vocabulary, matching status.ts/workflow_runs.ts/etc.
+  const status = normalizeWorkflowStatus( rawMeta?.status );
+  const meta = rawMeta ? { ...rawMeta, status } : rawMeta;
 
   const startMs = workflowStartMs( meta, events );
   const spans = correlate( events, startMs );
@@ -136,6 +142,6 @@ export async function fetchWorkflowHistory( options: FetchWorkflowHistoryOptions
     totalDurationMs: totalDuration( meta, spans, startMs ),
     // Only the common case (a workflow that continued as new) pays for the
     // scan; every other status skips it entirely.
-    continuedAsNewRunId: meta?.status === 'continued_as_new' ? continuedAsNewRunId( events ) : null
+    continuedAsNewRunId: status === 'continued_as_new' ? continuedAsNewRunId( events ) : null
   };
 }

--- a/sdk/cli/src/services/workflow_history.ts
+++ b/sdk/cli/src/services/workflow_history.ts
@@ -8,7 +8,7 @@
  * the `nextPageToken` (the endpoint requires runId once a pageToken is used).
  */
 import { getWorkflowIdHistory, type GetWorkflowIdHistory200 } from '#api/generated/api.js';
-import { correlate, type HistoryEvent, type Span } from '#services/workflow_history/correlator.js';
+import { correlate, eventAttributes, eventTypeName, type HistoryEvent, type Span } from '#services/workflow_history/correlator.js';
 
 const PAGE_SIZE = 50;
 
@@ -34,6 +34,7 @@ export interface WorkflowHistoryResult {
   events: HistoryEvent[];
   spans: Span[];
   totalDurationMs: number;
+  continuedAsNewRunId: string | null;
 }
 
 interface PageAccumulator {
@@ -70,6 +71,14 @@ function workflowStartMs( meta: WorkflowMeta | null, events: HistoryEvent[] ): n
     return fromStarted;
   }
   return earliestEventMs( events );
+}
+
+// The paginated history endpoint doesn't surface a resolved `newRunId` the way
+// the SSE stream endpoint does (see `stream_history.js`'s `doneChunk`), so pull
+// it directly off the WORKFLOW_EXECUTION_CONTINUED_AS_NEW event when present.
+function continuedAsNewRunId( events: HistoryEvent[] ): string | null {
+  const terminal = events.find( e => eventTypeName( e ) === 'WORKFLOW_EXECUTION_CONTINUED_AS_NEW' );
+  return ( eventAttributes( terminal )?.newExecutionRunId as string | undefined ) ?? null;
 }
 
 function totalDuration( meta: WorkflowMeta | null, spans: Span[], startMs: number | null ): number {
@@ -124,6 +133,9 @@ export async function fetchWorkflowHistory( options: FetchWorkflowHistoryOptions
     runId: resolvedRunId ?? meta?.runId ?? null,
     events,
     spans,
-    totalDurationMs: totalDuration( meta, spans, startMs )
+    totalDurationMs: totalDuration( meta, spans, startMs ),
+    // Only the common case (a workflow that continued as new) pays for the
+    // scan; every other status skips it entirely.
+    continuedAsNewRunId: meta?.status === 'continued_as_new' ? continuedAsNewRunId( events ) : null
   };
 }

--- a/sdk/cli/src/services/workflow_history.ts
+++ b/sdk/cli/src/services/workflow_history.ts
@@ -10,6 +10,7 @@
 import { getWorkflowIdHistory, type GetWorkflowIdHistory200 } from '#api/generated/api.js';
 import { correlate, eventAttributes, eventTypeName, type HistoryEvent, type Span } from '#services/workflow_history/correlator.js';
 import { normalizeWorkflowStatus } from '#utils/normalize_workflow_status.js';
+import { TERMINAL_STATUSES } from '#utils/format_workflow_result.js';
 
 const PAGE_SIZE = 50;
 
@@ -62,6 +63,13 @@ export interface WorkflowHistoryCursor {
   meta: WorkflowMeta | null;
   runId: string | undefined;
   events: HistoryEvent[];
+}
+
+// The status here comes from the request's own describe (fresh whenever `wait` is
+// set), so it can report the run closed before the closing event has been paged in.
+function isRunClosed( meta: WorkflowMeta | null ): boolean {
+  const status = normalizeWorkflowStatus( meta?.status );
+  return status === 'continued_as_new' || ( status !== undefined && TERMINAL_STATUSES.has( status ) );
 }
 
 function numericEventId( event: HistoryEvent ): number {
@@ -154,11 +162,13 @@ async function fetchPages(
   const nextToken = data.nextPageToken ?? undefined;
   const nextAcc: WorkflowHistoryCursor = { meta, runId: resolvedRunId, events, lastEventId, pageToken: nextToken ?? pageToken };
 
-  // While long-polling, stop and hand back the first batch of new events instead of
-  // draining further pages — a poller needs each transition rendered as it arrives, not
-  // several (possibly including a terminal one) silently merged into a single response
-  // after however long it took to walk to the current tip.
-  if ( wait && newEvents.length > 0 ) {
+  // While long-polling an open run, stop and hand back the first batch of new events
+  // instead of draining further pages — a poller needs each transition rendered as it
+  // arrives, and the buffered remainder will surface on subsequent ticks. Once the run
+  // is closed, though, no further ticks are coming: the poller acts on the closed
+  // status immediately, so stopping early would strand the trailing pages — including
+  // the terminal or CONTINUED_AS_NEW event — unfetched. Drain to the tip instead.
+  if ( wait && newEvents.length > 0 && !isRunClosed( meta ) ) {
     return nextAcc;
   }
 

--- a/sdk/cli/src/services/workflow_history.ts
+++ b/sdk/cli/src/services/workflow_history.ts
@@ -28,9 +28,10 @@ export interface FetchWorkflowHistoryOptions {
   workflowId: string;
   runId?: string;
   includePayloads?: boolean;
-  // Upper bound (ms) for a `wait` long-poll; only applies to `fetchWorkflowHistoryUpdates`.
-  // See `fetchPages`'s `wait` param — omitting it uses the server's full configured deadline.
-  waitMs?: number;
+  // Long-poll bound (ms) for `fetchWorkflowHistoryUpdates`: when set, each resumed poll asks the
+  // server to block up to this long for a new event (clamped to the server's ceiling). Required in
+  // practice for updates — omitting it makes each poll return immediately (no long-poll).
+  longPollTimeoutMs?: number;
 }
 
 export interface WorkflowHistoryResult {
@@ -126,20 +127,21 @@ function totalDuration( meta: WorkflowMeta | null, spans: Span[], startMs: numbe
 
 /**
  * Pages through history starting from `acc` (its `pageToken`/`lastEventId`/`events` carry
- * the resume position — pass a zeroed cursor for a fresh walk). With `wait` set, every
- * request asks the server to long-poll (`waitNewEvent`) rather than return immediately, so
- * the final hop blocks (bounded server-side, or by `waitMs` when given — see
- * `FetchWorkflowHistoryOptions.waitMs`) until either a new event exists or the deadline
- * elapses. `lastEventId` de-dupes: resuming from a previously-seen page token replays that
- * page's events, which are filtered out here rather than appended twice.
+ * the resume position — pass a zeroed cursor for a fresh walk). When `longPollTimeoutMs` is
+ * set, every request asks the server to long-poll (`waitNewEvent`) rather than return
+ * immediately, so the final hop blocks — up to that many milliseconds (clamped to the server's
+ * ceiling) — until either a new event exists or the deadline elapses. `lastEventId` de-dupes:
+ * resuming from a previously-seen page token replays that page's events, which are filtered out
+ * here rather than appended twice.
  */
 async function fetchPages(
-  workflowId: string, includePayloads: boolean, wait: boolean, acc: WorkflowHistoryCursor, waitMs?: number
+  workflowId: string, includePayloads: boolean, acc: WorkflowHistoryCursor, longPollTimeoutMs?: number
 ): Promise<WorkflowHistoryCursor> {
+  const wait = longPollTimeoutMs !== undefined && longPollTimeoutMs > 0;
   const { pageToken, runId } = acc;
   const response = await getWorkflowIdHistory( workflowId, {
     runId, pageSize: PAGE_SIZE, pageToken, includePayloads,
-    ...( wait ? { wait: true, ...( waitMs ? { waitMs } : {} ) } : {} )
+    ...( wait ? { longPollTimeoutMs } : {} )
   } );
   if ( !response.data ) {
     throw new Error( 'API returned invalid response (missing data)' );
@@ -179,7 +181,7 @@ async function fetchPages(
     return nextAcc;
   }
   if ( nextToken ) {
-    return fetchPages( workflowId, includePayloads, wait, nextAcc, waitMs );
+    return fetchPages( workflowId, includePayloads, nextAcc, longPollTimeoutMs );
   }
   // Drained: the server has nothing more buffered (`nextToken` is empty), but unlike
   // `nextToken`, `pageToken` — the position that fetched this now-empty page — is still a
@@ -214,7 +216,7 @@ export async function fetchWorkflowHistory( options: FetchWorkflowHistoryOptions
   const { workflowId, runId, includePayloads = false } = options;
 
   const pages = await fetchPages(
-    workflowId, includePayloads, false, { meta: null, runId, events: [], lastEventId: 0, pageToken: undefined }
+    workflowId, includePayloads, { meta: null, runId, events: [], lastEventId: 0, pageToken: undefined }
   );
 
   return buildResult( pages );
@@ -230,11 +232,11 @@ export async function fetchWorkflowHistoryUpdates(
   options: FetchWorkflowHistoryOptions,
   cursor?: WorkflowHistoryCursor
 ): Promise<{ result: WorkflowHistoryResult; cursor: WorkflowHistoryCursor }> {
-  const { workflowId, includePayloads = false, waitMs } = options;
+  const { workflowId, includePayloads = false, longPollTimeoutMs } = options;
   const seed: WorkflowHistoryCursor = cursor ??
     { meta: null, runId: options.runId, events: [], lastEventId: 0, pageToken: undefined };
 
-  const pages = await fetchPages( workflowId, includePayloads, true, seed, waitMs );
+  const pages = await fetchPages( workflowId, includePayloads, seed, longPollTimeoutMs );
 
   return { result: buildResult( pages ), cursor: pages };
 }

--- a/sdk/cli/src/services/workflow_history.ts
+++ b/sdk/cli/src/services/workflow_history.ts
@@ -134,8 +134,11 @@ async function fetchPages( workflowId: string, includePayloads: boolean, wait: b
   const data = response.data as GetWorkflowIdHistory200;
   // The generated `data.workflow` is an opaque `{ [key: string]: unknown }`, so
   // narrow it to WorkflowMeta via `unknown` (its real fields are validated by
-  // the server, mirroring Atlas's metadata shape).
-  const meta = acc.meta ?? ( data.workflow as unknown as WorkflowMeta | null ) ?? null;
+  // the server, mirroring Atlas's metadata shape). Prefer the *fresh* value when the
+  // server sent one — it re-describes on every `wait` call specifically so status
+  // updates (e.g. running -> completed) are seen; falling back to `acc.meta` only
+  // covers the pages within a walk where the server didn't re-describe.
+  const meta = ( data.workflow as unknown as WorkflowMeta | null ) ?? acc.meta;
   const resolvedRunId = runId ?? data.runId ?? acc.runId;
   const pageEvents = ( data.events as HistoryEvent[] | undefined ) ?? [];
   const newEvents = pageEvents.filter( event => numericEventId( event ) > acc.lastEventId );
@@ -143,21 +146,30 @@ async function fetchPages( workflowId: string, includePayloads: boolean, wait: b
   // Events arrive in increasing eventId order, so the last new one is the max — no scan needed.
   const lastEventId = newEvents.length > 0 ? numericEventId( newEvents[newEvents.length - 1] ) : acc.lastEventId;
   const nextToken = data.nextPageToken ?? undefined;
+  const nextAcc: WorkflowHistoryCursor = { meta, runId: resolvedRunId, events, lastEventId, pageToken: nextToken ?? pageToken };
+
+  // While long-polling, stop and hand back the first batch of new events instead of
+  // draining further pages — a poller needs each transition rendered as it arrives, not
+  // several (possibly including a terminal one) silently merged into a single response
+  // after however long it took to walk to the current tip.
+  if ( wait && newEvents.length > 0 ) {
+    return nextAcc;
+  }
 
   // The server echoes `pageToken` back unchanged (see `get_history.js`) when a waitNewEvent
   // call's deadline elapses with nothing new — that's the tip, stop for this tick.
-  const timedOut = wait && newEvents.length === 0 && nextToken === pageToken;
+  const timedOut = wait && nextToken === pageToken;
   if ( timedOut ) {
-    return { meta, runId: resolvedRunId, events, lastEventId, pageToken: nextToken };
+    return nextAcc;
   }
   if ( nextToken ) {
-    return fetchPages( workflowId, includePayloads, wait, { meta, runId: resolvedRunId, events, lastEventId, pageToken: nextToken } );
+    return fetchPages( workflowId, includePayloads, wait, nextAcc );
   }
   // Drained: the server has nothing more buffered (`nextToken` is empty), but unlike
   // `nextToken`, `pageToken` — the position that fetched this now-empty page — is still a
   // valid resume point: a future waitNewEvent call from here replays this page (de-duped by
   // `lastEventId`) and then genuinely waits at the tip, instead of restarting from page 1.
-  return { meta, runId: resolvedRunId, events, lastEventId, pageToken };
+  return nextAcc;
 }
 
 function buildResult( pages: WorkflowHistoryCursor ): WorkflowHistoryResult {

--- a/sdk/cli/src/services/workflow_history.ts
+++ b/sdk/cli/src/services/workflow_history.ts
@@ -31,17 +31,39 @@ export interface FetchWorkflowHistoryOptions {
 
 export interface WorkflowHistoryResult {
   workflow: WorkflowMeta | null;
+  // The server's response before status normalization, for callers (e.g. `history
+  // --raw`) that promise a verbatim passthrough of the API response rather than
+  // the client-side status vocabulary `workflow.status` is normalized into.
+  rawWorkflow: WorkflowMeta | null;
   runId: string | null;
   events: HistoryEvent[];
   spans: Span[];
   totalDurationMs: number;
   continuedAsNewRunId: string | null;
+  // Resume state for a follow-up `fetchWorkflowHistoryUpdates` call — populated by every
+  // fetch (not just the incremental path), so a poller can resume from *any* prior call,
+  // including the very first one, instead of re-paging from page 1 on its second call.
+  cursor: WorkflowHistoryCursor;
 }
 
-interface PageAccumulator {
+/**
+ * Resume state for `fetchWorkflowHistoryUpdates`: the accumulated events (so spans/duration
+ * are always computed over the full history, not just the latest delta), `lastEventId` for
+ * de-duping a replayed page, and `pageToken` — the position that fetched the *current* end of
+ * history, which is itself always a valid resume point (see `fetchPages`) even though the
+ * server's own `nextPageToken` for that position is empty.
+ */
+export interface WorkflowHistoryCursor {
+  pageToken: string | undefined;
+  lastEventId: number;
   meta: WorkflowMeta | null;
   runId: string | undefined;
   events: HistoryEvent[];
+}
+
+function numericEventId( event: HistoryEvent ): number {
+  const id = Number( ( event as { eventId?: unknown } ).eventId );
+  return Number.isFinite( id ) ? id : 0;
 }
 
 function toMs( value: string | null | undefined ): number | null {
@@ -91,14 +113,20 @@ function totalDuration( meta: WorkflowMeta | null, spans: Span[], startMs: numbe
   return Math.max( maxEnd, 1 );
 }
 
-async function fetchAllPages(
-  workflowId: string,
-  includePayloads: boolean,
-  runId: string | undefined,
-  pageToken: string | undefined,
-  acc: PageAccumulator
-): Promise<PageAccumulator> {
-  const response = await getWorkflowIdHistory( workflowId, { runId, pageSize: PAGE_SIZE, pageToken, includePayloads } );
+/**
+ * Pages through history starting from `acc` (its `pageToken`/`lastEventId`/`events` carry
+ * the resume position — pass a zeroed cursor for a fresh walk). With `wait` set, every
+ * request asks the server to long-poll (`waitNewEvent`) rather than return immediately, so
+ * the final hop blocks (bounded server-side) until either a new event exists or the deadline
+ * elapses. `lastEventId` de-dupes: resuming from a previously-seen page token replays that
+ * page's events, which are filtered out here rather than appended twice.
+ */
+async function fetchPages( workflowId: string, includePayloads: boolean, wait: boolean, acc: WorkflowHistoryCursor ): Promise<WorkflowHistoryCursor> {
+  const { pageToken, runId } = acc;
+  const response = await getWorkflowIdHistory( workflowId, {
+    runId, pageSize: PAGE_SIZE, pageToken, includePayloads,
+    ...( wait ? { wait: true } : {} )
+  } );
   if ( !response.data ) {
     throw new Error( 'API returned invalid response (missing data)' );
   }
@@ -109,23 +137,31 @@ async function fetchAllPages(
   // the server, mirroring Atlas's metadata shape).
   const meta = acc.meta ?? ( data.workflow as unknown as WorkflowMeta | null ) ?? null;
   const resolvedRunId = runId ?? data.runId ?? acc.runId;
-  acc.events.push( ...( ( data.events as HistoryEvent[] | undefined ) ?? [] ) );
+  const pageEvents = ( data.events as HistoryEvent[] | undefined ) ?? [];
+  const newEvents = pageEvents.filter( event => numericEventId( event ) > acc.lastEventId );
+  const events = [ ...acc.events, ...newEvents ];
+  // Events arrive in increasing eventId order, so the last new one is the max — no scan needed.
+  const lastEventId = newEvents.length > 0 ? numericEventId( newEvents[newEvents.length - 1] ) : acc.lastEventId;
   const nextToken = data.nextPageToken ?? undefined;
-  const nextAcc: PageAccumulator = { meta, runId: resolvedRunId, events: acc.events };
 
-  if ( nextToken ) {
-    return fetchAllPages( workflowId, includePayloads, resolvedRunId, nextToken, nextAcc );
+  // The server echoes `pageToken` back unchanged (see `get_history.js`) when a waitNewEvent
+  // call's deadline elapses with nothing new — that's the tip, stop for this tick.
+  const timedOut = wait && newEvents.length === 0 && nextToken === pageToken;
+  if ( timedOut ) {
+    return { meta, runId: resolvedRunId, events, lastEventId, pageToken: nextToken };
   }
-  return nextAcc;
+  if ( nextToken ) {
+    return fetchPages( workflowId, includePayloads, wait, { meta, runId: resolvedRunId, events, lastEventId, pageToken: nextToken } );
+  }
+  // Drained: the server has nothing more buffered (`nextToken` is empty), but unlike
+  // `nextToken`, `pageToken` — the position that fetched this now-empty page — is still a
+  // valid resume point: a future waitNewEvent call from here replays this page (de-duped by
+  // `lastEventId`) and then genuinely waits at the tip, instead of restarting from page 1.
+  return { meta, runId: resolvedRunId, events, lastEventId, pageToken };
 }
 
-export async function fetchWorkflowHistory( options: FetchWorkflowHistoryOptions ): Promise<WorkflowHistoryResult> {
-  const { workflowId, runId, includePayloads = false } = options;
-
-  const { meta: rawMeta, runId: resolvedRunId, events } = await fetchAllPages(
-    workflowId, includePayloads, runId, undefined, { meta: null, runId, events: [] }
-  );
-
+function buildResult( pages: WorkflowHistoryCursor ): WorkflowHistoryResult {
+  const { meta: rawMeta, runId: resolvedRunId, events } = pages;
   // Normalize once here so every consumer (monitor, history, etc.) sees the
   // same status vocabulary, matching status.ts/workflow_runs.ts/etc.
   const status = normalizeWorkflowStatus( rawMeta?.status );
@@ -136,12 +172,41 @@ export async function fetchWorkflowHistory( options: FetchWorkflowHistoryOptions
 
   return {
     workflow: meta,
+    rawWorkflow: rawMeta,
     runId: resolvedRunId ?? meta?.runId ?? null,
     events,
     spans,
     totalDurationMs: totalDuration( meta, spans, startMs ),
-    // Only the common case (a workflow that continued as new) pays for the
-    // scan; every other status skips it entirely.
-    continuedAsNewRunId: status === 'continued_as_new' ? continuedAsNewRunId( events ) : null
+    continuedAsNewRunId: continuedAsNewRunId( events ),
+    cursor: pages
   };
+}
+
+export async function fetchWorkflowHistory( options: FetchWorkflowHistoryOptions ): Promise<WorkflowHistoryResult> {
+  const { workflowId, runId, includePayloads = false } = options;
+
+  const pages = await fetchPages(
+    workflowId, includePayloads, false, { meta: null, runId, events: [], lastEventId: 0, pageToken: undefined }
+  );
+
+  return buildResult( pages );
+}
+
+/**
+ * Incremental counterpart to `fetchWorkflowHistory`, for a poller (`workflow monitor`) that
+ * calls repeatedly while a workflow is still running. Pass the previous call's `cursor`
+ * (from either function's result) to resume from where it left off instead of re-paging the
+ * whole history; omit it only to start a completely fresh walk.
+ */
+export async function fetchWorkflowHistoryUpdates(
+  options: FetchWorkflowHistoryOptions,
+  cursor?: WorkflowHistoryCursor
+): Promise<{ result: WorkflowHistoryResult; cursor: WorkflowHistoryCursor }> {
+  const { workflowId, includePayloads = false } = options;
+  const seed: WorkflowHistoryCursor = cursor ??
+    { meta: null, runId: options.runId, events: [], lastEventId: 0, pageToken: undefined };
+
+  const pages = await fetchPages( workflowId, includePayloads, true, seed );
+
+  return { result: buildResult( pages ), cursor: pages };
 }

--- a/sdk/cli/src/services/workflow_history.ts
+++ b/sdk/cli/src/services/workflow_history.ts
@@ -27,6 +27,9 @@ export interface FetchWorkflowHistoryOptions {
   workflowId: string;
   runId?: string;
   includePayloads?: boolean;
+  // Upper bound (ms) for a `wait` long-poll; only applies to `fetchWorkflowHistoryUpdates`.
+  // See `fetchPages`'s `wait` param — omitting it uses the server's full configured deadline.
+  waitMs?: number;
 }
 
 export interface WorkflowHistoryResult {
@@ -117,15 +120,18 @@ function totalDuration( meta: WorkflowMeta | null, spans: Span[], startMs: numbe
  * Pages through history starting from `acc` (its `pageToken`/`lastEventId`/`events` carry
  * the resume position — pass a zeroed cursor for a fresh walk). With `wait` set, every
  * request asks the server to long-poll (`waitNewEvent`) rather than return immediately, so
- * the final hop blocks (bounded server-side) until either a new event exists or the deadline
+ * the final hop blocks (bounded server-side, or by `waitMs` when given — see
+ * `FetchWorkflowHistoryOptions.waitMs`) until either a new event exists or the deadline
  * elapses. `lastEventId` de-dupes: resuming from a previously-seen page token replays that
  * page's events, which are filtered out here rather than appended twice.
  */
-async function fetchPages( workflowId: string, includePayloads: boolean, wait: boolean, acc: WorkflowHistoryCursor ): Promise<WorkflowHistoryCursor> {
+async function fetchPages(
+  workflowId: string, includePayloads: boolean, wait: boolean, acc: WorkflowHistoryCursor, waitMs?: number
+): Promise<WorkflowHistoryCursor> {
   const { pageToken, runId } = acc;
   const response = await getWorkflowIdHistory( workflowId, {
     runId, pageSize: PAGE_SIZE, pageToken, includePayloads,
-    ...( wait ? { wait: true } : {} )
+    ...( wait ? { wait: true, ...( waitMs ? { waitMs } : {} ) } : {} )
   } );
   if ( !response.data ) {
     throw new Error( 'API returned invalid response (missing data)' );
@@ -163,7 +169,7 @@ async function fetchPages( workflowId: string, includePayloads: boolean, wait: b
     return nextAcc;
   }
   if ( nextToken ) {
-    return fetchPages( workflowId, includePayloads, wait, nextAcc );
+    return fetchPages( workflowId, includePayloads, wait, nextAcc, waitMs );
   }
   // Drained: the server has nothing more buffered (`nextToken` is empty), but unlike
   // `nextToken`, `pageToken` — the position that fetched this now-empty page — is still a
@@ -214,11 +220,11 @@ export async function fetchWorkflowHistoryUpdates(
   options: FetchWorkflowHistoryOptions,
   cursor?: WorkflowHistoryCursor
 ): Promise<{ result: WorkflowHistoryResult; cursor: WorkflowHistoryCursor }> {
-  const { workflowId, includePayloads = false } = options;
+  const { workflowId, includePayloads = false, waitMs } = options;
   const seed: WorkflowHistoryCursor = cursor ??
     { meta: null, runId: options.runId, events: [], lastEventId: 0, pageToken: undefined };
 
-  const pages = await fetchPages( workflowId, includePayloads, true, seed );
+  const pages = await fetchPages( workflowId, includePayloads, true, seed, waitMs );
 
   return { result: buildResult( pages ), cursor: pages };
 }

--- a/sdk/cli/src/services/workflow_history/correlator.ts
+++ b/sdk/cli/src/services/workflow_history/correlator.ts
@@ -65,7 +65,7 @@ const CHILD_TERMINAL_TYPES = [
   'CHILD_WORKFLOW_EXECUTION_TERMINATED', 'START_CHILD_WORKFLOW_EXECUTION_FAILED'
 ];
 
-function eventTypeName( event: HistoryEvent ): string {
+export function eventTypeName( event: HistoryEvent ): string {
   return ( event.eventTypeName as string | undefined ) ?? '';
 }
 
@@ -73,7 +73,7 @@ function eventId( event: HistoryEvent ): string {
   return String( event.eventId );
 }
 
-function eventAttributes( event?: HistoryEvent ): Record<string, unknown> | undefined {
+export function eventAttributes( event?: HistoryEvent ): Record<string, unknown> | undefined {
   const key = event && Object.keys( event ).find( k => k.endsWith( 'EventAttributes' ) );
   return key ? ( ( event as HistoryEvent )[key] as Record<string, unknown> ) : undefined;
 }

--- a/sdk/cli/src/utils/color.spec.ts
+++ b/sdk/cli/src/utils/color.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { shouldColorize } from '#utils/color.js';
+
+describe( 'shouldColorize', () => {
+  const originalEnv = { ...process.env };
+  const originalTTY = process.stdout.isTTY;
+
+  beforeEach( () => {
+    delete process.env.NO_COLOR;
+    delete process.env.FORCE_COLOR;
+    Object.defineProperty( process.stdout, 'isTTY', { value: true, configurable: true } );
+  } );
+
+  afterEach( () => {
+    process.env = { ...originalEnv };
+    Object.defineProperty( process.stdout, 'isTTY', { value: originalTTY, configurable: true } );
+  } );
+
+  it( 'returns false when the flag itself is false', () => {
+    expect( shouldColorize( false ) ).toBe( false );
+  } );
+
+  it( 'returns true on a TTY with no overrides', () => {
+    expect( shouldColorize( true ) ).toBe( true );
+  } );
+
+  it( 'disables color when NO_COLOR is set to a non-empty value', () => {
+    process.env.NO_COLOR = '1';
+    expect( shouldColorize( true ) ).toBe( false );
+  } );
+
+  it( 'disables color when NO_COLOR is present but empty, per the NO_COLOR convention', () => {
+    process.env.NO_COLOR = '';
+    expect( shouldColorize( true ) ).toBe( false );
+  } );
+
+  it( 'enables color off a TTY when FORCE_COLOR is set', () => {
+    Object.defineProperty( process.stdout, 'isTTY', { value: false, configurable: true } );
+    process.env.FORCE_COLOR = '1';
+    expect( shouldColorize( true ) ).toBe( true );
+  } );
+
+  it( 'disables color off a TTY with no FORCE_COLOR', () => {
+    Object.defineProperty( process.stdout, 'isTTY', { value: false, configurable: true } );
+    expect( shouldColorize( true ) ).toBe( false );
+  } );
+
+  it( 'NO_COLOR wins even when FORCE_COLOR is also set', () => {
+    process.env.FORCE_COLOR = '1';
+    process.env.NO_COLOR = '1';
+    expect( shouldColorize( true ) ).toBe( false );
+  } );
+} );

--- a/sdk/cli/src/utils/color.ts
+++ b/sdk/cli/src/utils/color.ts
@@ -5,6 +5,8 @@
  * fall back to whether stdout is an interactive terminal.
  */
 export function shouldColorize( flag: boolean ): boolean {
-  return flag && !process.env.NO_COLOR &&
+  // Per the NO_COLOR convention (https://no-color.org/), presence disables color
+  // regardless of value — `NO_COLOR=` must opt out just like `NO_COLOR=1`.
+  return flag && process.env.NO_COLOR === undefined &&
     ( !!process.env.FORCE_COLOR || process.stdout.isTTY === true );
 }

--- a/sdk/cli/src/utils/color.ts
+++ b/sdk/cli/src/utils/color.ts
@@ -1,0 +1,10 @@
+/**
+ * Standard TTY/env precedence for whether a command should colorize its
+ * output: the command's own --color/--no-color flag wins first, then
+ * NO_COLOR opts out, then FORCE_COLOR opts in even off a TTY, then finally
+ * fall back to whether stdout is an interactive terminal.
+ */
+export function shouldColorize( flag: boolean ): boolean {
+  return flag && !process.env.NO_COLOR &&
+    ( !!process.env.FORCE_COLOR || process.stdout.isTTY === true );
+}

--- a/sdk/cli/src/utils/format_workflow_result.ts
+++ b/sdk/cli/src/utils/format_workflow_result.ts
@@ -7,6 +7,11 @@ export const ERROR_STATUSES: ReadonlySet<WorkflowResultResponseStatus | undefine
   [ 'failed', 'canceled', 'terminated', 'timed_out' ] as const
 );
 
+// Every error status plus the one success status — derived so the two sets can't
+// silently drift apart as error statuses evolve. Shared by `workflow monitor` and
+// the dev TUI's `useRunDetail`/`useStepGraph` so both agree on what "done" means.
+export const TERMINAL_STATUSES: ReadonlySet<string> = new Set( [ 'completed', ...ERROR_STATUSES ] as string[] );
+
 export function formatWorkflowResult( result: WorkflowResult ): string {
   const status = normalizeWorkflowStatus( result.status );
   const lines = [

--- a/sdk/cli/src/utils/monitor_log.spec.ts
+++ b/sdk/cli/src/utils/monitor_log.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import type { Span, SpanStatus } from '#services/workflow_history/correlator.js';
+import { diffSpanUpdates, formatSpanUpdate } from '#utils/monitor_log.js';
+
+const span = ( overrides: Partial<Span> & { id: string; status: SpanStatus } ): Span => ( {
+  name: 'Step',
+  technicalName: 'wf#step',
+  description: null,
+  kind: 'activity',
+  attempt: 1,
+  startedAt: null,
+  scheduledAt: null,
+  completedAt: null,
+  startOffsetMs: 0,
+  endOffsetMs: 0,
+  durationMs: 0,
+  failureMessage: null,
+  ...overrides
+} );
+
+describe( 'diffSpanUpdates', () => {
+  it( 'skips pending spans', () => {
+    const seen = new Map<string, SpanStatus>();
+    const updates = diffSpanUpdates( [ span( { id: '1', status: 'pending' } ) ], new Map(), seen );
+    expect( updates ).toHaveLength( 0 );
+    expect( seen.size ).toBe( 0 );
+  } );
+
+  it( 'reports a span the first time it is seen in a non-pending status', () => {
+    const seen = new Map<string, SpanStatus>();
+    const updates = diffSpanUpdates( [ span( { id: '1', status: 'running' } ) ], new Map( [ [ '1', 'Fetch page' ] ] ), seen );
+    expect( updates ).toHaveLength( 1 );
+    expect( updates[0].label ).toBe( 'Fetch page' );
+    expect( seen.get( '1' ) ).toBe( 'running' );
+  } );
+
+  it( 'does not re-report a span whose status is unchanged since the last call', () => {
+    const seen = new Map<string, SpanStatus>( [ [ '1', 'running' ] ] );
+    const updates = diffSpanUpdates( [ span( { id: '1', status: 'running' } ) ], new Map(), seen );
+    expect( updates ).toHaveLength( 0 );
+  } );
+
+  it( 'reports a span again once its status transitions (running -> completed)', () => {
+    const seen = new Map<string, SpanStatus>( [ [ '1', 'running' ] ] );
+    const updates = diffSpanUpdates( [ span( { id: '1', status: 'completed' } ) ], new Map(), seen );
+    expect( updates ).toHaveLength( 1 );
+    expect( seen.get( '1' ) ).toBe( 'completed' );
+  } );
+
+  it( 'falls back to the span name when no label is provided', () => {
+    const seen = new Map<string, SpanStatus>();
+    const updates = diffSpanUpdates( [ span( { id: '1', status: 'running', name: 'Unlabeled' } ) ], new Map(), seen );
+    expect( updates[0].label ).toBe( 'Unlabeled' );
+  } );
+} );
+
+describe( 'formatSpanUpdate', () => {
+  it( 'formats a running span', () => {
+    const line = formatSpanUpdate( { span: span( { id: '1', status: 'running' } ), label: 'Fetch page' }, false );
+    expect( line ).toBe( '● Fetch page running…' );
+  } );
+
+  it( 'formats a completed span with its duration', () => {
+    const line = formatSpanUpdate(
+      { span: span( { id: '1', status: 'completed', durationMs: 1234 } ), label: 'Fetch page' }, false
+    );
+    expect( line ).toBe( '✓ Fetch page  1s' );
+  } );
+
+  it( 'formats a failed span with its failure message', () => {
+    const line = formatSpanUpdate(
+      { span: span( { id: '1', status: 'failed', failureMessage: 'boom' } ), label: 'Fetch page' }, false
+    );
+    expect( line ).toBe( '✗ Fetch page failed: boom' );
+  } );
+
+  it( 'formats a failed span without a failure message', () => {
+    const line = formatSpanUpdate( { span: span( { id: '1', status: 'failed' } ), label: 'Fetch page' }, false );
+    expect( line ).toBe( '✗ Fetch page failed' );
+  } );
+
+  it( 'wraps the glyph in ANSI codes when color is enabled', () => {
+    const line = formatSpanUpdate( { span: span( { id: '1', status: 'running' } ), label: 'Fetch page' }, true );
+    expect( line ).toContain( '●' );
+    expect( line ).not.toBe( '● Fetch page running…' ); // color codes present
+  } );
+} );

--- a/sdk/cli/src/utils/monitor_log.ts
+++ b/sdk/cli/src/utils/monitor_log.ts
@@ -1,0 +1,60 @@
+/**
+ * Turns newly-correlated spans into append-only status lines for `workflow
+ * monitor`. Unlike the waterfall (which needs the full span set up front to
+ * lay out a time axis), a live monitor just reports each span's status
+ * transitions as they're observed on each poll.
+ */
+import type { Span, SpanStatus } from '#services/workflow_history/correlator.js';
+import { ANSI, formatDurationLabel } from '#utils/waterfall.js';
+
+const GLYPH: Record<SpanStatus, string> = {
+  pending: '·',
+  running: '●',
+  completed: '✓',
+  failed: '✗'
+};
+
+export interface SpanUpdate {
+  span: Span;
+  label: string;
+}
+
+/**
+ * Returns spans whose status changed since the last call. `seen` is mutated
+ * in place so callers can carry it across polls. Pending spans are skipped —
+ * nothing worth reporting until a step starts.
+ */
+export function diffSpanUpdates(
+  spans: Span[],
+  labels: Map<string, string>,
+  seen: Map<string, SpanStatus>
+): SpanUpdate[] {
+  const updates: SpanUpdate[] = [];
+  for ( const span of spans ) {
+    if ( span.status === 'pending' || seen.get( span.id ) === span.status ) {
+      continue;
+    }
+    seen.set( span.id, span.status );
+    updates.push( { span, label: labels.get( span.id ) ?? span.name } );
+  }
+  return updates;
+}
+
+export function formatSpanUpdate( update: SpanUpdate, color: boolean ): string {
+  const { span, label } = update;
+  const glyph = GLYPH[span.status];
+  const tint = ( text: string ): string => ( color ? `${ANSI[span.status]}${text}${ANSI.reset}` : text );
+
+  switch ( span.status ) {
+    case 'running':
+      return `${tint( glyph )} ${label} running…`;
+    case 'completed':
+      return `${tint( glyph )} ${label}  ${formatDurationLabel( Math.max( 0, span.durationMs ) )}`;
+    case 'failed': {
+      const reason = span.failureMessage ? `: ${span.failureMessage}` : '';
+      return `${tint( glyph )} ${label} failed${reason}`;
+    }
+    default:
+      return `${glyph} ${label} ${span.status}`;
+  }
+}

--- a/sdk/cli/src/utils/monitor_log.ts
+++ b/sdk/cli/src/utils/monitor_log.ts
@@ -5,7 +5,7 @@
  * transitions as they're observed on each poll.
  */
 import type { Span, SpanStatus } from '#services/workflow_history/correlator.js';
-import { ANSI, formatDurationLabel } from '#utils/waterfall.js';
+import { ANSI, formatDurationLabel, makeTint } from '#utils/waterfall.js';
 
 const GLYPH: Record<SpanStatus, string> = {
   pending: '·',
@@ -43,16 +43,17 @@ export function diffSpanUpdates(
 export function formatSpanUpdate( update: SpanUpdate, color: boolean ): string {
   const { span, label } = update;
   const glyph = GLYPH[span.status];
-  const tint = ( text: string ): string => ( color ? `${ANSI[span.status]}${text}${ANSI.reset}` : text );
+  const tint = makeTint( color );
+  const tintStatus = ( text: string ): string => tint( text, ANSI[span.status] );
 
   switch ( span.status ) {
     case 'running':
-      return `${tint( glyph )} ${label} running…`;
+      return `${tintStatus( glyph )} ${label} running…`;
     case 'completed':
-      return `${tint( glyph )} ${label}  ${formatDurationLabel( Math.max( 0, span.durationMs ) )}`;
+      return `${tintStatus( glyph )} ${label}  ${formatDurationLabel( Math.max( 0, span.durationMs ) )}`;
     case 'failed': {
       const reason = span.failureMessage ? `: ${span.failureMessage}` : '';
-      return `${tint( glyph )} ${label} failed${reason}`;
+      return `${tintStatus( glyph )} ${label} failed${reason}`;
     }
     default:
       return `${glyph} ${label} ${span.status}`;

--- a/sdk/cli/src/utils/monitor_log.ts
+++ b/sdk/cli/src/utils/monitor_log.ts
@@ -14,6 +14,10 @@ const GLYPH: Record<SpanStatus, string> = {
   failed: '✗'
 };
 
+// Continue-as-new is a workflow-level transition, not a span status, so it gets its own glyph
+// here in the formatting layer rather than being concatenated into the message at the call site.
+const CONTINUED_AS_NEW_GLYPH = '↻';
+
 export interface SpanUpdate {
   span: Span;
   label: string;
@@ -38,6 +42,11 @@ export function diffSpanUpdates(
     updates.push( { span, label: labels.get( span.id ) ?? span.name } );
   }
   return updates;
+}
+
+/** Formats the continue-as-new transition line, keeping its glyph in the formatting layer. */
+export function formatContinuedAsNew( runId: string ): string {
+  return `${CONTINUED_AS_NEW_GLYPH} continued as new run ${runId}`;
 }
 
 export function formatSpanUpdate( update: SpanUpdate, color: boolean ): string {

--- a/sdk/cli/src/utils/waterfall.ts
+++ b/sdk/cli/src/utils/waterfall.ts
@@ -39,7 +39,7 @@ const TICK_STEPS_MS = [
 ];
 const TARGET_TICKS = 8;
 
-const ANSI: Record<SpanStatus | 'dim' | 'reset', string> = {
+export const ANSI: Record<SpanStatus | 'dim' | 'reset', string> = {
   completed: '[92m',
   running: '[33m',
   failed: '[31m',

--- a/sdk/cli/src/utils/waterfall.ts
+++ b/sdk/cli/src/utils/waterfall.ts
@@ -48,6 +48,13 @@ export const ANSI: Record<SpanStatus | 'dim' | 'reset', string> = {
   reset: '[0m'
 };
 
+// Shared by renderWaterfall and monitor_log's live status lines so there's one
+// place that knows how to wrap text in an ANSI code (and reset it) -- or not,
+// when color is disabled.
+export function makeTint( color: boolean ): ( text: string, code: string ) => string {
+  return ( text, code ) => ( color ? `${code}${text}${ANSI.reset}` : text );
+}
+
 function clamp( value: number, lo: number, hi: number ): number {
   return Math.min( Math.max( value, lo ), hi );
 }
@@ -217,7 +224,7 @@ export default function renderWaterfall( spans: Span[], totalDurationMs: number,
     return [ header, 'No steps found for this run.' ].filter( Boolean ).join( '\n\n' );
   }
 
-  const tint = ( text: string, code: string ): string => ( color ? `${code}${text}${ANSI.reset}` : text );
+  const tint = makeTint( color );
   const labelFor = ( span: Span ): string => labels?.get( span.id ) ?? span.name;
   const durationFor = ( span: Span ): string => formatDurationLabel( Math.max( 0, span.durationMs ) );
 

--- a/sdk/cli/src/views/dev/hooks/use_run_detail.ts
+++ b/sdk/cli/src/views/dev/hooks/use_run_detail.ts
@@ -9,6 +9,7 @@ import {
 } from '#api/generated/api.js';
 import type { TraceData, DebugNode } from '#types/trace.js';
 import { normalizeWorkflowStatus } from '#utils/normalize_workflow_status.js';
+import { TERMINAL_STATUSES } from '#utils/format_workflow_result.js';
 
 export interface RunStep {
   index: number;
@@ -134,14 +135,9 @@ const fetchResult = async ( workflowId: string, runId: string | undefined ): Pro
   }
 };
 
-/**
- * Statuses that mean the workflow has stopped advancing. The cache is
- * intentionally only populated for these — partial results from a still-
- * running workflow would otherwise stick and stall the UI when the run
- * eventually finishes.
- */
-const TERMINAL_STATUSES = new Set( [ 'completed', 'failed', 'canceled', 'terminated', 'timed_out' ] );
-
+// The cache is intentionally only populated for terminal statuses — partial results
+// from a still-running workflow would otherwise stick and stall the UI when the run
+// eventually finishes. `TERMINAL_STATUSES` is shared with `workflow monitor`.
 export const isTerminalRunStatus = ( status: string | null | undefined ): boolean =>
   Boolean( status && TERMINAL_STATUSES.has( status ) );
 


### PR DESCRIPTION
## Summary

Adds a new CLI command, `workflow monitor [id]` that monitors the execution of a workflow by ID.

- tails and emits step status updates as they happen (can attach to executing workflows)
- uses Workflow History endpoint, and adds a resume cursor to avoid re-reading the entire history each poll
- follows `continue-as-new` chains to the new run automatically
- `--format json` emits `NDJSON`, one event per line, for consumption by scripts/agents
- on workflow completion/error, exit code matches result (`0` for success, `1` for failures, `130` on Ctrl+C detach)
- retries transient poll failures (network blips, 5xx) up to 5 times before giving up; fails fast on non-transient errors

## Test plan

- unit tests: monitor command loop (313 lines), history service paging/resume/drain, long-poll handler, color/log utils
- manual: `output workflow monitor <id>` against a running workflow — attach mid-run, idle long-poll, continue-as-new follow, failure exit code

Local testing: 

- clone repo, checkout branch `out_482_workflow_monitor`
- in a terminal session (1), run: `$ ./run.sh dev`
- in another session, run a workflow and record the workflow ID:

```console
WORKFLOW_ID=$(curl -sS -f -X POST http://localhost:3001/workflow/start \
  -H "Content-Type: application/json" \
  -d '{"workflowName":"sleep","input":{"urls":["https://a.com","https://b.com","https://c.com","https://d.com"],"delayMs":5000}}' \
  | jq -er '.workflowId')
```

- use the `WORKFLOW_ID` in the `workflow monitor` command:

```console
output workflow monitor ${WORKFLOW_ID}
```

of use `json`: 

```console
output workflow monitor ${WORKFLOW_ID} --format json
```

Example plain:


https://github.com/user-attachments/assets/5ec87cc7-636c-424d-98df-b7a7edbcef57



Example JSON:


https://github.com/user-attachments/assets/84b7474c-5a02-4ad7-a364-a2a7a0cf1dfb

