### PR TITLE
chore: Refactor HTTP logging, remove Morgan library

### DIFF
--- a/.changeset/heavy-friends-beg.md
+++ b/.changeset/heavy-friends-beg.md
@@ -1,0 +1,5 @@
+---
+"output-api": minor
+---
+
+API: removed morgan library, refactored logs to include more information in message, and changed 'status' to 'http.status_code'

--- a/api/package.json
+++ b/api/package.json
@@ -15,7 +15,6 @@
     "@aws-sdk/client-s3": "catalog:",
     "@temporalio/client": "catalog:",
     "express": "5.2.1",
-    "morgan": "1.10.1",
     "nanoid": "5.1.9",
     "winston": "catalog:",
     "zod": "catalog:"

--- a/api/src/middleware/error_handler.js
+++ b/api/src/middleware/error_handler.js
@@ -52,7 +52,7 @@ const grpcHttpStatus = err =>
   ( err ? directGrpcHttpStatus( err ) ?? grpcHttpStatus( err.cause ) : undefined );
 
 export default function errorHandler( error, req, res, next ) {
-  res.locals.error = error; // Surface the error to the access logger (morgan) on every path.
+  res.locals.error = error; // Surface the error to the HTTP access logger on every path.
 
   // Response already flushed (e.g. an SSE endpoint mid-stream): we can no longer write a JSON
   // error body. Streaming endpoints own their own post-flush error handling, so reaching here

--- a/api/src/middleware/http_logger.js
+++ b/api/src/middleware/http_logger.js
@@ -1,4 +1,3 @@
-import { performance } from 'node:perf_hooks';
 import { logger } from '#logger';
 import { isProduction } from '#configs';
 
@@ -54,13 +53,13 @@ const getPayloadSizeFields = ( status, error, contentLength ) => {
  */
 const gatherLogInfo = ( req, res, { method, url, responseTime } ) => {
   const status = res.statusCode;
-  const error = res.locals?.error ?? null;
+  const error = res.locals?.error;
   const requestContentLength = req.headers?.['content-length'];
 
   return {
     method,
     url,
-    'http.status_code': status,
+    statusCode: status,
     contentLength: String( res.getHeader( 'content-length' ) ?? '0' ),
     responseTime,
     requestId: req.id,
@@ -69,7 +68,7 @@ const gatherLogInfo = ( req, res, { method, url, responseTime } ) => {
       errorMessage: error.message
     } : {} ),
     ...getPayloadSizeFields( status, error, requestContentLength ),
-    workflowName: req.body?.workflowName || undefined
+    workflowName: req.body?.workflowName
   };
 };
 
@@ -79,14 +78,15 @@ const gatherLogInfo = ( req, res, { method, url, responseTime } ) => {
  * @param {Record<string, unknown>} info
  */
 const emit = info => {
-  const { method, url, 'http.status_code': status, contentLength, responseTime, errorType, errorMessage } = info;
-  const level = levelForStatus( status );
-  const summary = `${method} ${url} ${status} ${responseTime}ms`;
+  const { statusCode, ...rest } = info;
+  const { method, url, contentLength, responseTime, errorType, errorMessage } = rest;
+  const level = levelForStatus( statusCode );
 
   if ( isProduction ) {
-    logger[level]( summary, info );
+    logger[level]( `${method} ${url} ${statusCode} ${responseTime}ms`, { ...rest, 'http.status_code': statusCode } );
   } else {
-    logger[level]( `${method} ${url} ${status} ${contentLength}b ${responseTime}ms ${errorType ? `[${errorType}: ${errorMessage}]` : ''}`.trimEnd() );
+    const errorSuffix = errorType ? ` [${errorType}: ${errorMessage}]` : '';
+    logger[level]( `${method} ${url} ${statusCode} ${contentLength}b ${responseTime}ms${errorSuffix}` );
   }
 };
 
@@ -103,9 +103,9 @@ export const createHttpLoggingMiddleware = () => ( req, res, next ) => {
     return;
   }
 
-  const start = performance.now();
+  const start = Date.now();
   const method = req.method;
-  const url = req.originalUrl || req.url;
+  const url = req.originalUrl ?? req.url;
   const state = { logged: false };
 
   const log = () => {
@@ -113,7 +113,7 @@ export const createHttpLoggingMiddleware = () => ( req, res, next ) => {
       return;
     }
     state.logged = true;
-    const responseTime = Number( ( performance.now() - start ).toFixed( 3 ) );
+    const responseTime = Date.now() - start;
     emit( gatherLogInfo( req, res, { method, url, responseTime } ) );
   };
 

--- a/api/src/middleware/http_logger.js
+++ b/api/src/middleware/http_logger.js
@@ -1,4 +1,4 @@
-import morgan from 'morgan';
+import { performance } from 'node:perf_hooks';
 import { logger } from '#logger';
 import { isProduction } from '#configs';
 
@@ -10,6 +10,21 @@ const HEALTH_ENDPOINTS = new Set( [ '/health', '/heartbeat' ] );
  * @returns {boolean}
  */
 const shouldSkipLogging = req => HEALTH_ENDPOINTS.has( req.url );
+
+/**
+ * Winston level for a response status: 5xx -> error, 4xx -> warn, else http.
+ * @param {number} status
+ * @returns {'error'|'warn'|'http'}
+ */
+const levelForStatus = status => {
+  if ( status >= 500 ) {
+    return 'error';
+  }
+  if ( status >= 400 ) {
+    return 'warn';
+  }
+  return 'http';
+};
 
 /**
  * For status 413 with an error, returns request size (bytes and MB) and the configured limit.
@@ -31,85 +46,79 @@ const getPayloadSizeFields = ( status, error, contentLength ) => {
 };
 
 /**
- * Extracts information about the request and response.
- * @param {import('morgan').TokenIndexer} tokens - Morgan token accessor
+ * Builds the structured log record for a completed request/response.
  * @param {import('express').Request} req
  * @param {import('express').Response} res
+ * @param {{ method: string, url: string, responseTime: number }} timing
  * @returns {Record<string, unknown>}
  */
-const gatherLogInfo = ( tokens, req, res ) => {
-  const status = Number.parseInt( tokens.status( req, res ), 10 ) || 0;
-  const requestContentLength = req?.headers?.['content-length'];
+const gatherLogInfo = ( req, res, { method, url, responseTime } ) => {
+  const status = res.statusCode;
+  const error = res.locals?.error ?? null;
+  const requestContentLength = req.headers?.['content-length'];
 
   return {
-    method: tokens.method( req, res ),
-    url: tokens.url( req, res ),
-    status,
-    contentLength: tokens.res( req, res, 'content-length' ) || '0',
-    responseTime: Number.parseFloat( tokens['response-time']( req, res ) ) || 0,
+    method,
+    url,
+    'http.status_code': status,
+    contentLength: String( res.getHeader( 'content-length' ) ?? '0' ),
+    responseTime,
     requestId: req.id,
-    ...( res.locals.error ? {
-      errorType: res.locals.error.constructor.name,
-      errorMessage: res.locals.error.message
+    ...( error ? {
+      errorType: error.constructor.name,
+      errorMessage: error.message
     } : {} ),
-    ...getPayloadSizeFields( status, res.locals.error, requestContentLength ),
-    workflowName: req.body?.workflowName ? req.body.workflowName : undefined
+    ...getPayloadSizeFields( status, error, requestContentLength ),
+    workflowName: req.body?.workflowName || undefined
   };
 };
 
 /**
- * Parses and sends out a JSON message to the logger.
- * @param {string} message - Single line of JSON from morgan
+ * Emits the request log at a status-appropriate level. Production logs a descriptive
+ * message plus the structured record; development logs a single human-readable line.
+ * @param {Record<string, unknown>} info
  */
-const prodStreamWrite = message => {
-  try {
-    const parsedMessage = JSON.parse( message );
-    logger.http( 'HTTP request', parsedMessage );
-  } catch ( parseError ) {
-    if ( parseError instanceof SyntaxError ) {
-      logger.warn( 'Failed to parse HTTP log JSON', {
-        raw: message.trim(),
-        parseError: parseError.message
-      } );
-    } else {
-      throw parseError;
-    }
+const emit = info => {
+  const { method, url, 'http.status_code': status, contentLength, responseTime, errorType, errorMessage } = info;
+  const level = levelForStatus( status );
+  const summary = `${method} ${url} ${status} ${responseTime}ms`;
+
+  if ( isProduction ) {
+    logger[level]( summary, info );
+  } else {
+    logger[level]( `${method} ${url} ${status} ${contentLength}b ${responseTime}ms ${errorType ? `[${errorType}: ${errorMessage}]` : ''}`.trimEnd() );
   }
 };
 
 /**
- * Returns morgan middleware that logs each request as a single JSON object.
+ * Express middleware that logs each request once, on response completion, at a level
+ * derived from the response status. Listens for both 'finish' (response sent) and
+ * 'close' (connection ended, e.g. client abort mid-stream) so aborted requests are
+ * still recorded; a guard ensures a single emission.
  * @returns {import('express').RequestHandler}
  */
-const createProdHttpLogger = () =>
-  morgan( ( tokens, req, res ) => JSON.stringify( gatherLogInfo( tokens, req, res ) ), {
-    skip: shouldSkipLogging,
-    stream: { write: prodStreamWrite }
-  } );
+export const createHttpLoggingMiddleware = () => ( req, res, next ) => {
+  if ( shouldSkipLogging( req ) ) {
+    next();
+    return;
+  }
 
-/**
- * Passes the trimmed message to the HTTP logger.
- * @param {string} message - Human-readable log line
- */
-const devStreamWrite = message => {
-  logger.http( message.trim() );
+  const start = performance.now();
+  const method = req.method;
+  const url = req.originalUrl || req.url;
+  const state = { logged: false };
+
+  const log = () => {
+    if ( state.logged ) {
+      return;
+    }
+    state.logged = true;
+    const responseTime = Number( ( performance.now() - start ).toFixed( 3 ) );
+    emit( gatherLogInfo( req, res, { method, url, responseTime } ) );
+  };
+
+  res.once( 'finish', log );
+  res.once( 'close', log );
+
+  next();
 };
-
-/**
- * Returns morgan middleware that logs each request as one human-readable line
- * @returns {import('express').RequestHandler}
- */
-const createDevHttpLogger = () =>
-  morgan( ( tokens, req, res ) => {
-    const { method, url, status, contentLength, responseTime, errorType, errorMessage } = gatherLogInfo( tokens, req, res );
-    return `${method} ${url} ${status} ${contentLength}b ${responseTime}ms ${errorType ? `[${errorType}: ${errorMessage}]` : ''}`;
-  }, {
-    skip: shouldSkipLogging,
-    stream: { write: devStreamWrite }
-  } );
-
-/**
- * Returns HTTP logging middleware
- * @returns {import('express').RequestHandler}
- */
-export const createHttpLoggingMiddleware = () => isProduction ? createProdHttpLogger() : createDevHttpLogger();

--- a/api/src/middleware/http_logger.spec.js
+++ b/api/src/middleware/http_logger.spec.js
@@ -128,4 +128,29 @@ describe( 'http_logger', () => {
 
     expect( logger.http ).toHaveBeenCalledTimes( 1 );
   } );
+
+  it( 'reports requestSizeMB "unknown" for a 413 with no content-length', () => {
+    const middleware = createHttpLoggingMiddleware();
+    const error = new Error( 'request entity too large' );
+    error.status = 413;
+    error.limit = '2mb';
+    const req = { id: 'test-request-id', url: '/workflow', originalUrl: '/workflow', method: 'POST', headers: {}, body: {} };
+    const handlers = {};
+    const res = {
+      locals: { error },
+      statusCode: 413,
+      getHeader: vi.fn().mockReturnValue( '0' ),
+      once: vi.fn( ( event, cb ) => {
+        handlers[event] = cb;
+      } )
+    };
+
+    middleware( req, res, () => {} );
+    handlers.finish();
+
+    expect( logger.warn ).toHaveBeenCalledWith(
+      expect.any( String ),
+      expect.objectContaining( { requestSizeBytes: undefined, requestSizeMB: 'unknown', limit: '2mb' } )
+    );
+  } );
 } );

--- a/api/src/middleware/http_logger.spec.js
+++ b/api/src/middleware/http_logger.spec.js
@@ -6,8 +6,9 @@ vi.mock( '#configs', () => ( { isProduction: true } ) );
 
 vi.mock( '#logger', () => ( {
   logger: {
-    http: vi.fn(),
-    warn: vi.fn()
+    error: vi.fn(),
+    warn: vi.fn(),
+    http: vi.fn()
   }
 } ) );
 
@@ -32,7 +33,7 @@ describe( 'http_logger', () => {
     vi.clearAllMocks();
   } );
 
-  it( 'includes request size fields for 413 errors', async () => {
+  it( 'logs 4xx at warn with a descriptive message and request size fields for 413', async () => {
     const app = createApp( ( _req, res ) => {
       const error = new Error( 'request entity too large' );
       error.status = 413;
@@ -47,12 +48,12 @@ describe( 'http_logger', () => {
       .send( {} )
       .expect( 413 );
 
-    expect( logger.http ).toHaveBeenCalledWith(
-      'HTTP request',
+    expect( logger.warn ).toHaveBeenCalledWith(
+      expect.stringMatching( /^POST \/workflow 413 [\d.]+ms$/ ),
       expect.objectContaining( {
         method: 'POST',
         url: '/workflow',
-        status: 413,
+        'http.status_code': 413,
         requestId: 'test-request-id',
         errorType: 'Error',
         errorMessage: 'request entity too large',
@@ -61,35 +62,11 @@ describe( 'http_logger', () => {
         limit: '2mb'
       } )
     );
+    expect( logger.error ).not.toHaveBeenCalled();
+    expect( logger.http ).not.toHaveBeenCalled();
   } );
 
-  it( 'handles missing content-length for 413 errors', done => {
-    const middleware = createHttpLoggingMiddleware();
-    const error = new Error( 'request entity too large' );
-    error.status = 413;
-    error.limit = '2mb';
-    const req = { id: 'test-request-id', url: '/workflow', method: 'POST', headers: {}, body: {} };
-    const res = {
-      locals: { error },
-      statusCode: 413,
-      getHeader: vi.fn().mockReturnValue( '0' ),
-      once: vi.fn( ( event, cb ) => {
-        if ( event === 'finish' ) {
-          setImmediate( () => {
-            cb();
-            expect( logger.http ).toHaveBeenCalledWith(
-              'HTTP request',
-              expect.objectContaining( { requestSizeBytes: undefined, requestSizeMB: 'unknown', limit: '2mb' } )
-            );
-            done();
-          } );
-        }
-      } )
-    };
-    middleware( req, res, () => {} );
-  } );
-
-  it( 'does not include request size fields for non-413 errors', async () => {
+  it( 'logs 5xx at error and omits request size fields for non-413 errors', async () => {
     const app = createApp( ( _req, res ) => {
       res.locals.error = new Error( 'Something went wrong' );
       res.status( 500 ).send( {} );
@@ -97,9 +74,58 @@ describe( 'http_logger', () => {
 
     await request( app ).post( '/workflow' ).set( 'X-Request-ID', 'test-request-id' ).send( {} ).expect( 500 );
 
-    const logData = logger.http.mock.calls[0][1];
+    expect( logger.error ).toHaveBeenCalledTimes( 1 );
+    const [ message, logData ] = logger.error.mock.calls[0];
+    expect( message ).toMatch( /^POST \/workflow 500 [\d.]+ms$/ );
+    expect( logData ).toMatchObject( { 'http.status_code': 500, errorType: 'Error', errorMessage: 'Something went wrong' } );
     expect( logData ).not.toHaveProperty( 'requestSizeBytes' );
     expect( logData ).not.toHaveProperty( 'requestSizeMB' );
     expect( logData ).not.toHaveProperty( 'limit' );
+    expect( logger.warn ).not.toHaveBeenCalled();
+  } );
+
+  it( 'logs 2xx at http level', async () => {
+    const app = createApp( ( _req, res ) => res.status( 200 ).send( { ok: true } ) );
+
+    await request( app ).post( '/workflow' ).set( 'X-Request-ID', 'test-request-id' ).send( {} ).expect( 200 );
+
+    expect( logger.http ).toHaveBeenCalledWith(
+      expect.stringMatching( /^POST \/workflow 200 [\d.]+ms$/ ),
+      expect.objectContaining( { 'http.status_code': 200, requestId: 'test-request-id' } )
+    );
+    expect( logger.error ).not.toHaveBeenCalled();
+    expect( logger.warn ).not.toHaveBeenCalled();
+  } );
+
+  it( 'skips health and heartbeat endpoints', async () => {
+    const app = express();
+    app.use( createHttpLoggingMiddleware() );
+    app.get( '/health', ( _req, res ) => res.sendStatus( 200 ) );
+
+    await request( app ).get( '/health' ).expect( 200 );
+
+    expect( logger.http ).not.toHaveBeenCalled();
+    expect( logger.warn ).not.toHaveBeenCalled();
+    expect( logger.error ).not.toHaveBeenCalled();
+  } );
+
+  it( 'logs once when both finish and close fire', () => {
+    const middleware = createHttpLoggingMiddleware();
+    const req = { id: 'test-request-id', url: '/workflow', originalUrl: '/workflow', method: 'POST', headers: {}, body: {} };
+    const handlers = {};
+    const res = {
+      locals: {},
+      statusCode: 200,
+      getHeader: vi.fn().mockReturnValue( '2' ),
+      once: vi.fn( ( event, cb ) => {
+        handlers[event] = cb;
+      } )
+    };
+
+    middleware( req, res, () => {} );
+    handlers.finish();
+    handlers.close();
+
+    expect( logger.http ).toHaveBeenCalledTimes( 1 );
   } );
 } );

--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -160,7 +160,8 @@
                   "migrations/v0.6.0-to-v0.7.0",
                   "migrations/v0.7.0-to-v0.8.0",
                   "migrations/v0.8.0-to-v0.9.0",
-                  "migrations/v0.9.0-to-v0.10.0"
+                  "migrations/v0.9.0-to-v0.10.0",
+                  "migrations/v0.10.0-to-v0.11.0"
                 ]
               }
             ]

--- a/docs/guides/migrations/index.mdx
+++ b/docs/guides/migrations/index.mdx
@@ -45,4 +45,7 @@ It reads the `@outputai/*` version in your `package.json`, finds the matching gu
   <Card title="v0.9.0 → v0.10.0" href="/migrations/v0.9.0-to-v0.10.0">
     Trace destinations omit unavailable `local` and `remote` keys instead of returning `null`.
   </Card>
+  <Card title="v0.10.0 → v0.11.0" href="/migrations/v0.10.0-to-v0.11.0">
+    API HTTP request logs change level by response status, rename `status` to `http.status_code`, and use a request summary message.
+  </Card>
 </CardGroup>

--- a/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
+++ b/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
@@ -1,0 +1,141 @@
+---
+title: "v0.10.0 → v0.11.0"
+description: "Upgrading Output.ai projects from v0.10.0 to v0.11.0: the API HTTP request log format changed. Log level now derives from response status, the status field was renamed, and the log message is now a request summary."
+---
+
+This guide covers the HTTP request logging changes in `output-api` v0.11.0. The API server was refactored to remove the `morgan` dependency and emit richer request logs. The public HTTP API contract is unchanged, but the shape, level, and message of the per-request log lines the server emits are different. This only affects you if you consume `output-api` logs in an observability tool (Datadog, CloudWatch, Loki, etc.) or match on them in scripts.
+
+## What changed
+
+### Log level now derives from response status
+
+This is the most impactful change. Previously every request was logged at the `http` level regardless of outcome. Now the level is chosen from the response status:
+
+| Status | Level (before) | Level (after) |
+| ------ | -------------- | ------------- |
+| 2xx / 3xx | `http` | `http` |
+| 4xx | `http` | `warn` |
+| 5xx | `http` | `error` |
+
+If you have alerts or filters keyed on winston log levels, they will now behave differently: any alert on `error` or `warn` will fire on 4xx/5xx HTTP responses that previously logged at `http`.
+
+### The `status` field was renamed to `http.status_code`
+
+The structured metadata field carrying the numeric response status changed name. This aligns with Datadog's standard `http.status_code` attribute.
+
+```diff
+- "status": 200
++ "http.status_code": 200
+```
+
+### The log message changed from a constant to a request summary
+
+Previously the message was the constant string `"HTTP request"`, with all detail in the metadata. Now the message is a human-readable summary and the structured record is still attached as metadata.
+
+```diff
+- "HTTP request"
++ "POST /workflow 200 12ms"
+```
+
+### `responseTime` is now an integer
+
+`responseTime` is now whole milliseconds (measured with `Date.now()`) rather than a sub-millisecond float.
+
+```diff
+- "responseTime": 12.347
++ "responseTime": 12
+```
+
+## Before and after
+
+A successful request, before (v0.10.0):
+
+```json
+{
+  "level": "http",
+  "message": "HTTP request",
+  "method": "POST",
+  "url": "/workflow",
+  "status": 200,
+  "contentLength": "42",
+  "responseTime": 12.347,
+  "requestId": "8f3c...",
+  "workflowName": "simple"
+}
+```
+
+The same request, after (v0.11.0):
+
+```json
+{
+  "level": "http",
+  "message": "POST /workflow 200 12ms",
+  "method": "POST",
+  "url": "/workflow",
+  "http.status_code": 200,
+  "contentLength": "42",
+  "responseTime": 12,
+  "requestId": "8f3c...",
+  "workflowName": "simple"
+}
+```
+
+A server error, before — logged at `http`:
+
+```json
+{
+  "level": "http",
+  "message": "HTTP request",
+  "status": 500,
+  "errorType": "Error",
+  "errorMessage": "Something went wrong"
+}
+```
+
+After — logged at `error`, with the renamed field:
+
+```json
+{
+  "level": "error",
+  "message": "POST /workflow 500 34ms",
+  "http.status_code": 500,
+  "errorType": "Error",
+  "errorMessage": "Something went wrong"
+}
+```
+
+## Migration steps
+
+### Update alerts and level-based filters
+
+If you alert or filter on winston levels, audit those rules. HTTP 4xx now arrives at `warn` and 5xx at `error`. Decide whether that is what you want:
+
+- To keep alerting only on application errors, scope alerts to exclude HTTP request logs (for example, filter on the presence of `http.status_code`).
+- To alert on failing requests, this is now available directly from the log level with no extra query.
+
+### Update queries and facets that reference `status`
+
+Anywhere you query, facet, or dashboard on the request-log `status` field, switch to `http.status_code`.
+
+```diff
+# Datadog / log query
+- @status:500
++ @http.status_code:500
+```
+
+In Datadog specifically, `http.status_code` is a standard attribute and maps to the built-in HTTP status facet, so you may be able to drop a custom `status` facet definition.
+
+### Update anything that matches the message string
+
+Scripts, log processors, or saved searches that match the literal message `"HTTP request"` will no longer match. Match on a structural field instead (for example, the presence of `http.status_code` or `requestId`), or update the matcher to the new summary format `<METHOD> <URL> <STATUS> <ms>ms`.
+
+### Adjust `responseTime` consumers expecting sub-millisecond precision
+
+If a dashboard or aggregation relied on fractional milliseconds in `responseTime`, note that values are now whole milliseconds.
+
+## Checklist
+
+- Review winston level-based alerts and filters; 4xx now logs at `warn`, 5xx at `error`.
+- Rename `status` to `http.status_code` in log queries, facets, and dashboards.
+- Replace any match on the constant message `"HTTP request"` with a structural field or the new summary format.
+- Confirm `responseTime` consumers tolerate integer milliseconds.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,9 +150,6 @@ importers:
       express:
         specifier: 5.2.1
         version: 5.2.1
-      morgan:
-        specifier: 1.10.1
-        version: 1.10.1
       nanoid:
         specifier: 5.1.9
         version: 5.1.9
@@ -3514,10 +3511,6 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-auth@2.0.1:
-    resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
-    engines: {node: '>= 0.8'}
-
   basic-ftp@5.3.1:
     resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
@@ -5894,10 +5887,6 @@ packages:
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
-  morgan@1.10.1:
-    resolution: {integrity: sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==}
-    engines: {node: '>= 0.8.0'}
-
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -6081,16 +6070,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  on-finished@2.3.0:
-    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
-    engines: {node: '>= 0.8'}
-
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
-    engines: {node: '>= 0.8'}
-
-  on-headers@1.1.0:
-    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
@@ -6761,9 +6742,6 @@ packages:
   safe-array-concat@1.1.4:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
-
-  safe-buffer@5.1.2:
-    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -12093,10 +12071,6 @@ snapshots:
 
   baseline-browser-mapping@2.10.29: {}
 
-  basic-auth@2.0.1:
-    dependencies:
-      safe-buffer: 5.1.2
-
   basic-ftp@5.3.1: {}
 
   better-opn@3.0.2:
@@ -15146,16 +15120,6 @@ snapshots:
   mkdirp-classic@0.5.3:
     optional: true
 
-  morgan@1.10.1:
-    dependencies:
-      basic-auth: 2.0.1
-      debug: 2.6.9
-      depd: 2.0.0
-      on-finished: 2.3.0
-      on-headers: 1.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   mri@1.2.0: {}
 
   ms@2.0.0: {}
@@ -15344,15 +15308,9 @@ snapshots:
       - '@types/node'
       - supports-color
 
-  on-finished@2.3.0:
-    dependencies:
-      ee-first: 1.1.1
-
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
-
-  on-headers@1.1.0: {}
 
   once@1.4.0:
     dependencies:
@@ -16221,8 +16179,6 @@ snapshots:
       get-intrinsic: 1.3.0
       has-symbols: 1.1.0
       isarray: 2.0.5
-
-  safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
 


### PR DESCRIPTION
## Summary

The `morgan` library we were using wasn't giving us much, and we were serializing to JSON from it just to parse it in `winston`, so it was a bit wasteful. The only thing we were really getting was response times, so I replaced that part with our own.

Also, we were logging `HTTP Request` for every HTTP log, with the actual data we'd want in the metadata. This changes that to put more meaningful things in the actual message, as well as moving `status` (a reserved attribute in Datadog) to `http.status_code` as recommended

