### PR TITLE
refactor(llm): Handling Anthropic grammar error as retryable (OUT-518)

### DIFF
--- a/.changeset/slick-cameras-wonder.md
+++ b/.changeset/slick-cameras-wonder.md
@@ -1,0 +1,7 @@
+---
+"@outputai/llm": patch
+---
+
+Refactored Anthropic's error `"Grammar compilation timed out."` handling not to throw `FatalError` as this is transient and `FatalError`s terminate the workflow execution without retries.
+
+It seems that the Anthropic API throws this error (HTTP status code 400) when grammar compilation times out for a structured output schema, but after some investigation it was assessed that this error is indeed transient.

--- a/sdk/llm/src/utils/error_handler.js
+++ b/sdk/llm/src/utils/error_handler.js
@@ -77,7 +77,16 @@ export const mapAiError = error => {
     return error;
   }
 
-  if ( APICallError.isInstance( error ) && !error.isRetryable ) {
+  const isApiError = APICallError.isInstance( error );
+  const isGrammarCompilationError = error.message === 'Grammar compilation timed out.';
+  const isAnthropic = error.url?.includes( 'anthropic.com' );
+
+  // This error is actually transient, so instead of FatalError, return it
+  if ( isApiError && error.statusCode === 400 && isGrammarCompilationError && isAnthropic ) {
+    return error;
+  }
+
+  if ( isApiError && !error.isRetryable ) {
     // Non-retryable API failures are already classified by AI SDK as permanent provider failures.
     return toFatalError( error, error.statusCode ? `HTTP ${error.statusCode}` : '' );
   }

--- a/sdk/llm/src/utils/error_handler.js
+++ b/sdk/llm/src/utils/error_handler.js
@@ -79,10 +79,9 @@ export const mapAiError = error => {
 
   const isApiError = APICallError.isInstance( error );
   const isGrammarCompilationError = error.message === 'Grammar compilation timed out.';
-  const isAnthropic = error.url?.includes( 'anthropic.com' );
 
   // This error is actually transient, so instead of FatalError, return it
-  if ( isApiError && error.statusCode === 400 && isGrammarCompilationError && isAnthropic ) {
+  if ( isApiError && error.statusCode === 400 && isGrammarCompilationError ) {
     return error;
   }
 

--- a/sdk/llm/src/utils/error_handler.spec.js
+++ b/sdk/llm/src/utils/error_handler.spec.js
@@ -276,6 +276,17 @@ describe( 'mapAiError', () => {
     expect( mapAiError( error ) ).toBe( error );
   } );
 
+  it( 'preserves Anthropic grammar compilation timeouts as retryable activity failures', () => {
+    const error = makeApiCallError( {
+      message: 'Grammar compilation timed out.',
+      url: 'https://api.anthropic.com/v1/messages',
+      statusCode: 400,
+      isRetryable: false
+    } );
+
+    expect( mapAiError( error ) ).toBe( error );
+  } );
+
   it.each( fatalAiSdkErrors )( 'maps %s to FatalError', ( _name, makeError ) => {
     const error = makeError();
 

--- a/sdk/llm/src/utils/error_handler.spec.js
+++ b/sdk/llm/src/utils/error_handler.spec.js
@@ -279,7 +279,6 @@ describe( 'mapAiError', () => {
   it( 'preserves Anthropic grammar compilation timeouts as retryable activity failures', () => {
     const error = makeApiCallError( {
       message: 'Grammar compilation timed out.',
-      url: 'https://api.anthropic.com/v1/messages',
       statusCode: 400,
       isRetryable: false
     } );


### PR DESCRIPTION
## Summary

Refactored Anthropic's error `"Grammar compilation timed out."` handling not to throw `FatalError` as this is transient and `FatalError`s terminate the workflow execution without retries.

It seems that the Anthropic API throws this error (HTTP status code 400) when grammar compilation times out for a structured output schema, but after some investigation it was assessed that this error is indeed transient.
