### PR TITLE
refactor(core): Refactoring step call to remove workflow rewrite [OUT-488]

### DIFF
--- a/.changeset/lazy-suits-stop.md
+++ b/.changeset/lazy-suits-stop.md
@@ -4,22 +4,32 @@
 
 ## Workflow Activity Invocation
 
-- Refactored workflow activity invocation so steps, evaluators, and shared activities use the same runtime dispatcher instead of `this`-based handler dispatch.
-  Workflow handlers no longer need to be rewritten from arrow functions into regular functions for activity dispatch, reducing AST rewrite complexity during worker startup and making bundling more predictable.
+- Refactored workflow activity invocation so steps, evaluators, and shared activities use the same runtime dispatcher
+instead of `this`-based handler dispatch.
+
+  Workflow handlers no longer need to be rewritten from arrow functions into regular functions for activity dispatch,
+  reducing AST rewrite complexity during worker startup and making bundling more predictable.
+
+- Step and evaluator calls can now be placed in helper functions and imported helper modules used by a workflow.
+  Helpers no longer need to pass a workflow-bound `this` value through their call chain.
+
+## Child Workflow Activity Options
+
+- A child workflow's definition-level `options.activityOptions` now override activity options inherited from its parent. Invocation-level `activityOptions` still override both, and a step or evaluator's own `options.activityOptions` remain the most specific.
+
+- If a parent must override a child's retry or timeout configuration, pass `activityOptions` explicitly when invoking the child workflow.
 
 ## Shared Activity Namespaces
 
-- Removed the previous `"$shared"` activity namespace by registering shared activities into each workflow namespace.
-  This means workflows can call local and shared activities through the same activity resolution path.
+- Removed the previous `"$shared"` activity namespace by registering shared activities into each workflow namespace. This means workflows can call local and shared activities through the same activity resolution path.
 
-- Added validation that prevents workflow-scoped activities from using the same activity name as a shared activity.
-  If a workflow defines an activity with the same name as a shared activity, worker startup now fails validation instead of allowing ambiguous activity resolution.
+- Shared activity types now use `"<workflow-name>#<activity-name>"` instead of `"$shared#<activity-name>"`.
+
+- Added validation that prevents workflow-scoped activities from using the same activity name as a shared activity. If a workflow defines an activity with the same name as a shared activity, worker startup now fails validation instead of allowing ambiguous activity resolution.
 
 ## Workflow Code Validation
 
-- Added fail-fast validation for unsupported steps/evaluators export shapes.
-  Steps and evaluators already needed to be exposed through named exports for workflow rewriting.
-  The worker now fails fast with a validation error when steps/evaluators files use unsupported export shapes like default exports or `export *`.
+- Added fail-fast validation for default exports and `export *` declarations in steps/evaluators files. Steps and evaluators already needed to be exposed through named exports for workflow rewriting. The worker now reports these unsupported forms directly during startup.
 
   ```js
   // valid
@@ -30,8 +40,8 @@
   export * from './other_steps.js';
   ```
 
-- Added fail-fast validation for unsupported steps/evaluators import shapes.
-  Imports from steps/evaluators files already needed to use named imports or destructured requires for workflow rewriting.
+- Added fail-fast validation for unsupported steps/evaluators import shapes. Imports from steps/evaluators files already needed to use named imports or destructured requires for workflow rewriting.
+
   The worker now fails fast with a validation error for unsupported import shapes like default imports, namespace imports, or non-destructured requires.
 
   ```js

--- a/.changeset/lazy-suits-stop.md
+++ b/.changeset/lazy-suits-stop.md
@@ -1,0 +1,56 @@
+---
+"@outputai/core": minor
+---
+
+## Workflow Activity Invocation
+
+- Refactored workflow activity invocation so steps, evaluators, and shared activities use the same runtime dispatcher instead of `this`-based handler dispatch.
+  Workflow handlers no longer need to be rewritten from arrow functions into regular functions for activity dispatch, reducing AST rewrite complexity during worker startup and making bundling more predictable.
+
+## Shared Activity Namespaces
+
+- Removed the previous `"$shared"` activity namespace by registering shared activities into each workflow namespace.
+  This means workflows can call local and shared activities through the same activity resolution path.
+
+- Added validation that prevents workflow-scoped activities from using the same activity name as a shared activity.
+  If a workflow defines an activity with the same name as a shared activity, worker startup now fails validation instead of allowing ambiguous activity resolution.
+
+## Workflow Code Validation
+
+- Added fail-fast validation for unsupported steps/evaluators export shapes.
+  Steps and evaluators already needed to be exposed through named exports for workflow rewriting.
+  The worker now fails fast with a validation error when steps/evaluators files use unsupported export shapes like default exports or `export *`.
+
+  ```js
+  // valid
+  export const foo = step( { name: 'foo' } );
+
+  // invalid
+  export default step( { name: 'foo' } );
+  export * from './other_steps.js';
+  ```
+
+- Added fail-fast validation for unsupported steps/evaluators import shapes.
+  Imports from steps/evaluators files already needed to use named imports or destructured requires for workflow rewriting.
+  The worker now fails fast with a validation error for unsupported import shapes like default imports, namespace imports, or non-destructured requires.
+
+  ```js
+  // valid
+  import { foo } from './steps.js';
+  const { bar } = require( './evaluators.js' );
+
+  // invalid
+  import foo from './steps.js';
+  import * as steps from './steps.js';
+  const steps = require( './steps.js' );
+  ```
+
+- Added validation that activity calls must happen inside functions.
+  Calling a step or evaluator at module top level now fails validation.
+
+  ```js
+  import { foo } from './steps.js';
+
+  // invalid
+  foo();
+  ```

--- a/api/src/clients/temporal/workflow/reset.spec.js
+++ b/api/src/clients/temporal/workflow/reset.spec.js
@@ -60,21 +60,6 @@ describe( 'resolveResetEventId', () => {
     expect( resolveResetEventId( events, 'firstStep' ).toString() ).toBe( '13' );
   } );
 
-  it( 'matches shared-step activity names by suffix', async () => {
-    const events = [
-      event( 1, EventType.ACTIVITY_TASK_SCHEDULED, {
-        activityTaskScheduledEventAttributes: { activityType: { name: '$shared#commonStep' } }
-      } ),
-      event( 2, EventType.ACTIVITY_TASK_COMPLETED, {
-        activityTaskCompletedEventAttributes: { scheduledEventId: { toString: () => '1' } }
-      } ),
-      event( 3, EventType.WORKFLOW_TASK_COMPLETED )
-    ];
-    const { resolveResetEventId } = await import( './reset.js' );
-
-    expect( resolveResetEventId( events, 'commonStep' ).toString() ).toBe( '3' );
-  } );
-
   it( 'throws StepNotFoundError when the step was never scheduled', async () => {
     const { resolveResetEventId } = await import( './reset.js' );
 

--- a/docs/guides/migrations/index.mdx
+++ b/docs/guides/migrations/index.mdx
@@ -46,6 +46,6 @@ It reads the `@outputai/*` version in your `package.json`, finds the matching gu
     Trace destinations omit unavailable `local` and `remote` keys instead of returning `null`.
   </Card>
   <Card title="v0.10.0 → v0.11.0" href="/migrations/v0.10.0-to-v0.11.0">
-    API HTTP request logs change level by response status, rename `status` to `http.status_code`, and use a request summary message.
+    API request logging, Temporal rollout safety, shared activity names, and child workflow activity-option precedence.
   </Card>
 </CardGroup>

--- a/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
+++ b/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
@@ -1,11 +1,13 @@
 ---
 title: "v0.10.0 → v0.11.0"
-description: "Upgrading Output.ai projects from v0.10.0 to v0.11.0: the API HTTP request log format changed. Log level now derives from response status, the status field was renamed, and the log message is now a request summary."
+description: "Upgrading Output.ai projects from v0.10.0 to v0.11.0: API request logging, Temporal rollout safety, shared activity names, and child workflow activity-option precedence."
 ---
 
-This guide covers the HTTP request logging changes in `output-api` v0.11.0. The API server was refactored to remove the `morgan` dependency and emit richer request logs. The public HTTP API contract is unchanged, but the shape, level, and message of the per-request log lines the server emits are different. This only affects you if you consume `output-api` logs in an observability tool (Datadog, CloudWatch, Loki, etc.) or match on them in scripts.
+This guide covers customer-facing changes to API request logging in `output-api` and workflow execution in `@outputai/core`.
 
-## What changed
+## API HTTP request logging
+
+The API server was refactored to remove the `morgan` dependency and emit richer request logs. The public HTTP API contract is unchanged, but the shape, level, and message of the per-request log lines the server emits are different. This only affects you if you consume `output-api` logs in an observability tool (Datadog, CloudWatch, Loki, etc.) or match on them in scripts.
 
 ### Log level now derives from response status
 
@@ -46,7 +48,7 @@ Previously the message was the constant string `"HTTP request"`, with all detail
 + "responseTime": 12
 ```
 
-## Before and after
+### Before and after
 
 A successful request, before (v0.10.0):
 
@@ -104,16 +106,16 @@ After — logged at `error`, with the renamed field:
 }
 ```
 
-## Migration steps
+### Migration steps
 
-### Update alerts and level-based filters
+#### Update alerts and level-based filters
 
 If you alert or filter on winston levels, audit those rules. HTTP 4xx now arrives at `warn` and 5xx at `error`. Decide whether that is what you want:
 
 - To keep alerting only on application errors, scope alerts to exclude HTTP request logs (for example, filter on the presence of `http.status_code`).
 - To alert on failing requests, this is now available directly from the log level with no extra query.
 
-### Update queries and facets that reference `status`
+#### Update queries and facets that reference `status`
 
 Anywhere you query, facet, or dashboard on the request-log `status` field, switch to `http.status_code`.
 
@@ -125,17 +127,155 @@ Anywhere you query, facet, or dashboard on the request-log `status` field, switc
 
 In Datadog specifically, `http.status_code` is a standard attribute and maps to the built-in HTTP status facet, so you may be able to drop a custom `status` facet definition.
 
-### Update anything that matches the message string
+#### Update anything that matches the message string
 
 Scripts, log processors, or saved searches that match the literal message `"HTTP request"` will no longer match. Match on a structural field instead (for example, the presence of `http.status_code` or `requestId`), or update the matcher to the new summary format `<METHOD> <URL> <STATUS> <ms>ms`.
 
-### Adjust `responseTime` consumers expecting sub-millisecond precision
+#### Adjust `responseTime` consumers expecting sub-millisecond precision
 
 If a dashboard or aggregation relied on fractional milliseconds in `responseTime`, note that values are now whole milliseconds.
 
-## Checklist
+### API logging checklist
 
 - Review winston level-based alerts and filters; 4xx now logs at `warn`, 5xx at `error`.
 - Rename `status` to `http.status_code` in log queries, facets, and dashboards.
 - Replace any match on the constant message `"HTTP request"` with a structural field or the new summary format.
 - Confirm `responseTime` consumers tolerate integer milliseconds.
+
+## Workflow runtime changes
+
+This section covers the workflow execution changes in `@outputai/core` v0.11.0.
+
+### What changed
+
+- Steps, evaluators, and shared activities now use one workflow-scoped runtime dispatcher.
+- Shared activities are registered as `<workflow-name>#<activity-name>` instead of `$shared#<activity-name>`.
+- Child workflow invocation options are passed as workflow arguments instead of being propagated through Temporal memo.
+- A child workflow's definition-level `activityOptions` now override inherited parent options. Invocation-level and step-level options remain more specific.
+
+### Before upgrading running workers
+
+<Warning>
+Do not deploy v0.10.x and v0.11.0 workers to the same Temporal task queue, and do not replace a v0.10.x worker while affected workflow executions are still open.
+</Warning>
+
+The v0.11.0 runtime changes Temporal command attributes:
+
+- A shared activity previously scheduled as `$shared#send_event` is now scheduled as `lead_enrichment#send_event`.
+- A child workflow is now started with its invocation-level activity options in its argument payload instead of inherited through memo.
+
+Temporal replays a workflow's existing history when another worker processes it. If a v0.11.0 worker replays a history produced by v0.10.x and reaches one of these commands, the new command can differ from the recorded event. Temporal then reports a nondeterminism failure.
+
+A mixed-version rollout is also unsafe. The two versions use different memo and child-argument contracts, so an old parent and new child, or a new parent and old child, can lose inherited activity options even when replay does not fail immediately.
+
+#### Choose a safe rollout strategy
+
+Use one of these strategies before changing the worker version:
+
+1. **Drain the existing task queue.** Stop starting new workflows on the v0.10.x queue, wait for affected executions to complete, and then replace the worker.
+2. **Move v0.11.0 to a new task queue.** Keep the v0.10.x worker serving its existing queue while new executions are routed to a separate v0.11.0 queue.
+3. **Restart affected executions.** If an execution can be safely terminated and restarted from its original input or a checkpoint, restart it after the v0.11.0 cutover.
+
+At minimum, treat executions that call shared activities or child workflows as affected. Do not rely on a normal rolling restart on the same task queue.
+
+#### Update activity-type consumers
+
+Update dashboards, alerts, history processors, and scripts that match the old `$shared` activity prefix.
+
+##### Before
+
+```ts
+const isSharedActivity = activityType.startsWith( '$shared#' );
+```
+
+##### After
+
+Shared and local activities use the same workflow namespace. Match the full workflow activity type when possible:
+
+```ts
+const isSendEventActivity = activityType === 'lead_enrichment#send_event';
+```
+
+If the workflow name is not known:
+
+```ts
+const activityName = activityType.split( '#' ).at( -1 );
+const isSendEventActivity = activityName === 'send_event';
+```
+
+### Review child workflow activity options
+
+Activity options are merged from broad defaults to specific overrides. v0.11.0 changes the relative precedence of inherited parent options and the child workflow's definition.
+
+#### v0.10.x precedence
+
+1. Output's default activity options
+2. The child workflow's definition-level `options.activityOptions`
+3. Activity options inherited from the parent workflow
+4. The `activityOptions` passed to this child invocation
+5. The called step's own `options.activityOptions`
+
+#### v0.11.0 precedence
+
+1. Output's default activity options
+2. Activity options inherited from the parent workflow
+3. The child workflow's definition-level `options.activityOptions`
+4. The `activityOptions` passed to this child invocation
+5. The called step's own `options.activityOptions`
+
+This means a child definition now protects its own retry and timeout defaults from broader settings inherited through the parent.
+
+For example:
+
+```ts
+const childWorkflow = workflow( {
+  name: 'enrich_company',
+  options: {
+    activityOptions: {
+      retry: {
+        maximumAttempts: 2
+      }
+    }
+  },
+  async fn( input ) {
+    // ...
+  }
+} );
+```
+
+If the parent currently has `maximumAttempts: 8`, the child used 8 attempts in v0.10.x. In v0.11.0, the child uses 2 attempts.
+
+#### Preserve a parent-selected override
+
+Pass the policy on the child invocation when the parent must override the child's definition:
+
+```ts
+await childWorkflow(
+  { companyId: input.companyId },
+  {
+    activityOptions: {
+      retry: {
+        maximumAttempts: 8
+      }
+    }
+  }
+);
+```
+
+Invocation-level options remain more specific than inherited parent options and the child definition.
+
+Alternatively, remove the overlapping option from the child definition when the child should always inherit that field from its parent.
+
+<Note>
+Step-level `options.activityOptions` still have final precedence. Review step definitions as well as parent and child workflow definitions when calculating the effective policy.
+</Note>
+
+### Workflow runtime checklist
+
+- Inventory open v0.10.x executions that call shared activities or child workflows.
+- Drain the old task queue, keep a v0.10.x worker for old executions, or restart affected executions before the cutover.
+- Do not run v0.10.x and v0.11.0 workers on the same Temporal task queue.
+- Update dashboards and history tooling that match `$shared#<activity-name>`.
+- Audit parent and child workflows that configure the same retry or timeout fields.
+- Pass `activityOptions` on child invocations where the parent must override the child's definition.
+- Update tests that assert inherited parent options override child definition options.

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -15,6 +15,9 @@
       "types": "./src/hooks/index.d.ts",
       "import": "./src/hooks/index.js"
     },
+    "./invoker": {
+      "import": "./src/interface/invoker.js"
+    },
     "./sdk/helpers": {
       "types": "./src/sdk/helpers/index.d.ts",
       "import": "./src/sdk/helpers/index.js"

--- a/sdk/core/package.json
+++ b/sdk/core/package.json
@@ -15,9 +15,6 @@
       "types": "./src/hooks/index.d.ts",
       "import": "./src/hooks/index.js"
     },
-    "./invoker": {
-      "import": "./src/interface/invoker.js"
-    },
     "./sdk/helpers": {
       "types": "./src/sdk/helpers/index.d.ts",
       "import": "./src/sdk/helpers/index.js"

--- a/sdk/core/src/consts.js
+++ b/sdk/core/src/consts.js
@@ -4,7 +4,6 @@ export const ACTIVITY_SEND_HTTP_REQUEST = '__internal#sendHttpRequest';
 export const ACTIVITY_WRAPPER_VERSION_FIELD = '__output_activity_wrapper_version';
 export const ACTIVITY_LOGGER_SYMBOL = Symbol.for( '__activity_logger' );
 export const METADATA_ACCESS_SYMBOL = Symbol( '__metadata' );
-export const SHARED_STEP_PREFIX = '$shared';
 export const WORKFLOW_CATALOG = '$catalog';
 export const WORKFLOWS_INDEX_FILENAME = '__workflows_entrypoint.js';
 export const WORKFLOW_WRAPPER_VERSION_FIELD = '__output_workflow_wrapper_version';

--- a/sdk/core/src/consts.js
+++ b/sdk/core/src/consts.js
@@ -8,6 +8,8 @@ export const WORKFLOW_CATALOG = '$catalog';
 export const WORKFLOWS_INDEX_FILENAME = '__workflows_entrypoint.js';
 export const WORKFLOW_WRAPPER_VERSION_FIELD = '__output_workflow_wrapper_version';
 
+export const INVOKE_ACTIVITY_SYMBOL = Symbol.for( '@outputai/core:__invoke_activity' );
+
 export const ComponentType = {
   EVALUATOR: 'evaluator',
   INTERNAL_STEP: 'internal_step',

--- a/sdk/core/src/helpers/object.js
+++ b/sdk/core/src/helpers/object.js
@@ -59,18 +59,24 @@ export const deepMergeWithResolver = ( a, b, resolver ) => {
 };
 
 /**
- * Creates a new object merging object "b" onto object "a" biased to "b":
- * - Object "b" will overwrite fields on object "a";
- * - Object "b" fields that don't exist on object "a" will be added;
- * - Object "a" fields that don't exist on object "b" will be preserved;
+ * Creates a new object recursively merging the rightmost object over the previous one.
+ * Give two objects, (L)eft and (R)right
+ * - Object "R" will overwrite fields on object "L";
+ * - Object "R" fields that don't exist on object "L" will be added;
+ * - Object "L" fields that don't exist on object "R" will be preserved;
  *
- * If "b" isn't an object, a new object equal to "a" is returned
+ * If "R" isn't an object, a new object equal to "L" is returned
  *
  * @param {object} a - The base object
  * @param {object} b - The target object
  * @returns {object} A new object
  */
-export const deepMerge = ( a, b ) => deepMergeWithResolver( a, b, ( _, b ) => b );
+export const deepMerge = ( base, ...rest ) => {
+  if ( !isPlainObject( base ) ) {
+    throw new Error( 'First argument is not an object.' );
+  }
+  return rest.reduce( ( merged, o ) => deepMergeWithResolver( merged, o, ( _, b ) => b ), base );
+};
 
 /**
  * Adds an non-writable, non-configurable and non-enumerable property to an object

--- a/sdk/core/src/helpers/object.js
+++ b/sdk/core/src/helpers/object.js
@@ -44,7 +44,11 @@ export const deepMergeWithResolver = ( base, ...args ) => {
   const resolver = args.at( -1 );
 
   if ( !isPlainObject( base ) ) {
-    throw new Error( 'First argument is not an object.' );
+    throw new Error( 'First argument (base object) is not an object.' );
+  }
+
+  if ( typeof resolver !== 'function' ) {
+    throw new Error( 'Last argument (resolver) is not a function.' );
   }
 
   return objects.reduce( ( merged, object ) => {

--- a/sdk/core/src/helpers/object.js
+++ b/sdk/core/src/helpers/object.js
@@ -24,38 +24,45 @@ export const clone = v => {
 };
 
 /**
- * Creates a new object merging object "b" onto object "a", using a resolver function to define the value to keep.
- * - Object "b" fields that also exists on "a" will have their value defined by the "resolver" function
- * - Object "b" fields that don't exist on object "a" will be added;
- * - Object "a" fields that don't exist on object "b" will be preserved;
+ * Creates a new object recursively merging the rightmost object over the previous one using a resolver function.
+ * Give two objects, (L)eft and (R)right
+ * - Object "R" will overwrite fields on object "L" based on the result of the resolver function;
+ * - Object "R" fields that don't exist on object "L" will be added;
+ * - Object "L" fields that don't exist on object "R" will be preserved;
  *
- * If "b" isn't an object, a new object equal to "a" is returned
+ * If "R" isn't an object, a new object equal to "L" is returned.
  *
- * @param {object} a - The base object
- * @param {object} b - The target object
- * @param {function} resolver - A function that return the value to be kept. First argument is value a, second is value b
+ * The resolver function will define the final value of the merge, it receives two args value "L" and "R".
+ *
+ *
+ * @param {object} base - The base object
+ * @param {...(object|function)} args - Target objects followed by the resolver function
  * @returns {object} A new object
  */
-export const deepMergeWithResolver = ( a, b, resolver ) => {
-  if ( !isPlainObject( a ) ) {
-    throw new Error( 'Parameter "a" is not an object.' );
+export const deepMergeWithResolver = ( base, ...args ) => {
+  const objects = args.slice( 0, -1 );
+  const resolver = args.at( -1 );
+
+  if ( !isPlainObject( base ) ) {
+    throw new Error( 'First argument is not an object.' );
   }
-  if ( !isPlainObject( b ) ) {
-    return clone( a );
-  }
-  return Object.entries( b ).reduce( ( obj, [ k, v ] ) =>
-    Object.assign( obj, {
-      [k]: ( () => {
-        if ( isPlainObject( v ) && isPlainObject( a[k] ) ) {
-          return deepMergeWithResolver( a[k], v, resolver );
-        }
-        if ( Object.hasOwn( a, k ) ) {
-          return resolver( a[k], v );
-        }
-        return v;
-      } )()
-    } )
-  , clone( a ) );
+
+  return objects.reduce( ( merged, object ) => {
+    if ( !isPlainObject( object ) ) {
+      return merged;
+    }
+
+    for ( const [ k, v ] of Object.entries( object ) ) {
+      if ( isPlainObject( v ) && isPlainObject( merged[k] ) ) {
+        merged[k] = deepMergeWithResolver( merged[k], v, resolver );
+      } else if ( Object.hasOwn( merged, k ) ) {
+        merged[k] = resolver( merged[k], v );
+      } else {
+        merged[k] = v;
+      }
+    }
+    return merged;
+  }, clone( base ) );
 };
 
 /**
@@ -65,18 +72,14 @@ export const deepMergeWithResolver = ( a, b, resolver ) => {
  * - Object "R" fields that don't exist on object "L" will be added;
  * - Object "L" fields that don't exist on object "R" will be preserved;
  *
- * If "R" isn't an object, a new object equal to "L" is returned
+ * If "R" isn't an object, a new object equal to "L" is returned.
  *
- * @param {object} a - The base object
- * @param {object} b - The target object
+ * @param {object} base - The base object
+ * @param {...object} rest - The target objects
  * @returns {object} A new object
  */
-export const deepMerge = ( base, ...rest ) => {
-  if ( !isPlainObject( base ) ) {
-    throw new Error( 'First argument is not an object.' );
-  }
-  return rest.reduce( ( merged, o ) => deepMergeWithResolver( merged, o, ( _, b ) => b ), base );
-};
+export const deepMerge = ( base, ...rest ) =>
+  deepMergeWithResolver( base, ...rest, ( _, b ) => b );
 
 /**
  * Adds an non-writable, non-configurable and non-enumerable property to an object

--- a/sdk/core/src/helpers/object.js
+++ b/sdk/core/src/helpers/object.js
@@ -75,7 +75,7 @@ export const deepMerge = ( a, b ) => deepMergeWithResolver( a, b, ( _, b ) => b 
 /**
  * Adds an non-writable, non-configurable and non-enumerable property to an object
  * @param {object} obj
- * @param {string} key
+ * @param {string|Symbol} key
  * @param {any} value
  * @returns
  */

--- a/sdk/core/src/helpers/object.spec.js
+++ b/sdk/core/src/helpers/object.spec.js
@@ -224,6 +224,11 @@ describe( 'deepMergeWithResolver', () => {
     expect( () => deepMergeWithResolver( 'a', {}, ( x, y ) => x + y ) ).toThrow( Error );
   } );
 
+  it( 'throws when last argument is not a resolver function', () => {
+    expect( () => deepMergeWithResolver( { a: 1 }, { a: 2 } ) )
+      .toThrow( 'Last argument (resolver) is not a function.' );
+  } );
+
   it( 'merges multiple objects using the resolver from left to right', () => {
     const resolver = vi.fn( ( x, y ) => `${ x }:${ y }` );
 

--- a/sdk/core/src/helpers/object.spec.js
+++ b/sdk/core/src/helpers/object.spec.js
@@ -95,98 +95,86 @@ describe( 'clone', () => {
 } );
 
 describe( 'deepMerge', () => {
-  it( 'Overwrites properties in object "a"', () => {
+  it( 'returns a clone when only the base object is provided', () => {
     const a = {
-      a: 1,
-      b: {
-        c: 2
-      }
+      nested: { value: 1 }
     };
-    const b = {
-      a: false,
-      b: {
-        c: true
-      }
-    };
-    expect( deepMerge( a, b ) ).toEqual( {
-      a: false,
-      b: {
-        c: true
-      }
+    const result = deepMerge( a );
+
+    a.nested.value = 2;
+
+    expect( result ).toEqual( {
+      nested: { value: 1 }
     } );
-  } );
-
-  it( 'Adds properties existing in "b" but absent in "a"', () => {
-    const a = {
-      a: 1
-    };
-    const b = {
-      a: false,
-      b: true
-    };
-    expect( deepMerge( a, b ) ).toEqual( {
-      a: false,
-      b: true
-    } );
-  } );
-
-  it( 'Keep extra properties in "a"', () => {
-    const a = {
-      a: 1
-    };
-    const b = {
-      b: true
-    };
-    expect( deepMerge( a, b ) ).toEqual( {
-      a: 1,
-      b: true
-    } );
-  } );
-
-  it( 'Merge object is a clone', () => {
-    const a = {
-      a: 1
-    };
-    const b = {
-      b: 1
-    };
-    const result = deepMerge( a, b );
-    a.a = 2;
-    b.b = 2;
-    expect( result.a ).toEqual( 1 );
-  } );
-
-  it( 'Returns copy of "a" if "b" is not an object', () => {
-    const a = {
-      a: 1
-    };
-    expect( deepMerge( a, null ) ).toEqual( { a: 1 } );
-    expect( deepMerge( a, undefined ) ).toEqual( { a: 1 } );
-  } );
-
-  it( 'Copy of object "a" is a clone', () => {
-    const a = {
-      a: 1
-    };
-    const result = deepMerge( a, null );
-    a.a = 2;
-    expect( result.a ).toEqual( 1 );
   } );
 
   it( 'Throws when first argument is not a plain object', () => {
-    expect( () => deepMerge( Function ) ).toThrow( Error );
-    expect( () => deepMerge( () => {} ) ).toThrow( Error );
-    expect( () => deepMerge( 'a' ) ).toThrow( Error );
-    expect( () => deepMerge( true ) ).toThrow( Error );
-    expect( () => deepMerge( /a/ ) ).toThrow( Error );
-    expect( () => deepMerge( [] ) ).toThrow( Error );
-    expect( () => deepMerge( class Foo {}, class Foo {} ) ).toThrow( Error );
-    expect( () => deepMerge( Number.constructor, Number.constructor ) ).toThrow( Error );
-    expect( () => deepMerge( Number.constructor.prototype, Number.constructor.prototype ) ).toThrow( Error );
+    expect( () => deepMerge( null ) ).toThrow( Error );
+  } );
+
+  it( 'merges multiple objects from left to right using rightmost values', () => {
+    expect( deepMerge(
+      {
+        a: 1,
+        nested: {
+          a: 'base',
+          kept: true
+        }
+      },
+      {
+        b: 2,
+        nested: {
+          a: 'first',
+          b: 'first'
+        }
+      },
+      {
+        a: 3,
+        nested: {
+          b: 'second',
+          c: 'second'
+        }
+      }
+    ) ).toEqual( {
+      a: 3,
+      b: 2,
+      nested: {
+        a: 'first',
+        b: 'second',
+        c: 'second',
+        kept: true
+      }
+    } );
+  } );
+
+  it( 'ignores non-object values among multiple overlays', () => {
+    expect( deepMerge(
+      { a: 1 },
+      null,
+      { b: 2 },
+      undefined,
+      { a: 3 }
+    ) ).toEqual( {
+      a: 3,
+      b: 2
+    } );
   } );
 } );
 
 describe( 'deepMergeWithResolver', () => {
+  it( 'returns a clone when only the base object and resolver are provided', () => {
+    const a = {
+      nested: { value: 1 }
+    };
+    const result = deepMergeWithResolver( a, ( x, y ) => x + y );
+
+    a.nested.value = 2;
+
+    expect( result ).toEqual( {
+      nested: { value: 1 }
+    } );
+  } );
+
   it( 'uses resolver for existing leaf values, including nested leaves', () => {
     const a = {
       cost: { total: 1 },
@@ -234,6 +222,61 @@ describe( 'deepMergeWithResolver', () => {
     expect( () => deepMergeWithResolver( null, {}, ( x, y ) => x + y ) ).toThrow( Error );
     expect( () => deepMergeWithResolver( [], {}, ( x, y ) => x + y ) ).toThrow( Error );
     expect( () => deepMergeWithResolver( 'a', {}, ( x, y ) => x + y ) ).toThrow( Error );
+  } );
+
+  it( 'merges multiple objects using the resolver from left to right', () => {
+    const resolver = vi.fn( ( x, y ) => `${ x }:${ y }` );
+
+    expect( deepMergeWithResolver(
+      {
+        a: 'base',
+        nested: {
+          count: 1,
+          kept: 'yes'
+        }
+      },
+      {
+        a: 'first',
+        nested: {
+          count: 2,
+          firstOnly: true
+        }
+      },
+      {
+        a: 'second',
+        nested: {
+          count: 3,
+          secondOnly: true
+        }
+      },
+      resolver
+    ) ).toEqual( {
+      a: 'base:first:second',
+      nested: {
+        count: '1:2:3',
+        firstOnly: true,
+        kept: 'yes',
+        secondOnly: true
+      }
+    } );
+    expect( resolver ).toHaveBeenCalledTimes( 4 );
+  } );
+
+  it( 'ignores non-object values among multiple resolver overlays', () => {
+    const resolver = vi.fn( ( x, y ) => x + y );
+
+    expect( deepMergeWithResolver(
+      { a: 1 },
+      null,
+      { a: 2 },
+      undefined,
+      { b: 3 },
+      resolver
+    ) ).toEqual( {
+      a: 3,
+      b: 3
+    } );
+    expect( resolver ).toHaveBeenCalledOnce();
   } );
 } );
 

--- a/sdk/core/src/interface/invoker.js
+++ b/sdk/core/src/interface/invoker.js
@@ -1,5 +1,0 @@
-// Internal subpath used by generated workflow code. Importing from ./workflow.js
-// keeps this dispatcher on the same ESM module instance as the public workflow() export.
-import { __invokeActivity } from './workflow.js';
-
-export { __invokeActivity };

--- a/sdk/core/src/interface/invoker.js
+++ b/sdk/core/src/interface/invoker.js
@@ -1,0 +1,5 @@
+// Internal subpath used by generated workflow code. Importing from ./workflow.js
+// keeps this dispatcher on the same ESM module instance as the public workflow() export.
+import { __invokeActivity } from './workflow.js';
+
+export { __invokeActivity };

--- a/sdk/core/src/interface/workflow.js
+++ b/sdk/core/src/interface/workflow.js
@@ -7,16 +7,15 @@ import { TraceInfo } from '#helpers/trace_info';
 import { deepMerge } from '#helpers/object';
 import { defaultOptions } from './workflow_activity_options.js';
 import { createWorkflow } from '#helpers/component';
-import {
-  ACTIVITY_GET_TRACE_DESTINATIONS,
-  METADATA_ACCESS_SYMBOL,
-  SHARED_STEP_PREFIX,
-  WORKFLOW_WRAPPER_VERSION_FIELD
-} from '#consts';
+import { ACTIVITY_GET_TRACE_DESTINATIONS, METADATA_ACCESS_SYMBOL, WORKFLOW_WRAPPER_VERSION_FIELD } from '#consts';
 
-/**
- * Create a new workflow and return a wrapper function around its fn handler
- */
+const state = { activities: null, namespace: null };
+
+/** Invokes an activity in this workflow execution context */
+export const __invokeActivity = async ( name, ...args ) =>
+  state.activities[`${state.namespace}#${name}`]( ...args ).then( r => r.output );
+
+/** Create a new workflow and return a wrapper function around its fn handler */
 export function workflow( { name, description, inputSchema, outputSchema, fn, options = {}, aliases = [] } ) {
   WorkflowValidator.validateDefinition( { name, description, inputSchema, outputSchema, fn, options, aliases } );
 
@@ -72,29 +71,18 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
         memo.traceInfo = TraceInfo.build();
       }
 
-      const steps = proxyActivities( memo.activityOptions );
+      state.namespace = name;
+      state.activities = proxyActivities( memo.activityOptions );
+
       const traceDestinations = isRoot && {
         trace: {
-          destinations: disableTrace ? {} : ( await steps[ACTIVITY_GET_TRACE_DESTINATIONS]( memo.traceInfo ) ).output ?? {}
+          destinations: disableTrace ? {} : await state.activities[ACTIVITY_GET_TRACE_DESTINATIONS]( memo.traceInfo ).then( r => r.output ) ?? {}
         }
       };
 
       try {
         validator.validateInput( input );
-
-        // Creates an activity caller based on a prefix
-        const createCaller = prefix => async ( t, ...args ) => ( await steps[`${prefix}#${t}`]( ...args ) ).output;
-
-        // This are functions used by the AST to replace direct activity (step/evaluator) calls
-        const dispatchers = {
-          invokeStep: createCaller( name ),
-          invokeSharedStep: createCaller( SHARED_STEP_PREFIX ),
-          invokeEvaluator: createCaller( name ),
-          invokeSharedEvaluator: createCaller( SHARED_STEP_PREFIX )
-        };
-
-        // The workflow function execution with "this" set with the dispatchers
-        const output = await fn.call( dispatchers, input, WorkflowContext.build() );
+        const output = await fn( input, WorkflowContext.build() );
         validator.validateOutput( output );
 
         return { [WORKFLOW_WRAPPER_VERSION_FIELD]: 1, output, ...traceDestinations };

--- a/sdk/core/src/interface/workflow.js
+++ b/sdk/core/src/interface/workflow.js
@@ -7,19 +7,14 @@ import { TraceInfo } from '#helpers/trace_info';
 import { deepMerge } from '#helpers/object';
 import { defaultOptions } from './workflow_activity_options.js';
 import { createWorkflow } from '#helpers/component';
-import { ACTIVITY_GET_TRACE_DESTINATIONS, METADATA_ACCESS_SYMBOL, WORKFLOW_WRAPPER_VERSION_FIELD } from '#consts';
-
-const state = { activities: null, namespace: null };
-
-/** Invokes an activity in this workflow execution context */
-export const __invokeActivity = async ( name, ...args ) =>
-  state.activities[`${state.namespace}#${name}`]( ...args ).then( r => r.output );
+import * as C from '#consts';
 
 /** Create a new workflow and return a wrapper function around its fn handler */
 export function workflow( { name, description, inputSchema, outputSchema, fn, options = {}, aliases = [] } ) {
   WorkflowValidator.validateDefinition( { name, description, inputSchema, outputSchema, fn, options, aliases } );
 
-  const { disableTrace, activityOptions } = deepMerge( defaultOptions, options );
+  // Disable trace can only be defined at the definition level
+  const disableTrace = options.disableTrace ?? defaultOptions.disableTrace;
   const validator = new WorkflowValidator( { name, inputSchema, outputSchema } );
 
   return createWorkflow( {
@@ -29,54 +24,60 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
     outputSchema,
     options,
     aliases,
-    handler: async ( input, extra = {} ) => {
-      validator.validateInvocationOptions( extra );
+    handler: async ( input, invocationOptions = {} ) => {
+      validator.validateInvocationOptions( invocationOptions );
 
-      // this returns a plain function, for example, in unit tests
+      // If called outside Temporal workflow context, just execute the handler function
+      // This is important to allow for workflows to have unit tests
       if ( !inWorkflowContext() ) {
         validator.validateInput( input );
-        const output = await fn( input, deepMerge( WorkflowContext.build(), extra?.context ) );
+        const output = await fn( input, deepMerge( WorkflowContext.build(), invocationOptions?.context ) );
         validator.validateOutput( output );
         return output;
       }
 
       const { workflowId, memo, root } = workflowInfo();
 
-      // if the stack already includes this workflowId, means the workflow() function was called
-      // from within a running workflow, meaning it is suppose to start a child workflow
-      const isChild = Array.isArray( memo.stack ) ? memo.stack.includes( workflowId ) : false;
+      // Resolve the activity options:
+      // invocation options > parent options (memo) > definition options > default options
+      const activityOptions = deepMerge(
+        defaultOptions.activityOptions, // default
+        options?.activityOptions, // definition options
+        memo.activityOptions, // parent options
+        invocationOptions.activityOptions // invocation options
+      );
 
-      if ( isChild ) {
-        const result = await executeChild( name, {
+      // If the parent workflow already installed the activity dispatcher,
+      // this means that other calls to workflow() are suppose to start child workflows
+      const isChildWorkflowCall = !!globalThis[C.INVOKE_ACTIVITY_SYMBOL];
+      if ( isChildWorkflowCall ) {
+        return executeChild( name, {
           args: undefined === input ? [] : [ input ],
           workflowId: `${workflowId}-${toUrlSafeBase64( uuid4() )}`,
-          parentClosePolicy: ParentClosePolicy[extra?.detached ? 'ABANDON' : 'TERMINATE'],
-          memo: {
-            ...memo, // Preserve memo and mix activityOptions, if provided
-            ...( extra?.activityOptions && {
-              activityOptions: deepMerge( memo?.activityOptions ?? {}, extra?.activityOptions )
-            } )
-          }
-        } );
-        return result.output;
+          parentClosePolicy: ParentClosePolicy[invocationOptions?.detached ? 'ABANDON' : 'TERMINATE'],
+          memo: { ...memo, activityOptions }
+        } ).then( r => r.output );
       }
 
-      const isRoot = !root;
+      const isRoot = !root; // Check if this is the root most workflow
 
-      memo.stack = [ ...memo.stack ?? [], workflowId ];
-      // Parent options have prevalence on nested calls, child will be overwritten
-      memo.activityOptions = deepMerge( activityOptions, memo.activityOptions );
       // Trace info is only added in the root and only when trace is not disabled
       if ( isRoot && !disableTrace ) {
         memo.traceInfo = TraceInfo.build();
       }
+      // Set this execution activity options in memo, so the interceptor can access it to apply per-activity overrides.
+      memo.activityOptions = activityOptions;
 
-      state.namespace = name;
-      state.activities = proxyActivities( memo.activityOptions );
+      const activities = proxyActivities( activityOptions );
+
+      // Add a global var to be used to invoke activities. This is rewritten in the code by the webpack loader
+      // Note: Keep this as a configurable global assignment so Temporal's reusable VM can delete it when switching workflow scopes.
+      globalThis[C.INVOKE_ACTIVITY_SYMBOL] = async ( activityType, ...args ) =>
+        activities[`${name}#${activityType}`]( ...args ).then( r => r.output );
 
       const traceDestinations = isRoot && {
         trace: {
-          destinations: disableTrace ? {} : await state.activities[ACTIVITY_GET_TRACE_DESTINATIONS]( memo.traceInfo ).then( r => r.output ) ?? {}
+          destinations: disableTrace ? {} : await activities[C.ACTIVITY_GET_TRACE_DESTINATIONS]( memo.traceInfo ).then( r => r.output ) ?? {}
         }
       };
 
@@ -85,11 +86,11 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
         const output = await fn( input, WorkflowContext.build() );
         validator.validateOutput( output );
 
-        return { [WORKFLOW_WRAPPER_VERSION_FIELD]: 1, output, ...traceDestinations };
+        return { [C.WORKFLOW_WRAPPER_VERSION_FIELD]: 1, output, ...traceDestinations };
       } catch ( error ) {
         if ( traceDestinations ) {
           // Append the trace destinations so it is carried to interceptor
-          error[METADATA_ACCESS_SYMBOL] = traceDestinations;
+          error[C.METADATA_ACCESS_SYMBOL] = traceDestinations;
         }
         throw error;
       }

--- a/sdk/core/src/interface/workflow.js
+++ b/sdk/core/src/interface/workflow.js
@@ -7,7 +7,41 @@ import { TraceInfo } from '#helpers/trace_info';
 import { deepMerge } from '#helpers/object';
 import { defaultOptions } from './workflow_activity_options.js';
 import { createWorkflow } from '#helpers/component';
+import { FatalError } from '#errors';
 import * as C from '#consts';
+
+/**
+ * Execute the workflow without temporal, using the fn handler function.
+ * This is important to allow for workflows to have unit tests
+ */
+const executeWithoutTemporal = async ( { input, validator, handler, contextOverrides = {} } ) => {
+  validator.validateInput( input );
+  const output = await handler( input, deepMerge( WorkflowContext.build(), contextOverrides ) );
+  validator.validateOutput( output );
+  return output;
+};
+
+/**
+ * Add a global dispatcher function to be used to invoke activities.
+ * This will replace direct activity invocation in the user code by the webpack loader.
+ *
+ * Important: Keep this as a configurable global assignment (configurable=true, enumerable=true),
+ * so Temporal's reusable VM can delete it when switching workflow scopes.
+ */
+const createGlobalDispatcher = ( { runId, workflowType, activities } ) => {
+  const dispatcher = async ( activityType, ...args ) => activities[`${workflowType}#${activityType}`]( ...args ).then( r => r.output );
+  dispatcher.runId = runId;
+  globalThis[C.INVOKE_ACTIVITY_SYMBOL] = dispatcher;
+};
+
+/**  Validate if the global dispatcher wasn't set by another workflow, indicating global context contamination. */
+const checkGlobalContextContamination = runId => {
+  const globalContextRunId = globalThis?.[C.INVOKE_ACTIVITY_SYMBOL]?.runId;
+  if ( globalContextRunId && globalContextRunId !== runId ) {
+    throw new FatalError( 'Contamination of the workflow Node global context.' +
+      ` Var "globalThis[${String( C.INVOKE_ACTIVITY_SYMBOL )}]" was set by another workflow (${globalContextRunId})` );
+  }
+};
 
 /** Create a new workflow and return a wrapper function around its fn handler */
 export function workflow( { name, description, inputSchema, outputSchema, fn, options = {}, aliases = [] } ) {
@@ -17,83 +51,67 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
   const disableTrace = options.disableTrace ?? defaultOptions.disableTrace;
   const validator = new WorkflowValidator( { name, inputSchema, outputSchema } );
 
-  return createWorkflow( {
-    name,
-    description,
-    inputSchema,
-    outputSchema,
-    options,
-    aliases,
-    handler: async ( input, invocationOptions = {} ) => {
-      validator.validateInvocationOptions( invocationOptions );
+  const handler = async ( input, invocationOptions = {} ) => {
+    validator.validateInvocationOptions( invocationOptions );
 
-      // If called outside Temporal workflow context, just execute the handler function
-      // This is important to allow for workflows to have unit tests
-      if ( !inWorkflowContext() ) {
-        validator.validateInput( input );
-        const output = await fn( input, deepMerge( WorkflowContext.build(), invocationOptions?.context ) );
-        validator.validateOutput( output );
-        return output;
-      }
-
-      const { workflowId, memo, root } = workflowInfo();
-
-      // Resolve the activity options:
-      // invocation options > parent options (memo) > definition options > default options
-      const activityOptions = deepMerge(
-        defaultOptions.activityOptions, // default
-        options?.activityOptions, // definition options
-        memo.activityOptions, // parent options
-        invocationOptions.activityOptions // invocation options
-      );
-
-      // If the parent workflow already installed the activity dispatcher,
-      // this means that other calls to workflow() are suppose to start child workflows
-      const isChildWorkflowCall = !!globalThis[C.INVOKE_ACTIVITY_SYMBOL];
-      if ( isChildWorkflowCall ) {
-        return executeChild( name, {
-          args: undefined === input ? [] : [ input ],
-          workflowId: `${workflowId}-${toUrlSafeBase64( uuid4() )}`,
-          parentClosePolicy: ParentClosePolicy[invocationOptions?.detached ? 'ABANDON' : 'TERMINATE'],
-          memo: { ...memo, activityOptions }
-        } ).then( r => r.output );
-      }
-
-      const isRoot = !root; // Check if this is the root most workflow
-
-      // Trace info is only added in the root and only when trace is not disabled
-      if ( isRoot && !disableTrace ) {
-        memo.traceInfo = TraceInfo.build();
-      }
-      // Set this execution activity options in memo, so the interceptor can access it to apply per-activity overrides.
-      memo.activityOptions = activityOptions;
-
-      const activities = proxyActivities( activityOptions );
-
-      // Add a global var to be used to invoke activities. This is rewritten in the code by the webpack loader
-      // Note: Keep this as a configurable global assignment so Temporal's reusable VM can delete it when switching workflow scopes.
-      globalThis[C.INVOKE_ACTIVITY_SYMBOL] = async ( activityType, ...args ) =>
-        activities[`${name}#${activityType}`]( ...args ).then( r => r.output );
-
-      const traceDestinations = isRoot && {
-        trace: {
-          destinations: disableTrace ? {} : await activities[C.ACTIVITY_GET_TRACE_DESTINATIONS]( memo.traceInfo ).then( r => r.output ) ?? {}
-        }
-      };
-
-      try {
-        validator.validateInput( input );
-        const output = await fn( input, WorkflowContext.build() );
-        validator.validateOutput( output );
-
-        return { [C.WORKFLOW_WRAPPER_VERSION_FIELD]: 1, output, ...traceDestinations };
-      } catch ( error ) {
-        if ( traceDestinations ) {
-          // Append the trace destinations so it is carried to interceptor
-          error[C.METADATA_ACCESS_SYMBOL] = traceDestinations;
-        }
-        throw error;
-      }
+    // If called outside Temporal workflow context, just execute the handler function
+    if ( !inWorkflowContext() ) {
+      return executeWithoutTemporal( { input, validator, handler: fn, contextOverrides: invocationOptions?.context } );
     }
-  } );
+
+    const { workflowId, runId, memo, root } = workflowInfo();
+
+    checkGlobalContextContamination( runId );
+
+    // If the parent workflow already installed the activity dispatcher, it means that calls to workflow() will trigger child workflows
+    const isChildWorkflowCall = !!globalThis[C.INVOKE_ACTIVITY_SYMBOL];
+    if ( isChildWorkflowCall ) {
+      const parentClosePolicy = ParentClosePolicy[invocationOptions?.detached ? 'ABANDON' : 'TERMINATE'];
+      const childWorkflowId = `${workflowId}-${toUrlSafeBase64( uuid4() )}`;
+      const args = [ input, { activityOptions: invocationOptions?.activityOptions } ];
+      return executeChild( name, { args, workflowId: childWorkflowId, parentClosePolicy, memo } ).then( r => r.output );
+    }
+
+    const isRoot = !root; // Check if this is the root most workflow
+
+    // Trace info is only added in the root and only when trace is not disabled
+    if ( isRoot && !disableTrace ) {
+      memo.traceInfo = TraceInfo.build();
+    }
+
+    // Resolve the activity options: invocation options > definition options > parent options > default options
+    const activityOptions = deepMerge(
+      defaultOptions.activityOptions, // default
+      memo?.parentActivityOptions, // parent options
+      options?.activityOptions, // definition options
+      invocationOptions.activityOptions // invocation options
+    );
+    // Resolved activity options are added to memo so child workflow executions can continue the policy chain.
+    memo.parentActivityOptions = activityOptions;
+    const activities = proxyActivities( activityOptions );
+
+    createGlobalDispatcher( { runId, workflowType: name, activities } );
+
+    const traceDestinations = isRoot && {
+      trace: {
+        destinations: disableTrace ? {} : await activities[C.ACTIVITY_GET_TRACE_DESTINATIONS]( memo.traceInfo ).then( r => r.output ) ?? {}
+      }
+    };
+
+    try {
+      validator.validateInput( input );
+      const output = await fn( input, WorkflowContext.build() );
+      validator.validateOutput( output );
+
+      return { [C.WORKFLOW_WRAPPER_VERSION_FIELD]: 1, output, ...traceDestinations };
+    } catch ( error ) {
+      if ( traceDestinations ) {
+        // Append the trace destinations so it is carried to interceptor
+        error[C.METADATA_ACCESS_SYMBOL] = traceDestinations;
+      }
+      throw error;
+    }
+  };
+
+  return createWorkflow( { name, description, inputSchema, outputSchema, options, aliases, handler } );
 }

--- a/sdk/core/src/interface/workflow.spec.js
+++ b/sdk/core/src/interface/workflow.spec.js
@@ -4,7 +4,6 @@ import {
   ACTIVITY_GET_TRACE_DESTINATIONS,
   ACTIVITY_WRAPPER_VERSION_FIELD,
   METADATA_ACCESS_SYMBOL,
-  SHARED_STEP_PREFIX,
   WORKFLOW_WRAPPER_VERSION_FIELD
 } from '#consts';
 import { ValidationError } from '#errors';
@@ -532,8 +531,8 @@ describe( 'workflow()', () => {
   } );
 
   describe( 'activity dispatchers', () => {
-    it( 'invokes workflow-scoped steps and evaluators and unwraps activity output', async () => {
-      const { workflow } = await import( './workflow.js' );
+    it( 'invokes workflow-scoped activities and unwraps activity output', async () => {
+      const { workflow, __invokeActivity } = await import( './workflow.js' );
       setWorkflowInfo( { workflowType: 'dispatch_wf' } );
       const step = vi.fn().mockResolvedValue( activityOutput( 'step-output' ) );
       const evaluator = vi.fn().mockResolvedValue( activityOutput( 'eval-output' ) );
@@ -546,10 +545,10 @@ describe( 'workflow()', () => {
       const wf = workflow( workflowDefinition( {
         name: 'dispatch_wf',
         outputSchema: z.object( { stepResult: z.string(), evalResult: z.string() } ),
-        async fn() {
+        fn: async () => {
           return {
-            stepResult: await this.invokeStep( 'stepA', { a: 1 }, { b: 2 } ),
-            evalResult: await this.invokeEvaluator( 'evalA', { c: 3 } )
+            stepResult: await __invokeActivity( 'stepA', { a: 1 }, { b: 2 } ),
+            evalResult: await __invokeActivity( 'evalA', { c: 3 } )
           };
         }
       } ) );
@@ -563,24 +562,24 @@ describe( 'workflow()', () => {
       expect( evaluator ).toHaveBeenCalledWith( { c: 3 } );
     } );
 
-    it( 'invokes shared steps and shared evaluators with the shared prefix', async () => {
-      const { workflow } = await import( './workflow.js' );
+    it( 'invokes shared activities through the workflow namespace', async () => {
+      const { workflow, __invokeActivity } = await import( './workflow.js' );
       setWorkflowInfo( { workflowType: 'shared_dispatch_wf' } );
       const sharedStep = vi.fn().mockResolvedValue( activityOutput( 'shared-step-output' ) );
       const sharedEvaluator = vi.fn().mockResolvedValue( activityOutput( 'shared-eval-output' ) );
       mockActivities( {
         [ACTIVITY_GET_TRACE_DESTINATIONS]: vi.fn().mockResolvedValue( activityOutput( null ) ),
-        [`${SHARED_STEP_PREFIX}#stepA`]: sharedStep,
-        [`${SHARED_STEP_PREFIX}#evalA`]: sharedEvaluator
+        'shared_dispatch_wf#stepA': sharedStep,
+        'shared_dispatch_wf#evalA': sharedEvaluator
       } );
 
       const wf = workflow( workflowDefinition( {
         name: 'shared_dispatch_wf',
         outputSchema: z.object( { stepResult: z.string(), evalResult: z.string() } ),
-        async fn() {
+        fn: async () => {
           return {
-            stepResult: await this.invokeSharedStep( 'stepA' ),
-            evalResult: await this.invokeSharedEvaluator( 'evalA', { x: 1 } )
+            stepResult: await __invokeActivity( 'stepA' ),
+            evalResult: await __invokeActivity( 'evalA', { x: 1 } )
           };
         }
       } ) );

--- a/sdk/core/src/interface/workflow.spec.js
+++ b/sdk/core/src/interface/workflow.spec.js
@@ -500,7 +500,6 @@ describe( 'workflow()', () => {
       const { workflow } = await import( './workflow.js' );
       const getTraceDestinations = vi.fn().mockResolvedValue( activityOutput( { local: '/tmp/trace' } ) );
       const memo = {
-        stack: [ 'root-workflow' ],
         traceInfo: { workflowId: 'root-workflow' },
         activityOptions: {
           startToCloseTimeout: '9m',
@@ -651,9 +650,10 @@ describe( 'workflow()', () => {
   } );
 
   describe( 'error handling', () => {
-    it( 'attaches root trace destinations to root workflow errors before rethrowing', async () => {
+    it( 'attaches root trace destinations to root workflow errors and preserves existing details', async () => {
       const { workflow } = await import( './workflow.js' );
-      const error = new Error( 'root failed' );
+      const error = new Error( 'root failed with details' );
+      error.details = [ { domain: { reason: 'bad-input' } } ];
       setWorkflowInfo( { workflowType: 'root_error_wf' } );
 
       const wf = workflow( workflowDefinition( {
@@ -665,23 +665,6 @@ describe( 'workflow()', () => {
 
       const thrown = await wf( {} ).catch( e => e );
       expect( thrown ).toBe( error );
-      expect( error[METADATA_ACCESS_SYMBOL] ).toEqual( { trace: { destinations: { local: '/tmp/trace' } } } );
-    } );
-
-    it( 'preserves existing error details when attaching root trace metadata', async () => {
-      const { workflow } = await import( './workflow.js' );
-      const error = new Error( 'root failed with details' );
-      error.details = [ { domain: { reason: 'bad-input' } } ];
-      setWorkflowInfo( { workflowType: 'root_error_existing_details_wf' } );
-
-      const wf = workflow( workflowDefinition( {
-        name: 'root_error_existing_details_wf',
-        fn: async () => {
-          throw error;
-        }
-      } ) );
-
-      await expect( wf( {} ) ).rejects.toBe( error );
       expect( error.details ).toEqual( [ { domain: { reason: 'bad-input' } } ] );
       expect( error[METADATA_ACCESS_SYMBOL] ).toEqual( { trace: { destinations: { local: '/tmp/trace' } } } );
     } );
@@ -700,25 +683,6 @@ describe( 'workflow()', () => {
       } ) );
 
       await expect( wf( {} ) ).rejects.toBe( error );
-      expect( error[METADATA_ACCESS_SYMBOL] ).toEqual( { trace: { destinations: {} } } );
-    } );
-
-    it( 'preserves existing error details when no trace destinations are available', async () => {
-      const { workflow } = await import( './workflow.js' );
-      setWorkflowInfo( { workflowType: 'root_error_existing_details_no_trace_wf' } );
-      mockActivities( { [ACTIVITY_GET_TRACE_DESTINATIONS]: vi.fn().mockResolvedValue( activityOutput( {} ) ) } );
-      const error = new Error( 'root failed without trace' );
-      error.details = [ { domain: { reason: 'bad-input' } } ];
-
-      const wf = workflow( workflowDefinition( {
-        name: 'root_error_existing_details_no_trace_wf',
-        fn: async () => {
-          throw error;
-        }
-      } ) );
-
-      await expect( wf( {} ) ).rejects.toBe( error );
-      expect( error.details ).toEqual( [ { domain: { reason: 'bad-input' } } ] );
       expect( error[METADATA_ACCESS_SYMBOL] ).toEqual( { trace: { destinations: {} } } );
     } );
 
@@ -754,7 +718,7 @@ describe( 'workflow()', () => {
       setWorkflowInfo( {
         workflowId: 'nested-workflow',
         root: { workflowId: 'root-workflow', runId: 'root-run' },
-        memo: { stack: [ 'root-workflow' ], traceInfo: { workflowId: 'root-workflow' } }
+        memo: { traceInfo: { workflowId: 'root-workflow' } }
       } );
 
       const wf = workflow( workflowDefinition( {

--- a/sdk/core/src/interface/workflow.spec.js
+++ b/sdk/core/src/interface/workflow.spec.js
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import {
   ACTIVITY_GET_TRACE_DESTINATIONS,
   ACTIVITY_WRAPPER_VERSION_FIELD,
+  INVOKE_ACTIVITY_SYMBOL,
   METADATA_ACCESS_SYMBOL,
   WORKFLOW_WRAPPER_VERSION_FIELD
 } from '#consts';
@@ -104,6 +105,7 @@ const invokeWorkflowFromHelper = ( wf, input, options ) => wf( input, options );
 describe( 'workflow()', () => {
   beforeEach( () => {
     vi.clearAllMocks();
+    delete globalThis[INVOKE_ACTIVITY_SYMBOL];
     inWorkflowContextMock.mockReturnValue( true );
     executeChildMock.mockResolvedValue( { output: {} } );
     setWorkflowInfo();
@@ -255,11 +257,11 @@ describe( 'workflow()', () => {
   } );
 
   describe( 'child workflow trigger path', () => {
-    it( 'starts a child workflow when memo.stack already contains the current workflowId', async () => {
+    it( 'starts a child workflow when the current workflow already installed the activity dispatcher', async () => {
       const { workflow } = await import( './workflow.js' );
       const { ParentClosePolicy } = await import( '@temporalio/workflow' );
+      globalThis[INVOKE_ACTIVITY_SYMBOL] = vi.fn();
       const memo = {
-        stack: [ 'root-workflow', 'workflow-123' ],
         traceInfo: { workflowId: 'root-workflow' },
         activityOptions: {
           startToCloseTimeout: '10m',
@@ -296,12 +298,11 @@ describe( 'workflow()', () => {
         workflowId: expect.stringMatching( /^workflow-123-/ ),
         parentClosePolicy: ParentClosePolicy.ABANDON,
         memo: {
-          stack: [ 'root-workflow', 'workflow-123' ],
           traceInfo: { workflowId: 'root-workflow' },
-          activityOptions: {
+          activityOptions: expect.objectContaining( {
             startToCloseTimeout: '2m',
-            retry: { maximumAttempts: 7 }
-          }
+            retry: expect.objectContaining( { maximumAttempts: 7 } )
+          } )
         }
       } );
       expect( proxyActivitiesMock ).not.toHaveBeenCalled();
@@ -310,7 +311,8 @@ describe( 'workflow()', () => {
     it( 'uses empty args and terminate policy by default for child workflow execution', async () => {
       const { workflow } = await import( './workflow.js' );
       const { ParentClosePolicy } = await import( '@temporalio/workflow' );
-      setWorkflowInfo( { memo: { stack: [ 'workflow-123' ], activityOptions: { heartbeatTimeout: '1m' } } } );
+      globalThis[INVOKE_ACTIVITY_SYMBOL] = vi.fn();
+      setWorkflowInfo( { memo: { activityOptions: { heartbeatTimeout: '1m' } } } );
       executeChildMock.mockResolvedValueOnce( { output: 'done' } );
 
       const wf = workflow( workflowDefinition( {
@@ -324,7 +326,62 @@ describe( 'workflow()', () => {
       expect( executeChildMock ).toHaveBeenCalledWith( 'no_input_child_wf', expect.objectContaining( {
         args: [],
         parentClosePolicy: ParentClosePolicy.TERMINATE,
-        memo: { stack: [ 'workflow-123' ], activityOptions: { heartbeatTimeout: '1m' } }
+        memo: expect.objectContaining( { activityOptions: expect.objectContaining( { heartbeatTimeout: '1m' } ) } )
+      } ) );
+    } );
+
+    it( 'resolves activity options recursively by invocation, memo, definition, then default precedence', async () => {
+      const { workflow } = await import( './workflow.js' );
+      globalThis[INVOKE_ACTIVITY_SYMBOL] = vi.fn();
+      setWorkflowInfo( {
+        memo: {
+          activityOptions: {
+            heartbeatTimeout: '1m',
+            retry: {
+              maximumAttempts: 4,
+              maximumInterval: '30s'
+            }
+          }
+        }
+      } );
+      executeChildMock.mockResolvedValueOnce( { output: {} } );
+
+      const wf = workflow( workflowDefinition( {
+        name: 'activity_options_precedence_child_wf',
+        options: {
+          activityOptions: {
+            startToCloseTimeout: '5m',
+            retry: {
+              backoffCoefficient: 3,
+              maximumAttempts: 2
+            }
+          }
+        }
+      } ) );
+
+      await wf( {}, {
+        activityOptions: {
+          retry: {
+            initialInterval: '1s',
+            maximumAttempts: 9
+          }
+        }
+      } );
+
+      expect( executeChildMock ).toHaveBeenCalledWith( 'activity_options_precedence_child_wf', expect.objectContaining( {
+        memo: expect.objectContaining( {
+          activityOptions: {
+            startToCloseTimeout: '5m',
+            heartbeatTimeout: '1m',
+            retry: {
+              initialInterval: '1s',
+              backoffCoefficient: 3,
+              maximumInterval: '30s',
+              maximumAttempts: 9,
+              nonRetryableErrorTypes: [ ValidationError.name, 'FatalError' ]
+            }
+          }
+        } )
       } ) );
     } );
 
@@ -363,7 +420,6 @@ describe( 'workflow()', () => {
         args: [ { id: 1 } ],
         parentClosePolicy: ParentClosePolicy.TERMINATE,
         memo: expect.objectContaining( {
-          stack: [ 'workflow-123' ],
           traceInfo: info.memo.traceInfo,
           activityOptions: expect.objectContaining( {
             retry: expect.objectContaining( { maximumAttempts: 1 } )
@@ -375,6 +431,7 @@ describe( 'workflow()', () => {
 
     it( 'does not fallback to child execution when the replayed workflow type matches an alias', async () => {
       const { workflow } = await import( './workflow.js' );
+      delete globalThis[INVOKE_ACTIVITY_SYMBOL];
       setWorkflowInfo( { workflowType: 'old_root_wf', memo: {} } );
 
       const wf = workflow( workflowDefinition( {
@@ -395,7 +452,7 @@ describe( 'workflow()', () => {
     it( 'propagates executeChild errors without root ApplicationFailure wrapping', async () => {
       const { workflow } = await import( './workflow.js' );
       const error = new Error( 'child failed' );
-      setWorkflowInfo( { memo: { stack: [ 'workflow-123' ] } } );
+      globalThis[INVOKE_ACTIVITY_SYMBOL] = vi.fn();
       executeChildMock.mockRejectedValueOnce( error );
 
       const wf = workflow( workflowDefinition( { name: 'failing_child_wf' } ) );
@@ -429,7 +486,6 @@ describe( 'workflow()', () => {
         output: { ok: true },
         trace: { destinations: {} }
       } );
-      expect( info.memo.stack ).toEqual( [ 'workflow-123' ] );
       expect( info.memo.traceInfo ).toBeUndefined();
       expect( info.memo.activityOptions ).toEqual( expect.objectContaining( {
         startToCloseTimeout: '5m',
@@ -474,7 +530,6 @@ describe( 'workflow()', () => {
         [WORKFLOW_WRAPPER_VERSION_FIELD]: 1,
         output: { ok: true }
       } );
-      expect( info.memo.stack ).toEqual( [ 'root-workflow', 'child-workflow' ] );
       expect( info.memo.traceInfo ).toBe( memo.traceInfo );
       expect( info.memo.activityOptions ).toEqual( expect.objectContaining( {
         startToCloseTimeout: '9m',
@@ -521,6 +576,7 @@ describe( 'workflow()', () => {
       await expect( wf( { value: 1 } ) ).rejects.toBe( inputError );
       expect( inputError[METADATA_ACCESS_SYMBOL] ).toEqual( { trace: { destinations: { local: '/tmp/trace' } } } );
 
+      delete globalThis[INVOKE_ACTIVITY_SYMBOL];
       setWorkflowInfo( { workflowType: 'runtime_validation_wf', memo: {} } );
       validateOutputMock.mockImplementationOnce( () => {
         throw outputError;
@@ -532,7 +588,7 @@ describe( 'workflow()', () => {
 
   describe( 'activity dispatchers', () => {
     it( 'invokes workflow-scoped activities and unwraps activity output', async () => {
-      const { workflow, __invokeActivity } = await import( './workflow.js' );
+      const { workflow } = await import( './workflow.js' );
       setWorkflowInfo( { workflowType: 'dispatch_wf' } );
       const step = vi.fn().mockResolvedValue( activityOutput( 'step-output' ) );
       const evaluator = vi.fn().mockResolvedValue( activityOutput( 'eval-output' ) );
@@ -547,8 +603,8 @@ describe( 'workflow()', () => {
         outputSchema: z.object( { stepResult: z.string(), evalResult: z.string() } ),
         fn: async () => {
           return {
-            stepResult: await __invokeActivity( 'stepA', { a: 1 }, { b: 2 } ),
-            evalResult: await __invokeActivity( 'evalA', { c: 3 } )
+            stepResult: await globalThis[INVOKE_ACTIVITY_SYMBOL]( 'stepA', { a: 1 }, { b: 2 } ),
+            evalResult: await globalThis[INVOKE_ACTIVITY_SYMBOL]( 'evalA', { c: 3 } )
           };
         }
       } ) );
@@ -563,7 +619,7 @@ describe( 'workflow()', () => {
     } );
 
     it( 'invokes shared activities through the workflow namespace', async () => {
-      const { workflow, __invokeActivity } = await import( './workflow.js' );
+      const { workflow } = await import( './workflow.js' );
       setWorkflowInfo( { workflowType: 'shared_dispatch_wf' } );
       const sharedStep = vi.fn().mockResolvedValue( activityOutput( 'shared-step-output' ) );
       const sharedEvaluator = vi.fn().mockResolvedValue( activityOutput( 'shared-eval-output' ) );
@@ -578,8 +634,8 @@ describe( 'workflow()', () => {
         outputSchema: z.object( { stepResult: z.string(), evalResult: z.string() } ),
         fn: async () => {
           return {
-            stepResult: await __invokeActivity( 'stepA' ),
-            evalResult: await __invokeActivity( 'evalA', { x: 1 } )
+            stepResult: await globalThis[INVOKE_ACTIVITY_SYMBOL]( 'stepA' ),
+            evalResult: await globalThis[INVOKE_ACTIVITY_SYMBOL]( 'evalA', { x: 1 } )
           };
         }
       } ) );

--- a/sdk/core/src/interface/workflow.spec.js
+++ b/sdk/core/src/interface/workflow.spec.js
@@ -91,6 +91,13 @@ const mockActivities = handlers => {
   return activities;
 };
 
+const installGlobalDispatcher = runId => {
+  const dispatcher = vi.fn();
+  dispatcher.runId = runId;
+  globalThis[INVOKE_ACTIVITY_SYMBOL] = dispatcher;
+  return dispatcher;
+};
+
 const workflowDefinition = overrides => ( {
   name: 'test_wf',
   description: 'Test workflow',
@@ -99,8 +106,6 @@ const workflowDefinition = overrides => ( {
   fn: async () => ( {} ),
   ...overrides
 } );
-
-const invokeWorkflowFromHelper = ( wf, input, options ) => wf( input, options );
 
 describe( 'workflow()', () => {
   beforeEach( () => {
@@ -257,15 +262,18 @@ describe( 'workflow()', () => {
   } );
 
   describe( 'child workflow trigger path', () => {
-    it( 'starts a child workflow when the current workflow already installed the activity dispatcher', async () => {
+    it( 'starts a child workflow and forwards child-safe invocation options', async () => {
       const { workflow } = await import( './workflow.js' );
       const { ParentClosePolicy } = await import( '@temporalio/workflow' );
-      globalThis[INVOKE_ACTIVITY_SYMBOL] = vi.fn();
+      installGlobalDispatcher( 'run-123' );
       const memo = {
         traceInfo: { workflowId: 'root-workflow' },
-        activityOptions: {
-          startToCloseTimeout: '10m',
-          retry: { maximumAttempts: 2 }
+        parentActivityOptions: {
+          heartbeatTimeout: '30s',
+          retry: {
+            maximumInterval: '20s',
+            maximumAttempts: 4
+          }
         }
       };
       setWorkflowInfo( { memo } );
@@ -280,6 +288,7 @@ describe( 'workflow()', () => {
 
       await expect( wf( { id: 1 }, {
         detached: true,
+        context: { testOnly: true },
         activityOptions: {
           startToCloseTimeout: '2m',
           retry: { maximumAttempts: 7 }
@@ -287,6 +296,7 @@ describe( 'workflow()', () => {
       } ) ).resolves.toEqual( { child: 'ok' } );
       expect( validateInvocationOptionsMock ).toHaveBeenCalledWith( {
         detached: true,
+        context: { testOnly: true },
         activityOptions: {
           startToCloseTimeout: '2m',
           retry: { maximumAttempts: 7 }
@@ -294,25 +304,28 @@ describe( 'workflow()', () => {
       } );
 
       expect( executeChildMock ).toHaveBeenCalledWith( 'child_target_wf', {
-        args: [ { id: 1 } ],
+        args: [ {
+          id: 1
+        }, {
+          activityOptions: {
+            startToCloseTimeout: '2m',
+            retry: { maximumAttempts: 7 }
+          }
+        } ],
         workflowId: expect.stringMatching( /^workflow-123-/ ),
         parentClosePolicy: ParentClosePolicy.ABANDON,
-        memo: {
-          traceInfo: { workflowId: 'root-workflow' },
-          activityOptions: expect.objectContaining( {
-            startToCloseTimeout: '2m',
-            retry: expect.objectContaining( { maximumAttempts: 7 } )
-          } )
-        }
+        memo
       } );
+      expect( executeChildMock.mock.calls[0][1].args[1] ).not.toHaveProperty( 'detached' );
+      expect( executeChildMock.mock.calls[0][1].args[1] ).not.toHaveProperty( 'context' );
       expect( proxyActivitiesMock ).not.toHaveBeenCalled();
     } );
 
-    it( 'uses empty args and terminate policy by default for child workflow execution', async () => {
+    it( 'uses undefined input and terminate policy by default for child workflow execution', async () => {
       const { workflow } = await import( './workflow.js' );
       const { ParentClosePolicy } = await import( '@temporalio/workflow' );
-      globalThis[INVOKE_ACTIVITY_SYMBOL] = vi.fn();
-      setWorkflowInfo( { memo: { activityOptions: { heartbeatTimeout: '1m' } } } );
+      installGlobalDispatcher( 'run-123' );
+      setWorkflowInfo( { memo: { traceInfo: { workflowId: 'root-workflow' } } } );
       executeChildMock.mockResolvedValueOnce( { output: 'done' } );
 
       const wf = workflow( workflowDefinition( {
@@ -324,135 +337,16 @@ describe( 'workflow()', () => {
 
       await expect( wf() ).resolves.toBe( 'done' );
       expect( executeChildMock ).toHaveBeenCalledWith( 'no_input_child_wf', expect.objectContaining( {
-        args: [],
+        args: [ undefined, { activityOptions: undefined } ],
         parentClosePolicy: ParentClosePolicy.TERMINATE,
-        memo: expect.objectContaining( { activityOptions: expect.objectContaining( { heartbeatTimeout: '1m' } ) } )
+        memo: { traceInfo: { workflowId: 'root-workflow' } }
       } ) );
-    } );
-
-    it( 'resolves activity options recursively by invocation, memo, definition, then default precedence', async () => {
-      const { workflow } = await import( './workflow.js' );
-      globalThis[INVOKE_ACTIVITY_SYMBOL] = vi.fn();
-      setWorkflowInfo( {
-        memo: {
-          activityOptions: {
-            heartbeatTimeout: '1m',
-            retry: {
-              maximumAttempts: 4,
-              maximumInterval: '30s'
-            }
-          }
-        }
-      } );
-      executeChildMock.mockResolvedValueOnce( { output: {} } );
-
-      const wf = workflow( workflowDefinition( {
-        name: 'activity_options_precedence_child_wf',
-        options: {
-          activityOptions: {
-            startToCloseTimeout: '5m',
-            retry: {
-              backoffCoefficient: 3,
-              maximumAttempts: 2
-            }
-          }
-        }
-      } ) );
-
-      await wf( {}, {
-        activityOptions: {
-          retry: {
-            initialInterval: '1s',
-            maximumAttempts: 9
-          }
-        }
-      } );
-
-      expect( executeChildMock ).toHaveBeenCalledWith( 'activity_options_precedence_child_wf', expect.objectContaining( {
-        memo: expect.objectContaining( {
-          activityOptions: {
-            startToCloseTimeout: '5m',
-            heartbeatTimeout: '1m',
-            retry: {
-              initialInterval: '1s',
-              backoffCoefficient: 3,
-              maximumInterval: '30s',
-              maximumAttempts: 9,
-              nonRetryableErrorTypes: [ ValidationError.name, 'FatalError' ]
-            }
-          }
-        } )
-      } ) );
-    } );
-
-    it( 'starts a child workflow when the call is made through a helper outside the handler', async () => {
-      const { workflow } = await import( './workflow.js' );
-      const { ParentClosePolicy } = await import( '@temporalio/workflow' );
-      const getTraceDestinations = vi.fn().mockResolvedValue( activityOutput( null ) );
-      const info = setWorkflowInfo( { workflowType: 'indirect_parent_wf', memo: {} } );
-      mockActivities( { [ACTIVITY_GET_TRACE_DESTINATIONS]: getTraceDestinations } );
-      executeChildMock.mockResolvedValueOnce( { output: { child: 'ok' } } );
-      const childFn = vi.fn();
-
-      const childWorkflow = workflow( workflowDefinition( {
-        name: 'indirect_child_wf',
-        inputSchema: z.object( { id: z.number() } ),
-        outputSchema: z.object( { child: z.string() } ),
-        fn: childFn
-      } ) );
-      const parentWorkflow = workflow( workflowDefinition( {
-        name: 'indirect_parent_wf',
-        outputSchema: z.object( { child: z.string() } ),
-        fn: async () => invokeWorkflowFromHelper( childWorkflow, { id: 1 }, {
-          activityOptions: {
-            retry: { maximumAttempts: 1 }
-          }
-        } )
-      } ) );
-
-      await expect( parentWorkflow( {} ) ).resolves.toEqual( {
-        [WORKFLOW_WRAPPER_VERSION_FIELD]: 1,
-        output: { child: 'ok' },
-        trace: { destinations: {} }
-      } );
-      expect( childFn ).not.toHaveBeenCalled();
-      expect( executeChildMock ).toHaveBeenCalledWith( 'indirect_child_wf', expect.objectContaining( {
-        args: [ { id: 1 } ],
-        parentClosePolicy: ParentClosePolicy.TERMINATE,
-        memo: expect.objectContaining( {
-          traceInfo: info.memo.traceInfo,
-          activityOptions: expect.objectContaining( {
-            retry: expect.objectContaining( { maximumAttempts: 1 } )
-          } )
-        } )
-      } ) );
-      expect( getTraceDestinations ).toHaveBeenCalledWith( info.memo.traceInfo );
-    } );
-
-    it( 'does not fallback to child execution when the replayed workflow type matches an alias', async () => {
-      const { workflow } = await import( './workflow.js' );
-      delete globalThis[INVOKE_ACTIVITY_SYMBOL];
-      setWorkflowInfo( { workflowType: 'old_root_wf', memo: {} } );
-
-      const wf = workflow( workflowDefinition( {
-        name: 'renamed_root_wf',
-        aliases: [ 'old_root_wf' ],
-        outputSchema: z.object( { ok: z.boolean() } ),
-        fn: async () => ( { ok: true } )
-      } ) );
-
-      await expect( wf( {} ) ).resolves.toEqual( {
-        [WORKFLOW_WRAPPER_VERSION_FIELD]: 1,
-        output: { ok: true },
-        trace: { destinations: { local: '/tmp/trace' } }
-      } );
-      expect( executeChildMock ).not.toHaveBeenCalled();
     } );
 
     it( 'propagates executeChild errors without root ApplicationFailure wrapping', async () => {
       const { workflow } = await import( './workflow.js' );
       const error = new Error( 'child failed' );
-      globalThis[INVOKE_ACTIVITY_SYMBOL] = vi.fn();
+      installGlobalDispatcher( 'run-123' );
       executeChildMock.mockRejectedValueOnce( error );
 
       const wf = workflow( workflowDefinition( { name: 'failing_child_wf' } ) );
@@ -462,6 +356,23 @@ describe( 'workflow()', () => {
   } );
 
   describe( 'workflow execution path', () => {
+    it( 'rejects a global activity dispatcher left by another workflow run', async () => {
+      const { workflow } = await import( './workflow.js' );
+      const fn = vi.fn().mockResolvedValue( {} );
+      installGlobalDispatcher( 'stale-run' );
+      setWorkflowInfo( { runId: 'current-run' } );
+
+      const wf = workflow( workflowDefinition( {
+        name: 'contamination_wf',
+        fn
+      } ) );
+
+      await expect( wf( {} ) ).rejects.toThrow( /Contamination of the workflow Node global context/ );
+      expect( executeChildMock ).not.toHaveBeenCalled();
+      expect( proxyActivitiesMock ).not.toHaveBeenCalled();
+      expect( fn ).not.toHaveBeenCalled();
+    } );
+
     it( 'initializes root memo, skips trace destinations when trace is disabled, validates output, and returns an envelope', async () => {
       const { workflow } = await import( './workflow.js' );
       const getTraceDestinations = vi.fn().mockResolvedValue( activityOutput( { local: '/tmp/root-trace' } ) );
@@ -487,13 +398,70 @@ describe( 'workflow()', () => {
         trace: { destinations: {} }
       } );
       expect( info.memo.traceInfo ).toBeUndefined();
-      expect( info.memo.activityOptions ).toEqual( expect.objectContaining( {
+      expect( info.memo.activityOptions ).toBeUndefined();
+      expect( info.memo.parentActivityOptions ).toEqual( expect.objectContaining( {
         startToCloseTimeout: '5m',
         heartbeatTimeout: '5m',
         retry: expect.objectContaining( { maximumAttempts: 5 } )
       } ) );
-      expect( proxyActivitiesMock ).toHaveBeenCalledWith( info.memo.activityOptions );
+      expect( proxyActivitiesMock ).toHaveBeenCalledWith( expect.objectContaining( {
+        startToCloseTimeout: '5m',
+        heartbeatTimeout: '5m',
+        retry: expect.objectContaining( { maximumAttempts: 5 } )
+      } ) );
       expect( getTraceDestinations ).not.toHaveBeenCalled();
+    } );
+
+    it( 'resolves activity options by invocation, definition, inherited memo, then default precedence', async () => {
+      const { workflow } = await import( './workflow.js' );
+      const info = setWorkflowInfo( {
+        workflowType: 'activity_options_wf',
+        memo: {
+          parentActivityOptions: {
+            heartbeatTimeout: '30s',
+            retry: {
+              maximumInterval: '30s',
+              maximumAttempts: 4
+            }
+          }
+        }
+      } );
+
+      const wf = workflow( workflowDefinition( {
+        name: 'activity_options_wf',
+        options: {
+          activityOptions: {
+            startToCloseTimeout: '5m',
+            retry: {
+              backoffCoefficient: 3,
+              maximumAttempts: 2
+            }
+          }
+        }
+      } ) );
+
+      await wf( {}, {
+        activityOptions: {
+          heartbeatTimeout: '1m',
+          retry: {
+            initialInterval: '1s',
+            maximumAttempts: 9
+          }
+        }
+      } );
+
+      expect( proxyActivitiesMock ).toHaveBeenCalledWith( {
+        startToCloseTimeout: '5m',
+        heartbeatTimeout: '1m',
+        retry: {
+          initialInterval: '1s',
+          backoffCoefficient: 3,
+          maximumInterval: '30s',
+          maximumAttempts: 9,
+          nonRetryableErrorTypes: [ ValidationError.name, 'FatalError' ]
+        }
+      } );
+      expect( info.memo.parentActivityOptions ).toEqual( proxyActivitiesMock.mock.calls[0][0] );
     } );
 
     it( 'runs non-root workflow execution without rebuilding trace info or fetching trace destinations', async () => {
@@ -501,7 +469,7 @@ describe( 'workflow()', () => {
       const getTraceDestinations = vi.fn().mockResolvedValue( activityOutput( { local: '/tmp/trace' } ) );
       const memo = {
         traceInfo: { workflowId: 'root-workflow' },
-        activityOptions: {
+        parentActivityOptions: {
           startToCloseTimeout: '9m',
           retry: { maximumAttempts: 8 }
         }
@@ -530,11 +498,17 @@ describe( 'workflow()', () => {
         output: { ok: true }
       } );
       expect( info.memo.traceInfo ).toBe( memo.traceInfo );
-      expect( info.memo.activityOptions ).toEqual( expect.objectContaining( {
-        startToCloseTimeout: '9m',
-        retry: expect.objectContaining( { maximumAttempts: 8 } )
+      expect( info.memo.activityOptions ).toBeUndefined();
+      expect( info.memo.parentActivityOptions ).toEqual( expect.objectContaining( {
+        startToCloseTimeout: '1m',
+        heartbeatTimeout: '5m',
+        retry: expect.objectContaining( { maximumAttempts: 2 } )
       } ) );
-      expect( proxyActivitiesMock ).toHaveBeenCalledWith( info.memo.activityOptions );
+      expect( proxyActivitiesMock ).toHaveBeenCalledWith( expect.objectContaining( {
+        startToCloseTimeout: '1m',
+        heartbeatTimeout: '5m',
+        retry: expect.objectContaining( { maximumAttempts: 2 } )
+      } ) );
       expect( getTraceDestinations ).not.toHaveBeenCalled();
     } );
 

--- a/sdk/core/src/sdk/helpers/objects.d.ts
+++ b/sdk/core/src/sdk/helpers/objects.d.ts
@@ -36,16 +36,21 @@ export declare const Objects: {
   deepMerge( base: object, ...overlays: Array<object | null | undefined> ): object,
 
   /**
-   * Creates a new object by merging object `b` onto object `a`, biased toward `b`:
-   * - Fields in `b` that don't exist in `a` are created.
-   * - Fields in `a` that don't exist in `b` are left unchanged.
-   * - Fields in `a` and `b` are passed as arguments to the resolve function (a,b) and its return assigns the new value.
+   * Creates a new object by recursively merging overlays onto a base object.
+   * Existing leaf values are resolved by the resolver function.
    *
-   * @param a - The base object.
-   * @param b - The overriding object.
-   * @param resolver - The resolver function.
-   * @throws {Error} If either `a` or `b` is not a plain object.
+   * Non-object overlays are ignored.
+   *
+   * @param base - The base object.
+   * @param args - The overriding objects, applied from left to right, followed by the resolver function.
+   * @throws {Error} If `base` is not a plain object.
    * @returns A new merged object.
    */
-  deepMergeWithResolver( a: object, b: object | null | undefined, resolver: ( a: unknown, b: unknown ) => unknown ): object
+  deepMergeWithResolver(
+    base: object,
+    ...args: [
+      ...overlays: Array<object | null | undefined>,
+      resolver: ( a: unknown, b: unknown ) => unknown
+    ]
+  ): object
 };

--- a/sdk/core/src/sdk/helpers/objects.d.ts
+++ b/sdk/core/src/sdk/helpers/objects.d.ts
@@ -23,17 +23,17 @@ export declare const Objects: {
   isPlainObject( object: unknown ): boolean,
 
   /**
-   * Creates a new object by merging object `b` onto object `a`, biased toward `b`:
-   * - Fields in `b` overwrite fields in `a`.
-   * - Fields in `b` that don't exist in `a` are created.
-   * - Fields in `a` that don't exist in `b` are left unchanged.
+   * Creates a new object by recursively merging overlays onto a base object.
+   * Later objects overwrite fields from earlier objects.
    *
-   * @param a - The base object.
-   * @param b - The overriding object.
-   * @throws {Error} If either `a` or `b` is not a plain object.
+   * Non-object overlays are ignored.
+   *
+   * @param base - The base object.
+   * @param overlays - The overriding objects, applied from left to right.
+   * @throws {Error} If `base` is not a plain object.
    * @returns A new merged object.
    */
-  deepMerge( a: object, b: object | null | undefined ): object,
+  deepMerge( base: object, ...overlays: Array<object | null | undefined> ): object,
 
   /**
    * Creates a new object by merging object `b` onto object `a`, biased toward `b`:

--- a/sdk/core/src/worker/interceptors/workflow.js
+++ b/sdk/core/src/worker/interceptors/workflow.js
@@ -7,7 +7,7 @@ import { METADATA_ACCESS_SYMBOL, WorkflowSpecialOutput } from '#consts';
 import { createWorkflowDetails } from '#helpers/temporal_context';
 
 // this is a dynamic generated file with activity configs overwrites
-import activityOptions from '../temp/__activity_options.js';
+import activityOptionsMap from '../temp/__activity_options.js';
 
 /*
   This interceptor adds Memo and serialized workflowInfo() to the Activity invocation headers.
@@ -22,10 +22,10 @@ class HeadersInjectionInterceptor {
       ...memo,
       workflowDetails: createWorkflowDetails( info )
     } ) );
-    // Apply component-level activity options on top of workflow memo defaults.
-    const options = activityOptions[input.activityType];
-    if ( options ) {
-      input.options = deepMerge( memo.activityOptions, options );
+    // Apply component-level activity options on top of workflow options.
+    const activityOptionsOverrides = activityOptionsMap[input.activityType];
+    if ( activityOptionsOverrides ) {
+      input.options = deepMerge( input.options ?? {}, activityOptionsOverrides );
     }
     return next( input );
   }

--- a/sdk/core/src/worker/interceptors/workflow.js
+++ b/sdk/core/src/worker/interceptors/workflow.js
@@ -7,7 +7,7 @@ import { METADATA_ACCESS_SYMBOL, WorkflowSpecialOutput } from '#consts';
 import { createWorkflowDetails } from '#helpers/temporal_context';
 
 // this is a dynamic generated file with activity configs overwrites
-import stepOptions from '../temp/__activity_options.js';
+import activityOptions from '../temp/__activity_options.js';
 
 /*
   This interceptor adds Memo and serialized workflowInfo() to the Activity invocation headers.
@@ -22,8 +22,8 @@ class HeadersInjectionInterceptor {
       ...memo,
       workflowDetails: createWorkflowDetails( info )
     } ) );
-    // apply per-invocation options passed as second argument by rewritten calls
-    const options = stepOptions[input.activityType];
+    // Apply component-level activity options on top of workflow memo defaults.
+    const options = activityOptions[input.activityType];
     if ( options ) {
       input.options = deepMerge( memo.activityOptions, options );
     }

--- a/sdk/core/src/worker/interceptors/workflow.spec.js
+++ b/sdk/core/src/worker/interceptors/workflow.spec.js
@@ -56,8 +56,8 @@ vi.mock( './headers.js', () => ( { memoToHeaders: ( ...args ) => memoToHeadersMo
 const deepMergeMock = vi.fn( ( a, b ) => ( { ...( a || {} ), ...( b || {} ) } ) );
 vi.mock( '#helpers/object', () => ( { deepMerge: ( ...args ) => deepMergeMock( ...args ) } ) );
 
-const stepOptionsDefault = {};
-vi.mock( '../temp/__activity_options.js', () => ( { default: stepOptionsDefault } ) );
+const activityOptionsDefault = {};
+vi.mock( '../temp/__activity_options.js', () => ( { default: activityOptionsDefault } ) );
 
 describe( 'workflow interceptors', () => {
   beforeEach( () => {
@@ -91,8 +91,8 @@ describe( 'workflow interceptors', () => {
       expect( out ).toBe( 'result' );
     } );
 
-    it( 'merges stepOptions with memo.activityOptions when stepOptions exist for activityType', async () => {
-      stepOptionsDefault['MyWorkflow#step1'] = { scheduleToCloseTimeout: 60 };
+    it( 'merges activity options with memo.activityOptions when options exist for activityType', async () => {
+      activityOptionsDefault['MyWorkflow#step1'] = { scheduleToCloseTimeout: 60 };
       workflowInfoMock.mockReturnValue( {
         ...workflowInfo,
         memo: { traceInfo: workflowInfo.memo.traceInfo, activityOptions: { heartbeatTimeout: 10 } }
@@ -110,7 +110,7 @@ describe( 'workflow interceptors', () => {
 
       expect( deepMergeMock ).toHaveBeenCalledWith( { heartbeatTimeout: 10 }, { scheduleToCloseTimeout: 60 } );
       expect( input.options ).toEqual( { heartbeatTimeout: 10, scheduleToCloseTimeout: 60 } );
-      delete stepOptionsDefault['MyWorkflow#step1'];
+      delete activityOptionsDefault['MyWorkflow#step1'];
     } );
   } );
 

--- a/sdk/core/src/worker/interceptors/workflow.spec.js
+++ b/sdk/core/src/worker/interceptors/workflow.spec.js
@@ -62,6 +62,7 @@ vi.mock( '../temp/__activity_options.js', () => ( { default: activityOptionsDefa
 describe( 'workflow interceptors', () => {
   beforeEach( () => {
     vi.clearAllMocks();
+    Object.keys( activityOptionsDefault ).forEach( key => delete activityOptionsDefault[key] );
     isCancellationMock.mockReturnValue( false );
     workflowInfoMock.mockReturnValue( workflowInfo );
   } );
@@ -91,11 +92,11 @@ describe( 'workflow interceptors', () => {
       expect( out ).toBe( 'result' );
     } );
 
-    it( 'merges activity options with memo.activityOptions when options exist for activityType', async () => {
+    it( 'merges component activity options over the scheduled activity input options', async () => {
       activityOptionsDefault['MyWorkflow#step1'] = { scheduleToCloseTimeout: 60 };
       workflowInfoMock.mockReturnValue( {
         ...workflowInfo,
-        memo: { traceInfo: workflowInfo.memo.traceInfo, activityOptions: { heartbeatTimeout: 10 } }
+        memo: { traceInfo: workflowInfo.memo.traceInfo }
       } );
       memoToHeadersMock.mockReturnValue( {} );
       deepMergeMock.mockReturnValue( { heartbeatTimeout: 10, scheduleToCloseTimeout: 60 } );
@@ -103,14 +104,13 @@ describe( 'workflow interceptors', () => {
       const { interceptors } = await import( './workflow.js' );
       const { outbound } = interceptors();
       const interceptor = outbound[0];
-      const input = { headers: {}, activityType: 'MyWorkflow#step1' };
+      const input = { headers: {}, activityType: 'MyWorkflow#step1', options: { heartbeatTimeout: 10 } };
       const next = vi.fn().mockResolvedValue( undefined );
 
       await interceptor.scheduleActivity( input, next );
 
       expect( deepMergeMock ).toHaveBeenCalledWith( { heartbeatTimeout: 10 }, { scheduleToCloseTimeout: 60 } );
       expect( input.options ).toEqual( { heartbeatTimeout: 10, scheduleToCloseTimeout: 60 } );
-      delete activityOptionsDefault['MyWorkflow#step1'];
     } );
   } );
 

--- a/sdk/core/src/worker/loader/activities.js
+++ b/sdk/core/src/worker/loader/activities.js
@@ -2,74 +2,90 @@ import { dirname } from 'node:path';
 import { getTraceDestinations, sendHttpRequest } from '#internal_activities';
 import { findSharedActivitiesFromWorkflows, importComponents, matchFiles, writeFileInTempDir } from './tools.js';
 import { buildActivityMatcher, staticMatchers } from './matchers.js';
-import { ACTIVITY_SEND_HTTP_REQUEST, ACTIVITY_OPTIONS_FILENAME, SHARED_STEP_PREFIX, ACTIVITY_GET_TRACE_DESTINATIONS } from '#consts';
+import { ACTIVITY_SEND_HTTP_REQUEST, ACTIVITY_OPTIONS_FILENAME, ACTIVITY_GET_TRACE_DESTINATIONS } from '#consts';
 import { createChildLogger } from '#logger';
 import { ValidationError } from '#errors';
 
 const log = createChildLogger( 'Activities Loader' );
 
 /**
- * Load activities:
- * - Scans activities based on workflows, using each workflow folder as a point to lookup for steps, evaluators files;
- * - Scans shared activities in the rootDir;
- * - Loads internal activities as well;
+ * Load activities
+ * - Scan local project and external workflow npm packages and look for shared activities.
+ * - For each workflow, register shared activities under the workflow namespace.
+ * - For each workflow, load activities declared relative to that workflow directory.
  *
- * Builds a map of activities, where they is generated according to the type of activity and the value is the function itself and return it.
- * - Shared activity keys have a common prefix followed by the activity name;
- * - Internal activities are registered with a fixed key;
- * - Workflow activities keys are composed using the workflow name and the activity name;
+ * Builds a map of activities, key is workflowType#activityType, value is the component wrapper function.
  *
  * @param {string} rootDir
  * @param {import('./workflows.js').Workflow[]} workflows
  * @returns {object}
  */
 export async function loadActivities( rootDir, workflows ) {
-  const activities = {};
-  const activityOptionsMap = {};
+  const activities = new Map();
+  const activityOptions = new Map();
 
-  // Load workflow-based activities
-  for ( const { path: workflowPath, name: workflowName, external } of workflows ) {
-    const dir = dirname( workflowPath );
-    for await ( const { fn, metadata, path } of importComponents( matchFiles( dir, [ buildActivityMatcher( dir ) ] ) ) ) {
-      // Activities loaded from a workflow path will use the workflow name as a namespace, which is unique across the platform, avoiding collision
-      const activityKey = `${workflowName}#${metadata.name}`;
-
-      log.info( metadata.name, { workflow: workflowName, type: metadata.type, ...( external && { external } ), path } );
-
-      if ( activities[activityKey] ) {
-        throw new ValidationError( `Activity "${metadata.name}" in workflow "${workflowName}" conflicts with another \
-activity in the same workflow. Activity names must be unique within a workflow.` );
-      }
-      activities[activityKey] = fn;
-      // propagate the custom options set on the step()/evaluator() constructor
-      activityOptionsMap[activityKey] = metadata.options?.activityOptions ?? undefined;
-    }
-  }
+  const sharedActivities = new Map();
+  const sharedActivitiesOptions = new Map();
 
   // Load shared activities/evaluators from local and external npm modules
   const localSharedActivities = matchFiles( rootDir, [ staticMatchers.sharedStepsDir, staticMatchers.sharedEvaluatorsDir ] );
   const externalSharedActivities = findSharedActivitiesFromWorkflows( workflows.filter( w => w.external ) );
   for await ( const { fn, metadata, path } of importComponents( [ ...localSharedActivities, ...externalSharedActivities ] ) ) {
     const external = externalSharedActivities.some( a => a.path === path );
-    // Uses a global namespace for shared activities
-    const activityKey = `${SHARED_STEP_PREFIX}#${metadata.name}`;
 
+    if ( sharedActivities.has( metadata.name ) ) {
+      throw new ValidationError( `Shared activity "${metadata.name}" conflicts with another shared activity.` +
+        ' Shared activity names must be unique.' );
+    }
     log.info( metadata.name, { shared: true, type: metadata.type, ...( external && { external } ), path } );
 
-    if ( activities[activityKey] ) {
-      throw new ValidationError( `Shared activity "${metadata.name}" conflicts with another shared activity. \
-Shared activity names must be unique.` );
+    sharedActivities.set( metadata.name, fn );
+    if ( metadata.options?.activityOptions ) {
+      sharedActivitiesOptions.set( metadata.name, metadata.options.activityOptions );
     }
-    activities[activityKey] = fn;
-    activityOptionsMap[activityKey] = metadata.options?.activityOptions ?? undefined;
+  }
+
+  // Discover and load workflow activities
+  for ( const { path: workflowPath, name: workflowName, external } of workflows ) {
+    const dir = dirname( workflowPath );
+
+    // Add shared activities to this workflow namespace
+    for ( const [ name, fn ] of sharedActivities ) {
+      const id = `${workflowName}#${name}`;
+      activities.set( id, fn );
+      if ( sharedActivitiesOptions.has( name ) ) {
+        activityOptions.set( id, sharedActivitiesOptions.get( name ) );
+      }
+    }
+
+    for await ( const { fn, metadata, path } of importComponents( matchFiles( dir, [ buildActivityMatcher( dir ) ] ) ) ) {
+      // Activities loaded from a workflow path will use the workflow name as a namespace, which is unique across the platform, avoiding collision
+      const id = `${workflowName}#${metadata.name}`;
+
+      if ( sharedActivities.has( metadata.name ) ) {
+        throw new ValidationError( `Activity "${metadata.name}" in workflow "${workflowName}" conflicts with a shared activity.` +
+          ' Workflow activity names must not overlap with shared activity names.' );
+      }
+
+      if ( activities.has( id ) ) {
+        throw new ValidationError( `Activity "${metadata.name}" in workflow "${workflowName}" conflicts with another activity in the same workflow.` +
+          ' Activity names must be unique within a workflow.' );
+      }
+
+      log.info( metadata.name, { workflow: workflowName, type: metadata.type, ...( external && { external } ), path } );
+      activities.set( id, fn );
+      if ( metadata.options?.activityOptions ) {
+        activityOptions.set( id, metadata.options.activityOptions );
+      }
+    }
   }
 
   // writes down the activity option overrides
-  const optionsContent = `export default ${JSON.stringify( activityOptionsMap, undefined, 2 )};`;
+  const optionsContent = `export default ${JSON.stringify( Object.fromEntries( activityOptions ), undefined, 2 )};`;
   const optionsFile = writeFileInTempDir( optionsContent, ACTIVITY_OPTIONS_FILENAME );
 
   // system activities
-  activities[ACTIVITY_SEND_HTTP_REQUEST] = sendHttpRequest;
-  activities[ACTIVITY_GET_TRACE_DESTINATIONS] = getTraceDestinations;
-  return { activities, optionsFile };
+  activities.set( ACTIVITY_SEND_HTTP_REQUEST, sendHttpRequest );
+  activities.set( ACTIVITY_GET_TRACE_DESTINATIONS, getTraceDestinations );
+  return { activities: Object.fromEntries( activities ), optionsFile };
 };

--- a/sdk/core/src/worker/loader/activities.spec.js
+++ b/sdk/core/src/worker/loader/activities.spec.js
@@ -5,8 +5,7 @@ vi.mock( '#consts', () => ( {
   ACTIVITY_GET_TRACE_DESTINATIONS: '__internal#getTraceDestinations',
   WORKFLOWS_INDEX_FILENAME: '__workflows_entrypoint.js',
   WORKFLOW_CATALOG: 'catalog',
-  ACTIVITY_OPTIONS_FILENAME: '__activity_options.js',
-  SHARED_STEP_PREFIX: '$shared'
+  ACTIVITY_OPTIONS_FILENAME: '__activity_options.js'
 } ) );
 
 const sendHttpRequestMock = vi.fn();
@@ -63,6 +62,7 @@ describe( 'loadActivities', () => {
   it( 'loadActivities returns map including system activity and writes options file', async () => {
     const { loadActivities } = await import( './activities.js' );
 
+    importComponentsMock.mockImplementationOnce( async function *() {} );
     importComponentsMock.mockImplementationOnce( async function *() {
       yield {
         fn: () => {},
@@ -70,7 +70,6 @@ describe( 'loadActivities', () => {
         path: '/a/steps.js'
       };
     } );
-    importComponentsMock.mockImplementationOnce( async function *() {} );
 
     const workflows = [ { name: 'A', path: '/a/workflow.js' } ];
     const { activities, optionsFile } = await loadActivities( '/root', workflows );
@@ -89,11 +88,11 @@ describe( 'loadActivities', () => {
 
   it( 'loadActivities omits activity options when component has no options or no activityOptions', async () => {
     const { loadActivities } = await import( './activities.js' );
+    importComponentsMock.mockImplementationOnce( async function *() {} );
     importComponentsMock.mockImplementationOnce( async function *() {
       yield { fn: () => {}, metadata: { name: 'NoOptions' }, path: '/a/steps.js' };
       yield { fn: () => {}, metadata: { name: 'EmptyOptions', options: {} }, path: '/a/steps2.js' };
     } );
-    importComponentsMock.mockImplementationOnce( async function *() {} );
 
     await loadActivities( '/root', [ { name: 'A', path: '/a/workflow.js' } ] );
     const written = JSON.parse(
@@ -105,6 +104,7 @@ describe( 'loadActivities', () => {
 
   it( 'loadActivities throws when two activities in the same workflow share a name', async () => {
     const { loadActivities } = await import( './activities.js' );
+    importComponentsMock.mockImplementationOnce( async function *() {} );
     importComponentsMock.mockImplementationOnce( async function *() {
       yield { fn: () => {}, metadata: { name: 'DuplicateActivity' }, path: '/a/steps.js' };
       yield { fn: () => {}, metadata: { name: 'DuplicateActivity' }, path: '/a/evaluators.js' };
@@ -118,7 +118,6 @@ Activity names must be unique within a workflow.'
 
   it( 'loadActivities throws when two shared activities share a name', async () => {
     const { loadActivities } = await import( './activities.js' );
-    importComponentsMock.mockImplementationOnce( async function *() {} );
     importComponentsMock.mockImplementationOnce( async function *() {
       yield { fn: () => {}, metadata: { name: 'DuplicateShared' }, path: '/root/shared/steps/a.js' };
       yield { fn: () => {}, metadata: { name: 'DuplicateShared' }, path: '/root/shared/evaluators/a.js' };
@@ -133,8 +132,8 @@ Activity names must be unique within a workflow.'
     const { loadActivities } = await import( './activities.js' );
     const workflowFiles = [ { path: '/a/steps/foo.js' } ];
     const sharedFiles = [ { path: '/root/shared/steps/baz.js' } ];
-    matchFilesMock.mockReturnValueOnce( workflowFiles );
     matchFilesMock.mockReturnValueOnce( sharedFiles );
+    matchFilesMock.mockReturnValueOnce( workflowFiles );
     importComponentsMock.mockImplementationOnce( async function *() {} );
     importComponentsMock.mockImplementationOnce( async function *() {} );
 
@@ -143,12 +142,12 @@ Activity names must be unique within a workflow.'
 
     expect( matchFilesMock ).toHaveBeenCalledTimes( 2 );
     expect( buildActivityMatcherMock ).toHaveBeenCalledWith( '/a' );
-    expect( matchFilesMock ).toHaveBeenNthCalledWith( 1, '/a', [ activityMatcherMock ] );
-    expect( matchFilesMock ).toHaveBeenNthCalledWith( 2, '/root', [ sharedStepsDirMock, sharedEvaluatorsDirMock ] );
+    expect( matchFilesMock ).toHaveBeenNthCalledWith( 1, '/root', [ sharedStepsDirMock, sharedEvaluatorsDirMock ] );
+    expect( matchFilesMock ).toHaveBeenNthCalledWith( 2, '/a', [ activityMatcherMock ] );
 
     expect( importComponentsMock ).toHaveBeenCalledTimes( 2 );
-    expect( importComponentsMock ).toHaveBeenNthCalledWith( 1, workflowFiles );
-    expect( importComponentsMock ).toHaveBeenNthCalledWith( 2, sharedFiles );
+    expect( importComponentsMock ).toHaveBeenNthCalledWith( 1, sharedFiles );
+    expect( importComponentsMock ).toHaveBeenNthCalledWith( 2, workflowFiles );
   } );
 
   it( 'loads shared activities from external workflow packages', async () => {
@@ -157,8 +156,6 @@ Activity names must be unique within a workflow.'
     const localWorkflow = { name: 'Local', path: '/root/workflows/local/workflow.js' };
     const externalWorkflow = { name: 'External', path: '/root/node_modules/pkg/workflows/a/workflow.js', external: true };
     findSharedActivitiesFromWorkflowsMock.mockReturnValue( externalSharedFiles );
-    importComponentsMock.mockImplementationOnce( async function *() {} );
-    importComponentsMock.mockImplementationOnce( async function *() {} );
     importComponentsMock.mockImplementationOnce( async function *() {
       yield {
         fn: () => {},
@@ -170,27 +167,29 @@ Activity names must be unique within a workflow.'
     const { activities } = await loadActivities( '/root', [ localWorkflow, externalWorkflow ] );
 
     expect( findSharedActivitiesFromWorkflowsMock ).toHaveBeenCalledWith( [ externalWorkflow ] );
-    expect( importComponentsMock ).toHaveBeenNthCalledWith( 3, externalSharedFiles );
-    expect( activities['$shared#ExternalShared'] ).toBeTypeOf( 'function' );
+    expect( importComponentsMock ).toHaveBeenNthCalledWith( 1, externalSharedFiles );
+    expect( activities['Local#ExternalShared'] ).toBeTypeOf( 'function' );
+    expect( activities['External#ExternalShared'] ).toBeTypeOf( 'function' );
     const written = JSON.parse(
       writeFileInTempDirMock.mock.calls[0][0].replace( /^export default\s*/, '' ).replace( /;\s*$/, '' )
     );
-    expect( written['$shared#ExternalShared'] ).toEqual( { retry: { maximumAttempts: 2 } } );
+    expect( written['Local#ExternalShared'] ).toEqual( { retry: { maximumAttempts: 2 } } );
+    expect( written['External#ExternalShared'] ).toEqual( { retry: { maximumAttempts: 2 } } );
   } );
 
   it( 'loadActivities includes nested workflow steps and shared evaluators', async () => {
     const { loadActivities } = await import( './activities.js' );
     importComponentsMock.mockImplementationOnce( async function *() {
-      yield { fn: () => {}, metadata: { name: 'ActNested' }, path: '/a/steps/foo.js' };
+      yield { fn: () => {}, metadata: { name: 'SharedEval' }, path: '/root/shared/evaluators/bar.js' };
     } );
     importComponentsMock.mockImplementationOnce( async function *() {
-      yield { fn: () => {}, metadata: { name: 'SharedEval' }, path: '/root/shared/evaluators/bar.js' };
+      yield { fn: () => {}, metadata: { name: 'ActNested' }, path: '/a/steps/foo.js' };
     } );
 
     const workflows = [ { name: 'A', path: '/a/workflow.js' } ];
     const { activities } = await loadActivities( '/root', workflows );
     expect( activities['A#ActNested'] ).toBeTypeOf( 'function' );
-    expect( activities['$shared#SharedEval'] ).toBeTypeOf( 'function' );
+    expect( activities['A#SharedEval'] ).toBeTypeOf( 'function' );
   } );
 
   it( 'collects shared nested steps and evaluators across multiple subfolders', async () => {
@@ -205,9 +204,9 @@ Activity names must be unique within a workflow.'
 
     const workflows = [ { name: 'A', path: '/a/workflow.js' } ];
     const { activities } = await loadActivities( '/root', workflows );
-    expect( activities['$shared#SharedStepPrimary'] ).toBeTypeOf( 'function' );
-    expect( activities['$shared#SharedStepSecondary'] ).toBeTypeOf( 'function' );
-    expect( activities['$shared#SharedEvalPrimary'] ).toBeTypeOf( 'function' );
-    expect( activities['$shared#SharedEvalSecondary'] ).toBeTypeOf( 'function' );
+    expect( activities['A#SharedStepPrimary'] ).toBeTypeOf( 'function' );
+    expect( activities['A#SharedStepSecondary'] ).toBeTypeOf( 'function' );
+    expect( activities['A#SharedEvalPrimary'] ).toBeTypeOf( 'function' );
+    expect( activities['A#SharedEvalSecondary'] ).toBeTypeOf( 'function' );
   } );
 } );

--- a/sdk/core/src/worker/loader/workflows.spec.js
+++ b/sdk/core/src/worker/loader/workflows.spec.js
@@ -5,8 +5,7 @@ vi.mock( '#consts', () => ( {
   ACTIVITY_GET_TRACE_DESTINATIONS: '__internal#getTraceDestinations',
   WORKFLOWS_INDEX_FILENAME: '__workflows_entrypoint.js',
   WORKFLOW_CATALOG: 'catalog',
-  ACTIVITY_OPTIONS_FILENAME: '__activity_options.js',
-  SHARED_STEP_PREFIX: '$shared'
+  ACTIVITY_OPTIONS_FILENAME: '__activity_options.js'
 } ) );
 
 const { importComponentsMock, findWorkflowsInNodeModulesMock, matchFilesMock, writeFileInTempDirMock } = vi.hoisted( () => ( {

--- a/sdk/core/src/worker/webpack_loaders/consts.js
+++ b/sdk/core/src/worker/webpack_loaders/consts.js
@@ -7,3 +7,9 @@ export const ComponentFile = {
   STEPS: 'steps',
   WORKFLOW: 'workflow'
 };
+
+export const ComponentFactory = {
+  EVALUATOR: 'evaluator',
+  STEP: 'step',
+  WORKFLOW: 'workflow'
+};

--- a/sdk/core/src/worker/webpack_loaders/tools.js
+++ b/sdk/core/src/worker/webpack_loaders/tools.js
@@ -2,27 +2,14 @@ import parser from '@babel/parser';
 import { resolve as resolvePath } from 'node:path';
 import { readFileSync } from 'node:fs';
 import {
-  blockStatement,
-  callExpression,
-  functionExpression,
-  identifier,
-  isArrowFunctionExpression,
   isAssignmentPattern,
-  isBlockStatement,
   isCallExpression,
   isExportNamedDeclaration,
-  isFunctionExpression,
   isIdentifier,
-  isVariableDeclarator,
   isStringLiteral,
   isVariableDeclaration,
   isObjectExpression,
-  memberExpression,
-  returnStatement,
-  stringLiteral,
-  thisExpression,
-  isExportDefaultDeclaration,
-  isFunctionDeclaration
+  isExportDefaultDeclaration
 } from '@babel/types';
 import { ComponentFile, NodeType } from './consts.js';
 
@@ -98,17 +85,6 @@ export const getLocalNameFromDestructuredProperty = prop => {
     return prop.value.left.name;
   }
   return null;
-};
-
-/**
- * Convert an ArrowFunctionExpression to a FunctionExpression.
- * Wraps expression bodies in a block with a return statement.
- * @param {import('@babel/types').ArrowFunctionExpression} arrow - Arrow function.
- * @returns {import('@babel/types').FunctionExpression} Function expression.
- */
-export const toFunctionExpression = arrow => {
-  const body = isBlockStatement( arrow.body ) ? arrow.body : blockStatement( [ returnStatement( arrow.body ) ] );
-  return functionExpression( null, arrow.params, body, arrow.generator ?? false, arrow.async ?? false );
 };
 
 /**
@@ -230,38 +206,6 @@ export const getFileKind = path => {
   }
   return null;
 };
-
-/**
- * Create a `this.method(literalName, ...args)` CallExpression.
- * @param {string} method - Method name on `this`.
- * @param {string} literalName - First string literal argument.
- * @param {import('@babel/types').Expression[]} args - Remaining call arguments.
- * @returns {import('@babel/types').CallExpression} Call expression node.
- */
-export const createThisMethodCall = ( method, literalName, args ) =>
-  callExpression( memberExpression( thisExpression(), identifier( method ) ), [ stringLiteral( literalName ), ...args ] );
-
-/**
- * Build a CallExpression that binds `this` at the call site:
- *   fn(arg1, arg2) -> fn.call(this, arg1, arg2)
- *
- * When to use:
- * - Inside workflow `fn` rewriting, local call-chain functions must receive the dynamic `this`
- *   so that emitted `this.invokeStep(...)` and similar calls inside them operate correctly.
- *
- * Example:
- *   // Input AST intent:
- *   foo(a, b);
- *
- *   // Rewritten AST:
- *   foo.call(this, a, b);
- *
- * @param {string} calleeName - Identifier name of the function being called (e.g., 'foo').
- * @param {import('@babel/types').Expression[]} args - Original call arguments.
- * @returns {import('@babel/types').CallExpression} CallExpression node representing `callee.call(this, ...args)`.
- */
-export const bindThisAtCallSite = ( calleeName, args ) =>
-  callExpression( memberExpression( identifier( calleeName ), identifier( 'call' ) ), [ thisExpression(), ...args ] );
 
 /**
  * Resolve an options object's name property to a string.
@@ -466,92 +410,3 @@ export const buildWorkflowNameMap = ( path, cache ) => {
   return result;
 };
 
-/**
- * Determine whether a node represents a function body usable as a workflow `fn`.
- *
- * Why this matters:
- * - Workflow `fn` needs a dynamic `this` so the rewriter can emit calls like `this.invokeStep(...)`.
- * - Arrow functions do not have their own `this`; they capture `this` lexically, which breaks the runtime contract.
- *
- * Accepts:
- * - FunctionExpression (possibly async/generator), e.g.:
- *   const obj = {
- *     fn: async function (input) {
- *       return input;
- *     }
- *   };
- *
- * Rejects:
- * - ArrowFunctionExpression, e.g.:
- *   const obj = {
- *     fn: async (input) => input
- *   };
- *
- * - Any other non-function expression.
- *
- * Notes:
- * - The rewriter will proactively convert arrow `fn` to a FunctionExpression before further processing.
- *
- * @param {import('@babel/types').Expression} v - Candidate node for `fn` value.
- * @returns {boolean} True if `v` is a FunctionExpression and not an arrow function.
- */
-export const isFunction = v => isFunctionExpression( v ) && !isArrowFunctionExpression( v );
-
-/**
- * Determine whether a variable declarator represents a function-like value.
- *
- * Use case:
- * - When `fn` calls a locally-declared function (directly or transitively), we need to:
- *   - propagate `this` to that function call (`callee.call(this, ...)`)
- *   - traverse into that function's body to rewrite imported step/workflow/evaluator calls.
- *
- * Matches patterns like:
- * - Function expression:
- *   const foo = function (x) { return x + 1; };
- *
- * - Async/generator function expression:
- *   const foo = async function (x) { return await work(x); };
- *
- * - Arrow function (will be normalized to FunctionExpression by the rewriter):
- *   const foo = (x) => x + 1;
- *   const foo = async (x) => await work(x);
- *
- * Does not match:
- * - Non-function initializers:
- *   const foo = 42;
- *   const foo = someIdentifier;
- *
- * @param {import('@babel/types').Node} v - AST node (typically a VariableDeclarator).
- * @returns {boolean} True if the declarator's initializer is a function (arrow or function expression).
- */
-export const isVarFunction = v =>
-  isVariableDeclarator( v ) && ( isFunctionExpression( v.init ) || isArrowFunctionExpression( v.init ) );
-
-/**
- * Determine whether a binding node corresponds to a function-like declaration usable
- * as a call-chain function target during workflow rewriting.
- *
- * Matches:
- * - FunctionDeclaration:
- *     function foo(x) { return x + 1; }
- *
- * - VariableDeclarator initialized with a function or arrow (normalized later):
- *     const foo = function (x) { return x + 1; };
- *     const foo = (x) => x + 1;
- *
- * Non-matches:
- * - Any binding that is not a function declaration nor a variable declarator with a function initializer.
- *
- * Why this matters:
- * - The rewriter traverses call chains from the workflow `fn`. It must recognize which local
- *   callees are valid function bodies to rewrite and into which it can propagate `this`.
- *
- * @param {import('@babel/types').Node} node - Binding path node (FunctionDeclaration or VariableDeclarator).
- * @returns {boolean} True if the node represents a function-like binding.
- */
-export const isFunctionLikeBinding = node =>
-  isFunctionDeclaration( node ) ||
-  (
-    isVariableDeclarator( node ) &&
-    ( isFunctionExpression( node.init ) || isArrowFunctionExpression( node.init ) )
-  );

--- a/sdk/core/src/worker/webpack_loaders/tools.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/tools.spec.js
@@ -9,7 +9,6 @@ import {
   extractTopLevelStringConsts,
   getObjectKeyName,
   getLocalNameFromDestructuredProperty,
-  toFunctionExpression,
   isStepsPath,
   isSharedStepsPath,
   isAnyStepsPath,
@@ -17,7 +16,6 @@ import {
   isSharedEvaluatorsPath,
   isWorkflowPath,
   isAbsoluteWorkflowJsResource,
-  createThisMethodCall,
   resolveNameFromArg,
   resolveNameFromOptions,
   buildStepsNameMap,
@@ -130,17 +128,6 @@ describe( 'workflow_rewriter tools', () => {
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'toFunctionExpression: converts arrow, wraps expression bodies', () => {
-    const arrowExprBody = t.arrowFunctionExpression( [ t.identifier( 'x' ) ], t.identifier( 'x' ) );
-    const arrowBlockBody = t.arrowFunctionExpression( [], t.blockStatement( [ t.returnStatement( t.numericLiteral( 1 ) ) ] ) );
-    const fn1 = toFunctionExpression( arrowExprBody );
-    const fn2 = toFunctionExpression( arrowBlockBody );
-    expect( t.isFunctionExpression( fn1 ) ).toBe( true );
-    expect( t.isBlockStatement( fn1.body ) ).toBe( true );
-    expect( t.isReturnStatement( fn1.body.body[0] ) ).toBe( true );
-    expect( t.isFunctionExpression( fn2 ) ).toBe( true );
-  } );
-
   it( 'isStepsPath: matches LOCAL steps.js (no path traversal)', () => {
     // Local steps (without ../ or /shared/)
     expect( isStepsPath( 'steps.js' ) ).toBe( true );
@@ -224,16 +211,6 @@ describe( 'workflow_rewriter tools', () => {
     // Non-evaluators should NOT match
     expect( isSharedEvaluatorsPath( '../utils.js' ) ).toBe( false );
     expect( isSharedEvaluatorsPath( 'steps.js' ) ).toBe( false );
-  } );
-
-  it( 'createThisMethodCall: builds this.method(\'name\', ...args) call', () => {
-    const call = createThisMethodCall( 'invoke', 'n', [ t.numericLiteral( 1 ), t.identifier( 'x' ) ] );
-    expect( t.isCallExpression( call ) ).toBe( true );
-    expect( t.isMemberExpression( call.callee ) ).toBe( true );
-    expect( t.isThisExpression( call.callee.object ) ).toBe( true );
-    expect( t.isIdentifier( call.callee.property, { name: 'invoke' } ) ).toBe( true );
-    expect( t.isStringLiteral( call.arguments[0], { value: 'n' } ) ).toBe( true );
-    expect( call.arguments.length ).toBe( 3 );
   } );
 
   it( 'buildSharedStepsNameMap: reads names from shared steps module and caches result', () => {

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.js
@@ -73,7 +73,12 @@ const collectDestructuredRequires = ( path, absolutePath, req, descriptors ) => 
  *
  * @param {import('@babel/types').File} ast - Parsed file AST.
  * @param {string} fileDir - Absolute directory of the file represented by `ast`.
- * @param {{ stepsNameCache: Map<string,Map<string,string>> }} caches
+ * @param {{
+ *  stepsNameCache: Map<string,Map<string,string>>,
+ *  evaluatorsNameCache: Map<string,Map<string,string>>,
+ *  sharedStepsNameCache: Map<string,Map<string,string>>,
+ *  sharedEvaluatorsNameCache: Map<string,Map<string,string>>
+ * }} caches
  *  Resolved-name caches to avoid re-reading same modules.
  * @returns {{ activityImports: Array<{localName:string,activityName:string}> }} Collected import mappings.
  */
@@ -148,7 +153,7 @@ export default function collectTargetImports(
           },
           {
             match: isSharedStepsPath, buildMap: buildSharedStepsNameMap,
-            cache: sharedStepsNameCache ?? stepsNameCache,
+            cache: sharedStepsNameCache,
             target: activityImports, label: 'shared steps'
           },
           {
@@ -157,7 +162,7 @@ export default function collectTargetImports(
           },
           {
             match: isSharedEvaluatorsPath, buildMap: buildSharedEvaluatorsNameMap,
-            cache: sharedEvaluatorsNameCache ?? evaluatorsNameCache,
+            cache: sharedEvaluatorsNameCache,
             target: activityImports, label: 'shared evaluators'
           }
         ];

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.js
@@ -43,7 +43,7 @@ const removeRequireDeclarator = path => {
 
 const collectDestructuredRequires = ( path, absolutePath, req, descriptors ) => {
   const propFilter = p => isObjectProperty( p ) && isIdentifier( p.key );
-  for ( const { match, buildMap, cache, target, valueKey, label } of descriptors ) {
+  for ( const { match, buildMap, cache, label, target } of descriptors ) {
     if ( !match( req ) ) {
       continue;
     }
@@ -54,7 +54,7 @@ const collectDestructuredRequires = ( path, absolutePath, req, descriptors ) => 
       if ( localName ) {
         const resolved = nameMap.get( importedName );
         if ( resolved ) {
-          target.push( { localName, [valueKey]: resolved } );
+          target.push( { localName, activityName: resolved } );
         } else {
           throw unresolvedImportError( importedName, label, absolutePath );
         }
@@ -67,7 +67,7 @@ const collectDestructuredRequires = ( path, absolutePath, req, descriptors ) => 
 
 /**
  * Collect and strip target imports and requires from an AST, producing
- * step/evaluator import mappings for later rewrites.
+ * activity import mappings for later rewrites.
  *
  * Mutates the AST by removing matching import declarations and require declarators.
  *
@@ -75,17 +75,13 @@ const collectDestructuredRequires = ( path, absolutePath, req, descriptors ) => 
  * @param {string} fileDir - Absolute directory of the file represented by `ast`.
  * @param {{ stepsNameCache: Map<string,Map<string,string>> }} caches
  *  Resolved-name caches to avoid re-reading same modules.
- * @returns {{ stepImports: Array<{localName:string,stepName:string}>,
- *  evaluatorImports: Array<{localName:string,evaluatorName:string}> }} Collected info mappings.
+ * @returns {{ activityImports: Array<{localName:string,activityName:string}> }} Collected import mappings.
  */
 export default function collectTargetImports(
   ast, fileDir,
   { stepsNameCache, evaluatorsNameCache, sharedStepsNameCache, sharedEvaluatorsNameCache }
 ) {
-  const stepImports = [];
-  const sharedStepImports = [];
-  const evaluatorImports = [];
-  const sharedEvaluatorImports = [];
+  const activityImports = [];
 
   traverse( ast, {
     ImportDeclaration: path => {
@@ -98,7 +94,7 @@ export default function collectTargetImports(
       }
 
       const absolutePath = toAbsolutePath( fileDir, src );
-      const collectNamedImports = ( match, buildMapFn, cache, targetArr, valueKey, fileLabel ) => {
+      const collectNamedImports = ( match, buildMapFn, cache, fileLabel ) => {
         if ( !match ) {
           return;
         }
@@ -108,22 +104,17 @@ export default function collectTargetImports(
           const localName = s.local.name;
           const value = nameMap.get( importedName );
           if ( value ) {
-            const entry = { localName };
-            entry[valueKey] = value;
-            targetArr.push( entry );
+            activityImports.push( { localName, activityName: value } );
           } else {
             throw unresolvedImportError( importedName, fileLabel, absolutePath );
           }
         }
       };
 
-      collectNamedImports( isStepsPath( src ), buildStepsNameMap, stepsNameCache, stepImports, 'stepName', 'steps' );
-      collectNamedImports( isSharedStepsPath( src ), buildSharedStepsNameMap, sharedStepsNameCache, sharedStepImports, 'stepName', 'shared steps' );
-      collectNamedImports( isEvaluatorsPath( src ), buildEvaluatorsNameMap, evaluatorsNameCache, evaluatorImports, 'evaluatorName', 'evaluators' );
-      collectNamedImports(
-        isSharedEvaluatorsPath( src ), buildSharedEvaluatorsNameMap,
-        sharedEvaluatorsNameCache, sharedEvaluatorImports, 'evaluatorName', 'shared evaluators'
-      );
+      collectNamedImports( isStepsPath( src ), buildStepsNameMap, stepsNameCache, 'steps' );
+      collectNamedImports( isSharedStepsPath( src ), buildSharedStepsNameMap, sharedStepsNameCache, 'shared steps' );
+      collectNamedImports( isEvaluatorsPath( src ), buildEvaluatorsNameMap, evaluatorsNameCache, 'evaluators' );
+      collectNamedImports( isSharedEvaluatorsPath( src ), buildSharedEvaluatorsNameMap, sharedEvaluatorsNameCache, 'shared evaluators' );
       path.remove();
     },
     VariableDeclarator: path => {
@@ -153,25 +144,21 @@ export default function collectTargetImports(
         const cjsDescriptors = [
           {
             match: isStepsPath, buildMap: buildStepsNameMap,
-            cache: stepsNameCache, target: stepImports,
-            valueKey: 'stepName', label: 'steps'
+            cache: stepsNameCache, target: activityImports, label: 'steps'
           },
           {
             match: isSharedStepsPath, buildMap: buildSharedStepsNameMap,
             cache: sharedStepsNameCache ?? stepsNameCache,
-            target: sharedStepImports,
-            valueKey: 'stepName', label: 'shared steps'
+            target: activityImports, label: 'shared steps'
           },
           {
             match: isEvaluatorsPath, buildMap: buildEvaluatorsNameMap,
-            cache: evaluatorsNameCache, target: evaluatorImports,
-            valueKey: 'evaluatorName', label: 'evaluators'
+            cache: evaluatorsNameCache, target: activityImports, label: 'evaluators'
           },
           {
             match: isSharedEvaluatorsPath, buildMap: buildSharedEvaluatorsNameMap,
             cache: sharedEvaluatorsNameCache ?? evaluatorsNameCache,
-            target: sharedEvaluatorImports,
-            valueKey: 'evaluatorName', label: 'shared evaluators'
+            target: activityImports, label: 'shared evaluators'
           }
         ];
         collectDestructuredRequires(
@@ -182,5 +169,5 @@ export default function collectTargetImports(
     }
   } );
 
-  return { stepImports, sharedStepImports, evaluatorImports, sharedEvaluatorImports };
+  return { activityImports };
 }

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.spec.js
@@ -27,14 +27,15 @@ import WF, { FlowA } from './workflow.js';
 const x = 1;`;
 
     const ast = makeAst( source, join( dir, 'file.js' ) );
-    const { stepImports, evaluatorImports } = collectTargetImports(
+    const { activityImports } = collectTargetImports(
       ast,
       dir,
       { stepsNameCache: new Map(), evaluatorsNameCache: new Map() }
     );
-    expect( evaluatorImports ).toEqual( [ { localName: 'EvalA', evaluatorName: 'eval.a' } ] );
-
-    expect( stepImports ).toEqual( [ { localName: 'StepA', stepName: 'step.a' } ] );
+    expect( activityImports ).toEqual( [
+      { localName: 'StepA', activityName: 'step.a' },
+      { localName: 'EvalA', activityName: 'eval.a' }
+    ] );
     expect( ast.program.body.find( n => n.type === 'ImportDeclaration' )?.source.value ).toBe( './workflow.js' );
 
     rmSync( dir, { recursive: true, force: true } );
@@ -53,14 +54,15 @@ const WF = require( './workflow.js' );
 const obj = {};`;
 
     const ast = makeAst( source, join( dir, 'file.js' ) );
-    const { stepImports, evaluatorImports } = collectTargetImports(
+    const { activityImports } = collectTargetImports(
       ast,
       dir,
       { stepsNameCache: new Map(), evaluatorsNameCache: new Map() }
     );
-    expect( evaluatorImports ).toEqual( [ { localName: 'EvalB', evaluatorName: 'eval.b' } ] );
-
-    expect( stepImports ).toEqual( [ { localName: 'StepB', stepName: 'step.b' } ] );
+    expect( activityImports ).toEqual( [
+      { localName: 'StepB', activityName: 'step.b' },
+      { localName: 'EvalB', activityName: 'eval.b' }
+    ] );
     // Only non-target require declarators should remain.
     const hasRequireDecl = ast.program.body.some( n =>
       n.type === 'VariableDeclaration' && n.declarations.some( d => d.init && d.init.type === 'CallExpression' )
@@ -77,12 +79,12 @@ const obj = {};`;
     const source = 'import { MyExport } from \'./evaluators.js\';';
     const ast = makeAst( source, join( dir, 'file.js' ) );
 
-    const { evaluatorImports } = collectTargetImports(
+    const { activityImports } = collectTargetImports(
       ast,
       dir,
       { stepsNameCache: new Map(), evaluatorsNameCache: new Map() }
     );
-    expect( evaluatorImports ).toEqual( [ { localName: 'MyExport', evaluatorName: 'bad' } ] );
+    expect( activityImports ).toEqual( [ { localName: 'MyExport', activityName: 'bad' } ] );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
@@ -94,12 +96,12 @@ const obj = {};`;
     const source = 'import { MyExport } from \'./steps.js\';';
     const ast = makeAst( source, join( dir, 'file.js' ) );
 
-    const { stepImports } = collectTargetImports(
+    const { activityImports } = collectTargetImports(
       ast,
       dir,
       { stepsNameCache: new Map(), evaluatorsNameCache: new Map() }
     );
-    expect( stepImports ).toEqual( [ { localName: 'MyExport', stepName: 'bad' } ] );
+    expect( activityImports ).toEqual( [ { localName: 'MyExport', activityName: 'bad' } ] );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
@@ -111,12 +113,12 @@ const obj = {};`;
     const source = 'const { MyExport } = require( \'./evaluators.js\' );';
     const ast = makeAst( source, join( dir, 'file.js' ) );
 
-    const { evaluatorImports } = collectTargetImports(
+    const { activityImports } = collectTargetImports(
       ast,
       dir,
       { stepsNameCache: new Map(), evaluatorsNameCache: new Map() }
     );
-    expect( evaluatorImports ).toEqual( [ { localName: 'MyExport', evaluatorName: 'bad' } ] );
+    expect( activityImports ).toEqual( [ { localName: 'MyExport', activityName: 'bad' } ] );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
@@ -128,12 +130,12 @@ const obj = {};`;
     const source = 'const { MyExport } = require( \'./steps.js\' );';
     const ast = makeAst( source, join( dir, 'file.js' ) );
 
-    const { stepImports } = collectTargetImports(
+    const { activityImports } = collectTargetImports(
       ast,
       dir,
       { stepsNameCache: new Map(), evaluatorsNameCache: new Map() }
     );
-    expect( stepImports ).toEqual( [ { localName: 'MyExport', stepName: 'bad' } ] );
+    expect( activityImports ).toEqual( [ { localName: 'MyExport', activityName: 'bad' } ] );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
@@ -201,12 +203,12 @@ const obj = {};`;
     const source = 'import { SharedEval } from \'../../shared/evaluators/common.js\';';
     const ast = makeAst( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
 
-    const { sharedEvaluatorImports } = collectTargetImports(
+    const { activityImports } = collectTargetImports(
       ast,
       join( dir, 'workflows', 'my_workflow' ),
       { stepsNameCache: new Map(), evaluatorsNameCache: new Map(), sharedEvaluatorsNameCache: new Map() }
     );
-    expect( sharedEvaluatorImports ).toEqual( [ { localName: 'SharedEval', evaluatorName: 'shared.eval' } ] );
+    expect( activityImports ).toEqual( [ { localName: 'SharedEval', activityName: 'shared.eval' } ] );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
@@ -223,12 +225,12 @@ const obj = {};`;
     const source = 'const { SharedEval } = require( \'../../shared/evaluators/common.js\' );';
     const ast = makeAst( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
 
-    const { sharedEvaluatorImports } = collectTargetImports(
+    const { activityImports } = collectTargetImports(
       ast,
       join( dir, 'workflows', 'my_workflow' ),
       { stepsNameCache: new Map(), evaluatorsNameCache: new Map(), sharedEvaluatorsNameCache: new Map() }
     );
-    expect( sharedEvaluatorImports ).toEqual( [ { localName: 'SharedEval', evaluatorName: 'shared.eval' } ] );
+    expect( activityImports ).toEqual( [ { localName: 'SharedEval', activityName: 'shared.eval' } ] );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
@@ -245,7 +247,7 @@ const obj = {};`;
     const source = 'const { SharedA } = require( \'../../shared/steps/common.js\' );';
     const ast = makeAst( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
 
-    const { sharedStepImports } = collectTargetImports(
+    const { activityImports } = collectTargetImports(
       ast,
       join( dir, 'workflows', 'my_workflow' ),
       {
@@ -253,7 +255,7 @@ const obj = {};`;
         evaluatorsNameCache: new Map(), sharedEvaluatorsNameCache: new Map()
       }
     );
-    expect( sharedStepImports ).toEqual( [ { localName: 'SharedA', stepName: 'shared.a' } ] );
+    expect( activityImports ).toEqual( [ { localName: 'SharedA', activityName: 'shared.a' } ] );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
@@ -270,7 +272,7 @@ const obj = {};`;
     const source = 'const { MyExport } = require( \'../../shared/steps/common.js\' );';
     const ast = makeAst( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
 
-    const { sharedStepImports } = collectTargetImports(
+    const { activityImports } = collectTargetImports(
       ast,
       join( dir, 'workflows', 'my_workflow' ),
       {
@@ -278,7 +280,7 @@ const obj = {};`;
         evaluatorsNameCache: new Map(), sharedEvaluatorsNameCache: new Map()
       }
     );
-    expect( sharedStepImports ).toEqual( [ { localName: 'MyExport', stepName: 'bad' } ] );
+    expect( activityImports ).toEqual( [ { localName: 'MyExport', activityName: 'bad' } ] );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
@@ -295,12 +297,12 @@ const obj = {};`;
     const source = 'const { MyExport } = require( \'../../shared/evaluators/common.js\' );';
     const ast = makeAst( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
 
-    const { sharedEvaluatorImports } = collectTargetImports(
+    const { activityImports } = collectTargetImports(
       ast,
       join( dir, 'workflows', 'my_workflow' ),
       { stepsNameCache: new Map(), evaluatorsNameCache: new Map(), sharedEvaluatorsNameCache: new Map() }
     );
-    expect( sharedEvaluatorImports ).toEqual( [ { localName: 'MyExport', evaluatorName: 'bad' } ] );
+    expect( activityImports ).toEqual( [ { localName: 'MyExport', activityName: 'bad' } ] );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
@@ -317,12 +319,12 @@ const obj = {};`;
     const source = 'import { MyExport } from \'../../shared/evaluators/common.js\';';
     const ast = makeAst( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
 
-    const { sharedEvaluatorImports } = collectTargetImports(
+    const { activityImports } = collectTargetImports(
       ast,
       join( dir, 'workflows', 'my_workflow' ),
       { stepsNameCache: new Map(), evaluatorsNameCache: new Map(), sharedEvaluatorsNameCache: new Map() }
     );
-    expect( sharedEvaluatorImports ).toEqual( [ { localName: 'MyExport', evaluatorName: 'bad' } ] );
+    expect( activityImports ).toEqual( [ { localName: 'MyExport', activityName: 'bad' } ] );
 
     rmSync( dir, { recursive: true, force: true } );
   } );

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/collect_target_imports.spec.js
@@ -5,329 +5,130 @@ import { join } from 'node:path';
 import { parse } from '../tools.js';
 import collectTargetImports from './collect_target_imports.js';
 
-function makeAst( source, filename ) {
-  return parse( source, filename );
-}
+const caches = () => ( {
+  stepsNameCache: new Map(),
+  evaluatorsNameCache: new Map(),
+  sharedStepsNameCache: new Map(),
+  sharedEvaluatorsNameCache: new Map()
+} );
+
+const makeAst = ( source, filename ) => parse( source, filename );
 
 describe( 'collect_target_imports', () => {
-  it( 'collects ESM imports for steps and evaluators and leaves workflow imports intact', () => {
+  it( 'collects ESM activity imports and leaves workflow imports intact', () => {
     const dir = mkdtempSync( join( tmpdir(), 'collect-esm-' ) );
-    writeFileSync( join( dir, 'steps.js' ), `
-export const StepA = step({ name: 'step.a' });
-export const StepB = step({ name: 'step.b' });` );
+    writeFileSync( join( dir, 'steps.js' ), 'export const StepA = step({ name: \'step.a\' });' );
     writeFileSync( join( dir, 'evaluators.js' ), 'export const EvalA = evaluator({ name: \'eval.a\' });' );
-    writeFileSync( join( dir, 'workflow.js' ), `
-export const FlowA = workflow({ name: 'flow.a' });
-export default workflow({ name: 'flow.def' });` );
+    writeFileSync( join( dir, 'workflow.js' ), 'export const FlowA = workflow({ name: \'flow.a\' });' );
 
-    const source = `
+    const ast = makeAst( `
 import { StepA } from './steps.js';
 import { EvalA } from './evaluators.js';
-import WF, { FlowA } from './workflow.js';
-const x = 1;`;
+import { FlowA } from './workflow.js';`, join( dir, 'file.js' ) );
 
-    const ast = makeAst( source, join( dir, 'file.js' ) );
-    const { activityImports } = collectTargetImports(
-      ast,
-      dir,
-      { stepsNameCache: new Map(), evaluatorsNameCache: new Map() }
-    );
+    const { activityImports } = collectTargetImports( ast, dir, caches() );
+
     expect( activityImports ).toEqual( [
       { localName: 'StepA', activityName: 'step.a' },
       { localName: 'EvalA', activityName: 'eval.a' }
     ] );
     expect( ast.program.body.find( n => n.type === 'ImportDeclaration' )?.source.value ).toBe( './workflow.js' );
-
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'collects CJS requires for steps and evaluators and leaves workflow requires intact', () => {
+  it( 'collects CJS activity requires and leaves workflow requires intact', () => {
     const dir = mkdtempSync( join( tmpdir(), 'collect-cjs-' ) );
-    writeFileSync( join( dir, 'steps.js' ), 'export const StepB = step({ name: \'step.b\' })' );
-    writeFileSync( join( dir, 'evaluators.js' ), 'export const EvalB = evaluator({ name: \'eval.b\' })' );
-    writeFileSync( join( dir, 'workflow.js' ), 'export default workflow({ name: \'flow.c\' })' );
+    writeFileSync( join( dir, 'steps.js' ), 'export const StepB = step({ name: \'step.b\' });' );
+    writeFileSync( join( dir, 'evaluators.js' ), 'export const EvalB = evaluator({ name: \'eval.b\' });' );
+    writeFileSync( join( dir, 'workflow.js' ), 'export const helper = () => 42;' );
 
-    const source = `
-const { StepB } = require( './steps.js' );
-const { EvalB } = require( './evaluators.js' );
-const WF = require( './workflow.js' );
-const obj = {};`;
+    const ast = makeAst( `
+const { StepB } = require('./steps.js');
+const { EvalB } = require('./evaluators.js');
+const { helper } = require('./workflow.js');`, join( dir, 'file.js' ) );
 
-    const ast = makeAst( source, join( dir, 'file.js' ) );
-    const { activityImports } = collectTargetImports(
-      ast,
-      dir,
-      { stepsNameCache: new Map(), evaluatorsNameCache: new Map() }
-    );
+    const { activityImports } = collectTargetImports( ast, dir, caches() );
+
     expect( activityImports ).toEqual( [
       { localName: 'StepB', activityName: 'step.b' },
       { localName: 'EvalB', activityName: 'eval.b' }
     ] );
-    // Only non-target require declarators should remain.
-    const hasRequireDecl = ast.program.body.some( n =>
-      n.type === 'VariableDeclaration' && n.declarations.some( d => d.init && d.init.type === 'CallExpression' )
-    );
-    expect( hasRequireDecl ).toBe( true );
-
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'resolves ESM import from evaluators.js regardless of callee name', () => {
-    const dir = mkdtempSync( join( tmpdir(), 'collect-esm-mismatch-eval-' ) );
-    writeFileSync( join( dir, 'evaluators.js' ), 'export const MyExport = step({ name: \'bad\' });' );
-
-    const source = 'import { MyExport } from \'./evaluators.js\';';
-    const ast = makeAst( source, join( dir, 'file.js' ) );
-
-    const { activityImports } = collectTargetImports(
-      ast,
-      dir,
-      { stepsNameCache: new Map(), evaluatorsNameCache: new Map() }
-    );
-    expect( activityImports ).toEqual( [ { localName: 'MyExport', activityName: 'bad' } ] );
-
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'resolves ESM import from steps.js regardless of callee name', () => {
-    const dir = mkdtempSync( join( tmpdir(), 'collect-esm-mismatch-step-' ) );
-    writeFileSync( join( dir, 'steps.js' ), 'export const MyExport = evaluator({ name: \'bad\' });' );
-
-    const source = 'import { MyExport } from \'./steps.js\';';
-    const ast = makeAst( source, join( dir, 'file.js' ) );
-
-    const { activityImports } = collectTargetImports(
-      ast,
-      dir,
-      { stepsNameCache: new Map(), evaluatorsNameCache: new Map() }
-    );
-    expect( activityImports ).toEqual( [ { localName: 'MyExport', activityName: 'bad' } ] );
-
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'resolves CJS require from evaluators.js regardless of callee name', () => {
-    const dir = mkdtempSync( join( tmpdir(), 'collect-cjs-mismatch-eval-' ) );
-    writeFileSync( join( dir, 'evaluators.js' ), 'export const MyExport = step({ name: \'bad\' });' );
-
-    const source = 'const { MyExport } = require( \'./evaluators.js\' );';
-    const ast = makeAst( source, join( dir, 'file.js' ) );
-
-    const { activityImports } = collectTargetImports(
-      ast,
-      dir,
-      { stepsNameCache: new Map(), evaluatorsNameCache: new Map() }
-    );
-    expect( activityImports ).toEqual( [ { localName: 'MyExport', activityName: 'bad' } ] );
-
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'resolves CJS require from steps.js regardless of callee name', () => {
-    const dir = mkdtempSync( join( tmpdir(), 'collect-cjs-mismatch-step-' ) );
-    writeFileSync( join( dir, 'steps.js' ), 'export const MyExport = evaluator({ name: \'bad\' });' );
-
-    const source = 'const { MyExport } = require( \'./steps.js\' );';
-    const ast = makeAst( source, join( dir, 'file.js' ) );
-
-    const { activityImports } = collectTargetImports(
-      ast,
-      dir,
-      { stepsNameCache: new Map(), evaluatorsNameCache: new Map() }
-    );
-    expect( activityImports ).toEqual( [ { localName: 'MyExport', activityName: 'bad' } ] );
-
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'leaves ESM imports from workflow.js alone', () => {
-    const dir = mkdtempSync( join( tmpdir(), 'collect-esm-mismatch-wf-' ) );
-    writeFileSync( join( dir, 'workflow.js' ), 'export const helper = () => 42;' );
-
-    const source = 'import { helper } from \'./workflow.js\';';
-    const ast = makeAst( source, join( dir, 'file.js' ) );
-
-    expect( () => collectTargetImports(
-      ast,
-      dir,
-      { stepsNameCache: new Map(), evaluatorsNameCache: new Map() }
-    ) ).not.toThrow();
-    expect( ast.program.body.find( n => n.type === 'ImportDeclaration' )?.source.value ).toBe( './workflow.js' );
-
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'leaves CJS requires from workflow.js alone', () => {
-    const dir = mkdtempSync( join( tmpdir(), 'collect-cjs-mismatch-wf-' ) );
-    writeFileSync( join( dir, 'workflow.js' ), 'export const helper = () => 42;' );
-
-    const source = 'const { helper } = require( \'./workflow.js\' );';
-    const ast = makeAst( source, join( dir, 'file.js' ) );
-
-    expect( () => collectTargetImports(
-      ast,
-      dir,
-      { stepsNameCache: new Map(), evaluatorsNameCache: new Map() }
-    ) ).not.toThrow();
     expect( ast.program.body.some( n => n.type === 'VariableDeclaration' ) ).toBe( true );
-
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'does not collect CJS destructured require from workflow.js', () => {
-    const dir = mkdtempSync( join( tmpdir(), 'collect-cjs-wf-destruct-' ) );
+  it( 'uses file path to choose component type instead of factory callee name', () => {
+    const dir = mkdtempSync( join( tmpdir(), 'collect-path-scoped-' ) );
+    writeFileSync( join( dir, 'steps.js' ), 'export const StepExport = evaluator({ name: \'from.steps\' });' );
+    writeFileSync( join( dir, 'evaluators.js' ), 'export const EvalExport = step({ name: \'from.evaluators\' });' );
+
+    const esmAst = makeAst( `
+import { StepExport } from './steps.js';
+import { EvalExport } from './evaluators.js';`, join( dir, 'esm.js' ) );
+    const cjsAst = makeAst( `
+const { StepExport } = require('./steps.js');
+const { EvalExport } = require('./evaluators.js');`, join( dir, 'cjs.js' ) );
+
+    expect( collectTargetImports( esmAst, dir, caches() ).activityImports ).toEqual( [
+      { localName: 'StepExport', activityName: 'from.steps' },
+      { localName: 'EvalExport', activityName: 'from.evaluators' }
+    ] );
+    expect( collectTargetImports( cjsAst, dir, caches() ).activityImports ).toEqual( [
+      { localName: 'StepExport', activityName: 'from.steps' },
+      { localName: 'EvalExport', activityName: 'from.evaluators' }
+    ] );
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'collects shared steps and evaluators from ESM and CJS imports', () => {
+    const dir = mkdtempSync( join( tmpdir(), 'collect-shared-' ) );
+    mkdirSync( join( dir, 'shared', 'steps' ), { recursive: true } );
+    mkdirSync( join( dir, 'shared', 'evaluators' ), { recursive: true } );
+    mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
+    writeFileSync( join( dir, 'shared', 'steps', 'common.js' ), 'export const SharedStep = step({ name: \'shared.step\' });' );
+    writeFileSync(
+      join( dir, 'shared', 'evaluators', 'common.js' ),
+      'export const SharedEval = evaluator({ name: \'shared.eval\' });'
+    );
+
+    const fileDir = join( dir, 'workflows', 'my_workflow' );
+    const esmAst = makeAst( `
+import { SharedStep } from '../../shared/steps/common.js';
+import { SharedEval } from '../../shared/evaluators/common.js';`, join( fileDir, 'workflow.js' ) );
+    const cjsAst = makeAst( `
+const { SharedStep } = require('../../shared/steps/common.js');
+const { SharedEval } = require('../../shared/evaluators/common.js');`, join( fileDir, 'helper.js' ) );
+
+    expect( collectTargetImports( esmAst, fileDir, caches() ).activityImports ).toEqual( [
+      { localName: 'SharedStep', activityName: 'shared.step' },
+      { localName: 'SharedEval', activityName: 'shared.eval' }
+    ] );
+    expect( collectTargetImports( cjsAst, fileDir, caches() ).activityImports ).toEqual( [
+      { localName: 'SharedStep', activityName: 'shared.step' },
+      { localName: 'SharedEval', activityName: 'shared.eval' }
+    ] );
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'leaves destructured workflow requires untouched', () => {
+    const dir = mkdtempSync( join( tmpdir(), 'collect-workflow-require-' ) );
     writeFileSync( join( dir, 'workflow.js' ), 'export const FlowX = workflow({ name: \'flow.x\' });' );
 
-    const source = 'const { FlowX } = require( \'./workflow.js\' );\nconst obj = {};';
-    const ast = makeAst( source, join( dir, 'file.js' ) );
+    const ast = makeAst( 'const { FlowX } = require(\'./workflow.js\');', join( dir, 'file.js' ) );
+    const { activityImports } = collectTargetImports( ast, dir, caches() );
 
-    collectTargetImports(
-      ast,
-      dir,
-      { stepsNameCache: new Map(), evaluatorsNameCache: new Map() }
-    );
+    expect( activityImports ).toEqual( [] );
     expect( ast.program.body.some( n => n.type === 'VariableDeclaration' ) ).toBe( true );
-
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'collects ESM shared evaluator imports', () => {
-    const dir = mkdtempSync( join( tmpdir(), 'collect-esm-shared-eval-' ) );
-    mkdirSync( join( dir, 'shared', 'evaluators' ), { recursive: true } );
-    mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-    writeFileSync(
-      join( dir, 'shared', 'evaluators', 'common.js' ),
-      'export const SharedEval = evaluator({ name: \'shared.eval\' });'
-    );
+  it( 'throws when a named activity import cannot be resolved from the target file', () => {
+    const dir = mkdtempSync( join( tmpdir(), 'collect-unresolved-' ) );
+    writeFileSync( join( dir, 'steps.js' ), 'export const StepA = step({ name: \'step.a\' });' );
 
-    const source = 'import { SharedEval } from \'../../shared/evaluators/common.js\';';
-    const ast = makeAst( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
+    const ast = makeAst( 'import { MissingStep } from \'./steps.js\';', join( dir, 'file.js' ) );
 
-    const { activityImports } = collectTargetImports(
-      ast,
-      join( dir, 'workflows', 'my_workflow' ),
-      { stepsNameCache: new Map(), evaluatorsNameCache: new Map(), sharedEvaluatorsNameCache: new Map() }
-    );
-    expect( activityImports ).toEqual( [ { localName: 'SharedEval', activityName: 'shared.eval' } ] );
-
+    expect( () => collectTargetImports( ast, dir, caches() ) ).toThrow( /Unresolved import 'MissingStep'/ );
     rmSync( dir, { recursive: true, force: true } );
   } );
-
-  it( 'collects CJS shared evaluator requires', () => {
-    const dir = mkdtempSync( join( tmpdir(), 'collect-cjs-shared-eval-' ) );
-    mkdirSync( join( dir, 'shared', 'evaluators' ), { recursive: true } );
-    mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-    writeFileSync(
-      join( dir, 'shared', 'evaluators', 'common.js' ),
-      'export const SharedEval = evaluator({ name: \'shared.eval\' });'
-    );
-
-    const source = 'const { SharedEval } = require( \'../../shared/evaluators/common.js\' );';
-    const ast = makeAst( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
-
-    const { activityImports } = collectTargetImports(
-      ast,
-      join( dir, 'workflows', 'my_workflow' ),
-      { stepsNameCache: new Map(), evaluatorsNameCache: new Map(), sharedEvaluatorsNameCache: new Map() }
-    );
-    expect( activityImports ).toEqual( [ { localName: 'SharedEval', activityName: 'shared.eval' } ] );
-
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'collects CJS shared steps requires', () => {
-    const dir = mkdtempSync( join( tmpdir(), 'collect-cjs-shared-step-' ) );
-    mkdirSync( join( dir, 'shared', 'steps' ), { recursive: true } );
-    mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-    writeFileSync(
-      join( dir, 'shared', 'steps', 'common.js' ),
-      'export const SharedA = step({ name: \'shared.a\' });'
-    );
-
-    const source = 'const { SharedA } = require( \'../../shared/steps/common.js\' );';
-    const ast = makeAst( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
-
-    const { activityImports } = collectTargetImports(
-      ast,
-      join( dir, 'workflows', 'my_workflow' ),
-      {
-        stepsNameCache: new Map(), sharedStepsNameCache: new Map(),
-        evaluatorsNameCache: new Map(), sharedEvaluatorsNameCache: new Map()
-      }
-    );
-    expect( activityImports ).toEqual( [ { localName: 'SharedA', activityName: 'shared.a' } ] );
-
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'resolves CJS shared steps require regardless of callee name', () => {
-    const dir = mkdtempSync( join( tmpdir(), 'collect-cjs-shared-step-mismatch-' ) );
-    mkdirSync( join( dir, 'shared', 'steps' ), { recursive: true } );
-    mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-    writeFileSync(
-      join( dir, 'shared', 'steps', 'common.js' ),
-      'export const MyExport = evaluator({ name: \'bad\' });'
-    );
-
-    const source = 'const { MyExport } = require( \'../../shared/steps/common.js\' );';
-    const ast = makeAst( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
-
-    const { activityImports } = collectTargetImports(
-      ast,
-      join( dir, 'workflows', 'my_workflow' ),
-      {
-        stepsNameCache: new Map(), sharedStepsNameCache: new Map(),
-        evaluatorsNameCache: new Map(), sharedEvaluatorsNameCache: new Map()
-      }
-    );
-    expect( activityImports ).toEqual( [ { localName: 'MyExport', activityName: 'bad' } ] );
-
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'resolves CJS shared evaluator require regardless of callee name', () => {
-    const dir = mkdtempSync( join( tmpdir(), 'collect-cjs-shared-eval-mismatch-' ) );
-    mkdirSync( join( dir, 'shared', 'evaluators' ), { recursive: true } );
-    mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-    writeFileSync(
-      join( dir, 'shared', 'evaluators', 'common.js' ),
-      'export const MyExport = step({ name: \'bad\' });'
-    );
-
-    const source = 'const { MyExport } = require( \'../../shared/evaluators/common.js\' );';
-    const ast = makeAst( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
-
-    const { activityImports } = collectTargetImports(
-      ast,
-      join( dir, 'workflows', 'my_workflow' ),
-      { stepsNameCache: new Map(), evaluatorsNameCache: new Map(), sharedEvaluatorsNameCache: new Map() }
-    );
-    expect( activityImports ).toEqual( [ { localName: 'MyExport', activityName: 'bad' } ] );
-
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'resolves ESM shared evaluator import regardless of callee name', () => {
-    const dir = mkdtempSync( join( tmpdir(), 'collect-esm-shared-eval-mismatch-' ) );
-    mkdirSync( join( dir, 'shared', 'evaluators' ), { recursive: true } );
-    mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-    writeFileSync(
-      join( dir, 'shared', 'evaluators', 'common.js' ),
-      'export const MyExport = step({ name: \'bad\' });'
-    );
-
-    const source = 'import { MyExport } from \'../../shared/evaluators/common.js\';';
-    const ast = makeAst( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
-
-    const { activityImports } = collectTargetImports(
-      ast,
-      join( dir, 'workflows', 'my_workflow' ),
-      { stepsNameCache: new Map(), evaluatorsNameCache: new Map(), sharedEvaluatorsNameCache: new Map() }
-    );
-    expect( activityImports ).toEqual( [ { localName: 'MyExport', activityName: 'bad' } ] );
-
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
 } );
-

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.mjs
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.mjs
@@ -15,8 +15,8 @@ const evaluatorsNameCache = new Map(); // path -> Map<exported, evaluatorName>
 const sharedEvaluatorsNameCache = new Map(); // path -> Map<exported, evaluatorName> (shared)
 
 /**
- * Webpack loader that rewrites step/evaluator calls by reading names from
- * the respective modules and transforming `fn` bodies accordingly.
+ * Webpack loader that rewrites imported step/evaluator calls by reading
+ * declared activity names and transforming function-body calls accordingly.
  * Preserves sourcemaps.
  *
  * @param {string|Buffer} source - Module source code.
@@ -33,15 +33,14 @@ export default function stepImportRewriterAstLoader( source, inputMap ) {
     const filename = this.resourcePath;
     const ast = parse( String( source ), filename );
     const fileDir = dirname( filename );
-    const { stepImports, sharedStepImports, evaluatorImports, sharedEvaluatorImports } =
-      collectTargetImports( ast, fileDir, cache, filename );
+    const { activityImports } = collectTargetImports( ast, fileDir, cache, filename );
 
     // No imports
-    if ( [].concat( stepImports, sharedStepImports, evaluatorImports, sharedEvaluatorImports ).length === 0 ) {
+    if ( activityImports.length === 0 ) {
       return callback( null, source, inputMap );
     }
 
-    const rewrote = rewriteFnBodies( { ast, stepImports, sharedStepImports, evaluatorImports, sharedEvaluatorImports } );
+    const rewrote = rewriteFnBodies( { ast, activityImports } );
     // No edits performed
     if ( !rewrote ) {
       return callback( null, source, inputMap );

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.mjs
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.mjs
@@ -2,7 +2,7 @@ import { dirname } from 'node:path';
 import generatorModule from '@babel/generator';
 import { parse } from '../tools.js';
 
-import rewriteFnBodies from './rewrite_fn_bodies.js';
+import rewriteActivityCalls from './rewrite_activity_calls.js';
 import collectTargetImports from './collect_target_imports.js';
 
 // Handle CJS/ESM interop for Babel packages when executed as a webpack loader
@@ -16,7 +16,7 @@ const sharedEvaluatorsNameCache = new Map(); // path -> Map<exported, evaluatorN
 
 /**
  * Webpack loader that rewrites imported step/evaluator calls by reading
- * declared activity names and transforming function-body calls accordingly.
+ * declared activity names and transforming function-body activity calls accordingly.
  * Preserves sourcemaps.
  *
  * @param {string|Buffer} source - Module source code.
@@ -40,7 +40,7 @@ export default function stepImportRewriterAstLoader( source, inputMap ) {
       return callback( null, source, inputMap );
     }
 
-    const rewrote = rewriteFnBodies( { ast, activityImports } );
+    const rewrote = rewriteActivityCalls( { ast, activityImports } );
     // No edits performed
     if ( !rewrote ) {
       return callback( null, source, inputMap );

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.mjs
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.mjs
@@ -33,7 +33,7 @@ export default function stepImportRewriterAstLoader( source, inputMap ) {
     const filename = this.resourcePath;
     const ast = parse( String( source ), filename );
     const fileDir = dirname( filename );
-    const { activityImports } = collectTargetImports( ast, fileDir, cache, filename );
+    const { activityImports } = collectTargetImports( ast, fileDir, cache );
 
     // No imports
     if ( activityImports.length === 0 ) {

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.spec.js
@@ -30,7 +30,7 @@ const invokeActivityPattern = activityName =>
   new RegExp( `globalThis\\[globalThis\\.Symbol\\.for\\(([\"'])${escapeRegExp( invokeActivitySymbolKey )}\\1\\)\\]\\('${activityName}'` );
 
 describe( 'workflows_rewriter Webpack loader spec', () => {
-  it( 'rewrites ESM step imports to the global dispatcher and leaves workflow calls intact', async () => {
+  it( 'rewrites ESM activity imports and leaves workflow imports intact', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'ast-loader-esm-' ) );
     writeFileSync( join( dir, 'steps.js' ), 'export const StepA = step({ name: \'step.a\' });' );
     writeFileSync( join( dir, 'workflow.js' ), `
@@ -42,7 +42,7 @@ import { StepA } from './steps.js';
 import FlowDef, { FlowA } from './workflow.js';
 
 const obj = {
-  fn: async (x) => {
+  fn: async x => {
     StepA(1);
     FlowA(2);
     FlowDef(3);
@@ -53,66 +53,14 @@ const obj = {
 
     expect( code ).not.toMatch( /from '\.\/steps\.js'/ );
     expect( code ).toMatch( /from '\.\/workflow\.js'/ );
-    expect( code ).not.toMatch( /@outputai\/core\/invoker/ );
-    expect( code ).toMatch( /fn:\s*async x =>/ );
     expect( code ).toMatch( invokeActivityPattern( 'step\\.a' ) );
     expect( code ).toMatch( /,\s*1\)/ );
     expect( code ).toMatch( /FlowA\(2\)/ );
     expect( code ).toMatch( /FlowDef\(3\)/ );
-
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'rewrites ESM shared steps imports to the global dispatcher', async () => {
-    // Create directory structure: shared/steps/common.js
-    const dir = mkdtempSync( join( tmpdir(), 'ast-loader-esm-shared-' ) );
-    mkdirSync( join( dir, 'shared', 'steps' ), { recursive: true } );
-    mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-    writeFileSync( join( dir, 'shared', 'steps', 'common.js' ), 'export const SharedA = step({ name: \'shared.a\' });' );
-
-    const source = `
-import { SharedA } from '../../shared/steps/common.js';
-
-const obj = {
-  fn: async (x) => {
-    SharedA(1);
-  }
-}`;
-
-    const { code } = await runLoader( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
-
-    expect( code ).not.toMatch( /from '\.\.\/\.\.\/shared\/steps\/common\.js'/ );
-    expect( code ).toMatch( invokeActivityPattern( 'shared\\.a' ) );
-    expect( code ).toMatch( /,\s*1\)/ );
-
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'rewrites CJS shared steps requires to the global dispatcher', async () => {
-    // Create directory structure: shared/steps/common.js
-    const dir = mkdtempSync( join( tmpdir(), 'ast-loader-cjs-shared-' ) );
-    mkdirSync( join( dir, 'shared', 'steps' ), { recursive: true } );
-    mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-    writeFileSync( join( dir, 'shared', 'steps', 'common.js' ), 'export const SharedB = step({ name: \'shared.b\' });' );
-
-    const source = `
-const { SharedB } = require( '../../shared/steps/common.js' );
-
-const obj = {
-  fn: async (y) => {
-    SharedB();
-  }
-}`;
-
-    const { code } = await runLoader( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
-
-    expect( code ).not.toMatch( /require\('\.\.\/\.\.\/shared\/steps\/common\.js'\)/ );
-    expect( code ).toMatch( invokeActivityPattern( 'shared\\.b' ) );
-
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'rewrites CJS step requires and leaves workflow calls intact', async () => {
+  it( 'rewrites CJS activity requires and leaves workflow requires intact', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'ast-loader-cjs-' ) );
     writeFileSync( join( dir, 'steps.js' ), 'export const StepB = step({ name: \'step.b\' });' );
     writeFileSync( join( dir, 'workflow.js' ), 'export default workflow({ name: \'flow.c\' });' );
@@ -122,8 +70,8 @@ const { StepB } = require( './steps.js' );
 const FlowDefault = require( './workflow.js' );
 
 const obj = {
-  fn: async (y) => {
-    StepB();
+  fn: async y => {
+    StepB(y);
     FlowDefault();
   }
 }`;
@@ -133,116 +81,46 @@ const obj = {
     expect( code ).not.toMatch( /require\('\.\/steps\.js'\)/ );
     expect( code ).toMatch( /require\('\.\/workflow\.js'\)/ );
     expect( code ).toMatch( invokeActivityPattern( 'step\\.b' ) );
+    expect( code ).toMatch( /,\s*y\)/ );
     expect( code ).toMatch( /FlowDefault\(\)/ );
-
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'resolves top-level const name variables', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'ast-loader-const-' ) );
-    writeFileSync( join( dir, 'steps.js' ), `
-const NAME = 'step.const';
-export const StepC = step({ name: NAME });` );
-    writeFileSync( join( dir, 'workflow.js' ), `
-const WF = 'wf.const';
-export const FlowC = workflow({ name: WF });
-const D = 'wf.def';
-export default workflow({ name: D });` );
-
-    const source = `
-import { StepC } from './steps.js';
-import FlowDef, { FlowC } from './workflow.js';
-const obj = { fn: async () => { StepC(); FlowC(); FlowDef(); } }`;
-
-    const { code } = await runLoader( source, join( dir, 'file.js' ) );
-    expect( code ).toMatch( invokeActivityPattern( 'step\\.const' ) );
-    expect( code ).toMatch( /FlowC\(\)/ );
-    expect( code ).toMatch( /FlowDef\(\)/ );
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'rewrites ESM shared evaluator imports to the global dispatcher', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'ast-loader-esm-shared-eval-' ) );
+  it( 'rewrites shared activity imports from helper modules', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'ast-loader-shared-helper-' ) );
     mkdirSync( join( dir, 'shared', 'evaluators' ), { recursive: true } );
     mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-    writeFileSync( join( dir, 'shared', 'evaluators', 'common.js' ), 'export const SharedEval = evaluator({ name: \'shared.eval\' });' );
+    writeFileSync(
+      join( dir, 'shared', 'evaluators', 'common.js' ),
+      'export const SharedEval = evaluator({ name: \'shared.eval\' });'
+    );
 
     const source = `
 import { SharedEval } from '../../shared/evaluators/common.js';
 
-const obj = {
-  fn: async (x) => {
-    SharedEval(1);
-  }
-}`;
+export const helper = async value => SharedEval(value);`;
 
-    const { code } = await runLoader( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
+    const { code } = await runLoader( source, join( dir, 'workflows', 'my_workflow', 'helper.js' ) );
 
-    expect( code ).not.toMatch( /from '\.\.\/\.\.\/shared\/evaluators\/common\.js'/ );
+    expect( code ).not.toMatch( /shared\/evaluators\/common\.js/ );
     expect( code ).toMatch( invokeActivityPattern( 'shared\\.eval' ) );
-    expect( code ).toMatch( /,\s*1\)/ );
-
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'rewrites CJS shared evaluator requires to the global dispatcher', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'ast-loader-cjs-shared-eval-' ) );
-    mkdirSync( join( dir, 'shared', 'evaluators' ), { recursive: true } );
-    mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-    writeFileSync( join( dir, 'shared', 'evaluators', 'common.js' ), 'export const SharedEval = evaluator({ name: \'shared.eval\' });' );
-
-    const source = `
-const { SharedEval } = require( '../../shared/evaluators/common.js' );
-
-const obj = {
-  fn: async (y) => {
-    SharedEval();
-  }
-}`;
-
-    const { code } = await runLoader( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
-
-    expect( code ).not.toMatch( /require\('\.\.\/\.\.\/shared\/evaluators\/common\.js'\)/ );
-    expect( code ).toMatch( invokeActivityPattern( 'shared\\.eval' ) );
-
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'rewrites helper modules without requiring workflow fn objects', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'ast-loader-helper-' ) );
-    writeFileSync( join( dir, 'steps.js' ), 'export const StepA = step({ name: \'step.helper\' });' );
-
-    const source = `
-import { StepA } from './steps.js';
-
-export const helper = async value => StepA(value);`;
-
-    const { code } = await runLoader( source, join( dir, 'helper.js' ) );
-
-    expect( code ).toMatch( invokeActivityPattern( 'step\\.helper' ) );
     expect( code ).toMatch( /,\s*value\)/ );
     expect( code ).toMatch( /export const helper = async value =>/ );
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'does not need aliases when local invoke names are taken', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'ast-loader-collision-' ) );
-    writeFileSync( join( dir, 'steps.js' ), 'export const StepA = step({ name: \'step.collision\' });' );
+  it( 'resolves top-level const activity names', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'ast-loader-const-' ) );
+    writeFileSync( join( dir, 'steps.js' ), `
+const NAME = 'step.const';
+export const StepC = step({ name: NAME });` );
 
     const source = `
-import { StepA } from './steps.js';
-const __invokeActivity = () => null;
-const _invokeActivity = () => null;
-export function helper() {
-  return StepA();
-}`;
+import { StepC } from './steps.js';
+const obj = { fn: async () => StepC() };`;
 
-    const { code } = await runLoader( source, join( dir, 'helper.js' ) );
-
-    expect( code ).not.toMatch( /@outputai\/core\/invoker/ );
-    expect( code ).toMatch( invokeActivityPattern( 'step\\.collision' ) );
-    expect( code ).toMatch( /const __invokeActivity = \(\) => null/ );
-    expect( code ).toMatch( /const _invokeActivity = \(\) => null/ );
+    const { code } = await runLoader( source, join( dir, 'file.js' ) );
+    expect( code ).toMatch( invokeActivityPattern( 'step\\.const' ) );
     rmSync( dir, { recursive: true, force: true } );
   } );
 
@@ -260,19 +138,15 @@ export function helper(globalThis) {
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'throws on non-static name', async () => {
+  it( 'propagates errors for non-static activity names', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'ast-loader-error-' ) );
     writeFileSync( join( dir, 'steps.js' ), `
 function n() { return 'x'; }
 export const StepX = step({ name: n() });` );
-    writeFileSync( join( dir, 'workflow.js' ), `
-const base = 'a';
-export default workflow({ name: \`\${base}-b\` });` );
 
     const source = `
 import { StepX } from './steps.js';
-import WF from './workflow.js';
-const obj = { fn: async () => { StepX(); WF(); } }`;
+const obj = { fn: async () => StepX() };`;
 
     await expect( runLoader( source, join( dir, 'file.js' ) ) ).rejects.toThrow( /Invalid step name/ );
     rmSync( dir, { recursive: true, force: true } );

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.spec.js
@@ -1,8 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import loader from './index.mjs';
+
+const { invokeActivitySymbolKey } = vi.hoisted( () => ( {
+  invokeActivitySymbolKey: 'test:invoke_activity'
+} ) );
+
+vi.mock( '#consts', async importOriginal => ( {
+  ...await importOriginal(),
+  INVOKE_ACTIVITY_SYMBOL: Symbol.for( invokeActivitySymbolKey )
+} ) );
 
 function runLoader( source, resourcePath ) {
   return new Promise( ( resolve, reject ) => {
@@ -16,8 +25,12 @@ function runLoader( source, resourcePath ) {
   } );
 }
 
+const escapeRegExp = value => value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+const invokeActivityPattern = activityName =>
+  new RegExp( `globalThis\\[globalThis\\.Symbol\\.for\\(([\"'])${escapeRegExp( invokeActivitySymbolKey )}\\1\\)\\]\\('${activityName}'` );
+
 describe( 'workflows_rewriter Webpack loader spec', () => {
-  it( 'rewrites ESM step imports to __invokeActivity and leaves workflow calls intact', async () => {
+  it( 'rewrites ESM step imports to the global dispatcher and leaves workflow calls intact', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'ast-loader-esm-' ) );
     writeFileSync( join( dir, 'steps.js' ), 'export const StepA = step({ name: \'step.a\' });' );
     writeFileSync( join( dir, 'workflow.js' ), `
@@ -40,16 +53,17 @@ const obj = {
 
     expect( code ).not.toMatch( /from '\.\/steps\.js'/ );
     expect( code ).toMatch( /from '\.\/workflow\.js'/ );
-    expect( code ).toMatch( /import \{ __invokeActivity as _invokeActivity \} from '@outputai\/core\/invoker';/ );
+    expect( code ).not.toMatch( /@outputai\/core\/invoker/ );
     expect( code ).toMatch( /fn:\s*async x =>/ );
-    expect( code ).toMatch( /_invokeActivity\('step\.a',\s*1\)/ );
+    expect( code ).toMatch( invokeActivityPattern( 'step\\.a' ) );
+    expect( code ).toMatch( /,\s*1\)/ );
     expect( code ).toMatch( /FlowA\(2\)/ );
     expect( code ).toMatch( /FlowDef\(3\)/ );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'rewrites ESM shared steps imports to __invokeActivity', async () => {
+  it( 'rewrites ESM shared steps imports to the global dispatcher', async () => {
     // Create directory structure: shared/steps/common.js
     const dir = mkdtempSync( join( tmpdir(), 'ast-loader-esm-shared-' ) );
     mkdirSync( join( dir, 'shared', 'steps' ), { recursive: true } );
@@ -68,12 +82,13 @@ const obj = {
     const { code } = await runLoader( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
 
     expect( code ).not.toMatch( /from '\.\.\/\.\.\/shared\/steps\/common\.js'/ );
-    expect( code ).toMatch( /_invokeActivity\('shared\.a',\s*1\)/ );
+    expect( code ).toMatch( invokeActivityPattern( 'shared\\.a' ) );
+    expect( code ).toMatch( /,\s*1\)/ );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'rewrites CJS shared steps requires to __invokeActivity', async () => {
+  it( 'rewrites CJS shared steps requires to the global dispatcher', async () => {
     // Create directory structure: shared/steps/common.js
     const dir = mkdtempSync( join( tmpdir(), 'ast-loader-cjs-shared-' ) );
     mkdirSync( join( dir, 'shared', 'steps' ), { recursive: true } );
@@ -92,7 +107,7 @@ const obj = {
     const { code } = await runLoader( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
 
     expect( code ).not.toMatch( /require\('\.\.\/\.\.\/shared\/steps\/common\.js'\)/ );
-    expect( code ).toMatch( /_invokeActivity\('shared\.b'\)/ );
+    expect( code ).toMatch( invokeActivityPattern( 'shared\\.b' ) );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
@@ -117,7 +132,7 @@ const obj = {
 
     expect( code ).not.toMatch( /require\('\.\/steps\.js'\)/ );
     expect( code ).toMatch( /require\('\.\/workflow\.js'\)/ );
-    expect( code ).toMatch( /_invokeActivity\('step\.b'\)/ );
+    expect( code ).toMatch( invokeActivityPattern( 'step\\.b' ) );
     expect( code ).toMatch( /FlowDefault\(\)/ );
 
     rmSync( dir, { recursive: true, force: true } );
@@ -140,13 +155,13 @@ import FlowDef, { FlowC } from './workflow.js';
 const obj = { fn: async () => { StepC(); FlowC(); FlowDef(); } }`;
 
     const { code } = await runLoader( source, join( dir, 'file.js' ) );
-    expect( code ).toMatch( /_invokeActivity\('step\.const'\)/ );
+    expect( code ).toMatch( invokeActivityPattern( 'step\\.const' ) );
     expect( code ).toMatch( /FlowC\(\)/ );
     expect( code ).toMatch( /FlowDef\(\)/ );
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'rewrites ESM shared evaluator imports to __invokeActivity', async () => {
+  it( 'rewrites ESM shared evaluator imports to the global dispatcher', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'ast-loader-esm-shared-eval-' ) );
     mkdirSync( join( dir, 'shared', 'evaluators' ), { recursive: true } );
     mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
@@ -164,12 +179,13 @@ const obj = {
     const { code } = await runLoader( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
 
     expect( code ).not.toMatch( /from '\.\.\/\.\.\/shared\/evaluators\/common\.js'/ );
-    expect( code ).toMatch( /_invokeActivity\('shared\.eval',\s*1\)/ );
+    expect( code ).toMatch( invokeActivityPattern( 'shared\\.eval' ) );
+    expect( code ).toMatch( /,\s*1\)/ );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'rewrites CJS shared evaluator requires to __invokeActivity', async () => {
+  it( 'rewrites CJS shared evaluator requires to the global dispatcher', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'ast-loader-cjs-shared-eval-' ) );
     mkdirSync( join( dir, 'shared', 'evaluators' ), { recursive: true } );
     mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
@@ -187,7 +203,7 @@ const obj = {
     const { code } = await runLoader( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
 
     expect( code ).not.toMatch( /require\('\.\.\/\.\.\/shared\/evaluators\/common\.js'\)/ );
-    expect( code ).toMatch( /_invokeActivity\('shared\.eval'\)/ );
+    expect( code ).toMatch( invokeActivityPattern( 'shared\\.eval' ) );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
@@ -203,17 +219,19 @@ export const helper = async value => StepA(value);`;
 
     const { code } = await runLoader( source, join( dir, 'helper.js' ) );
 
-    expect( code ).toMatch( /_invokeActivity\('step\.helper',\s*value\)/ );
+    expect( code ).toMatch( invokeActivityPattern( 'step\\.helper' ) );
+    expect( code ).toMatch( /,\s*value\)/ );
     expect( code ).toMatch( /export const helper = async value =>/ );
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'aliases __invokeActivity import when the preferred local name is taken', async () => {
+  it( 'does not need aliases when local invoke names are taken', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'ast-loader-collision-' ) );
     writeFileSync( join( dir, 'steps.js' ), 'export const StepA = step({ name: \'step.collision\' });' );
 
     const source = `
 import { StepA } from './steps.js';
+const __invokeActivity = () => null;
 const _invokeActivity = () => null;
 export function helper() {
   return StepA();
@@ -221,9 +239,24 @@ export function helper() {
 
     const { code } = await runLoader( source, join( dir, 'helper.js' ) );
 
-    expect( code ).toMatch( /import \{ __invokeActivity as _invokeActivity2 \} from '@outputai\/core\/invoker';/ );
-    expect( code ).toMatch( /_invokeActivity2\('step\.collision'\)/ );
+    expect( code ).not.toMatch( /@outputai\/core\/invoker/ );
+    expect( code ).toMatch( invokeActivityPattern( 'step\\.collision' ) );
+    expect( code ).toMatch( /const __invokeActivity = \(\) => null/ );
     expect( code ).toMatch( /const _invokeActivity = \(\) => null/ );
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'throws when globalThis is shadowed at a rewritten call site', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'ast-loader-globalthis-shadow-' ) );
+    writeFileSync( join( dir, 'steps.js' ), 'export const StepA = step({ name: \'step.shadow\' });' );
+
+    const source = `
+import { StepA } from './steps.js';
+export function helper(globalThis) {
+  return StepA();
+}`;
+
+    await expect( runLoader( source, join( dir, 'helper.js' ) ) ).rejects.toThrow( /globalThis.*shadowed/ );
     rmSync( dir, { recursive: true, force: true } );
   } );
 

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.spec.js
@@ -17,7 +17,7 @@ function runLoader( source, resourcePath ) {
 }
 
 describe( 'workflows_rewriter Webpack loader spec', () => {
-  it( 'rewrites ESM step imports and leaves workflow calls intact', async () => {
+  it( 'rewrites ESM step imports to __invokeActivity and leaves workflow calls intact', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'ast-loader-esm-' ) );
     writeFileSync( join( dir, 'steps.js' ), 'export const StepA = step({ name: \'step.a\' });' );
     writeFileSync( join( dir, 'workflow.js' ), `
@@ -40,15 +40,16 @@ const obj = {
 
     expect( code ).not.toMatch( /from '\.\/steps\.js'/ );
     expect( code ).toMatch( /from '\.\/workflow\.js'/ );
-    expect( code ).toMatch( /fn:\s*async function \(x\)/ );
-    expect( code ).toMatch( /this\.invokeStep\('step\.a',\s*1\)/ );
+    expect( code ).toMatch( /import \{ __invokeActivity as _invokeActivity \} from '@outputai\/core\/invoker';/ );
+    expect( code ).toMatch( /fn:\s*async x =>/ );
+    expect( code ).toMatch( /_invokeActivity\('step\.a',\s*1\)/ );
     expect( code ).toMatch( /FlowA\(2\)/ );
     expect( code ).toMatch( /FlowDef\(3\)/ );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'rewrites ESM shared steps imports to invokeSharedStep', async () => {
+  it( 'rewrites ESM shared steps imports to __invokeActivity', async () => {
     // Create directory structure: shared/steps/common.js
     const dir = mkdtempSync( join( tmpdir(), 'ast-loader-esm-shared-' ) );
     mkdirSync( join( dir, 'shared', 'steps' ), { recursive: true } );
@@ -67,13 +68,12 @@ const obj = {
     const { code } = await runLoader( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
 
     expect( code ).not.toMatch( /from '\.\.\/\.\.\/shared\/steps\/common\.js'/ );
-    expect( code ).toMatch( /fn:\s*async function \(x\)/ );
-    expect( code ).toMatch( /this\.invokeSharedStep\('shared\.a',\s*1\)/ );
+    expect( code ).toMatch( /_invokeActivity\('shared\.a',\s*1\)/ );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'rewrites CJS shared steps requires to invokeSharedStep', async () => {
+  it( 'rewrites CJS shared steps requires to __invokeActivity', async () => {
     // Create directory structure: shared/steps/common.js
     const dir = mkdtempSync( join( tmpdir(), 'ast-loader-cjs-shared-' ) );
     mkdirSync( join( dir, 'shared', 'steps' ), { recursive: true } );
@@ -92,8 +92,7 @@ const obj = {
     const { code } = await runLoader( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
 
     expect( code ).not.toMatch( /require\('\.\.\/\.\.\/shared\/steps\/common\.js'\)/ );
-    expect( code ).toMatch( /fn:\s*async function \(y\)/ );
-    expect( code ).toMatch( /this\.invokeSharedStep\('shared\.b'\)/ );
+    expect( code ).toMatch( /_invokeActivity\('shared\.b'\)/ );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
@@ -118,8 +117,7 @@ const obj = {
 
     expect( code ).not.toMatch( /require\('\.\/steps\.js'\)/ );
     expect( code ).toMatch( /require\('\.\/workflow\.js'\)/ );
-    expect( code ).toMatch( /fn:\s*async function \(y\)/ );
-    expect( code ).toMatch( /this\.invokeStep\('step\.b'\)/ );
+    expect( code ).toMatch( /_invokeActivity\('step\.b'\)/ );
     expect( code ).toMatch( /FlowDefault\(\)/ );
 
     rmSync( dir, { recursive: true, force: true } );
@@ -142,13 +140,13 @@ import FlowDef, { FlowC } from './workflow.js';
 const obj = { fn: async () => { StepC(); FlowC(); FlowDef(); } }`;
 
     const { code } = await runLoader( source, join( dir, 'file.js' ) );
-    expect( code ).toMatch( /this\.invokeStep\('step\.const'\)/ );
+    expect( code ).toMatch( /_invokeActivity\('step\.const'\)/ );
     expect( code ).toMatch( /FlowC\(\)/ );
     expect( code ).toMatch( /FlowDef\(\)/ );
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'rewrites ESM shared evaluator imports to invokeSharedEvaluator', async () => {
+  it( 'rewrites ESM shared evaluator imports to __invokeActivity', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'ast-loader-esm-shared-eval-' ) );
     mkdirSync( join( dir, 'shared', 'evaluators' ), { recursive: true } );
     mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
@@ -166,13 +164,12 @@ const obj = {
     const { code } = await runLoader( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
 
     expect( code ).not.toMatch( /from '\.\.\/\.\.\/shared\/evaluators\/common\.js'/ );
-    expect( code ).toMatch( /fn:\s*async function \(x\)/ );
-    expect( code ).toMatch( /this\.invokeSharedEvaluator\('shared\.eval',\s*1\)/ );
+    expect( code ).toMatch( /_invokeActivity\('shared\.eval',\s*1\)/ );
 
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'rewrites CJS shared evaluator requires to invokeSharedEvaluator', async () => {
+  it( 'rewrites CJS shared evaluator requires to __invokeActivity', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'ast-loader-cjs-shared-eval-' ) );
     mkdirSync( join( dir, 'shared', 'evaluators' ), { recursive: true } );
     mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
@@ -190,9 +187,43 @@ const obj = {
     const { code } = await runLoader( source, join( dir, 'workflows', 'my_workflow', 'workflow.js' ) );
 
     expect( code ).not.toMatch( /require\('\.\.\/\.\.\/shared\/evaluators\/common\.js'\)/ );
-    expect( code ).toMatch( /fn:\s*async function \(y\)/ );
-    expect( code ).toMatch( /this\.invokeSharedEvaluator\('shared\.eval'\)/ );
+    expect( code ).toMatch( /_invokeActivity\('shared\.eval'\)/ );
 
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'rewrites helper modules without requiring workflow fn objects', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'ast-loader-helper-' ) );
+    writeFileSync( join( dir, 'steps.js' ), 'export const StepA = step({ name: \'step.helper\' });' );
+
+    const source = `
+import { StepA } from './steps.js';
+
+export const helper = async value => StepA(value);`;
+
+    const { code } = await runLoader( source, join( dir, 'helper.js' ) );
+
+    expect( code ).toMatch( /_invokeActivity\('step\.helper',\s*value\)/ );
+    expect( code ).toMatch( /export const helper = async value =>/ );
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'aliases __invokeActivity import when the preferred local name is taken', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'ast-loader-collision-' ) );
+    writeFileSync( join( dir, 'steps.js' ), 'export const StepA = step({ name: \'step.collision\' });' );
+
+    const source = `
+import { StepA } from './steps.js';
+const _invokeActivity = () => null;
+export function helper() {
+  return StepA();
+}`;
+
+    const { code } = await runLoader( source, join( dir, 'helper.js' ) );
+
+    expect( code ).toMatch( /import \{ __invokeActivity as _invokeActivity2 \} from '@outputai\/core\/invoker';/ );
+    expect( code ).toMatch( /_invokeActivity2\('step\.collision'\)/ );
+    expect( code ).toMatch( /const _invokeActivity = \(\) => null/ );
     rmSync( dir, { recursive: true, force: true } );
   } );
 

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/rewrite_activity_calls.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/rewrite_activity_calls.js
@@ -53,7 +53,7 @@ const createInvokeActivityCall = ( activityName, args ) =>
   );
 
 // Rewrite valid function-body activity calls; top-level call validation belongs to the validator loader.
-const rewriteActivityCalls = ( { ast, activityNames } ) => {
+const rewriteActivityCallsInFunctions = ( { ast, activityNames } ) => {
   const state = { rewrote: false };
 
   traverse( ast, {
@@ -78,11 +78,11 @@ const rewriteActivityCalls = ( { ast, activityNames } ) => {
 };
 
 // Entry point: resolve collected component imports into plain dispatcher calls.
-export default function rewriteFnBodies( { ast, activityImports } ) {
+export default function rewriteActivityCalls( { ast, activityImports } ) {
   const activityNames = buildActivityNameMap( activityImports );
   if ( activityNames.size === 0 ) {
     return false;
   }
 
-  return rewriteActivityCalls( { ast, activityNames } );
+  return rewriteActivityCallsInFunctions( { ast, activityNames } );
 };

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/rewrite_activity_calls.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/rewrite_activity_calls.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import generatorModule from '@babel/generator';
 import { parse } from '../tools.js';
-import rewriteFnBodies from './rewrite_fn_bodies.js';
+import rewriteActivityCalls from './rewrite_activity_calls.js';
 
 const { invokeActivitySymbolKey } = vi.hoisted( () => ( {
   invokeActivitySymbolKey: 'test:invoke_activity'
@@ -17,7 +17,7 @@ const escapeRegExp = value => value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
 const invokeActivityPattern = activityName =>
   new RegExp( `globalThis\\[globalThis\\.Symbol\\.for\\(([\"'])${escapeRegExp( invokeActivitySymbolKey )}\\1\\)\\]\\(([\"'])${activityName}\\2` );
 
-describe( 'rewrite_fn_bodies', () => {
+describe( 'rewrite_activity_calls', () => {
   it( 'rewrites step calls inside functions without changing function shape', () => {
     const src = `
 const obj = {
@@ -29,7 +29,7 @@ const obj = {
     const ast = parse( src, 'file.js' );
     const activityImports = [ { localName: 'StepA', activityName: 'step.a' } ];
 
-    const rewrote = rewriteFnBodies( { ast, activityImports } );
+    const rewrote = rewriteActivityCalls( { ast, activityImports } );
     expect( rewrote ).toBe( true );
 
     const { code } = generate( ast, { quotes: 'single' } );
@@ -49,7 +49,7 @@ const obj = {
 };`;
     const ast = parse( src, 'file.js' );
     const activityImports = [ { localName: 'EvalA', activityName: 'eval.a' } ];
-    const rewrote = rewriteFnBodies( { ast, activityImports } );
+    const rewrote = rewriteActivityCalls( { ast, activityImports } );
     expect( rewrote ).toBe( true );
     const { code } = generate( ast, { quotes: 'single' } );
     expect( code ).toMatch( invokeActivityPattern( 'eval\\.a' ) );
@@ -59,7 +59,7 @@ const obj = {
   it( 'does nothing when no matching calls are present', () => {
     const src = [ 'const obj = { fn: function() { other(); } }' ].join( '\n' );
     const ast = parse( src, 'file.js' );
-    const rewrote = rewriteFnBodies( { ast, activityImports: [] } );
+    const rewrote = rewriteActivityCalls( { ast, activityImports: [] } );
     expect( rewrote ).toBe( false );
   } );
 
@@ -86,7 +86,7 @@ const obj = {
       { localName: 'EvalA', activityName: 'eval.a' }
     ];
 
-    const rewrote = rewriteFnBodies( { ast, activityImports } );
+    const rewrote = rewriteActivityCalls( { ast, activityImports } );
     expect( rewrote ).toBe( true );
 
     const { code } = generate( ast, { quotes: 'single' } );
@@ -109,7 +109,7 @@ function helper() {
 
     const ast = parse( src, 'file.js' );
     const activityImports = [ { localName: 'StepA', activityName: 'step.a' } ];
-    const rewrote = rewriteFnBodies( { ast, activityImports } );
+    const rewrote = rewriteActivityCalls( { ast, activityImports } );
     expect( rewrote ).toBe( true );
 
     const { code } = generate( ast, { quotes: 'single' } );
@@ -127,7 +127,7 @@ function helper() {
 }`;
     const ast = parse( src, 'file.js' );
     const activityImports = [ { localName: 'StepA', activityName: 'step.a' } ];
-    const rewrote = rewriteFnBodies( { ast, activityImports } );
+    const rewrote = rewriteActivityCalls( { ast, activityImports } );
     expect( rewrote ).toBe( true );
 
     const { code } = generate( ast, { quotes: 'single' } );
@@ -144,7 +144,7 @@ function helper( Symbol ) {
 }`;
     const ast = parse( src, 'file.js' );
     const activityImports = [ { localName: 'StepA', activityName: 'step.a' } ];
-    const rewrote = rewriteFnBodies( { ast, activityImports } );
+    const rewrote = rewriteActivityCalls( { ast, activityImports } );
     expect( rewrote ).toBe( true );
 
     const { code } = generate( ast, { quotes: 'single' } );
@@ -160,7 +160,6 @@ function helper( globalThis ) {
     const ast = parse( src, 'file.js' );
     const activityImports = [ { localName: 'StepA', activityName: 'step.a' } ];
 
-    expect( () => rewriteFnBodies( { ast, activityImports } ) ).toThrow( /globalThis.*shadowed/ );
+    expect( () => rewriteActivityCalls( { ast, activityImports } ) ).toThrow( /globalThis.*shadowed/ );
   } );
 } );
-

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/rewrite_fn_bodies.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/rewrite_fn_bodies.js
@@ -1,15 +1,20 @@
 import traverseModule from '@babel/traverse';
+import { INVOKE_ACTIVITY_SYMBOL } from '#consts';
 import {
   callExpression,
   identifier,
-  importDeclaration,
-  importSpecifier,
   isIdentifier,
+  memberExpression,
   stringLiteral
 } from '@babel/types';
 
 // Handle CJS/ESM interop for Babel packages when executed as a webpack loader
 const traverse = traverseModule.default ?? traverseModule;
+const invokeActivitySymbolKey = Symbol.keyFor( INVOKE_ACTIVITY_SYMBOL );
+
+if ( !invokeActivitySymbolKey ) {
+  throw new Error( 'INVOKE_ACTIVITY_SYMBOL must be created with Symbol.for().' );
+}
 
 // Only direct function calls are rewritten. Member calls and dynamic callees stay untouched.
 const isIdentifierCallee = cPath => isIdentifier( cPath.node.callee );
@@ -24,31 +29,31 @@ const hasLiveLocalBinding = ( path, name ) => {
   return binding && !binding.path.removed;
 };
 
-// Reserve a collision-safe binding name for the internal activity dispatcher.
-const generateInvokeActivityIdentifier = ast => {
-  const state = { localIdentifier: null };
-  traverse( ast, {
-    Program: path => {
-      state.localIdentifier = path.scope.generateUidIdentifier( 'invokeActivity' );
-      path.stop();
-    }
-  } );
-  return state.localIdentifier;
-};
-
-// Add the dispatcher import only after we know a call was actually rewritten.
-const injectInvokeActivityImport = ( ast, localIdentifier ) => {
-  ast.program.body.unshift( importDeclaration( [
-    importSpecifier( localIdentifier, identifier( '__invokeActivity' ) )
-  ], stringLiteral( '@outputai/core/invoker' ) ) );
+const assertGlobalThisIsSafe = path => {
+  if ( hasLiveLocalBinding( path, 'globalThis' ) ) {
+    throw new Error( 'Cannot rewrite activity call because "globalThis" is shadowed in this scope.' );
+  }
 };
 
 // Build the generated dispatcher call, preserving the original call arguments.
-const createInvokeActivityCall = ( invokeActivityId, activityName, args ) =>
-  callExpression( identifier( invokeActivityId.name ), [ stringLiteral( activityName ), ...args ] );
+const createInvokeActivityCall = ( activityName, args ) =>
+  callExpression(
+    memberExpression(
+      identifier( 'globalThis' ),
+      callExpression(
+        memberExpression(
+          memberExpression( identifier( 'globalThis' ), identifier( 'Symbol' ) ),
+          identifier( 'for' )
+        ),
+        [ stringLiteral( invokeActivitySymbolKey ) ]
+      ),
+      true
+    ),
+    [ stringLiteral( activityName ), ...args ]
+  );
 
 // Rewrite valid function-body activity calls; top-level call validation belongs to the validator loader.
-const rewriteActivityCalls = ( { ast, activityNames, invokeActivityId } ) => {
+const rewriteActivityCalls = ( { ast, activityNames } ) => {
   const state = { rewrote: false };
 
   traverse( ast, {
@@ -63,30 +68,13 @@ const rewriteActivityCalls = ( { ast, activityNames, invokeActivityId } ) => {
         return;
       }
 
-      path.replaceWith( createInvokeActivityCall( invokeActivityId, activityName, path.node.arguments ) );
+      assertGlobalThisIsSafe( path );
+      path.replaceWith( createInvokeActivityCall( activityName, path.node.arguments ) );
       state.rewrote = true;
     }
   } );
 
   return state.rewrote;
-};
-
-// Reuse an existing framework import so repeated loader passes do not add duplicate imports.
-const getExistingInvokeActivityLocal = ast => {
-  for ( const node of ast.program.body ) {
-    if ( node.type !== 'ImportDeclaration' || node.source.value !== '@outputai/core/invoker' ) {
-      continue;
-    }
-    const spec = node.specifiers.find( s =>
-      s.type === 'ImportSpecifier' &&
-      s.imported.type === 'Identifier' &&
-      s.imported.name === '__invokeActivity'
-    );
-    if ( spec ) {
-      return spec.local;
-    }
-  }
-  return null;
 };
 
 // Entry point: resolve collected component imports into plain dispatcher calls.
@@ -96,16 +84,5 @@ export default function rewriteFnBodies( { ast, activityImports } ) {
     return false;
   }
 
-  const existingLocal = getExistingInvokeActivityLocal( ast );
-  const invokeActivityId = existingLocal ?? generateInvokeActivityIdentifier( ast );
-  const rewrote = rewriteActivityCalls( { ast, activityNames, invokeActivityId } );
-  if ( !rewrote ) {
-    return false;
-  }
-
-  if ( !existingLocal ) {
-    injectInvokeActivityImport( ast, invokeActivityId );
-  }
-
-  return rewrote;
+  return rewriteActivityCalls( { ast, activityNames } );
 };

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/rewrite_fn_bodies.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/rewrite_fn_bodies.js
@@ -1,193 +1,122 @@
 import traverseModule from '@babel/traverse';
-import { isArrowFunctionExpression, isIdentifier } from '@babel/types';
 import {
-  toFunctionExpression,
-  createThisMethodCall,
-  isFunction,
-  bindThisAtCallSite,
-  isFunctionLikeBinding
-} from '../tools.js';
+  callExpression,
+  identifier,
+  importDeclaration,
+  importSpecifier,
+  isIdentifier,
+  stringLiteral
+} from '@babel/types';
 
 // Handle CJS/ESM interop for Babel packages when executed as a webpack loader
 const traverse = traverseModule.default ?? traverseModule;
 
-/**
- * Check whether a CallExpression callee is a simple Identifier.
- * Only direct identifier calls are rewritten; member/dynamic calls are skipped.
- *
- * We only support rewriting `Foo()` calls that refer to imported steps/evaluators
- * or local call-chain functions. Calls like `obj.Foo()` or `(getFn())()` are out of scope.
- *
- * Examples:
- * - Supported: `Foo()`
- * - Skipped:   `obj.Foo()`, `(getFn())()`
- *
- * @param {import('@babel/traverse').NodePath} cPath - Path to a CallExpression node.
- * @returns {boolean} True when callee is an Identifier.
- */
+// Only direct function calls are rewritten. Member calls and dynamic callees stay untouched.
 const isIdentifierCallee = cPath => isIdentifier( cPath.node.callee );
 
-/**
- * Convert an ArrowFunctionExpression at the given path into a FunctionExpression
- * to ensure dynamic `this` semantics inside the function body.
- *
- * Workflow code relies on `this` to invoke steps/evaluators (e.g., `this.invokeStep(...)`).
- * Arrow functions capture `this` lexically, which would break that contract.
- *
- * If the node is an arrow, it is replaced by an equivalent FunctionExpression and
- * the `state.rewrote` flag is set. If not an arrow, this is a no-op.
- *
- * @param {import('@babel/traverse').NodePath} nodePath - Path to a function node.
- * @param {{ rewrote: boolean }} state - Mutation target to indicate a rewrite occurred.
- * @returns {void}
- */
-const normalizeArrowToFunctionPath = ( nodePath, state ) => {
-  if ( isArrowFunctionExpression( nodePath.node ) ) {
-    nodePath.replaceWith( toFunctionExpression( nodePath.node ) );
-    state.rewrote = true;
-  }
+// Collapse collected activity imports into local identifier -> declared activity name.
+const buildActivityNameMap = activityImports =>
+  activityImports.reduce( ( map, { localName, activityName } ) => map.set( localName, activityName ), new Map() );
+
+// Ignore calls when the imported binding has been shadowed by a live local binding.
+const hasLiveLocalBinding = ( path, name ) => {
+  const binding = path.scope.getBinding( name );
+  return binding && !binding.path.removed;
 };
-/**
- * Rewrite calls inside a function body and collect call-chain functions discovered within.
- * - Imported calls (steps/shared/evaluators) are rewritten to `this.invokeX`.
- * - Local call-chain function calls are rewritten to `fn.call(this, ...)` to bind `this` correctly.
- * - Returns a map of call-chain function name -> binding path for further recursive processing.
- *
- * @param {import('@babel/traverse').NodePath} bodyPath - Path to a function's body node.
- * @param {Array<{ list: Array<any>, method: string, key: string }>} descriptors - Import rewrite descriptors.
- * @param {{ rewrote: boolean }} state - Mutable state used to flag that edits were performed.
- * @returns {Map<string, import('@babel/traverse').NodePath>} Discovered call-chain function bindings.
- */
-const rewriteCallsInBody = ( bodyPath, descriptors, state ) => {
-  const callChainFunctions = new Map();
-  bodyPath.traverse( {
-    CallExpression: cPath => {
-      if ( !isIdentifierCallee( cPath ) ) {
-        return; // Only identifier callees are supported (skip member/dynamic)
-      }
-      const callee = cPath.node.callee;
 
-      // Rewrite imported calls (steps/shared/evaluators)
-      for ( const { list, method, key } of descriptors ) {
-        const found = list.find( x => x.localName === callee.name );
-        if ( found ) {
-          const args = cPath.node.arguments;
-          cPath.replaceWith( createThisMethodCall( method, found[key], args ) );
-          state.rewrote = true;
-          return;
-        }
-      }
+// Reserve a collision-safe binding name for the internal activity dispatcher.
+const generateInvokeActivityIdentifier = ast => {
+  const state = { localIdentifier: null };
+  traverse( ast, {
+    Program: path => {
+      state.localIdentifier = path.scope.generateUidIdentifier( 'invokeActivity' );
+      path.stop();
+    }
+  } );
+  return state.localIdentifier;
+};
 
-      // Rewrite local call-chain function calls and track for recursive processing
-      const binding = cPath.scope.getBinding( callee.name );
-      if ( !binding ) {
+// Add the dispatcher import only after we know a call was actually rewritten.
+const injectInvokeActivityImport = ( ast, localIdentifier ) => {
+  ast.program.body.unshift( importDeclaration( [
+    importSpecifier( localIdentifier, identifier( '__invokeActivity' ) )
+  ], stringLiteral( '@outputai/core/invoker' ) ) );
+};
+
+// Build the generated dispatcher call, preserving the original call arguments.
+const createInvokeActivityCall = ( invokeActivityId, activityName, args ) =>
+  callExpression( identifier( invokeActivityId.name ), [ stringLiteral( activityName ), ...args ] );
+
+// Rewrite valid function-body activity calls; top-level call validation belongs to the validator loader.
+const rewriteActivityCalls = ( { ast, activityNames, invokeActivityId } ) => {
+  const state = { rewrote: false };
+
+  traverse( ast, {
+    CallExpression: path => {
+      if ( !path.getFunctionParent() || !isIdentifierCallee( path ) ) {
         return;
       }
-      if ( !isFunctionLikeBinding( binding.path.node ) ) {
-        return; // Not a function-like binding
+
+      const callee = path.node.callee;
+      const activityName = activityNames.get( callee.name );
+      if ( !activityName || hasLiveLocalBinding( path, callee.name ) ) {
+        return;
       }
 
-      // Queue call-chain function for recursive processing
-      if ( !callChainFunctions.has( callee.name ) ) {
-        callChainFunctions.set( callee.name, binding.path );
-      }
-
-      // Bind `this` at callsite: fn(...) -> fn.call(this, ...)
-      cPath.replaceWith( bindThisAtCallSite( callee.name, cPath.node.arguments ) );
+      path.replaceWith( createInvokeActivityCall( invokeActivityId, activityName, path.node.arguments ) );
       state.rewrote = true;
     }
   } );
-  return callChainFunctions;
-};
 
-/**
- * Recursively process a call-chain function:
- * - Ensures the function is a FunctionExpression (converts arrow when needed).
- * - Rewrites calls inside the function using `rewriteCallsInBody`.
- * - Follows nested call-chain functions depth-first while avoiding cycles via `processedFns`.
- *
- * @param {object} params - Params for processing a call-chain function.
- * @param {string} params.name - Local identifier name in the current scope.
- * @param {import('@babel/traverse').NodePath} params.bindingPath - Binding path of the function declaration.
- * @param {{ rewrote: boolean }} params.state - Mutable state used to flag that edits were performed.
- * @param {Array<{ list: Array<any>, method: string, key: string }>} params.descriptors - Import rewrite descriptors.
- * @param {Set<string>} [params.processedFns] - Already processed names to avoid cycles.
- */
-const processFunction = ( { name, bindingPath, state, descriptors, processedFns = new Set() } ) => {
-  // Avoid infinite loops for recursive/repeated references
-  if ( processedFns.has( name ) || bindingPath.removed ) {
-    return;
-  }
-  processedFns.add( name );
-
-  if ( bindingPath.isVariableDeclarator() ) {
-    // Case 1: const foo = <function or arrow>
-    const initPath = bindingPath.get( 'init' );
-    // Arrow functions capture `this` lexically; normalize for dynamic `this`
-    normalizeArrowToFunctionPath( initPath, state );
-    // Rewrite calls in body; collect nested call-chain functions from this scope
-    const callChainFunctions = rewriteCallsInBody( initPath.get( 'body' ), descriptors, state );
-    // DFS: process nested call-chain functions (processedFns prevents cycles)
-    callChainFunctions.forEach( ( childBindingPath, childName ) => {
-      processFunction( { name: childName, bindingPath: childBindingPath, state, descriptors, processedFns } );
-    } );
-  } else if ( bindingPath.isFunctionDeclaration() ) {
-    // Case 2: function foo(...) { ... }
-    // Function declarations already have dynamic `this`; no normalization needed
-    const callChainFunctions = rewriteCallsInBody( bindingPath.get( 'body' ), descriptors, state );
-    // Continue DFS into any functions called from this declaration
-    callChainFunctions.forEach( ( childBindingPath, childName ) => {
-      processFunction( { name: childName, bindingPath: childBindingPath, state, descriptors, processedFns } );
-    } );
-  }
-};
-
-/**
- * Rewrite calls to imported steps/evaluators within `fn` object properties.
- * Converts arrow fns to functions and replaces `StepX(...)` with
- * `this.invokeStep('name', ...)`.
- *
- * @param {object} params
- * @param {import('@babel/types').File} params.ast - Parsed file AST.
- * @param {Array<{localName:string,stepName:string}>} params.stepImports - Step imports.
- * @param {Array<{localName:string,stepName:string}>} params.sharedStepImports - Shared step imports.
- * @param {Array<{localName:string,evaluatorName:string}>} params.evaluatorImports - Evaluator imports.
- * @returns {boolean} True if the AST was modified; false otherwise.
- */
-export default function rewriteFnBodies( { ast, stepImports, sharedStepImports = [], evaluatorImports, sharedEvaluatorImports = [] } ) {
-  const state = { rewrote: false };
-  // Build rewrite descriptors once per traversal
-  const descriptors = [
-    { list: stepImports, method: 'invokeStep', key: 'stepName' },
-    { list: sharedStepImports, method: 'invokeSharedStep', key: 'stepName' },
-    { list: evaluatorImports, method: 'invokeEvaluator', key: 'evaluatorName' },
-    { list: sharedEvaluatorImports, method: 'invokeSharedEvaluator', key: 'evaluatorName' }
-  ];
-  traverse( ast, {
-    ObjectProperty: path => {
-      // Only transform object properties named 'fn'
-      if ( !isIdentifier( path.node.key, { name: 'fn' } ) ) {
-        return;
-      }
-
-      const val = path.node.value;
-
-      // Only functions (including arrows) are eligible
-      if ( !isFunction( val ) && !isArrowFunctionExpression( val ) ) {
-        return;
-      }
-
-      // Normalize arrow to function for correct dynamic `this`
-      normalizeArrowToFunctionPath( path.get( 'value' ), state );
-
-      // Rewrite the main workflow fn body and collect call-chain functions discovered within it
-      const callChainFunctions = rewriteCallsInBody( path.get( 'value.body' ), descriptors, state );
-
-      // Recursively rewrite call-chain functions and any functions they call
-      callChainFunctions.forEach( ( bindingPath, name ) => {
-        processFunction( { name, bindingPath, state, descriptors } );
-      } );
-    }
-  } );
   return state.rewrote;
+};
+
+// Used to avoid reporting an import-only edit as useful when no call was rewritten.
+const hasInvokeActivityImport = ast => ast.program.body.some( node =>
+  node.type === 'ImportDeclaration' &&
+  node.source.value === '@outputai/core/invoker' &&
+  node.specifiers.some( spec =>
+    spec.type === 'ImportSpecifier' &&
+    spec.imported.type === 'Identifier' &&
+    spec.imported.name === '__invokeActivity'
+  )
+);
+
+// Reuse an existing framework import so repeated loader passes do not add duplicate imports.
+const getExistingInvokeActivityLocal = ast => {
+  for ( const node of ast.program.body ) {
+    if ( node.type !== 'ImportDeclaration' || node.source.value !== '@outputai/core/invoker' ) {
+      continue;
+    }
+    const spec = node.specifiers.find( s =>
+      s.type === 'ImportSpecifier' &&
+      s.imported.type === 'Identifier' &&
+      s.imported.name === '__invokeActivity'
+    );
+    if ( spec ) {
+      return spec.local;
+    }
+  }
+  return null;
+};
+
+// Entry point: resolve collected component imports into plain dispatcher calls.
+export default function rewriteFnBodies( { ast, activityImports } ) {
+  const activityNames = buildActivityNameMap( activityImports );
+  if ( activityNames.size === 0 ) {
+    return false;
+  }
+
+  const existingLocal = getExistingInvokeActivityLocal( ast );
+  const invokeActivityId = existingLocal ?? generateInvokeActivityIdentifier( ast );
+  const rewrote = rewriteActivityCalls( { ast, activityNames, invokeActivityId } );
+  if ( !rewrote ) {
+    return false;
+  }
+
+  if ( !hasInvokeActivityImport( ast ) ) {
+    injectInvokeActivityImport( ast, invokeActivityId );
+  }
+
+  return rewrote;
 };

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/rewrite_fn_bodies.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/rewrite_fn_bodies.js
@@ -71,17 +71,6 @@ const rewriteActivityCalls = ( { ast, activityNames, invokeActivityId } ) => {
   return state.rewrote;
 };
 
-// Used to avoid reporting an import-only edit as useful when no call was rewritten.
-const hasInvokeActivityImport = ast => ast.program.body.some( node =>
-  node.type === 'ImportDeclaration' &&
-  node.source.value === '@outputai/core/invoker' &&
-  node.specifiers.some( spec =>
-    spec.type === 'ImportSpecifier' &&
-    spec.imported.type === 'Identifier' &&
-    spec.imported.name === '__invokeActivity'
-  )
-);
-
 // Reuse an existing framework import so repeated loader passes do not add duplicate imports.
 const getExistingInvokeActivityLocal = ast => {
   for ( const node of ast.program.body ) {
@@ -114,7 +103,7 @@ export default function rewriteFnBodies( { ast, activityImports } ) {
     return false;
   }
 
-  if ( !hasInvokeActivityImport( ast ) ) {
+  if ( !existingLocal ) {
     injectInvokeActivityImport( ast, invokeActivityId );
   }
 

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/rewrite_fn_bodies.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/rewrite_fn_bodies.spec.js
@@ -1,9 +1,21 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import generatorModule from '@babel/generator';
 import { parse } from '../tools.js';
 import rewriteFnBodies from './rewrite_fn_bodies.js';
 
+const { invokeActivitySymbolKey } = vi.hoisted( () => ( {
+  invokeActivitySymbolKey: 'test:invoke_activity'
+} ) );
+
+vi.mock( '#consts', async importOriginal => ( {
+  ...await importOriginal(),
+  INVOKE_ACTIVITY_SYMBOL: Symbol.for( invokeActivitySymbolKey )
+} ) );
+
 const generate = generatorModule.default ?? generatorModule;
+const escapeRegExp = value => value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+const invokeActivityPattern = activityName =>
+  new RegExp( `globalThis\\[globalThis\\.Symbol\\.for\\(([\"'])${escapeRegExp( invokeActivitySymbolKey )}\\1\\)\\]\\(([\"'])${activityName}\\2` );
 
 describe( 'rewrite_fn_bodies', () => {
   it( 'rewrites step calls inside functions without changing function shape', () => {
@@ -21,13 +33,14 @@ const obj = {
     expect( rewrote ).toBe( true );
 
     const { code } = generate( ast, { quotes: 'single' } );
-    expect( code ).toMatch( /import \{ __invokeActivity as _invokeActivity \} from "@outputai\/core\/invoker";/ );
+    expect( code ).not.toMatch( /@outputai\/core\/invoker/ );
     expect( code ).toMatch( /fn:\s*async x =>/ );
-    expect( code ).toMatch( /_invokeActivity\(([\"'])step\.a\1,\s*1\)/ );
+    expect( code ).toMatch( invokeActivityPattern( 'step\\.a' ) );
+    expect( code ).toMatch( /,\s*1\)/ );
     expect( code ).toMatch( /FlowB\(2\)/ );
   } );
 
-  it( 'rewrites evaluator calls to __invokeActivity', () => {
+  it( 'rewrites evaluator calls to the global activity dispatcher', () => {
     const src = `
 const obj = {
   fn: async x => {
@@ -39,7 +52,8 @@ const obj = {
     const rewrote = rewriteFnBodies( { ast, activityImports } );
     expect( rewrote ).toBe( true );
     const { code } = generate( ast, { quotes: 'single' } );
-    expect( code ).toMatch( /_invokeActivity\(([\"'])eval\.a\1,\s*3\)/ );
+    expect( code ).toMatch( invokeActivityPattern( 'eval\\.a' ) );
+    expect( code ).toMatch( /,\s*3\)/ );
   } );
 
   it( 'does nothing when no matching calls are present', () => {
@@ -77,8 +91,10 @@ const obj = {
 
     const { code } = generate( ast, { quotes: 'single' } );
 
-    expect( code ).toMatch( /_invokeActivity\(([\"'])step\.a\1,\s*1\)/ );
-    expect( code ).toMatch( /_invokeActivity\(([\"'])eval\.a\1,\s*x\)/ );
+    expect( code ).toMatch( invokeActivityPattern( 'step\\.a' ) );
+    expect( code ).toMatch( invokeActivityPattern( 'eval\\.a' ) );
+    expect( code ).toMatch( /,\s*1\)/ );
+    expect( code ).toMatch( /,\s*x\)/ );
     expect( code ).toMatch( /foo\(\)/ );
     expect( code ).toMatch( /bar\(2\)/ );
     expect( code ).toMatch( /const foo = async \(\) =>/ );
@@ -98,12 +114,14 @@ function helper() {
 
     const { code } = generate( ast, { quotes: 'single' } );
     expect( code ).toMatch( /StepA\(1\)/ );
-    expect( code ).toMatch( /_invokeActivity\(([\"'])step\.a\1,\s*2\)/ );
+    expect( code ).toMatch( invokeActivityPattern( 'step\\.a' ) );
+    expect( code ).toMatch( /,\s*2\)/ );
   } );
 
-  it( 'uses an existing __invokeActivity import when present', () => {
+  it( 'ignores local invoke activity names because globalThis is explicit', () => {
     const src = `
-import { __invokeActivity as invoke } from '@outputai/core/invoker';
+const __invokeActivity = () => 'local';
+const _invokeActivity = () => 'local';
 function helper() {
   StepA();
 }`;
@@ -113,8 +131,36 @@ function helper() {
     expect( rewrote ).toBe( true );
 
     const { code } = generate( ast, { quotes: 'single' } );
-    expect( code.match( /__invokeActivity/g ) ).toHaveLength( 1 );
-    expect( code ).toMatch( /invoke\(([\"'])step\.a\1\)/ );
+    expect( code ).not.toMatch( /@outputai\/core\/invoker/ );
+    expect( code ).toMatch( /const __invokeActivity = \(\) => 'local'/ );
+    expect( code ).toMatch( /const _invokeActivity = \(\) => 'local'/ );
+    expect( code ).toMatch( invokeActivityPattern( 'step\\.a' ) );
+  } );
+
+  it( 'reads Symbol through globalThis so local Symbol bindings are safe', () => {
+    const src = `
+function helper( Symbol ) {
+  StepA();
+}`;
+    const ast = parse( src, 'file.js' );
+    const activityImports = [ { localName: 'StepA', activityName: 'step.a' } ];
+    const rewrote = rewriteFnBodies( { ast, activityImports } );
+    expect( rewrote ).toBe( true );
+
+    const { code } = generate( ast, { quotes: 'single' } );
+    expect( code ).toMatch( /function helper\(Symbol\)/ );
+    expect( code ).toMatch( invokeActivityPattern( 'step\\.a' ) );
+  } );
+
+  it( 'throws when globalThis is shadowed at an activity call site', () => {
+    const src = `
+function helper( globalThis ) {
+  StepA();
+}`;
+    const ast = parse( src, 'file.js' );
+    const activityImports = [ { localName: 'StepA', activityName: 'step.a' } ];
+
+    expect( () => rewriteFnBodies( { ast, activityImports } ) ).toThrow( /globalThis.*shadowed/ );
   } );
 } );
 

--- a/sdk/core/src/worker/webpack_loaders/workflow_rewriter/rewrite_fn_bodies.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_rewriter/rewrite_fn_bodies.spec.js
@@ -6,7 +6,7 @@ import rewriteFnBodies from './rewrite_fn_bodies.js';
 const generate = generatorModule.default ?? generatorModule;
 
 describe( 'rewrite_fn_bodies', () => {
-  it( 'converts arrow to function and rewrites step calls without rewriting workflow calls', () => {
+  it( 'rewrites step calls inside functions without changing function shape', () => {
     const src = `
 const obj = {
   fn: async x => {
@@ -15,17 +15,19 @@ const obj = {
   }
 }`;
     const ast = parse( src, 'file.js' );
-    const stepImports = [ { localName: 'StepA', stepName: 'step.a' } ];
+    const activityImports = [ { localName: 'StepA', activityName: 'step.a' } ];
 
-    const rewrote = rewriteFnBodies( { ast, stepImports, evaluatorImports: [] } );
+    const rewrote = rewriteFnBodies( { ast, activityImports } );
     expect( rewrote ).toBe( true );
 
     const { code } = generate( ast, { quotes: 'single' } );
-    expect( code ).toMatch( /this\.invokeStep\(([\"'])step\.a\1,\s*1\)/ );
+    expect( code ).toMatch( /import \{ __invokeActivity as _invokeActivity \} from "@outputai\/core\/invoker";/ );
+    expect( code ).toMatch( /fn:\s*async x =>/ );
+    expect( code ).toMatch( /_invokeActivity\(([\"'])step\.a\1,\s*1\)/ );
     expect( code ).toMatch( /FlowB\(2\)/ );
   } );
 
-  it( 'rewrites evaluator calls to this.invokeEvaluator', () => {
+  it( 'rewrites evaluator calls to __invokeActivity', () => {
     const src = `
 const obj = {
   fn: async x => {
@@ -33,19 +35,21 @@ const obj = {
   }
 };`;
     const ast = parse( src, 'file.js' );
-    const evaluatorImports = [ { localName: 'EvalA', evaluatorName: 'eval.a' } ];
-    const rewrote = rewriteFnBodies( { ast, stepImports: [], evaluatorImports } );
+    const activityImports = [ { localName: 'EvalA', activityName: 'eval.a' } ];
+    const rewrote = rewriteFnBodies( { ast, activityImports } );
     expect( rewrote ).toBe( true );
+    const { code } = generate( ast, { quotes: 'single' } );
+    expect( code ).toMatch( /_invokeActivity\(([\"'])eval\.a\1,\s*3\)/ );
   } );
 
   it( 'does nothing when no matching calls are present', () => {
     const src = [ 'const obj = { fn: function() { other(); } }' ].join( '\n' );
     const ast = parse( src, 'file.js' );
-    const rewrote = rewriteFnBodies( { ast, stepImports: [], evaluatorImports: [] } );
+    const rewrote = rewriteFnBodies( { ast, activityImports: [] } );
     expect( rewrote ).toBe( false );
   } );
 
-  it( 'rewrites helper calls and helper bodies (steps and evaluators)', () => {
+  it( 'rewrites imported activity calls in any function body', () => {
     const src = `
 const foo = async () => {
   StepA( 1 );
@@ -63,61 +67,54 @@ const obj = {
 }`;
 
     const ast = parse( src, 'file.js' );
-    const stepImports = [ { localName: 'StepA', stepName: 'step.a' } ];
-    const evaluatorImports = [ { localName: 'EvalA', evaluatorName: 'eval.a' } ];
+    const activityImports = [
+      { localName: 'StepA', activityName: 'step.a' },
+      { localName: 'EvalA', activityName: 'eval.a' }
+    ];
 
-    const rewrote = rewriteFnBodies( { ast, stepImports, sharedStepImports: [], evaluatorImports } );
+    const rewrote = rewriteFnBodies( { ast, activityImports } );
     expect( rewrote ).toBe( true );
 
     const { code } = generate( ast, { quotes: 'single' } );
 
-    // Helper calls in fn are rewritten to call(this, ...)
-    expect( code ).toMatch( /foo\.call\(this\)/ );
-    expect( code ).toMatch( /bar\.call\(this,\s*2\)/ );
-
-    // Inside helpers, calls are rewritten
-    expect( code ).toMatch( /this\.invokeStep\(([\"'])step\.a\1,\s*1\)/ );
-    expect( code ).toMatch( /this\.invokeEvaluator\(([\"'])eval\.a\1,\s*x\)/ );
-
-    // Arrow helper converted to function expression to allow dynamic this
-    expect( code ).toMatch( /const foo = async function/ );
+    expect( code ).toMatch( /_invokeActivity\(([\"'])step\.a\1,\s*1\)/ );
+    expect( code ).toMatch( /_invokeActivity\(([\"'])eval\.a\1,\s*x\)/ );
+    expect( code ).toMatch( /foo\(\)/ );
+    expect( code ).toMatch( /bar\(2\)/ );
+    expect( code ).toMatch( /const foo = async \(\) =>/ );
   } );
 
-  it( 'rewrites nested helper chains until the step invocation', () => {
+  it( 'does not rewrite top-level calls', () => {
     const src = `
-const foo = () => {
-  bar();
-};
-
-function bar() {
-  baz( 42 );
-}
-
-const baz = n => {
-  StepA( n );
-};
-
-const obj = {
-  fn: async () => {
-    foo();
-  }
+StepA( 1 );
+function helper() {
+  StepA( 2 );
 }`;
 
     const ast = parse( src, 'file.js' );
-    const stepImports = [ { localName: 'StepA', stepName: 'step.a' } ];
-    const rewrote = rewriteFnBodies( { ast, stepImports, evaluatorImports: [] } );
+    const activityImports = [ { localName: 'StepA', activityName: 'step.a' } ];
+    const rewrote = rewriteFnBodies( { ast, activityImports } );
     expect( rewrote ).toBe( true );
 
     const { code } = generate( ast, { quotes: 'single' } );
-    // Calls along the chain are bound with this
-    expect( code ).toMatch( /foo\.call\(this\)/ );
-    expect( code ).toMatch( /bar\.call\(this\)/ );
-    expect( code ).toMatch( /baz\.call\(this,\s*42\)/ );
-    // Deep step rewrite in the last helper
-    expect( code ).toMatch( /this\.invokeStep\(([\"'])step\.a\1,\s*n\)/ );
-    // Arrow helpers converted to functions
-    expect( code ).toMatch( /const foo = function/ );
-    expect( code ).toMatch( /const baz = function/ );
+    expect( code ).toMatch( /StepA\(1\)/ );
+    expect( code ).toMatch( /_invokeActivity\(([\"'])step\.a\1,\s*2\)/ );
+  } );
+
+  it( 'uses an existing __invokeActivity import when present', () => {
+    const src = `
+import { __invokeActivity as invoke } from '@outputai/core/invoker';
+function helper() {
+  StepA();
+}`;
+    const ast = parse( src, 'file.js' );
+    const activityImports = [ { localName: 'StepA', activityName: 'step.a' } ];
+    const rewrote = rewriteFnBodies( { ast, activityImports } );
+    expect( rewrote ).toBe( true );
+
+    const { code } = generate( ast, { quotes: 'single' } );
+    expect( code.match( /__invokeActivity/g ) ).toHaveLength( 1 );
+    expect( code ).toMatch( /invoke\(([\"'])step\.a\1\)/ );
   } );
 } );
 

--- a/sdk/core/src/worker/webpack_loaders/workflow_validator/index.mjs
+++ b/sdk/core/src/worker/webpack_loaders/workflow_validator/index.mjs
@@ -27,7 +27,7 @@ import {
   resolveBareImportSpecifiersAsWorkflows,
   resolveBareDestructuredRequireAsWorkflows,
   resolveBareDefaultRequireAsWorkflow
-} from '../npm_workflow_export_resolve.js';
+} from './npm_workflow_export_resolve.js';
 import { ComponentFile } from '../consts.js';
 import {
   isCallExpression,
@@ -83,6 +83,54 @@ const validateInstantiationLocation = ( calleeName, filename ) => {
   }
 };
 
+const validateActivityCallsAreInsideFunctions = ( {
+  ast, filename, localStepIds, localEvaluatorIds, importedStepIds, importedEvaluatorIds
+} ) => {
+  traverse( ast, {
+    CallExpression: path => {
+      const callee = path.node.callee;
+      if ( !isIdentifier( callee ) || path.getFunctionParent() ) {
+        return;
+      }
+
+      const { name } = callee;
+      const violation = [
+        [ 'step', localStepIds.has( name ) || importedStepIds.has( name ) ],
+        [ 'evaluator', localEvaluatorIds.has( name ) || importedEvaluatorIds.has( name ) ]
+      ].find( v => v[1] )?.[0];
+
+      if ( violation ) {
+        throw new Error( `Invalid top-level ${violation} call '${name}' in ${filename}. Activities can only be invoked inside functions.` );
+      }
+    }
+  } );
+};
+
+const isActivityPath = specifier => isAnyStepsPath( specifier ) || isAnyEvaluatorsPath( specifier );
+
+const validateActivityImportShape = ( specifier, specifiers ) => {
+  if ( !isActivityPath( specifier ) ) {
+    return;
+  }
+
+  if ( specifiers.some( s => !isImportSpecifier( s ) ) ) {
+    throw new Error(
+      `Invalid activity import from "${specifier}": use named imports only. ` +
+      'Default and namespace imports from steps/evaluators files cannot be rewritten.'
+    );
+  }
+};
+
+const validateActivityExportShape = ( fileKind, node ) => {
+  if ( ![ ComponentFile.STEPS, ComponentFile.EVALUATORS ].includes( fileKind ) ) {
+    return;
+  }
+
+  if ( node.type === 'ExportDefaultDeclaration' || node.type === 'ExportAllDeclaration' ) {
+    throw new Error( 'Invalid activity export: steps/evaluators files must use named exports only.' );
+  }
+};
+
 /**
  * Webpack loader that validates component instantiation and fn body calls.
  * Returns the source unchanged unless a validation error is found.
@@ -122,6 +170,8 @@ export default function workflowValidatorLoader( source, inputMap ) {
       ImportDeclaration: path => {
         const specifier = path.node.source.value;
 
+        validateActivityImportShape( specifier, path.node.specifiers );
+
         if ( isBareNpmSpecifier( specifier ) && fileMayBindBareNpmWorkflowImports( filename ) ) {
           const outcome = resolveBareImportSpecifiersAsWorkflows( {
             fromAbsoluteFile: filename,
@@ -151,6 +201,12 @@ export default function workflowValidatorLoader( source, inputMap ) {
             }
           }
         }
+      },
+      ExportDefaultDeclaration: path => {
+        validateActivityExportShape( fileKind, path.node );
+      },
+      ExportAllDeclaration: path => {
+        validateActivityExportShape( fileKind, path.node );
       },
       VariableDeclarator: path => {
         const init = path.node.init;
@@ -208,6 +264,12 @@ export default function workflowValidatorLoader( source, inputMap ) {
 
           // Collect imported identifiers from require patterns
           const reqType = getFileKind( toAbsolutePath( fileDir, req ) );
+          if ( [ ComponentFile.STEPS, ComponentFile.EVALUATORS ].includes( reqType ) && !isObjectPattern( path.node.id ) ) {
+            throw new Error(
+              `Invalid activity require from "${req}": use destructured requires only. ` +
+              'Default-style requires from steps/evaluators files cannot be rewritten.'
+            );
+          }
           if ( reqType === ComponentFile.STEPS && isObjectPattern( path.node.id ) ) {
             for ( const prop of path.node.id.properties ) {
               if ( isObjectProperty( prop ) && isIdentifier( prop.value ) ) {
@@ -227,6 +289,10 @@ export default function workflowValidatorLoader( source, inputMap ) {
           }
         }
       }
+    } );
+
+    validateActivityCallsAreInsideFunctions( {
+      ast, filename, localStepIds, localEvaluatorIds, importedStepIds, importedEvaluatorIds
     } );
 
     // Function-body call validations for steps/evaluators files

--- a/sdk/core/src/worker/webpack_loaders/workflow_validator/index.mjs
+++ b/sdk/core/src/worker/webpack_loaders/workflow_validator/index.mjs
@@ -9,6 +9,24 @@ import {
   isWorkflowPath,
   isAbsoluteWorkflowJsResource
 } from '../tools.js';
+import {
+  isBareNpmSpecifier,
+  resolveBareImportSpecifiersAsWorkflows,
+  resolveBareDestructuredRequireAsWorkflows,
+  resolveBareDefaultRequireAsWorkflow
+} from './npm_workflow_export_resolve.js';
+import { ComponentFactory, ComponentFile } from '../consts.js';
+import {
+  isCallExpression,
+  isFunctionExpression,
+  isArrowFunctionExpression,
+  isIdentifier,
+  isImportDefaultSpecifier,
+  isImportSpecifier,
+  isObjectPattern,
+  isObjectProperty,
+  isStringLiteral
+} from '@babel/types';
 
 /**
  * Files where a bare npm import may bind to child workflows (catalog packages, etc.).
@@ -22,24 +40,6 @@ const fileMayBindBareNpmWorkflowImports = filename => {
   return isAbsoluteWorkflowJsResource( filename ) ||
     isAnyStepsPath( n ) || isAnyEvaluatorsPath( n );
 };
-import {
-  isBareNpmSpecifier,
-  resolveBareImportSpecifiersAsWorkflows,
-  resolveBareDestructuredRequireAsWorkflows,
-  resolveBareDefaultRequireAsWorkflow
-} from './npm_workflow_export_resolve.js';
-import { ComponentFile } from '../consts.js';
-import {
-  isCallExpression,
-  isFunctionExpression,
-  isArrowFunctionExpression,
-  isIdentifier,
-  isImportDefaultSpecifier,
-  isImportSpecifier,
-  isObjectPattern,
-  isObjectProperty,
-  isStringLiteral
-} from '@babel/types';
 
 // Handle CJS/ESM interop for Babel packages when executed as a webpack loader
 const traverse = traverseModule.default ?? traverseModule;
@@ -72,13 +72,13 @@ const getFileKindLabel = filename => {
  * @param {string} filename - The file path where the call occurs
  */
 const validateInstantiationLocation = ( calleeName, filename ) => {
-  if ( calleeName === 'step' && !isAnyStepsPath( filename ) ) {
+  if ( calleeName === ComponentFactory.STEP && !isAnyStepsPath( filename ) ) {
     throw new Error( `Invalid instantiation location: step() can only be called in files with 'steps' in the path. Found in: ${filename}` );
   }
-  if ( calleeName === 'evaluator' && !isAnyEvaluatorsPath( filename ) ) {
+  if ( calleeName === ComponentFactory.EVALUATOR && !isAnyEvaluatorsPath( filename ) ) {
     throw new Error( `Invalid instantiation location: evaluator() can only be called in files with 'evaluators' in the path. Found in: ${filename}` );
   }
-  if ( calleeName === 'workflow' && !isWorkflowPath( filename ) ) {
+  if ( calleeName === ComponentFactory.WORKFLOW && !isWorkflowPath( filename ) ) {
     throw new Error( `Invalid instantiation location: workflow() can only be called in files with 'workflow' in the path. Found in: ${filename}` );
   }
 };
@@ -95,8 +95,8 @@ const validateActivityCallsAreInsideFunctions = ( {
 
       const { name } = callee;
       const violation = [
-        [ 'step', localStepIds.has( name ) || importedStepIds.has( name ) ],
-        [ 'evaluator', localEvaluatorIds.has( name ) || importedEvaluatorIds.has( name ) ]
+        [ ComponentFactory.STEP, localStepIds.has( name ) || importedStepIds.has( name ) ],
+        [ ComponentFactory.EVALUATOR, localEvaluatorIds.has( name ) || importedEvaluatorIds.has( name ) ]
       ].find( v => v[1] )?.[0];
 
       if ( violation ) {
@@ -137,10 +137,11 @@ const validateActivityExportShape = ( fileKind, node ) => {
  *
  * Rules enforced:
  *  - Instantiation location: step() must be in steps path, evaluator() in evaluators path, workflow() in workflow path
+ *  - Activity files must use named exports only
+ *  - Activity imports/requires must use named bindings so the rewriter can target each call
+ *  - Top-level activity calls are rejected
  *  - steps.js `fn`: calling any step, evaluator, or workflow inside fn body emits warning
  *  - evaluators.js `fn`: calling any step, evaluator, or workflow inside fn body emits warning
- *
- * NOTE: Import restrictions have been removed - any file can import any other file.
  *
  * @param {string|Buffer} source
  * @param {any} inputMap
@@ -215,20 +216,20 @@ export default function workflowValidatorLoader( source, inputMap ) {
         }
 
         // Validate instantiation location for step/evaluator/workflow calls
-        if ( isIdentifier( init.callee, { name: 'step' } ) ) {
-          validateInstantiationLocation( 'step', filename );
+        if ( isIdentifier( init.callee, { name: ComponentFactory.STEP } ) ) {
+          validateInstantiationLocation( ComponentFactory.STEP, filename );
           if ( isIdentifier( path.node.id ) ) {
             localStepIds.add( path.node.id.name );
           }
         }
-        if ( isIdentifier( init.callee, { name: 'evaluator' } ) ) {
-          validateInstantiationLocation( 'evaluator', filename );
+        if ( isIdentifier( init.callee, { name: ComponentFactory.EVALUATOR } ) ) {
+          validateInstantiationLocation( ComponentFactory.EVALUATOR, filename );
           if ( isIdentifier( path.node.id ) ) {
             localEvaluatorIds.add( path.node.id.name );
           }
         }
-        if ( isIdentifier( init.callee, { name: 'workflow' } ) ) {
-          validateInstantiationLocation( 'workflow', filename );
+        if ( isIdentifier( init.callee, { name: ComponentFactory.WORKFLOW } ) ) {
+          validateInstantiationLocation( ComponentFactory.WORKFLOW, filename );
         }
 
         // CommonJS requires: collect identifiers for fn body call checks
@@ -314,9 +315,9 @@ export default function workflowValidatorLoader( source, inputMap ) {
                 const { name } = callee;
                 const fileLabel = getFileKindLabel( filename );
                 const violation = [
-                  [ 'step', localStepIds.has( name ) || importedStepIds.has( name ) ],
-                  [ 'evaluator', localEvaluatorIds.has( name ) || importedEvaluatorIds.has( name ) ],
-                  [ 'workflow', importedWorkflowIds.has( name ) ]
+                  [ ComponentFactory.STEP, localStepIds.has( name ) || importedStepIds.has( name ) ],
+                  [ ComponentFactory.EVALUATOR, localEvaluatorIds.has( name ) || importedEvaluatorIds.has( name ) ],
+                  [ ComponentFactory.WORKFLOW, importedWorkflowIds.has( name ) ]
                 ].find( v => v[1] )?.[0];
 
                 if ( violation ) {

--- a/sdk/core/src/worker/webpack_loaders/workflow_validator/index.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_validator/index.spec.js
@@ -58,6 +58,20 @@ describe( 'workflow_validator loader', () => {
     rmSync( dir, { recursive: true, force: true } );
   } );
 
+  it( 'workflow.js: rejects default and namespace imports from activity files', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'wf-activity-import-shape-' ) );
+    await expect(
+      runLoader( join( dir, 'workflow.js' ), 'import StepA from "./steps.js";' )
+    ).rejects.toThrow( /Invalid activity import.*named imports only/ );
+    await expect(
+      runLoader( join( dir, 'workflow.js' ), 'import * as steps from "./steps.js";' )
+    ).rejects.toThrow( /Invalid activity import.*named imports only/ );
+    await expect(
+      runLoader( join( dir, 'workflow.js' ), 'import EvalA, { EvalB } from "./evaluators.js";' )
+    ).rejects.toThrow( /Invalid activity import.*named imports only/ );
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
   it( 'workflow.js: allows imports from any non-component file', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'wf-any-allow-' ) );
     const src = 'import x from "./foo.js";';
@@ -95,6 +109,20 @@ describe( 'workflow_validator loader', () => {
     const src = 'import { E } from "./evaluators.js";';
     const result = await runLoader( join( dir, 'evaluators.js' ), src );
     expect( result.warnings ).toHaveLength( 0 );
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'steps.js/evaluators.js: rejects non-named activity exports', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'activity-export-shape-' ) );
+    await expect(
+      runLoader( join( dir, 'steps.js' ), 'export default step({ name: "a" });' )
+    ).rejects.toThrow( /Invalid activity export.*named exports only/ );
+    await expect(
+      runLoader( join( dir, 'evaluators.js' ), 'export * from "./other_evaluators.js";' )
+    ).rejects.toThrow( /Invalid activity export.*named exports only/ );
+    await expect(
+      runLoader( join( dir, 'steps.js' ), 'export const A = step({ name: "a" });' )
+    ).resolves.toBeTruthy();
     rmSync( dir, { recursive: true, force: true } );
   } );
 
@@ -199,6 +227,17 @@ describe( 'workflow_validator loader', () => {
     rmSync( dir, { recursive: true, force: true } );
   } );
 
+  it( 'workflow.js: rejects non-destructured requires from activity files', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'wf-activity-require-shape-' ) );
+    await expect(
+      runLoader( join( dir, 'workflow.js' ), 'const steps = require("./steps.js");' )
+    ).rejects.toThrow( /Invalid activity require.*destructured requires only/ );
+    await expect(
+      runLoader( join( dir, 'workflow.js' ), 'const evaluators = require("./evaluators.js");' )
+    ).rejects.toThrow( /Invalid activity require.*destructured requires only/ );
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
   it( 'steps.js: allows importing evaluators/workflow variants (no import restrictions)', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'steps-allow-import2-' ) );
     const result1 = await runLoader( join( dir, 'steps.js' ), 'import { E } from "./evaluators.js";' );
@@ -217,12 +256,23 @@ describe( 'workflow_validator loader', () => {
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'top-level calls outside fn are allowed in steps.js and evaluators.js', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'toplevel-allowed-' ) );
+  it( 'rejects top-level activity calls in steps.js and evaluators.js', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'toplevel-reject-' ) );
     const stepsTop = [ 'const A = step({ name: "a" });', 'A();' ].join( '\n' );
-    await expect( runLoader( join( dir, 'steps.js' ), stepsTop ) ).resolves.toBeTruthy();
+    await expect( runLoader( join( dir, 'steps.js' ), stepsTop ) ).rejects.toThrow( /Invalid top-level step call 'A'/ );
     const evaluatorsTop = [ 'const E = evaluator({ name: "e" });', 'E();' ].join( '\n' );
-    await expect( runLoader( join( dir, 'evaluators.js' ), evaluatorsTop ) ).resolves.toBeTruthy();
+    await expect( runLoader( join( dir, 'evaluators.js' ), evaluatorsTop ) ).rejects.toThrow(
+      /Invalid top-level evaluator call 'E'/
+    );
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'allows activity calls inside helper functions', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'function-call-allowed-' ) );
+    const stepsSrc = [ 'const A = step({ name: "a" });', 'function helper() { return A(); }' ].join( '\n' );
+    await expect( runLoader( join( dir, 'steps.js' ), stepsSrc ) ).resolves.toBeTruthy();
+    const evaluatorsSrc = [ 'const E = evaluator({ name: "e" });', 'const helper = () => E();' ].join( '\n' );
+    await expect( runLoader( join( dir, 'evaluators.js' ), evaluatorsSrc ) ).resolves.toBeTruthy();
     rmSync( dir, { recursive: true, force: true } );
   } );
 

--- a/sdk/core/src/worker/webpack_loaders/workflow_validator/index.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_validator/index.spec.js
@@ -4,11 +4,6 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import validatorLoader from './index.mjs';
 
-/**
- * Minimal published catalog under `dir/node_modules` so `require.resolve` / export following works.
- * @param {string} dir - Temp project root containing `steps.js` / `workflow.js` under test.
- * @param {string} workflowName - Declared workflow `name` in the leaf `workflow.js`.
- */
 const writeMockGrowthxlabsCatalog = ( dir, workflowName ) => {
   const pkgRoot = join( dir, 'node_modules', '@growthxlabs', 'workflows_catalog' );
   const srcDir = join( pkgRoot, 'src' );
@@ -41,685 +36,167 @@ function runLoader( filename, source ) {
 }
 
 describe( 'workflow_validator loader', () => {
-  it( 'workflow.js: allows imports from steps/evaluators/workflow', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'wf-allow-' ) );
+  it( 'allows supported workflow imports and arbitrary non-component imports', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'wf-imports-allow-' ) );
     writeFileSync( join( dir, 'steps.js' ), 'export const S = step({ name: "s" })\n' );
     writeFileSync( join( dir, 'evaluators.js' ), 'export const E = evaluator({ name: "e" })\n' );
     writeFileSync( join( dir, 'workflow.js' ), 'export const W = workflow({ name: "w" })\n' );
+    mkdirSync( join( dir, 'utils' ) );
+    writeFileSync( join( dir, 'utils', 'helper.js' ), 'export const helper = () => 1;\n' );
 
-    const src = [
+    const source = [
       'import { S } from "./steps.js";',
       'import { E } from "./evaluators.js";',
       'import { W } from "./workflow.js";',
+      'import { helper } from "./utils/helper.js";',
       'const x = 1;'
     ].join( '\n' );
 
-    await expect( runLoader( join( dir, 'workflow.js' ), src ) ).resolves.toBeTruthy();
+    await expect( runLoader( join( dir, 'workflow.js' ), source ) ).resolves.toBeTruthy();
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'workflow.js: rejects default and namespace imports from activity files', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'wf-activity-import-shape-' ) );
-    await expect(
-      runLoader( join( dir, 'workflow.js' ), 'import StepA from "./steps.js";' )
-    ).rejects.toThrow( /Invalid activity import.*named imports only/ );
-    await expect(
-      runLoader( join( dir, 'workflow.js' ), 'import * as steps from "./steps.js";' )
-    ).rejects.toThrow( /Invalid activity import.*named imports only/ );
-    await expect(
-      runLoader( join( dir, 'workflow.js' ), 'import EvalA, { EvalB } from "./evaluators.js";' )
-    ).rejects.toThrow( /Invalid activity import.*named imports only/ );
+  it( 'allows cross-component imports and requires in activity files', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'activity-cross-imports-' ) );
+    const stepsResult = await runLoader( join( dir, 'steps.js' ), [
+      'import { E } from "./evaluators.js";',
+      'const W = require("./workflow.js");'
+    ].join( '\n' ) );
+    const evaluatorResult = await runLoader( join( dir, 'evaluators.js' ), [
+      'import { S } from "./steps.js";',
+      'const util = require("./util.js");'
+    ].join( '\n' ) );
+
+    expect( stepsResult.warnings ).toHaveLength( 0 );
+    expect( evaluatorResult.warnings ).toHaveLength( 0 );
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'workflow.js: allows imports from any non-component file', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'wf-any-allow-' ) );
-    const src = 'import x from "./foo.js";';
-    await expect( runLoader( join( dir, 'workflow.js' ), src ) ).resolves.toBeTruthy();
+  it( 'rejects default and namespace imports from activity files', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'activity-import-shape-' ) );
+
+    await expect( runLoader( join( dir, 'workflow.js' ), 'import StepA from "./steps.js";' ) )
+      .rejects.toThrow( /Invalid activity import.*named imports only/ );
+    await expect( runLoader( join( dir, 'workflow.js' ), 'import * as steps from "./steps.js";' ) )
+      .rejects.toThrow( /Invalid activity import.*named imports only/ );
+    await expect( runLoader( join( dir, 'workflow.js' ), 'import EvalA, { EvalB } from "./evaluators.js";' ) )
+      .rejects.toThrow( /Invalid activity import.*named imports only/ );
+
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'workflow.js: allows imports from @outputai/core', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'wf-allow-external-' ) );
-    const src = [
-      'import a from "@outputai/core";',
-      'const z = 1;'
-    ].join( '\n' );
-    await expect( runLoader( join( dir, 'workflow.js' ), src ) ).resolves.toBeTruthy();
+  it( 'rejects non-destructured requires from activity files', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'activity-require-shape-' ) );
+
+    await expect( runLoader( join( dir, 'workflow.js' ), 'const steps = require("./steps.js");' ) )
+      .rejects.toThrow( /Invalid activity require.*destructured requires only/ );
+    await expect( runLoader( join( dir, 'workflow.js' ), 'const evaluators = require("./evaluators.js");' ) )
+      .rejects.toThrow( /Invalid activity require.*destructured requires only/ );
+
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'steps.js: allows importing steps/evaluators/workflow (no import restrictions)', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'steps-allow-import-' ) );
-    const src = 'import { S } from "./steps.js";';
-    const result = await runLoader( join( dir, 'steps.js' ), src );
-    expect( result.warnings ).toHaveLength( 0 );
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'steps.js: allows other imports', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'steps-allow-' ) );
-    const src = 'import x from "./util.js";\nconst obj = { fn: () => 1 };';
-    await expect( runLoader( join( dir, 'steps.js' ), src ) ).resolves.toBeTruthy();
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'evaluators.js: allows importing evaluators/steps/workflow (no import restrictions)', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'evals-allow-import-' ) );
-    const src = 'import { E } from "./evaluators.js";';
-    const result = await runLoader( join( dir, 'evaluators.js' ), src );
-    expect( result.warnings ).toHaveLength( 0 );
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'steps.js/evaluators.js: rejects non-named activity exports', async () => {
+  it( 'rejects non-named exports from activity files', async () => {
     const dir = mkdtempSync( join( tmpdir(), 'activity-export-shape-' ) );
-    await expect(
-      runLoader( join( dir, 'steps.js' ), 'export default step({ name: "a" });' )
-    ).rejects.toThrow( /Invalid activity export.*named exports only/ );
-    await expect(
-      runLoader( join( dir, 'evaluators.js' ), 'export * from "./other_evaluators.js";' )
-    ).rejects.toThrow( /Invalid activity export.*named exports only/ );
-    await expect(
-      runLoader( join( dir, 'steps.js' ), 'export const A = step({ name: "a" });' )
-    ).resolves.toBeTruthy();
+
+    await expect( runLoader( join( dir, 'steps.js' ), 'export default step({ name: "a" });' ) )
+      .rejects.toThrow( /Invalid activity export.*named exports only/ );
+    await expect( runLoader( join( dir, 'evaluators.js' ), 'export * from "./other_evaluators.js";' ) )
+      .rejects.toThrow( /Invalid activity export.*named exports only/ );
+    await expect( runLoader( join( dir, 'steps.js' ), 'export const A = step({ name: "a" });' ) )
+      .resolves.toBeTruthy();
+
     rmSync( dir, { recursive: true, force: true } );
   } );
 
-  it( 'steps.js: warns when calling imported catalog workflow inside fn', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'steps-catalog-warn-' ) );
+  it( 'rejects top-level activity calls but allows calls inside helper functions', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'top-level-activity-calls-' ) );
+
+    await expect( runLoader( join( dir, 'steps.js' ), 'const A = step({ name: "a" });\nA();' ) )
+      .rejects.toThrow( /Invalid top-level step call 'A'/ );
+    await expect( runLoader( join( dir, 'evaluators.js' ), 'const E = evaluator({ name: "e" });\nE();' ) )
+      .rejects.toThrow( /Invalid top-level evaluator call 'E'/ );
+    await expect( runLoader( join( dir, 'steps.js' ), 'const A = step({ name: "a" });\nfunction helper() { return A(); }' ) )
+      .resolves.toBeTruthy();
+
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'warns when activity fn bodies call activities or workflows', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'activity-fn-call-warnings-' ) );
     writeMockGrowthxlabsCatalog( dir, 'cat.warn' );
-    const src = [
-      'import { sumNumbers } from "@growthxlabs/workflows_catalog";',
-      'const A = step({ name: "a", fn: async () => ({}) });',
-      'const obj = { fn: function() { sumNumbers(); } };'
-    ].join( '\n' );
-    const result = await runLoader( join( dir, 'steps.js' ), src );
-    expect( result.warnings ).toHaveLength( 1 );
-    expect( result.warnings[0].message ).toMatch( /Invalid call in .*steps\.js fn: calling a workflow/ );
-    rmSync( dir, { recursive: true, force: true } );
-  } );
 
-  it( 'evaluators.js: warns when calling catalog workflow inside fn (require)', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'evals-catalog-warn-' ) );
-    writeMockGrowthxlabsCatalog( dir, 'cat.warn.req' );
-    const src = [
-      'const { sumNumbers } = require("@growthxlabs/workflows_catalog");',
-      'const E = evaluator({ name: "e", fn: async () => ({ value: 1 }) });',
-      'const obj = { fn: function() { sumNumbers(); } };'
-    ].join( '\n' );
-    const result = await runLoader( join( dir, 'evaluators.js' ), src );
-    expect( result.warnings ).toHaveLength( 1 );
-    expect( result.warnings[0].message ).toMatch( /Invalid call in .*evaluators\.js fn: calling a workflow/ );
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'workflow.js: allows import from @growthxlabs/workflows_catalog', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'wf-catalog-allow-' ) );
-    writeMockGrowthxlabsCatalog( dir, 'cat.allow' );
-    const src = [
-      'import { sumNumbers } from "@growthxlabs/workflows_catalog";',
-      'const x = 1;'
-    ].join( '\n' );
-    const result = await runLoader( join( dir, 'workflow.js' ), src );
-    expect( result.warnings ).toHaveLength( 0 );
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'steps.js: warns when calling another step inside fn', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'steps-call-reject-' ) );
-    // Can only test same-type components since cross-type declarations are now blocked by instantiation validation
-    const src = [
+    const stepResult = await runLoader( join( dir, 'steps.js' ), [
       'const A = step({ name: "a" });',
       'const B = step({ name: "b" });',
       'const obj = { fn: function() { B(); } };'
-    ].join( '\n' );
-    const result = await runLoader( join( dir, 'steps.js' ), src );
+    ].join( '\n' ) );
+    const evaluatorResult = await runLoader( join( dir, 'evaluators.js' ), [
+      'import { sumNumbers } from "@growthxlabs/workflows_catalog";',
+      'const E = evaluator({ name: "e", fn: async () => ({ value: 1 }) });',
+      'const obj = { fn: function() { sumNumbers(); } };'
+    ].join( '\n' ) );
+
+    expect( stepResult.warnings ).toHaveLength( 1 );
+    expect( stepResult.warnings[0].message ).toMatch( /Invalid call in .*steps\.js fn: calling a step/ );
+    expect( evaluatorResult.warnings ).toHaveLength( 1 );
+    expect( evaluatorResult.warnings[0].message ).toMatch( /Invalid call in .*evaluators\.js fn: calling a workflow/ );
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'allows component instantiation in matching files', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'instantiation-allowed-' ) );
+    mkdirSync( join( dir, 'steps' ) );
+    mkdirSync( join( dir, 'evaluators' ) );
+
+    await expect( runLoader(
+      join( dir, 'steps', 'fetch_data.js' ),
+      'export const fetchData = step({ name: "fetch_data", fn: async () => ({}) });'
+    ) ).resolves.toBeTruthy();
+    await expect( runLoader(
+      join( dir, 'evaluators', 'quality.js' ),
+      'export const quality = evaluator({ name: "quality", fn: async () => ({ value: 1 }) });'
+    ) ).resolves.toBeTruthy();
+    await expect( runLoader(
+      join( dir, 'workflow.js' ),
+      'export default workflow({ name: "wf", fn: async () => ({}) });'
+    ) ).resolves.toBeTruthy();
+
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'rejects component instantiation in mismatched files', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'instantiation-rejected-' ) );
+    mkdirSync( join( dir, 'shared' ) );
+
+    await expect( runLoader(
+      join( dir, 'utils.js' ),
+      'export const badStep = step({ name: "bad", fn: async () => ({}) });'
+    ) ).rejects.toThrow( /Invalid instantiation location.*step\(\).*steps/ );
+    await expect( runLoader(
+      join( dir, 'steps.js' ),
+      'export const badEval = evaluator({ name: "bad", fn: async () => ({ value: 1 }) });'
+    ) ).rejects.toThrow( /Invalid instantiation location.*evaluator\(\).*evaluators/ );
+    await expect( runLoader(
+      join( dir, 'shared', 'common.js' ),
+      'export const badWf = workflow({ name: "bad", fn: async () => ({}) });'
+    ) ).rejects.toThrow( /Invalid instantiation location.*workflow\(\).*workflow/ );
+
+    rmSync( dir, { recursive: true, force: true } );
+  } );
+
+  it( 'resolves bare npm workflows for require warnings in activity fn bodies', async () => {
+    const dir = mkdtempSync( join( tmpdir(), 'bare-require-workflow-warning-' ) );
+    writeMockGrowthxlabsCatalog( dir, 'cat.warn.req' );
+
+    const result = await runLoader( join( dir, 'evaluators.js' ), [
+      'const { sumNumbers } = require("@growthxlabs/workflows_catalog");',
+      'const E = evaluator({ name: "e", fn: async () => ({ value: 1 }) });',
+      'const obj = { fn: function() { sumNumbers(); } };'
+    ].join( '\n' ) );
+
     expect( result.warnings ).toHaveLength( 1 );
-    expect( result.warnings[0].message ).toMatch( /Invalid call in .*\.js fn/ );
+    expect( result.warnings[0].message ).toMatch( /Invalid call in .*evaluators\.js fn: calling a workflow/ );
     rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'evaluators.js: warns when calling another evaluator inside fn', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'evals-call-reject-' ) );
-    // Can only test same-type components since cross-type declarations are now blocked by instantiation validation
-    const src = [
-      'const E1 = evaluator({ name: "e1" });',
-      'const E2 = evaluator({ name: "e2" });',
-      'const obj = { fn: function() { E2(); } };'
-    ].join( '\n' );
-    const result = await runLoader( join( dir, 'evaluators.js' ), src );
-    expect( result.warnings ).toHaveLength( 1 );
-    expect( result.warnings[0].message ).toMatch( /Invalid call in .*\.js fn/ );
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'steps.js/evaluators.js: allows calling unrelated local functions in fn', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'fn-allow-' ) );
-    const stepsSrc = [
-      'function helper() { return 1; }',
-      'const obj = { fn: function() { helper(); } };'
-    ].join( '\n' );
-    await expect( runLoader( join( dir, 'steps.js' ), stepsSrc ) ).resolves.toBeTruthy();
-
-    const evalsSrc = [
-      'function helper() { return 1; }',
-      'const obj = { fn: () => { helper(); } };'
-    ].join( '\n' );
-    await expect( runLoader( join( dir, 'evaluators.js' ), evalsSrc ) ).resolves.toBeTruthy();
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'workflow.js: allows require from steps/evaluators/workflow; allows other require', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'wf-req-' ) );
-    writeFileSync( join( dir, 'steps.js' ), 'export const S = step({ name: "s" })\n' );
-    writeFileSync( join( dir, 'evaluators.js' ), 'export const E = evaluator({ name: "e" })\n' );
-    writeFileSync( join( dir, 'workflow.js' ), 'export default workflow({ name: "w" })\n' );
-    const ok = [
-      'const { S } = require("./steps.js");',
-      'const { E } = require("./evaluators.js");',
-      'const W = require("./workflow.js");'
-    ].join( '\n' );
-    await expect( runLoader( join( dir, 'workflow.js' ), ok ) ).resolves.toBeTruthy();
-    // Also allow random files (not rejected anymore)
-    const ok2 = 'const X = require("./random_file.js");';
-    await expect( runLoader( join( dir, 'workflow.js' ), ok2 ) ).resolves.toBeTruthy();
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'workflow.js: rejects non-destructured requires from activity files', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'wf-activity-require-shape-' ) );
-    await expect(
-      runLoader( join( dir, 'workflow.js' ), 'const steps = require("./steps.js");' )
-    ).rejects.toThrow( /Invalid activity require.*destructured requires only/ );
-    await expect(
-      runLoader( join( dir, 'workflow.js' ), 'const evaluators = require("./evaluators.js");' )
-    ).rejects.toThrow( /Invalid activity require.*destructured requires only/ );
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'steps.js: allows importing evaluators/workflow variants (no import restrictions)', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'steps-allow-import2-' ) );
-    const result1 = await runLoader( join( dir, 'steps.js' ), 'import { E } from "./evaluators.js";' );
-    expect( result1.warnings ).toHaveLength( 0 );
-    const result2 = await runLoader( join( dir, 'steps.js' ), 'import WF from "./workflow.js";' );
-    expect( result2.warnings ).toHaveLength( 0 );
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'evaluators.js: allows importing steps/workflow variants (no import restrictions)', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'evals-allow-import2-' ) );
-    const result1 = await runLoader( join( dir, 'evaluators.js' ), 'import { S } from "./steps.js";' );
-    expect( result1.warnings ).toHaveLength( 0 );
-    const result2 = await runLoader( join( dir, 'evaluators.js' ), 'import WF from "./workflow.js";' );
-    expect( result2.warnings ).toHaveLength( 0 );
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'rejects top-level activity calls in steps.js and evaluators.js', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'toplevel-reject-' ) );
-    const stepsTop = [ 'const A = step({ name: "a" });', 'A();' ].join( '\n' );
-    await expect( runLoader( join( dir, 'steps.js' ), stepsTop ) ).rejects.toThrow( /Invalid top-level step call 'A'/ );
-    const evaluatorsTop = [ 'const E = evaluator({ name: "e" });', 'E();' ].join( '\n' );
-    await expect( runLoader( join( dir, 'evaluators.js' ), evaluatorsTop ) ).rejects.toThrow(
-      /Invalid top-level evaluator call 'E'/
-    );
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'allows activity calls inside helper functions', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'function-call-allowed-' ) );
-    const stepsSrc = [ 'const A = step({ name: "a" });', 'function helper() { return A(); }' ].join( '\n' );
-    await expect( runLoader( join( dir, 'steps.js' ), stepsSrc ) ).resolves.toBeTruthy();
-    const evaluatorsSrc = [ 'const E = evaluator({ name: "e" });', 'const helper = () => E();' ].join( '\n' );
-    await expect( runLoader( join( dir, 'evaluators.js' ), evaluatorsSrc ) ).resolves.toBeTruthy();
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'workflow.js: allows importing ./types.js and bare types', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'wf-types-allow-' ) );
-    writeFileSync( join( dir, 'types.js' ), 'export const T = {}\n' );
-    const src1 = 'import { T } from "./types.js";';
-    await expect( runLoader( join( dir, 'workflow.js' ), src1 ) ).resolves.toBeTruthy();
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'workflow.js: allows importing any file (consts/constants/vars/variables/random)', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'wf-extra-allow-' ) );
-    const bases = [ 'consts', 'constants', 'vars', 'variables', 'random', 'anything' ];
-    for ( const base of bases ) {
-      writeFileSync( join( dir, `${base}.js` ), 'export const X = 1\n' );
-      const src = `import x from "./${base}.js";`;
-      await expect( runLoader( join( dir, 'workflow.js' ), src ) ).resolves.toBeTruthy();
-    }
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'steps.js: allows require of steps/evaluators/workflow (no import restrictions)', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'steps-require-allow-' ) );
-    const result1 = await runLoader( join( dir, 'steps.js' ), 'const { S } = require("./steps.js");' );
-    expect( result1.warnings ).toHaveLength( 0 );
-    const result2 = await runLoader( join( dir, 'steps.js' ), 'const { E } = require("./evaluators.js");' );
-    expect( result2.warnings ).toHaveLength( 0 );
-    const result3 = await runLoader( join( dir, 'steps.js' ), 'const W = require("./workflow.js");' );
-    expect( result3.warnings ).toHaveLength( 0 );
-    const ok = 'const util = require("./util.js");';
-    const resultOk = await runLoader( join( dir, 'steps.js' ), ok );
-    expect( resultOk.warnings ).toHaveLength( 0 );
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  it( 'evaluators.js: allows require of steps/workflow (no import restrictions)', async () => {
-    const dir = mkdtempSync( join( tmpdir(), 'evals-require-allow-' ) );
-    const result1 = await runLoader( join( dir, 'evaluators.js' ), 'const { S } = require("./steps.js");' );
-    expect( result1.warnings ).toHaveLength( 0 );
-    const result2 = await runLoader( join( dir, 'evaluators.js' ), 'const W = require("./workflow.js");' );
-    expect( result2.warnings ).toHaveLength( 0 );
-    const ok = 'const util = require("./util.js");';
-    const resultOk = await runLoader( join( dir, 'evaluators.js' ), ok );
-    expect( resultOk.warnings ).toHaveLength( 0 );
-    rmSync( dir, { recursive: true, force: true } );
-  } );
-
-  // =====================================================
-  // Folder-based utilities and shared directory
-  // =====================================================
-
-  describe( 'folder-based utilities', () => {
-    it( 'workflow.js: allows imports from ./utils/helper.js (folder-based utils)', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'wf-folder-utils-' ) );
-      mkdirSync( join( dir, 'utils' ) );
-      writeFileSync( join( dir, 'utils', 'helper.js' ), 'export const helper = () => 1;\n' );
-      const src = 'import { helper } from "./utils/helper.js";';
-      await expect( runLoader( join( dir, 'workflow.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'workflow.js: allows imports from ./clients/redis.js (folder-based clients)', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'wf-folder-clients-' ) );
-      mkdirSync( join( dir, 'clients' ) );
-      writeFileSync( join( dir, 'clients', 'redis.js' ), 'export const client = {};\n' );
-      const src = 'import { client } from "./clients/redis.js";';
-      await expect( runLoader( join( dir, 'workflow.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'steps/fetch_data.js: allows imports from ../utils/http.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'steps-folder-utils-' ) );
-      mkdirSync( join( dir, 'steps' ) );
-      mkdirSync( join( dir, 'utils' ) );
-      writeFileSync( join( dir, 'utils', 'http.js' ), 'export const get = () => {};\n' );
-      const src = 'import { get } from "../utils/http.js";';
-      await expect( runLoader( join( dir, 'steps', 'fetch_data.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'evaluators/quality.js: allows imports from ../utils/metrics.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'evals-folder-utils-' ) );
-      mkdirSync( join( dir, 'evaluators' ) );
-      mkdirSync( join( dir, 'utils' ) );
-      writeFileSync( join( dir, 'utils', 'metrics.js' ), 'export const compute = () => {};\n' );
-      const src = 'import { compute } from "../utils/metrics.js";';
-      await expect( runLoader( join( dir, 'evaluators', 'quality.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-  } );
-
-  describe( 'shared directory imports', () => {
-    it( 'workflow.js: allows imports from ../../shared/utils/keys.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'wf-shared-utils-' ) );
-      mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-      mkdirSync( join( dir, 'shared', 'utils' ), { recursive: true } );
-      writeFileSync( join( dir, 'shared', 'utils', 'keys.js' ), 'export const KEY = "test";\n' );
-      const src = 'import { KEY } from "../../shared/utils/keys.js";';
-      await expect( runLoader( join( dir, 'workflows', 'my_workflow', 'workflow.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'workflow.js: allows imports from ../../shared/steps/common.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'wf-shared-steps-' ) );
-      mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-      mkdirSync( join( dir, 'shared', 'steps' ), { recursive: true } );
-      writeFileSync( join( dir, 'shared', 'steps', 'common.js' ), 'export const commonStep = step({ name: "common" });\n' );
-      const src = 'import { commonStep } from "../../shared/steps/common.js";';
-      await expect( runLoader( join( dir, 'workflows', 'my_workflow', 'workflow.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'workflow.js: allows imports from ../../shared/evaluators/quality.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'wf-shared-evals-' ) );
-      mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-      mkdirSync( join( dir, 'shared', 'evaluators' ), { recursive: true } );
-      writeFileSync( join( dir, 'shared', 'evaluators', 'quality.js' ), 'export const qualityEval = evaluator({ name: "quality" });\n' );
-      const src = 'import { qualityEval } from "../../shared/evaluators/quality.js";';
-      await expect( runLoader( join( dir, 'workflows', 'my_workflow', 'workflow.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'workflow.js: allows imports from ../../clients/pokeapi.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'wf-clients-' ) );
-      mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-      mkdirSync( join( dir, 'clients' ), { recursive: true } );
-      writeFileSync( join( dir, 'clients', 'pokeapi.js' ), 'export const getPokemon = () => {};\n' );
-      const src = 'import { getPokemon } from "../../clients/pokeapi.js";';
-      await expect( runLoader( join( dir, 'workflows', 'my_workflow', 'workflow.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'steps.ts: allows imports from ../../shared/utils/keys.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'steps-shared-utils-' ) );
-      mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-      mkdirSync( join( dir, 'shared', 'utils' ), { recursive: true } );
-      writeFileSync( join( dir, 'shared', 'utils', 'keys.js' ), 'export const KEY = "test";\n' );
-      const src = 'import { KEY } from "../../shared/utils/keys.js";';
-      await expect( runLoader( join( dir, 'workflows', 'my_workflow', 'steps.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'steps.ts: allows imports from ../../clients/redis.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'steps-clients-' ) );
-      mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-      mkdirSync( join( dir, 'clients' ), { recursive: true } );
-      writeFileSync( join( dir, 'clients', 'redis.js' ), 'export const client = {};\n' );
-      const src = 'import { client } from "../../clients/redis.js";';
-      await expect( runLoader( join( dir, 'workflows', 'my_workflow', 'steps.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'evaluators.ts: allows imports from ../../shared/utils/helpers.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'evals-shared-utils-' ) );
-      mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-      mkdirSync( join( dir, 'shared', 'utils' ), { recursive: true } );
-      writeFileSync( join( dir, 'shared', 'utils', 'helpers.js' ), 'export const helper = () => 1;\n' );
-      const src = 'import { helper } from "../../shared/utils/helpers.js";';
-      await expect( runLoader( join( dir, 'workflows', 'my_workflow', 'evaluators.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-  } );
-
-  describe( 'cross-component imports - now allowed (no import restrictions)', () => {
-    it( 'steps.ts: allows imports from ../../shared/steps/common.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'steps-shared-steps-allow-' ) );
-      mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-      mkdirSync( join( dir, 'shared', 'steps' ), { recursive: true } );
-      writeFileSync( join( dir, 'shared', 'steps', 'common.js' ), 'export const commonStep = step({ name: "common" });\n' );
-      const src = 'import { commonStep } from "../../shared/steps/common.js";';
-      const result = await runLoader( join( dir, 'workflows', 'my_workflow', 'steps.js' ), src );
-      expect( result.warnings ).toHaveLength( 0 );
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'steps.ts: allows imports from ../../shared/evaluators/quality.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'steps-shared-evals-allow-' ) );
-      mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-      mkdirSync( join( dir, 'shared', 'evaluators' ), { recursive: true } );
-      writeFileSync( join( dir, 'shared', 'evaluators', 'quality.js' ), 'export const qualityEval = evaluator({ name: "quality" });\n' );
-      const src = 'import { qualityEval } from "../../shared/evaluators/quality.js";';
-      const result = await runLoader( join( dir, 'workflows', 'my_workflow', 'steps.js' ), src );
-      expect( result.warnings ).toHaveLength( 0 );
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'evaluators.ts: allows imports from ../../shared/steps/common.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'evals-shared-steps-allow-' ) );
-      mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-      mkdirSync( join( dir, 'shared', 'steps' ), { recursive: true } );
-      writeFileSync( join( dir, 'shared', 'steps', 'common.js' ), 'export const commonStep = step({ name: "common" });\n' );
-      const src = 'import { commonStep } from "../../shared/steps/common.js";';
-      const result = await runLoader( join( dir, 'workflows', 'my_workflow', 'evaluators.js' ), src );
-      expect( result.warnings ).toHaveLength( 0 );
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'evaluators.ts: allows imports from ../../shared/evaluators/other.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'evals-shared-evals-allow-' ) );
-      mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-      mkdirSync( join( dir, 'shared', 'evaluators' ), { recursive: true } );
-      writeFileSync( join( dir, 'shared', 'evaluators', 'other.js' ), 'export const otherEval = evaluator({ name: "other" });\n' );
-      const src = 'import { otherEval } from "../../shared/evaluators/other.js";';
-      const result = await runLoader( join( dir, 'workflows', 'my_workflow', 'evaluators.js' ), src );
-      expect( result.warnings ).toHaveLength( 0 );
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-  } );
-
-  describe( 'workflow import scope', () => {
-    it( 'workflow.js: allows imports from other workflow directories (cross-workflow)', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'wf-cross-allow-' ) );
-      mkdirSync( join( dir, 'workflows', 'workflow_a' ), { recursive: true } );
-      mkdirSync( join( dir, 'workflows', 'workflow_b' ), { recursive: true } );
-      writeFileSync( join( dir, 'workflows', 'workflow_b', 'steps.js' ), 'export const S = step({ name: "s" });\n' );
-      // Cross-workflow imports are allowed for workflows (they can import steps from other workflows)
-      const src = 'import { S } from "../workflow_b/steps.js";';
-      await expect( runLoader( join( dir, 'workflows', 'workflow_a', 'workflow.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'workflow.js: allows imports from utils with relative parent paths', async () => {
-      // The validator does not enforce strict scope boundaries, it validates by file type patterns
-      const dir = mkdtempSync( join( tmpdir(), 'wf-parent-utils-' ) );
-      mkdirSync( join( dir, 'src', 'workflows', 'my_workflow' ), { recursive: true } );
-      mkdirSync( join( dir, 'utils' ), { recursive: true } );
-      writeFileSync( join( dir, 'utils', 'helpers.js' ), 'export const helper = () => 1;\n' );
-      const src = 'import { helper } from "../../../utils/helpers.js";';
-      // This should pass because it's not a component file
-      await expect( runLoader( join( dir, 'src', 'workflows', 'my_workflow', 'workflow.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-  } );
-
-  // =====================================================
-  // Arbitrary path imports (proving any folder name works)
-  // =====================================================
-
-  describe( 'arbitrary path imports', () => {
-    it( 'workflow.js: allows imports from ./foobar.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'wf-arbitrary-1-' ) );
-      const src = 'import { foo } from "./foobar.js";';
-      await expect( runLoader( join( dir, 'workflow.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'workflow.js: allows imports from ./foobar/baz.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'wf-arbitrary-2-' ) );
-      mkdirSync( join( dir, 'foobar' ) );
-      writeFileSync( join( dir, 'foobar', 'baz.js' ), 'export const baz = 1;\n' );
-      const src = 'import { baz } from "./foobar/baz.js";';
-      await expect( runLoader( join( dir, 'workflow.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'workflow.js: allows imports from ../../shared/foobar.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'wf-arbitrary-3-' ) );
-      mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-      mkdirSync( join( dir, 'shared' ), { recursive: true } );
-      writeFileSync( join( dir, 'shared', 'foobar.js' ), 'export const foobar = 1;\n' );
-      const src = 'import { foobar } from "../../shared/foobar.js";';
-      await expect( runLoader( join( dir, 'workflows', 'my_workflow', 'workflow.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'workflow.js: allows imports from ../../shared/foobar/baz.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'wf-arbitrary-4-' ) );
-      mkdirSync( join( dir, 'workflows', 'my_workflow' ), { recursive: true } );
-      mkdirSync( join( dir, 'shared', 'foobar' ), { recursive: true } );
-      writeFileSync( join( dir, 'shared', 'foobar', 'baz.js' ), 'export const baz = 1;\n' );
-      const src = 'import { baz } from "../../shared/foobar/baz.js";';
-      await expect( runLoader( join( dir, 'workflows', 'my_workflow', 'workflow.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'steps.js: allows imports from ./helpers/anything.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'steps-arbitrary-1-' ) );
-      mkdirSync( join( dir, 'helpers' ) );
-      writeFileSync( join( dir, 'helpers', 'anything.js' ), 'export const anything = 1;\n' );
-      const src = 'import { anything } from "./helpers/anything.js";';
-      await expect( runLoader( join( dir, 'steps.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'evaluators.js: allows imports from ./my_custom_lib/tools.js', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'evals-arbitrary-1-' ) );
-      mkdirSync( join( dir, 'my_custom_lib' ) );
-      writeFileSync( join( dir, 'my_custom_lib', 'tools.js' ), 'export const tools = {};\n' );
-      const src = 'import { tools } from "./my_custom_lib/tools.js";';
-      await expect( runLoader( join( dir, 'evaluators.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-  } );
-
-  // =====================================================
-  // Instantiation location validation
-  // =====================================================
-
-  describe( 'instantiation location tests - correct locations', () => {
-    it( 'step() called in steps/fetch_data.js is allowed', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'step-folder-allowed-' ) );
-      mkdirSync( join( dir, 'steps' ) );
-      const src = [
-        'import { step } from "@outputai/core";',
-        'export const fetchData = step({ name: "fetch_data", fn: async () => ({}) });'
-      ].join( '\n' );
-      await expect( runLoader( join( dir, 'steps', 'fetch_data.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'step() called in src/shared/steps/common.js is allowed', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'step-shared-allowed-' ) );
-      mkdirSync( join( dir, 'src', 'shared', 'steps' ), { recursive: true } );
-      const src = [
-        'import { step } from "@outputai/core";',
-        'export const commonStep = step({ name: "common_step", fn: async () => ({}) });'
-      ].join( '\n' );
-      await expect( runLoader( join( dir, 'src', 'shared', 'steps', 'common.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'evaluator() called in evaluators/quality.js is allowed', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'eval-folder-allowed-' ) );
-      mkdirSync( join( dir, 'evaluators' ) );
-      const src = [
-        'import { evaluator } from "@outputai/core";',
-        'export const quality = evaluator({ name: "quality", fn: async () => ({ value: 1 }) });'
-      ].join( '\n' );
-      await expect( runLoader( join( dir, 'evaluators', 'quality.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'evaluator() called in src/shared/evaluators/metrics.js is allowed', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'eval-shared-allowed-' ) );
-      mkdirSync( join( dir, 'src', 'shared', 'evaluators' ), { recursive: true } );
-      const src = [
-        'import { evaluator } from "@outputai/core";',
-        'export const metrics = evaluator({ name: "metrics", fn: async () => ({ value: 1 }) });'
-      ].join( '\n' );
-      await expect( runLoader( join( dir, 'src', 'shared', 'evaluators', 'metrics.js' ), src ) ).resolves.toBeTruthy();
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-  } );
-
-  describe( 'instantiation location tests - wrong locations', () => {
-    it( 'step() called in utils.js is blocked by validator', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'step-utils-fail-' ) );
-      const src = [
-        'import { step } from "@outputai/core";',
-        'export const badStep = step({ name: "bad", fn: async () => ({}) });'
-      ].join( '\n' );
-      await expect( runLoader( join( dir, 'utils.js' ), src ) )
-        .rejects.toThrow( /Invalid instantiation location.*step\(\).*steps/ );
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'step() called in clients/api.js is blocked by validator', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'step-clients-fail-' ) );
-      mkdirSync( join( dir, 'clients' ) );
-      const src = [
-        'import { step } from "@outputai/core";',
-        'export const badStep = step({ name: "bad", fn: async () => ({}) });'
-      ].join( '\n' );
-      await expect( runLoader( join( dir, 'clients', 'api.js' ), src ) )
-        .rejects.toThrow( /Invalid instantiation location.*step\(\).*steps/ );
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'evaluator() called in utils.js is blocked by validator', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'eval-utils-fail-' ) );
-      const src = [
-        'import { evaluator } from "@outputai/core";',
-        'export const badEval = evaluator({ name: "bad", fn: async () => ({ value: 1 }) });'
-      ].join( '\n' );
-      await expect( runLoader( join( dir, 'utils.js' ), src ) )
-        .rejects.toThrow( /Invalid instantiation location.*evaluator\(\).*evaluators/ );
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'evaluator() called in clients/api.js is blocked by validator', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'eval-clients-fail-' ) );
-      mkdirSync( join( dir, 'clients' ) );
-      const src = [
-        'import { evaluator } from "@outputai/core";',
-        'export const badEval = evaluator({ name: "bad", fn: async () => ({ value: 1 }) });'
-      ].join( '\n' );
-      await expect( runLoader( join( dir, 'clients', 'api.js' ), src ) )
-        .rejects.toThrow( /Invalid instantiation location.*evaluator\(\).*evaluators/ );
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'evaluator() called in helpers.js is blocked by validator', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'eval-helpers-fail-' ) );
-      const src = [
-        'import { evaluator } from "@outputai/core";',
-        'export const badEval = evaluator({ name: "bad", fn: async () => ({ value: 1 }) });'
-      ].join( '\n' );
-      await expect( runLoader( join( dir, 'helpers.js' ), src ) )
-        .rejects.toThrow( /Invalid instantiation location.*evaluator\(\).*evaluators/ );
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'step() called in evaluators.js is blocked by validator', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'step-evals-fail-' ) );
-      const src = [
-        'import { step } from "@outputai/core";',
-        'export const badStep = step({ name: "bad", fn: async () => ({}) });'
-      ].join( '\n' );
-      await expect( runLoader( join( dir, 'evaluators.js' ), src ) )
-        .rejects.toThrow( /Invalid instantiation location.*step\(\).*steps/ );
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'evaluator() called in steps.js is blocked by validator', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'eval-steps-fail-' ) );
-      const src = [
-        'import { evaluator } from "@outputai/core";',
-        'export const badEval = evaluator({ name: "bad", fn: async () => ({ value: 1 }) });'
-      ].join( '\n' );
-      await expect( runLoader( join( dir, 'steps.js' ), src ) )
-        .rejects.toThrow( /Invalid instantiation location.*evaluator\(\).*evaluators/ );
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'workflow() called in shared/common.js is blocked by validator', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'wf-shared-fail-' ) );
-      mkdirSync( join( dir, 'shared' ) );
-      const src = [
-        'import { workflow } from "@outputai/core";',
-        'export const badWf = workflow({ name: "bad", fn: async () => ({}) });'
-      ].join( '\n' );
-      await expect( runLoader( join( dir, 'shared', 'common.js' ), src ) )
-        .rejects.toThrow( /Invalid instantiation location.*workflow\(\).*workflow/ );
-      rmSync( dir, { recursive: true, force: true } );
-    } );
-
-    it( 'workflow() called in utils/index.js is blocked by validator', async () => {
-      const dir = mkdtempSync( join( tmpdir(), 'wf-utils-fail-' ) );
-      mkdirSync( join( dir, 'utils' ) );
-      const src = [
-        'import { workflow } from "@outputai/core";',
-        'export const badWf = workflow({ name: "bad", fn: async () => ({}) });'
-      ].join( '\n' );
-      await expect( runLoader( join( dir, 'utils', 'index.js' ), src ) )
-        .rejects.toThrow( /Invalid instantiation location.*workflow\(\).*workflow/ );
-      rmSync( dir, { recursive: true, force: true } );
-    } );
   } );
 } );

--- a/sdk/core/src/worker/webpack_loaders/workflow_validator/npm_workflow_export_resolve.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_validator/npm_workflow_export_resolve.js
@@ -12,7 +12,7 @@ import {
   isStringLiteral
 } from '@babel/types';
 import { existsSync, readFileSync } from 'node:fs';
-import { parse, isWorkflowPath, buildWorkflowNameMap } from './tools.js';
+import { parse, isWorkflowPath, buildWorkflowNameMap } from '../tools.js';
 
 /**
  * Resolves bare npm imports to workflow runtime names:

--- a/sdk/core/src/worker/webpack_loaders/workflow_validator/npm_workflow_export_resolve.spec.js
+++ b/sdk/core/src/worker/webpack_loaders/workflow_validator/npm_workflow_export_resolve.spec.js
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
-import { parse } from './tools.js';
+import { parse } from '../tools.js';
 import {
   isBareNpmSpecifier,
   resolveBareImportSpecifiersAsWorkflows,

--- a/sdk/evals/src/eval_workflow.spec.ts
+++ b/sdk/evals/src/eval_workflow.spec.ts
@@ -2,10 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { evalWorkflow } from './eval_workflow.js';
 
 type EvalWorkflowRunner = {
-  call: (
-    context: { invokeEvaluator: ( name: string, input: unknown ) => Promise<unknown> },
-    input: { datasets: Array<Record<string, unknown>> }
-  ) => Promise<{
+  ( input: { datasets: Array<Record<string, unknown>> } ): Promise<{
     cases: Array<{
       datasetName: string;
       evaluators: Array<{ name: string; verdict: string; criticality: string }>
@@ -13,6 +10,7 @@ type EvalWorkflowRunner = {
   }>
 };
 
+const INVOKE_ACTIVITY_SYMBOL = Symbol.for( '@outputai/core:__invoke_activity' );
 const workflowMock = vi.hoisted( () => vi.fn( ( { fn }: { fn: unknown } ) => fn ) );
 const executeInParallelMock = vi.hoisted( () => vi.fn( async ( { jobs }: { jobs: Array<() => Promise<unknown>> } ) => {
   const results = await Promise.all( jobs.map( async job => ( { ok: true, result: await job() } ) ) );
@@ -40,6 +38,7 @@ vi.mock( '@outputai/core/sdk/helpers', () => ( {
 describe( 'evalWorkflow', () => {
   beforeEach( () => {
     vi.clearAllMocks();
+    delete ( globalThis as Record<symbol, unknown> )[INVOKE_ACTIVITY_SYMBOL];
     hasMock.mockReturnValue( true );
     getNameMock.mockReturnValue( 'quality_eval' );
   } );
@@ -53,9 +52,10 @@ describe( 'evalWorkflow', () => {
         interpret: { type: 'boolean' }
       } ]
     } ) as EvalWorkflowRunner;
-    const invokeEvaluator = vi.fn().mockResolvedValue( { value: true, confidence: 1, feedback: [], dimensions: [] } );
+    const invokeActivity = vi.fn().mockResolvedValue( { value: true, confidence: 1, feedback: [], dimensions: [] } );
+    ( globalThis as Record<symbol, unknown> )[INVOKE_ACTIVITY_SYMBOL] = invokeActivity;
 
-    const output = await workflowFn.call( { invokeEvaluator }, {
+    const output = await workflowFn( {
       datasets: [ {
         name: 'case_1',
         input: { prompt: 'hello' },
@@ -71,7 +71,7 @@ describe( 'evalWorkflow', () => {
 
     expect( hasMock ).toHaveBeenCalledWith( evaluator );
     expect( getNameMock ).toHaveBeenCalledWith( evaluator );
-    expect( invokeEvaluator ).toHaveBeenCalledWith( 'quality_eval', {
+    expect( invokeActivity ).toHaveBeenCalledWith( 'quality_eval', {
       input: { prompt: 'hello' },
       output: { answer: 'hello' },
       ground_truth: { shared: 'value', expected: 'hello' }

--- a/sdk/evals/src/eval_workflow.ts
+++ b/sdk/evals/src/eval_workflow.ts
@@ -55,7 +55,9 @@ export function evalWorkflow( { name, evals, fn, config = {} }: EvalWorkflowOpti
   } );
 
   const defaultFn = async function ( this: unknown, input: EvalWorkflowInput ) {
-    const { invokeEvaluator } = this as { invokeEvaluator: ( name: string, input: unknown ) => Promise<unknown> };
+    const invoke = ( globalThis as unknown as Record<symbol, ( name: string, input: unknown ) => Promise<unknown>> )[
+      Symbol.for( '@outputai/core:__invoke_activity' )
+    ];
 
     const jobs = input.datasets.map( ( dataset: Dataset ) => async () => {
       const evaluatorResults = [];
@@ -65,7 +67,7 @@ export function evalWorkflow( { name, evals, fn, config = {} }: EvalWorkflowOpti
         const evalTruth = perEvalTruth?.[evalDef.name] ?? {};
         const mergedTruth = { ...globalTruth, ...evalTruth };
 
-        const result = await invokeEvaluator( evalDef.name, {
+        const result = await invoke( evalDef.name, {
           input: dataset.input,
           output: dataset.last_output?.output,
           ground_truth: mergedTruth

--- a/sdk/evals/src/index_sandbox.ts
+++ b/sdk/evals/src/index_sandbox.ts
@@ -9,8 +9,8 @@
  * The webpack rewriter (workflow_rewriter/index.mjs) is supposed to strip evaluator
  * imports from the AST via collectTargetImports(), which calls path.remove() on each
  * matched import declaration. However, after collecting imports, the rewriter checks
- * if rewriteFnBodies() performed any rewrites. For eval workflows — which have no
- * fn body, only a config object — rewriteFnBodies() returns false. When that happens,
+ * if rewriteActivityCalls() performed any rewrites. For eval workflows — which have no
+ * function-body activity calls, only a config object — rewriteActivityCalls() returns false. When that happens,
  * the rewriter returns the original source string unchanged (lines 46-48), discarding
  * the import stripping that collectTargetImports() already applied to the AST.
  *
@@ -26,8 +26,8 @@
  *
  * Remove when:
  * The workflow rewriter in sdk/core/src/worker/webpack_loaders/workflow_rewriter/index.mjs
- * is fixed to generate output from the modified AST even when rewriteFnBodies() returns
- * false — i.e. when collectTargetImports() stripped imports but no fn bodies needed
+ * is fixed to generate output from the modified AST even when rewriteActivityCalls() returns
+ * false — i.e. when collectTargetImports() stripped imports but no activity calls needed
  * rewriting. This also requires injecting metadata stubs for the stripped evaluator
  * references, since evalWorkflow() calls ComponentMetadata.getName(def.evaluator) at
  * module init time and the identifiers would otherwise be undefined. Once the rewriter

--- a/test_workflows/src/workflows/nested/parallel_children/child/workflow.ts
+++ b/test_workflows/src/workflows/nested/parallel_children/child/workflow.ts
@@ -1,0 +1,19 @@
+import { workflow, z } from '@outputai/core';
+import { sleep } from '@temporalio/workflow';
+
+export default workflow( {
+  name: 'nested_parallel_children_child',
+  description: 'Parallel nested child workflow',
+  inputSchema: z.object( {
+    index: z.number()
+  } ),
+  outputSchema: z.object( {
+    value: z.string()
+  } ),
+  fn: async ( { index } ) => {
+    await sleep( '3s' );
+    return {
+      value: `child-${index}`
+    };
+  }
+} );

--- a/test_workflows/src/workflows/nested/parallel_children/workflow.ts
+++ b/test_workflows/src/workflows/nested/parallel_children/workflow.ts
@@ -1,0 +1,16 @@
+import { workflow, z } from '@outputai/core';
+import child from './child/workflow.js';
+
+export default workflow( {
+  name: 'nested_parallel_children',
+  description: 'Nested parallel child workflow calls',
+  outputSchema: z.object( {
+    values: z.array( z.string() )
+  } ),
+  fn: async () => {
+    const childCalls = [ 1, 2, 3 ].map( index => child( { index } ) );
+    const results = await Promise.all( childCalls );
+
+    return { values: results.map( ( { value } ) => value ) };
+  }
+} );


### PR DESCRIPTION
## Summary
- Refactored worker workflow rewrite and `workflow()` interface to replace `this.invokeStep()` / `this.invokeEvaluator()` style activity dispatchers on the workflow handler, in favor of a `globalThis` function created during runtime:
  - The old approach required rewriting workflow functions to convert arrow functions to regular functions (to have `this`), which was a source of complexity and possible edge cases;
  - The new function defined on `globalThis` takes advantage of Temporal sandbox isolation;
  - Invoking activities via a simple `globalThis` function is much easier to rewrite in the webpack loader:
  _Given this user code:_
    ```js
    import { foo } from 'step.js';

    workflow( {
      name: 'test',
      fn: async () => {
        await foo();
      }
    } );
    ```
    _The loader will now rewrite internally to:_
    ```js
    workflow( {
      name: 'test',
      fn: async () => {
        await globalThis[globalThis.Symbol.for('@outputai/core:__invoke_activity')]( 'stepName' );
      }
    } );
    ```
    _Versus how it was before:_
    ```js
    workflow( {
      name: 'test',
      fn: async function () {
        await this.invokeStep( 'stepName' );
      }
    } );
    ```
- Refactored child workflow detection to use the same `globalThis` mechanism: if the dispatcher function was already defined, the call is a nested workflow call and should start a child workflow.
- Removed most of the workflow body rewrite during worker start;
- Removed distinction between step, evaluator, shared step and shared evaluator during rewrite, treating them all as simple activities;
- Added top-level activity call validation, preventing steps and evaluators from being invoked outside functions:
  ```js
  import { foo } from 'step.js';

  foo();
  ```
  _This throws an error._;
- Added validation to prevent `globalThis` shadowing in rewritten activity call sites;
- Added validation requiring steps/evaluators files to use named exports only, and requiring workflow imports from steps/evaluators files to use named imports/destructured requires only;
  ```js
  // valid imports
  import { foo } from './steps.js';
  const { bar } = require( './evaluators.js' );

  // invalid imports
  import foo from './steps.js';
  import * as steps from './steps.js';
  const steps = require( './steps.js' );
  ```
  ```js
  // valid exports
  export const foo = step( { name: 'foo' } );

  // invalid exports
  export default step( { name: 'foo' } );
  export * from './other_steps.js';
  ```
- Removed `"$shared"` activity namespace in favor of loading each shared activity into each workflow namespace, further simplifying AST rewrite and activity invocation, as all activities are handled equally. This adds a new constraint that workflow activities cannot have the same name as shared activities, which is a fair trade-off.
- Refactored `activityOptions` resolution chain and resolution order, making it easier to read and understand the precedence of the options:
  - Old order: `invocation > definition > parent > default`
  - New order: `invocation > parent > definition > default`
- Refactored child `activityOptions` propagation
  - Old behavior: Parent workflow resolved the options chain with the child invocation options and started child workflow creating a new memo with these `activityOptions`;
  - New behavior: Parent resolves its own `activityOptions` and sets to `memo` as `parentActivityOptions`, when it invokes a child, it forwards its `memo` and the original `invocationOptions.activityOptions` arguments, so the child will resolve their own options chain.
- Updated `Objects.deepMerge()` to support merging multiple objects from left to right, with later objects taking precedence.
