### PR TITLE
fix(llm): include Gemini grounding in cost metrics

### DIFF
--- a/.changeset/curvy-taxis-search.md
+++ b/.changeset/curvy-taxis-search.md
@@ -1,0 +1,6 @@
+---
+'@outputai/core': patch
+'@outputai/llm': patch
+---
+
+Include Gemini 3 Google Search grounding queries in LLM cost totals while keeping non-token usage out of token aggregates.

--- a/docs/guides/costs/cost-events.mdx
+++ b/docs/guides/costs/cost-events.mdx
@@ -95,18 +95,21 @@ The handler receives a single LLM usage attribute object:
 | `modelId` | `string` | Model identifier (e.g. `claude-sonnet-4-20250514`, `gpt-4o`). From the prompt file config. |
 | `usage` | `array` | Priced usage entries for this call. See [Usage entries](#usage-entries). |
 | `total` | `number` | Total estimated cost in dollars. |
-| `tokensUsed` | `number` | Total number of tokens represented by `usage`. |
+| `tokensUsed` | `number` | Total token count. Non-token priced usage, such as grounding queries, is excluded. |
 
 ### Usage entries
 
-Cost is computed from the model's per-million-token pricing, fetched from a built-in pricing source and cached for 24 hours. For each priced dimension, the dollar amount is `(tokens / 1_000_000) * pricePerMillion`. Non-cached input tokens use `inputTokens - (cachedInputTokens ?? 0)`.
+Cost is computed from list pricing. Model token pricing is fetched from a built-in pricing source and cached for 24 hours. For each priced dimension, the dollar amount is `(amount / 1_000_000) * ppm`. Non-cached input tokens use `inputTokens - (cachedInputTokens ?? 0)`.
+
+Gemini 3 Google Search grounding is included when the provider returns `groundingMetadata.webSearchQueries`. It appears as `google_search_grounding` with `unit: "query"`, using Google's $14 per 1,000-query list price. Account-level free tiers and negotiated discounts are not applied to per-call estimates.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `type` | `string` | Usage dimension. |
-| `ppm` | `number` | Price per million tokens for this dimension. |
-| `amount` | `number` | Token count for this dimension. |
+| `ppm` | `number` | Price per million units for this dimension. |
+| `amount` | `number` | Number of priced units. |
 | `total` | `number` | Cost for this dimension. |
+| `unit` | `string` | Optional unit when the entry is not token-based, such as `query`. |
 
 `usage[].type` values:
 
@@ -116,6 +119,7 @@ Cost is computed from the model's per-million-token pricing, fetched from a buil
 | `input_cached` | Cached prompt read tokens (`cachedInputTokens`). |
 | `output` | Completion tokens. |
 | `reasoning` | Reasoning tokens, only when the model defines separate reasoning pricing. |
+| `google_search_grounding` | Gemini 3 Google Search queries (`unit: "query"`). |
 
 Only available, finite usage dimensions are included. For example, `reasoning` is omitted when the model does not define separate reasoning pricing, and `input_cached` is omitted when there are no cached input tokens.
 

--- a/sdk/core/src/helpers/aggregations.js
+++ b/sdk/core/src/helpers/aggregations.js
@@ -34,6 +34,7 @@ export const aggregateAttributes = attributes => ( {
     ...Object.entries( attributes
       .filter( a => Attribute.LLMUsage.TYPE === a.type )
       .flatMap( a => a.usage )
+      .filter( a => !a.unit || a.unit === 'token' )
       .reduce( ( obj, a ) => Object.assign( obj, { [a.type]: ( obj[a.type] ?? Decimal( 0 ) ).add( a.amount ) } ), {} ) )
       .reduce( ( obj, [ k, v ] ) => Object.assign( obj, { [k]: v.toNumber() } ), {} ) // convert all values to number
 

--- a/sdk/core/src/helpers/aggregations.spec.js
+++ b/sdk/core/src/helpers/aggregations.spec.js
@@ -88,5 +88,20 @@ describe( 'aggregateAttributes', () => {
       output: 5
     } );
   } );
-} );
 
+  it( 'includes non-token usage in cost but excludes it from token aggregates', () => {
+    const llmUsage = new Attribute.LLMUsage( 'gemini-3.5-flash' );
+    llmUsage.addUsage( { type: 'input', ppm: 1.5, amount: 1_000 } );
+    llmUsage.addUsage( {
+      type: 'google_search_grounding',
+      unit: 'query',
+      ppm: 14_000,
+      amount: 2
+    } );
+
+    expect( aggregateAttributes( [ llmUsage ] ) ).toMatchObject( {
+      cost: { total: 0.0295 },
+      tokens: { total: 1_000, input: 1_000 }
+    } );
+  } );
+} );

--- a/sdk/core/src/tracing/trace_attribute.d.ts
+++ b/sdk/core/src/tracing/trace_attribute.d.ts
@@ -4,6 +4,7 @@ export declare namespace Attribute {
     ppm: number;
     amount: number;
     total: number;
+    unit?: string;
   }
 
   export class HTTPRequestCount {
@@ -29,7 +30,7 @@ export declare namespace Attribute {
     modelId: string;
     usage: Usage[];
     constructor( modelId: string );
-    addUsage( usage: { type: string; ppm: number; amount: number } ): void;
+    addUsage( usage: { type: string; ppm: number; amount: number; unit?: string } ): void;
     readonly total: number;
     readonly tokensUsed: number;
   }

--- a/sdk/core/src/tracing/trace_attribute.js
+++ b/sdk/core/src/tracing/trace_attribute.js
@@ -49,16 +49,19 @@ class LLMUsage extends BaseAttribute {
     this.modelId = modelId;
   }
 
-  addUsage( { type, ppm, amount } ) {
+  addUsage( { type, ppm, amount, unit = 'token' } ) {
     const total = Decimal( amount ).div( 1_000_000 ).mul( ppm ).toNumber();
     this.usage.push( {
       type,
       ppm,
       amount,
-      total
+      total,
+      ...( unit === 'token' ? {} : { unit } )
     } );
     this.total = Decimal( this.total ).add( total ).toNumber();
-    this.tokensUsed = Decimal( this.tokensUsed ).add( amount ).toNumber();
+    if ( unit === 'token' ) {
+      this.tokensUsed = Decimal( this.tokensUsed ).add( amount ).toNumber();
+    }
   }
 }
 

--- a/sdk/llm/src/cost/google_search_grounding.js
+++ b/sdk/llm/src/cost/google_search_grounding.js
@@ -1,0 +1,40 @@
+const GEMINI_3_GOOGLE_SEARCH_PPM = 14_000;
+
+const getQueryCount = providerMetadata => {
+  if ( !providerMetadata || typeof providerMetadata !== 'object' ) {
+    return 0;
+  }
+  for ( const provider of [ 'vertex', 'google' ] ) {
+    const queries = providerMetadata[provider]?.groundingMetadata?.webSearchQueries;
+    if ( Array.isArray( queries ) ) {
+      return queries.length;
+    }
+  }
+  return 0;
+};
+
+/**
+ * Return Gemini 3 Google Search grounding as a priced, non-token usage item.
+ * Google bills each search query at $14/1K after the account-level free tier;
+ * cost telemetry intentionally reports list price, as it does for model tokens.
+ */
+export const getGoogleSearchGroundingUsage = ( { modelId, providerMetadata, steps } ) => {
+  if ( !String( modelId ).includes( 'gemini-3' ) ) {
+    return null;
+  }
+
+  const searchQueries = Array.isArray( steps ) && steps.length > 0 ?
+    steps.reduce( ( total, step ) => total + getQueryCount( step?.providerMetadata ), 0 ) :
+    getQueryCount( providerMetadata );
+
+  if ( searchQueries === 0 ) {
+    return null;
+  }
+
+  return {
+    type: 'google_search_grounding',
+    unit: 'query',
+    ppm: GEMINI_3_GOOGLE_SEARCH_PPM,
+    amount: searchQueries
+  };
+};

--- a/sdk/llm/src/cost/google_search_grounding.spec.js
+++ b/sdk/llm/src/cost/google_search_grounding.spec.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { getGoogleSearchGroundingUsage } from './google_search_grounding.js';
+
+describe( 'getGoogleSearchGroundingUsage', () => {
+  it( 'prices Gemini 3 Vertex search queries at $14 per 1K queries', () => {
+    expect( getGoogleSearchGroundingUsage( {
+      modelId: 'gemini-3.5-flash',
+      providerMetadata: {
+        vertex: { groundingMetadata: { webSearchQueries: [ 'one', 'two' ] } }
+      }
+    } ) ).toEqual( {
+      type: 'google_search_grounding',
+      unit: 'query',
+      ppm: 14_000,
+      amount: 2
+    } );
+  } );
+
+  it( 'sums per-step queries without double-counting top-level metadata', () => {
+    expect( getGoogleSearchGroundingUsage( {
+      modelId: 'google/gemini-3.5-flash',
+      providerMetadata: {
+        google: { groundingMetadata: { webSearchQueries: [ 'duplicated top-level' ] } }
+      },
+      steps: [
+        { providerMetadata: { google: { groundingMetadata: { webSearchQueries: [ 'one', 'two' ] } } } },
+        { providerMetadata: { google: { groundingMetadata: { webSearchQueries: [ 'three' ] } } } }
+      ]
+    } ) ).toEqual( expect.objectContaining( { amount: 3 } ) );
+  } );
+
+  it( 'does not apply Gemini 3 query pricing to older model families', () => {
+    expect( getGoogleSearchGroundingUsage( {
+      modelId: 'gemini-2.5-flash',
+      providerMetadata: {
+        vertex: { groundingMetadata: { webSearchQueries: [ 'one' ] } }
+      }
+    } ) ).toBeNull();
+  } );
+
+  it( 'returns null when grounding metadata is missing or explicitly empty', () => {
+    expect( getGoogleSearchGroundingUsage( {
+      modelId: 'gemini-3.5-flash',
+      providerMetadata: { vertex: {} }
+    } ) ).toBeNull();
+    expect( getGoogleSearchGroundingUsage( {
+      modelId: 'gemini-3.5-flash',
+      providerMetadata: { vertex: { groundingMetadata: { webSearchQueries: [] } } }
+    } ) ).toBeNull();
+  } );
+} );

--- a/sdk/llm/src/cost/index.js
+++ b/sdk/llm/src/cost/index.js
@@ -1,15 +1,18 @@
 import { fetchModelsPricing } from './fetch_models_pricing.js';
 import { Tracing } from '@outputai/core/sdk/runtime';
 import { Logger } from '@outputai/core';
+import { getGoogleSearchGroundingUsage } from './google_search_grounding.js';
 
 /**
  * Calculates the cost of an llm call based on the model and usage.
  * @param {object} args
  * @param {string} args.modelId - Name of the model, provider prefix is optional
  * @param {object} args.usage - Usage, as returned from AI SDK
+ * @param {object} [args.providerMetadata] - AI SDK provider metadata
+ * @param {Array<object>} [args.steps] - AI SDK text-generation steps
  * @returns {object} The cost with total value and components
  */
-export const calculateLLMCallCost = async ( { modelId, usage } ) => {
+export const calculateLLMCallCost = async ( { modelId, usage, providerMetadata, steps } ) => {
   try {
     const models = await fetchModelsPricing();
 
@@ -47,6 +50,11 @@ export const calculateLLMCallCost = async ( { modelId, usage } ) => {
     // When there are no reasoning costs, providers do not differentiate reasoning vs output, so the price is included in the output
     if ( Number.isFinite( pricing.reasoning ) && Number.isFinite( reasoningTokens ) ) {
       llmUsage.addUsage( { type: 'reasoning', ppm: pricing.reasoning, amount: reasoningTokens } );
+    }
+
+    const groundingUsage = getGoogleSearchGroundingUsage( { modelId, providerMetadata, steps } );
+    if ( groundingUsage ) {
+      llmUsage.addUsage( groundingUsage );
     }
 
     return llmUsage;

--- a/sdk/llm/src/cost/index.spec.js
+++ b/sdk/llm/src/cost/index.spec.js
@@ -17,12 +17,13 @@ vi.mock( '@outputai/core/sdk/runtime', () => {
       this.modelId = modelId;
     }
 
-    addUsage( { type, ppm, amount } ) {
+    addUsage( { type, ppm, amount, unit = 'token' } ) {
       this.usage.push( {
         type,
         ppm,
         amount,
-        total: ( amount / 1_000_000 ) * ppm
+        total: ( amount / 1_000_000 ) * ppm,
+        ...( unit === 'token' ? {} : { unit } )
       } );
     }
 
@@ -31,7 +32,9 @@ vi.mock( '@outputai/core/sdk/runtime', () => {
     }
 
     get tokensUsed() {
-      return this.usage.reduce( ( total, current ) => total + current.amount, 0 );
+      return this.usage
+        .filter( current => !current.unit || current.unit === 'token' )
+        .reduce( ( total, current ) => total + current.amount, 0 );
     }
   }
 
@@ -105,6 +108,38 @@ describe( 'calculateLLMCallCost', () => {
       ],
       total: 7,
       tokensUsed: 1_500_000
+    } );
+  } );
+
+  it( 'includes Gemini 3 search grounding cost without counting queries as tokens', async () => {
+    mockFetchModelsPricing.mockResolvedValue( new Map( [ [
+      'gemini-3.5-flash',
+      { input: 1.5, output: 9 }
+    ] ] ) );
+
+    const result = await calculateLLMCallCost( {
+      modelId: 'gemini-3.5-flash',
+      usage: { inputTokens: 1_000, outputTokens: 100 },
+      providerMetadata: {
+        vertex: { groundingMetadata: { webSearchQueries: [ 'one', 'two' ] } }
+      }
+    } );
+
+    expectLLMUsage( result, {
+      modelId: 'gemini-3.5-flash',
+      usage: [
+        { type: 'input', ppm: 1.5, amount: 1_000, total: 0.0015 },
+        { type: 'output', ppm: 9, amount: 100, total: ( 100 / 1_000_000 ) * 9 },
+        {
+          type: 'google_search_grounding',
+          unit: 'query',
+          ppm: 14_000,
+          amount: 2,
+          total: ( 2 / 1_000_000 ) * 14_000
+        }
+      ],
+      total: 0.0304,
+      tokensUsed: 1_100
     } );
   } );
 

--- a/sdk/llm/src/index.d.ts
+++ b/sdk/llm/src/index.d.ts
@@ -359,6 +359,7 @@ export type LLMUsageEvent = {
     ppm: number;
     amount: number;
     total: number;
+    unit?: string;
   }>;
   total: number;
   tokensUsed: number;

--- a/sdk/llm/src/utils/response_wrappers.js
+++ b/sdk/llm/src/utils/response_wrappers.js
@@ -19,7 +19,7 @@ import { calculateBase64FileSize } from './image.js';
 export const wrapTextResponse = async ( { traceId, modelId, response } ) => {
   const { totalUsage: usage, providerMetadata, text: result, steps, sources } = response;
 
-  const cost = await calculateLLMCallCost( { usage, modelId } );
+  const cost = await calculateLLMCallCost( { usage, modelId, providerMetadata, steps } );
   const sourcesFromTools = extractSourcesFromSteps( steps );
 
   endTraceWithSuccess( { traceId, usage, cost, result, providerMetadata, sourcesFromTools } );

--- a/sdk/llm/src/utils/response_wrappers.spec.js
+++ b/sdk/llm/src/utils/response_wrappers.spec.js
@@ -71,7 +71,9 @@ describe( 'wrapTextResponse', () => {
     expect( wrapped.cost ).toEqual( mockCost );
     expect( mocks.calculateLLMCallCost ).toHaveBeenCalledWith( {
       usage: response.totalUsage,
-      modelId
+      modelId,
+      providerMetadata: response.providerMetadata,
+      steps: response.steps
     } );
     expect( mocks.extractSourcesFromSteps ).toHaveBeenCalledWith( response.steps );
     expect( mocks.endTraceWithSuccess ).toHaveBeenCalledWith( {
@@ -188,7 +190,9 @@ describe( 'wrapStreamOnFinishResponse', () => {
     } );
     expect( mocks.calculateLLMCallCost ).toHaveBeenCalledWith( {
       usage: response.totalUsage,
-      modelId
+      modelId,
+      providerMetadata: response.providerMetadata,
+      steps: response.steps
     } );
   } );
 } );


### PR DESCRIPTION
## Problem

`cost:llm:request.total` currently includes token charges only. Gemini 3 Google Search grounding is billed separately per search query, so workflows using grounding materially under-report LLM dollars even though AI SDK returns the billed queries in provider metadata.

This surfaced while validating checkthat-workflows PR #385: query counts were observable, but the shared LLM dollar metric omitted them.

## Fix

- Read `groundingMetadata.webSearchQueries` from Vertex/Google provider metadata.
- Price Gemini 3 Google Search grounding at the current **$14 per 1,000 queries** list rate.
- Add it to `cost:llm:request.total` as `google_search_grounding` with `unit: query`.
- Keep query counts out of `tokensUsed` and token breakdown aggregations.
- Sum multi-step metadata without double-counting the top-level response.
- Document that account-level free tiers and negotiated discounts are not applied to per-call list-price estimates.

## Example

```json
{
  "type": "google_search_grounding",
  "unit": "query",
  "ppm": 14000,
  "amount": 2,
  "total": 0.028
}
```

## Verification

- Core + LLM suites: **92 files, 995 tests passed**
- Focused cost suites: **27 tests passed**
- `@outputai/core` type build passed
- `@outputai/llm` type build passed
- ESLint passed on changed source/test files
- `git diff --check` passed

## Review

Codex adversarial review: **PROCEED**. Verified `gemini-3.5-flash` exists in the live model-pricing catalog and confirmed non-token usage remains excluded from token totals.