### PR TITLE
feat(core): Adding custom events to hooks + refactor (OUT-520)

### DIFF
--- a/.changeset/two-socks-post.md
+++ b/.changeset/two-socks-post.md
@@ -1,0 +1,18 @@
+---
+"@outputai/core": minor
+---
+
+- Added `emit()` to `/hooks` entrypoint to emit custom events. Emitted events can be listened using `on()` and will have their payload wrapped in an envelope:
+  ```js
+  {
+    eventId: string,
+    eventDate: number,
+    outputActivityKind: string,
+    workflowDetails: {},
+    activityInfo: {},
+    payload: <original emitted payload>
+  }
+  ```
+- Added the same wrapping envelope to all other events listened to with `on()`: `http:request`, `cost:llm:request`, `cost:http:request`;
+- Added internal activity events to activity lifecycle: `onActivityStart`, `onActivityEnd`, `onActivityError`;
+- Updated internal triggers so `onError()` no longer receives errors from the internal `$catalog` workflow.

--- a/.changeset/two-socks-post.md
+++ b/.changeset/two-socks-post.md
@@ -7,12 +7,13 @@
   {
     eventId: string,
     eventDate: number,
-    outputActivityKind: string,
-    workflowDetails: {},
-    activityInfo: {},
+    outputActivityKind?: string,
+    workflowDetails?: {},
+    activityInfo?: {},
     payload: <original emitted payload>
   }
   ```
+  Events emitted outside an activity context omit `outputActivityKind`, `workflowDetails`, and `activityInfo`.
 - Added the same wrapping envelope to all other events listened to with `on()`: `http:request`, `cost:llm:request`, `cost:http:request`;
 - Added internal activity events to activity lifecycle: `onActivityStart`, `onActivityEnd`, `onActivityError`;
 - Updated internal triggers so `onError()` no longer receives errors from the internal `$catalog` workflow.

--- a/docs/guides/costs/cost-events.mdx
+++ b/docs/guides/costs/cost-events.mdx
@@ -25,7 +25,7 @@ import { on } from '@outputai/core/hooks';
 import type { LLMUsageEvent } from '@outputai/llm';
 
 on<LLMUsageEvent>( 'cost:llm:request', async ( { eventId, eventDate, workflowDetails, activityInfo, payload } ) => {
-  if (!payload) {
+  if (!workflowDetails || !activityInfo || !payload) {
     return;
   }
 
@@ -47,7 +47,7 @@ import { on } from '@outputai/core/hooks';
 import type { HttpRequestCostEvent } from '@outputai/http';
 
 on<HttpRequestCostEvent>( 'cost:http:request', async ( { eventId, eventDate, workflowDetails, activityInfo, payload } ) => {
-  if (!payload) {
+  if (!workflowDetails || !activityInfo || !payload) {
     return;
   }
 
@@ -106,9 +106,9 @@ The handler receives an event envelope. The LLM usage attribute is available und
 |-------|------|-------------|
 | `eventId` | `string` | UUID v4 stamped per emit. Use as an idempotency key — `cost:llm:request` and `http:request` for the same fetch get distinct `eventId`s. |
 | `eventDate` | `number` | Millisecond epoch timestamp for when the event was emitted. |
-| `activityInfo` | `object` | Temporal [`activity.Info`](https://typescript.temporal.io/api/interfaces/activity.Info) for the activity that made the call. |
-| `workflowDetails` | `object` | Output's serializable subset of Temporal [`workflow.WorkflowInfo`](https://typescript.temporal.io/api/interfaces/workflow.WorkflowInfo). |
-| `outputActivityKind` | `string` | Output activity kind. Possible values are `step`, `evaluator`, and `internal_step`. |
+| `activityInfo` | `object \| undefined` | Temporal [`activity.Info`](https://typescript.temporal.io/api/interfaces/activity.Info) when the call is made in an activity context. |
+| `workflowDetails` | `object \| undefined` | Output's serializable subset of Temporal [`workflow.WorkflowInfo`](https://typescript.temporal.io/api/interfaces/workflow.WorkflowInfo), when available. |
+| `outputActivityKind` | `string \| undefined` | Output activity kind when available. Possible values are `step`, `evaluator`, and `internal_step`. |
 | `payload.type` | `"llm:usage"` | Attribute type. |
 | `payload.modelId` | `string` | Model identifier (e.g. `claude-sonnet-4-20250514`, `gpt-4o`). From the prompt file config. |
 | `payload.usage` | `array` | Priced usage entries for this call. See [Usage entries](#usage-entries). |
@@ -172,9 +172,9 @@ The handler receives an event envelope. The HTTP request cost attribute is avail
 |-------|------|-------------|
 | `eventId` | `string` | UUID v4 stamped per emit. Use as an idempotency key — `cost:http:request` and `http:request` for the same fetch get distinct `eventId`s, so consumers keying by `eventId` won't collapse the two. |
 | `eventDate` | `number` | Millisecond epoch timestamp for when the event was emitted. |
-| `activityInfo` | `object` | Temporal [`activity.Info`](https://typescript.temporal.io/api/interfaces/activity.Info) for the activity that made the request. |
-| `workflowDetails` | `object` | Output's serializable subset of Temporal [`workflow.WorkflowInfo`](https://typescript.temporal.io/api/interfaces/workflow.WorkflowInfo). |
-| `outputActivityKind` | `string` | Output activity kind. Possible values are `step`, `evaluator`, and `internal_step`. |
+| `activityInfo` | `object \| undefined` | Temporal [`activity.Info`](https://typescript.temporal.io/api/interfaces/activity.Info) when the request is made in an activity context. |
+| `workflowDetails` | `object \| undefined` | Output's serializable subset of Temporal [`workflow.WorkflowInfo`](https://typescript.temporal.io/api/interfaces/workflow.WorkflowInfo), when available. |
+| `outputActivityKind` | `string \| undefined` | Output activity kind when available. Possible values are `step`, `evaluator`, and `internal_step`. |
 | `payload.type` | `"http:request:cost"` | Attribute type. |
 | `payload.requestId` | `string` | Internal id linking this payload to the HTTP trace event for that request. |
 | `payload.url` | `string` | Final response URL (same as `response.url`). |

--- a/docs/guides/costs/cost-events.mdx
+++ b/docs/guides/costs/cost-events.mdx
@@ -24,16 +24,20 @@ See [Error Hooks — Setup](/operations/error-hooks#setup) for the hook file reg
 import { on } from '@outputai/core/hooks';
 import type { LLMUsageEvent } from '@outputai/llm';
 
-on<LLMUsageEvent>( 'cost:llm:request', async ( { eventId, eventDate, workflowDetails, activityInfo, modelId, total, tokensUsed, usage } ) => {
+on<LLMUsageEvent>( 'cost:llm:request', async ( { eventId, eventDate, workflowDetails, activityInfo, payload } ) => {
+  if (!payload) {
+    return;
+  }
+
   console.log( 'LLM call', {
     eventId,
     eventDate,
     workflowId: workflowDetails.workflowId,
     activityId: activityInfo.activityId,
-    modelId,
-    tokens: tokensUsed,
-    cost: total,
-    usage
+    modelId: payload.modelId,
+    tokens: payload.tokensUsed,
+    cost: payload.total,
+    usage: payload.usage
   } );
 } );
 ```
@@ -42,8 +46,20 @@ on<LLMUsageEvent>( 'cost:llm:request', async ( { eventId, eventDate, workflowDet
 import { on } from '@outputai/core/hooks';
 import type { HttpRequestCostEvent } from '@outputai/http';
 
-on<HttpRequestCostEvent>( 'cost:http:request', async ( { eventId, eventDate, workflowDetails, activityInfo, requestId, url, total } ) => {
-  console.log( 'HTTP request', { eventId, eventDate, workflowId: workflowDetails.workflowId, activityId: activityInfo.activityId, requestId, url, total } );
+on<HttpRequestCostEvent>( 'cost:http:request', async ( { eventId, eventDate, workflowDetails, activityInfo, payload } ) => {
+  if (!payload) {
+    return;
+  }
+
+  console.log( 'HTTP request', {
+    eventId,
+    eventDate,
+    workflowId: workflowDetails.workflowId,
+    activityId: activityInfo.activityId,
+    requestId: payload.requestId,
+    url: payload.url,
+    total: payload.total
+  } );
 } );
 ```
 
@@ -57,13 +73,12 @@ An `cost:llm:request` event is emitted after every `generateText` and `streamTex
 
 ### Payload
 
-The handler receives a single LLM usage attribute object:
+The handler receives an event envelope. The LLM usage attribute is available under `payload`:
 
 ```json
 {
   "eventId": "550e8400-e29b-41d4-a716-446655440000",
   "eventDate": 1780401600000,
-  "type": "llm:usage",
   "activityInfo": {
     "activityId": "activity-1",
     "activityType": "generateSummary"
@@ -74,13 +89,16 @@ The handler receives a single LLM usage attribute object:
     "workflowType": "lead_enrichment"
   },
   "outputActivityKind": "step",
-  "modelId": "gpt-4o",
-  "usage": [
-    { "type": "input", "ppm": 5, "amount": 217, "total": 0.001085 },
-    { "type": "output", "ppm": 15, "amount": 9, "total": 0.000135 }
-  ],
-  "total": 0.00122,
-  "tokensUsed": 226
+  "payload": {
+    "type": "llm:usage",
+    "modelId": "gpt-4o",
+    "usage": [
+      { "type": "input", "ppm": 5, "amount": 217, "total": 0.001085 },
+      { "type": "output", "ppm": 15, "amount": 9, "total": 0.000135 }
+    ],
+    "total": 0.00122,
+    "tokensUsed": 226
+  }
 }
 ```
 
@@ -88,14 +106,14 @@ The handler receives a single LLM usage attribute object:
 |-------|------|-------------|
 | `eventId` | `string` | UUID v4 stamped per emit. Use as an idempotency key — `cost:llm:request` and `http:request` for the same fetch get distinct `eventId`s. |
 | `eventDate` | `number` | Millisecond epoch timestamp for when the event was emitted. |
-| `type` | `"llm:usage"` | Attribute type. |
 | `activityInfo` | `object` | Temporal [`activity.Info`](https://typescript.temporal.io/api/interfaces/activity.Info) for the activity that made the call. |
 | `workflowDetails` | `object` | Output's serializable subset of Temporal [`workflow.WorkflowInfo`](https://typescript.temporal.io/api/interfaces/workflow.WorkflowInfo). |
 | `outputActivityKind` | `string` | Output activity kind. Possible values are `step`, `evaluator`, and `internal_step`. |
-| `modelId` | `string` | Model identifier (e.g. `claude-sonnet-4-20250514`, `gpt-4o`). From the prompt file config. |
-| `usage` | `array` | Priced usage entries for this call. See [Usage entries](#usage-entries). |
-| `total` | `number` | Total estimated cost in dollars. |
-| `tokensUsed` | `number` | Total number of tokens represented by `usage`. |
+| `payload.type` | `"llm:usage"` | Attribute type. |
+| `payload.modelId` | `string` | Model identifier (e.g. `claude-sonnet-4-20250514`, `gpt-4o`). From the prompt file config. |
+| `payload.usage` | `array` | Priced usage entries for this call. See [Usage entries](#usage-entries). |
+| `payload.total` | `number` | Total estimated cost in dollars. |
+| `payload.tokensUsed` | `number` | Total number of tokens represented by `payload.usage`. |
 
 ### Usage entries
 
@@ -108,7 +126,7 @@ Cost is computed from the model's per-million-token pricing, fetched from a buil
 | `amount` | `number` | Token count for this dimension. |
 | `total` | `number` | Cost for this dimension. |
 
-`usage[].type` values:
+`payload.usage[].type` values:
 
 | `type` | Description |
 |--------|-------------|
@@ -125,13 +143,12 @@ Events fire only when your code calls [`addRequestCost( response, total )`](/pac
 
 ### Payload
 
-The handler receives a single HTTP request cost attribute object:
+The handler receives an event envelope. The HTTP request cost attribute is available under `payload`:
 
 ```json
 {
   "eventId": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
   "eventDate": 1780401600000,
-  "type": "http:request:cost",
   "activityInfo": {
     "activityId": "activity-1",
     "activityType": "searchVendors"
@@ -142,9 +159,12 @@ The handler receives a single HTTP request cost attribute object:
     "workflowType": "lead_enrichment"
   },
   "outputActivityKind": "step",
-  "requestId": "req-123",
-  "url": "https://api.vendor.com/search",
-  "total": 0.42
+  "payload": {
+    "type": "http:request:cost",
+    "requestId": "req-123",
+    "url": "https://api.vendor.com/search",
+    "total": 0.42
+  }
 }
 ```
 
@@ -152,10 +172,10 @@ The handler receives a single HTTP request cost attribute object:
 |-------|------|-------------|
 | `eventId` | `string` | UUID v4 stamped per emit. Use as an idempotency key — `cost:http:request` and `http:request` for the same fetch get distinct `eventId`s, so consumers keying by `eventId` won't collapse the two. |
 | `eventDate` | `number` | Millisecond epoch timestamp for when the event was emitted. |
-| `type` | `"http:request:cost"` | Attribute type. |
 | `activityInfo` | `object` | Temporal [`activity.Info`](https://typescript.temporal.io/api/interfaces/activity.Info) for the activity that made the request. |
 | `workflowDetails` | `object` | Output's serializable subset of Temporal [`workflow.WorkflowInfo`](https://typescript.temporal.io/api/interfaces/workflow.WorkflowInfo). |
 | `outputActivityKind` | `string` | Output activity kind. Possible values are `step`, `evaluator`, and `internal_step`. |
-| `requestId` | `string` | Internal id linking this payload to the HTTP trace event for that request. |
-| `url` | `string` | Final response URL (same as `response.url`). |
-| `total` | `number` | Dollar cost passed to `addRequestCost`. |
+| `payload.type` | `"http:request:cost"` | Attribute type. |
+| `payload.requestId` | `string` | Internal id linking this payload to the HTTP trace event for that request. |
+| `payload.url` | `string` | Final response URL (same as `response.url`). |
+| `payload.total` | `number` | Dollar cost passed to `addRequestCost`. |

--- a/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
+++ b/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
@@ -1,9 +1,9 @@
 ---
 title: "v0.10.0 → v0.11.0"
-description: "Upgrading Output.ai projects from v0.10.0 to v0.11.0: API request logging, Temporal rollout safety, shared activity names, and child workflow activity-option precedence."
+description: "Upgrading Output.ai projects from v0.10.0 to v0.11.0: hook event envelopes, API request logging, Temporal rollout safety, shared activity names, and child workflow activity-option precedence."
 ---
 
-This guide covers customer-facing changes to API request logging in `output-api` and workflow execution in `@outputai/core`.
+This guide covers customer-facing changes to hooks and workflow execution in `@outputai/core`, plus API request logging in `output-api`.
 
 ## API HTTP request logging
 
@@ -141,6 +141,127 @@ If a dashboard or aggregation relied on fractional milliseconds in `responseTime
 - Rename `status` to `http.status_code` in log queries, facets, and dashboards.
 - Replace any match on the constant message `"HTTP request"` with a structural field or the new summary format.
 - Confirm `responseTime` consumers tolerate integer milliseconds.
+
+## Hook event changes
+
+This section applies to hook files that import from `@outputai/core/hooks`.
+
+### `on()` now receives an event envelope
+
+In v0.10.x, SDK event fields were merged into the same object as framework metadata. In v0.11.0, framework metadata remains at the top level and event-specific data is available under `payload`.
+
+This affects every handler registered with `on()`, including:
+
+- `http:request`
+- `cost:http:request`
+- `cost:llm:request`
+- Custom events
+
+Lifecycle hooks such as `onWorkflowStart`, `onActivityEnd`, and `onError` remain flat.
+
+#### Before
+
+```ts
+import { on } from '@outputai/core/hooks';
+import type { HttpRequestEvent } from '@outputai/http';
+
+on<HttpRequestEvent>( 'http:request', event => {
+  console.log( event.eventId, event.workflowDetails.workflowId, event.method, event.url );
+} );
+```
+
+#### After
+
+```ts
+import { on } from '@outputai/core/hooks';
+import type { HttpRequestEvent } from '@outputai/http';
+
+on<HttpRequestEvent>( 'http:request', event => {
+  if ( !event.payload ) {
+    return;
+  }
+
+  console.log(
+    event.eventId,
+    event.workflowDetails.workflowId,
+    event.payload.method,
+    event.payload.url
+  );
+} );
+```
+
+The envelope has this shape:
+
+```ts
+{
+  eventId: string;
+  eventDate: number;
+  activityInfo: Info;
+  workflowDetails: WorkflowDetails;
+  outputActivityKind?: string;
+  payload: T | undefined;
+}
+```
+
+The generic passed to `on<T>()` still describes the event-specific data. The difference is that `T` now types `event.payload` instead of fields on `event` itself.
+
+Because custom events can omit their payload, check `event.payload` before reading its fields. SDK events such as `http:request` and cost events always supply one, but the public handler type still represents the optional case.
+
+v0.11.0 also adds `emit(eventName, payload?)` for publishing custom events from an Output activity:
+
+```ts
+import { emit, on } from '@outputai/core/hooks';
+
+emit( 'company:enriched', { companyId: 'company-123' } );
+
+on<{ companyId: string }>( 'company:enriched', event => {
+  if ( !event.payload ) {
+    return;
+  }
+
+  console.log( event.payload.companyId );
+} );
+```
+
+### Activity lifecycle hooks include internal activities
+
+`onActivityStart`, `onActivityEnd`, and `onActivityError` now run for internal activities as well as steps and evaluators. Internal activity payloads have:
+
+```ts
+{
+  outputActivityKind: 'internal_step'
+}
+```
+
+If your handler should keep the v0.10.x behavior, add an explicit filter:
+
+```ts
+import { onActivityStart } from '@outputai/core/hooks';
+
+onActivityStart( event => {
+  if ( event.outputActivityKind === 'internal_step' ) {
+    return;
+  }
+
+  // Handle steps and evaluators.
+} );
+```
+
+Review metrics, logs, webhooks, and state updates triggered by activity lifecycle hooks. Without a filter, internal activities now contribute to those side effects.
+
+### `onError` excludes the internal catalog workflow
+
+The internal `$catalog` workflow was already excluded from `onWorkflowStart`, `onWorkflowEnd`, and `onWorkflowError`. In v0.11.0, its workflow and activity errors are also excluded from `onError`.
+
+No migration is needed unless an `onError` handler explicitly relied on `$catalog` failures. Worker startup and catalog-manager failures still surface as runtime errors. Monitor Temporal or API catalog health if you need to detect the catalog workflow being terminated after startup.
+
+### Hook migration checklist
+
+- Update every `on()` handler to read event-specific fields from `event.payload`.
+- Guard `event.payload` before accessing its fields.
+- Keep framework fields such as `eventId`, `workflowDetails`, and `activityInfo` at the top level.
+- Filter `outputActivityKind === 'internal_step'` in activity lifecycle hooks when internal activities should remain hidden.
+- Remove assumptions that `onError` reports `$catalog` workflow failures.
 
 ## Workflow runtime changes
 

--- a/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
+++ b/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
@@ -198,7 +198,7 @@ The envelope has this shape:
   eventDate: number;
   activityInfo: Info;
   workflowDetails: WorkflowDetails;
-  outputActivityKind?: string;
+  outputActivityKind: string;
   payload: T | undefined;
 }
 ```

--- a/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
+++ b/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
@@ -177,7 +177,7 @@ import { on } from '@outputai/core/hooks';
 import type { HttpRequestEvent } from '@outputai/http';
 
 on<HttpRequestEvent>( 'http:request', event => {
-  if ( !event.payload ) {
+  if ( !event.workflowDetails || !event.payload ) {
     return;
   }
 
@@ -196,9 +196,9 @@ The envelope has this shape:
 {
   eventId: string;
   eventDate: number;
-  activityInfo: Info;
-  workflowDetails: WorkflowDetails;
-  outputActivityKind: string;
+  activityInfo?: Info;
+  workflowDetails?: WorkflowDetails;
+  outputActivityKind?: string;
   payload: T | undefined;
 }
 ```
@@ -221,6 +221,41 @@ on<{ companyId: string }>( 'company:enriched', event => {
 
   console.log( event.payload.companyId );
 } );
+```
+
+When an event is emitted outside an activity context, `activityInfo`, `workflowDetails`, and `outputActivityKind` are omitted. These fields are therefore optional on `ExternalHookPayload<T>`; check any context field before using it.
+
+### Update imported hook payload types
+
+The exported base and envelope types were simplified in v0.11.0. If your hook files import these types directly, make the following replacements:
+
+- Replace `OnHookPayload<T>` with `ExternalHookPayload<T>`.
+- Replace `OnHookEnvelope` with `ActivityPayloadBase`.
+- Replace `ActivityHookPayload` with `ActivityPayloadBase`.
+
+`HookPayloadBase` now contains only `eventId` and `eventDate`. Use `WorkflowPayloadBase` when you also need `workflowDetails`, or `ActivityPayloadBase` when you need the workflow and activity context fields.
+
+#### Before
+
+```ts
+import type {
+  ActivityHookPayload,
+  OnHookEnvelope,
+  OnHookPayload
+} from '@outputai/core/hooks';
+
+type CompanyEnrichedEvent = OnHookPayload<{ companyId: string }>;
+```
+
+#### After
+
+```ts
+import type {
+  ActivityPayloadBase,
+  ExternalHookPayload
+} from '@outputai/core/hooks';
+
+type CompanyEnrichedEvent = ExternalHookPayload<{ companyId: string }>;
 ```
 
 ### Activity lifecycle hooks include internal activities

--- a/docs/guides/operations/error-hooks.mdx
+++ b/docs/guides/operations/error-hooks.mdx
@@ -41,13 +41,13 @@ Errors are emitted from three origins. Every payload includes `eventId`, `eventD
 
 | Source | When it fires | Fields besides `eventId`, `eventDate`, `source`, and `error` |
 |--------|----------------|----------------------------------------|
-| `activity` | A step or evaluator fails (after retries are exhausted). | `activityInfo`, `workflowDetails`, `outputActivityKind`, `aggregations` |
+| `activity` | A step, evaluator, or internal activity fails (after retries are exhausted). | `activityInfo`, `workflowDetails`, `outputActivityKind`, `aggregations` |
 | `workflow` | The workflow function itself throws (e.g. uncaught step error or logic error). | `workflowDetails` |
 | `runtime` | An error outside workflow/activity scope (e.g. in the worker/runtime). | — |
 
 So:
 
-- **Activity** — `eventId`, `eventDate`, `source: 'activity'`, `activityInfo`, `workflowDetails`, `outputActivityKind`, `aggregations`, `error`.
+- **Activity** — `eventId`, `eventDate`, `source: 'activity'`, `activityInfo`, `workflowDetails`, `outputActivityKind`, `aggregations`, `error`. This includes internal activities.
 - **Workflow** — `eventId`, `eventDate`, `source: 'workflow'`, `workflowDetails`, `error` (no activity fields).
 - **Runtime** — `eventId`, `eventDate`, `source: 'runtime'`, and `error` only.
 
@@ -58,6 +58,8 @@ So:
 `aggregations` contains activity-scoped attribute totals collected before the failure, such as `cost.total`, `tokens.total`, provider-specific token buckets, and `httpRequests.total`. It is `null` when no attributes were collected.
 
 `eventId` is a UUID v4 stamped per emit — use it as a stable idempotency key when forwarding errors to external systems (Sentry, PagerDuty, your own incident pipeline). `eventDate` is the millisecond epoch timestamp for when the event was emitted. Use `source` to branch in one handler, or ignore payload fields that are undefined for that source.
+
+Errors from the internal `$catalog` workflow are excluded.
 
 ## Handler safety: no throws
 

--- a/docs/guides/packages/core.mdx
+++ b/docs/guides/packages/core.mdx
@@ -107,10 +107,10 @@ Every hook payload includes an **`eventId`** — a UUID v4 stamped per emit — 
 | `onWorkflowStart` | A user workflow execution starts | `eventId`, `eventDate`, `workflowDetails` |
 | `onWorkflowEnd` | A user workflow execution completes successfully | `eventId`, `eventDate`, `workflowDetails` |
 | `onWorkflowError` | A user workflow execution fails | `eventId`, `eventDate`, `workflowDetails`, `error` |
-| `onActivityStart` | A step or evaluator activity starts | `eventId`, `eventDate`, `activityInfo`, `workflowDetails`, `outputActivityKind` |
-| `onActivityEnd` | A step or evaluator activity completes successfully | `eventId`, `eventDate`, `activityInfo`, `workflowDetails`, `outputActivityKind`, `aggregations` |
-| `onActivityError` | A step or evaluator activity fails | `eventId`, `eventDate`, `activityInfo`, `workflowDetails`, `outputActivityKind`, `aggregations`, `error` |
-| `on(eventName, handler)` | Custom events emitted elsewhere in the stack | Your event payload plus `eventId` and `eventDate`. When emitted from an Output activity, the framework also attaches `activityInfo`, `workflowDetails`, and `outputActivityKind`. |
+| `onActivityStart` | An Output activity starts, including internal activities | `eventId`, `eventDate`, `activityInfo`, `workflowDetails`, `outputActivityKind` |
+| `onActivityEnd` | An Output activity completes successfully, including internal activities | `eventId`, `eventDate`, `activityInfo`, `workflowDetails`, `outputActivityKind`, `aggregations` |
+| `onActivityError` | An Output activity fails, including internal activities | `eventId`, `eventDate`, `activityInfo`, `workflowDetails`, `outputActivityKind`, `aggregations`, `error` |
+| `on(eventName, handler)` | SDK and custom events emitted from an Output activity | An envelope containing `eventId`, `eventDate`, `activityInfo`, `workflowDetails`, `outputActivityKind`, and your original value under `payload` |
 
 **Context objects on hook payloads**
 
@@ -118,6 +118,47 @@ Every hook payload includes an **`eventId`** — a UUID v4 stamped per emit — 
 - `workflowDetails` is Output's serializable subset of Temporal's [`workflow.WorkflowInfo`](https://typescript.temporal.io/api/interfaces/workflow.WorkflowInfo). It includes `workflowId`, `runId`, `workflowType`, `parent`, `root`, `firstExecutionRunId`, `continuedFromExecutionRunId`, `startTime`, `runStartTime`, and `attempt`.
 - `outputActivityKind` is Output metadata for activity hooks and custom events emitted from activities. Possible values are `step`, `evaluator`, and `internal_step`.
 - `aggregations` contains activity-scoped attribute totals collected while the step or evaluator ran. It is `null` when no attributes were collected.
+
+**SDK and custom event envelopes**
+
+Events received with `on(eventName, handler)` keep framework context separate from event-specific data:
+
+```typescript
+{
+  eventId: string;
+  eventDate: number;
+  activityInfo: Info;
+  workflowDetails: WorkflowDetails;
+  outputActivityKind?: string;
+  payload: unknown;
+}
+```
+
+Use `emit(eventName, payload)` from a step or evaluator to publish a custom event. The payload is optional and can be any JavaScript value.
+
+```typescript
+import { emit, on } from '@outputai/core/hooks';
+
+emit('company:enriched', {
+  companyId: 'company-123',
+  domain: 'example.com'
+});
+
+on<{ companyId: string; domain: string }>('company:enriched', ({ eventId, workflowDetails, payload }) => {
+  if (!payload) {
+    return;
+  }
+
+  console.log('Company enriched', {
+    eventId,
+    workflowId: workflowDetails.workflowId,
+    companyId: payload.companyId,
+    domain: payload.domain
+  });
+});
+```
+
+SDK events use the same envelope. For example, `http:request` stores its request fields under `payload`, while `eventId` and activity context remain at the top level.
 
 ```typescript
 type WorkflowDetails = {
@@ -151,7 +192,7 @@ type Aggregations = {
 - **`workflow`** — `eventId`, `eventDate`, `source`, `workflowDetails`, `error`
 - **`runtime`** — `eventId`, `eventDate`, `source`, `error`
 
-`onWorkflowStart`, `onWorkflowEnd`, and `onWorkflowError` do **not** run for the internal `$catalog` workflow. `onActivityStart`, `onActivityEnd`, and `onActivityError` do **not** run for internal activities. `onError` can still report failures from any workflow or activity, including internal ones, if you need them.
+The internal `$catalog` workflow is excluded from lifecycle and error hooks. Activity hooks include internal activities, identified by `outputActivityKind: 'internal_step'`.
 
 ## HTTP from Workflows
 

--- a/docs/guides/packages/core.mdx
+++ b/docs/guides/packages/core.mdx
@@ -129,7 +129,7 @@ Events received with `on(eventName, handler)` keep framework context separate fr
   eventDate: number;
   activityInfo: Info;
   workflowDetails: WorkflowDetails;
-  outputActivityKind?: string;
+  outputActivityKind: string;
   payload: unknown;
 }
 ```

--- a/docs/guides/packages/core.mdx
+++ b/docs/guides/packages/core.mdx
@@ -110,7 +110,7 @@ Every hook payload includes an **`eventId`** — a UUID v4 stamped per emit — 
 | `onActivityStart` | An Output activity starts, including internal activities | `eventId`, `eventDate`, `activityInfo`, `workflowDetails`, `outputActivityKind` |
 | `onActivityEnd` | An Output activity completes successfully, including internal activities | `eventId`, `eventDate`, `activityInfo`, `workflowDetails`, `outputActivityKind`, `aggregations` |
 | `onActivityError` | An Output activity fails, including internal activities | `eventId`, `eventDate`, `activityInfo`, `workflowDetails`, `outputActivityKind`, `aggregations`, `error` |
-| `on(eventName, handler)` | SDK and custom events emitted from an Output activity | An envelope containing `eventId`, `eventDate`, `activityInfo`, `workflowDetails`, `outputActivityKind`, and your original value under `payload` |
+| `on(eventName, handler)` | SDK and custom events | An envelope containing `eventId`, `eventDate`, and your original value under `payload`; activity context fields are included when available |
 
 **Context objects on hook payloads**
 
@@ -127,14 +127,16 @@ Events received with `on(eventName, handler)` keep framework context separate fr
 {
   eventId: string;
   eventDate: number;
-  activityInfo: Info;
-  workflowDetails: WorkflowDetails;
-  outputActivityKind: string;
+  activityInfo?: Info;
+  workflowDetails?: WorkflowDetails;
+  outputActivityKind?: string;
   payload: unknown;
 }
 ```
 
 Use `emit(eventName, payload)` from a step or evaluator to publish a custom event. The payload is optional and can be any JavaScript value.
+
+If you call `emit()` outside a step or evaluator (and therefore outside an activity context), the event still includes `eventId`, `eventDate`, and `payload`, but it does not include `activityInfo`, `workflowDetails`, or `outputActivityKind`.
 
 ```typescript
 import { emit, on } from '@outputai/core/hooks';
@@ -145,7 +147,7 @@ emit('company:enriched', {
 });
 
 on<{ companyId: string; domain: string }>('company:enriched', ({ eventId, workflowDetails, payload }) => {
-  if (!payload) {
+  if (!workflowDetails || !payload) {
     return;
   }
 

--- a/docs/guides/packages/http.mdx
+++ b/docs/guides/packages/http.mdx
@@ -136,7 +136,7 @@ import { on } from '@outputai/core/hooks';
 import type { HttpRequestEvent } from '@outputai/http';
 
 on<HttpRequestEvent>( 'http:request', async ( { eventId, workflowDetails, payload } ) => {
-  if (!payload) {
+  if (!workflowDetails || !payload) {
     return;
   }
 
@@ -153,9 +153,9 @@ The handler receives an event envelope. Request-specific fields are available un
 |-------|-------------|
 | `eventId` | UUID v4 stamped per emit. Stable per-emit idempotency key — `http:request` and `cost:http:request` for the same fetch get distinct `eventId`s, so dedup keyed on `eventId` won't collapse the two. |
 | `eventDate` | Millisecond epoch timestamp for when the event was emitted. |
-| `activityInfo` | Temporal [`activity.Info`](https://typescript.temporal.io/api/interfaces/activity.Info) for the activity that made the request. |
-| `workflowDetails` | Output's serializable subset of Temporal [`workflow.WorkflowInfo`](https://typescript.temporal.io/api/interfaces/workflow.WorkflowInfo). |
-| `outputActivityKind` | Output activity kind. Possible values are `step`, `evaluator`, and `internal_step`. |
+| `activityInfo?` | Temporal [`activity.Info`](https://typescript.temporal.io/api/interfaces/activity.Info) when the request is made in an activity context. |
+| `workflowDetails?` | Output's serializable subset of Temporal [`workflow.WorkflowInfo`](https://typescript.temporal.io/api/interfaces/workflow.WorkflowInfo), when available. |
+| `outputActivityKind?` | Output activity kind when available. Possible values are `step`, `evaluator`, and `internal_step`. |
 | `payload.requestId` | UUID generated per request inside `@outputai/http`. Shared between the matching `http:request` and `cost:http:request` events for cross-event correlation. |
 | `payload.method` | HTTP method (uppercase). |
 | `payload.url` | Absolute request URL. |

--- a/docs/guides/packages/http.mdx
+++ b/docs/guides/packages/http.mdx
@@ -135,27 +135,33 @@ Every HTTP call made through `@outputai/http`'s `fetch` (and the higher-level `h
 import { on } from '@outputai/core/hooks';
 import type { HttpRequestEvent } from '@outputai/http';
 
-on<HttpRequestEvent>( 'http:request', async ( payload ) => {
-  // payload: { eventId, eventDate, requestId, method, url, status?, durationMs, outcome, activityInfo, workflowDetails, outputActivityKind }
-  console.log( `[${payload.outcome}] ${payload.method} ${payload.url} ${payload.status ?? '-'} ${payload.durationMs}ms` );
+on<HttpRequestEvent>( 'http:request', async ( { eventId, workflowDetails, payload } ) => {
+  if (!payload) {
+    return;
+  }
+
+  console.log( `[${payload.outcome}] ${payload.method} ${payload.url} ${payload.status ?? '-'} ${payload.durationMs}ms`, {
+    eventId,
+    workflowId: workflowDetails.workflowId
+  } );
 } );
 ```
 
-The payload includes:
+The handler receives an event envelope. Request-specific fields are available under `payload`:
 
 | Field | Description |
 |-------|-------------|
 | `eventId` | UUID v4 stamped per emit. Stable per-emit idempotency key — `http:request` and `cost:http:request` for the same fetch get distinct `eventId`s, so dedup keyed on `eventId` won't collapse the two. |
 | `eventDate` | Millisecond epoch timestamp for when the event was emitted. |
-| `requestId` | UUID generated per request inside `@outputai/http`. Shared between the matching `http:request` and `cost:http:request` events for cross-event correlation. |
-| `method` | HTTP method (uppercase). |
-| `url` | Absolute request URL. |
-| `status` | HTTP status code; `undefined` on network failure. |
-| `durationMs` | Elapsed time from request issuance to response (or failure), in milliseconds. |
-| `outcome` | One of `'success'` (2xx-3xx), `'error'` (status >= 400), `'failure'` (DNS / timeout / abort). |
 | `activityInfo` | Temporal [`activity.Info`](https://typescript.temporal.io/api/interfaces/activity.Info) for the activity that made the request. |
 | `workflowDetails` | Output's serializable subset of Temporal [`workflow.WorkflowInfo`](https://typescript.temporal.io/api/interfaces/workflow.WorkflowInfo). |
 | `outputActivityKind` | Output activity kind. Possible values are `step`, `evaluator`, and `internal_step`. |
+| `payload.requestId` | UUID generated per request inside `@outputai/http`. Shared between the matching `http:request` and `cost:http:request` events for cross-event correlation. |
+| `payload.method` | HTTP method (uppercase). |
+| `payload.url` | Absolute request URL. |
+| `payload.status` | HTTP status code; `undefined` on network failure. |
+| `payload.durationMs` | Elapsed time from request issuance to response (or failure), in milliseconds. |
+| `payload.outcome` | One of `'success'` (2xx-3xx), `'error'` (status >= 400), `'failure'` (DNS / timeout / abort). |
 
 The event fires for **every** call — success, non-2xx responses, and network failures alike. The existing [`cost:http:request`](/costs/cost-events#http-request-cost) event is unchanged and continues to fire only when you call `addRequestCost`.
 

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -849,7 +849,7 @@ Built-in providers are initialized with a custom fetch that extends Undici's `he
 
 ## LLM call cost event
 
-Each `generateText` and `streamText` call emits a `cost:llm:request` event after the LLM responds and cost can be computed. You can observe it with the same [hooks mechanism](/packages/core#error-hooks) as error hooks: register a handler with `on('cost:llm:request', handler)` from `@outputai/core/hooks` in a hook file listed under `outputai.hookFiles`. The payload is the same LLM usage attribute exposed on `response.cost`. For payload details, see [Cost Events](/costs/cost-events).
+Each `generateText` and `streamText` call emits a `cost:llm:request` event after the LLM responds and cost can be computed. You can observe it with the same [hooks mechanism](/packages/core#error-hooks) as error hooks: register a handler with `on('cost:llm:request', handler)` from `@outputai/core/hooks` in a hook file listed under `outputai.hookFiles`. The handler receives an event envelope whose `payload` field is the same LLM usage attribute exposed on `response.cost`. For payload details, see [Cost Events](/costs/cost-events).
 
 ## loadPrompt
 

--- a/sdk/core/src/bus.js
+++ b/sdk/core/src/bus.js
@@ -1,30 +1,68 @@
 import { EventEmitter } from 'node:events';
 import { randomUUID } from 'node:crypto';
-import { isPlainObject } from '#helpers/object';
+import { Storage } from '#async_storage';
+import { WORKFLOW_CATALOG } from '#consts';
 
-const emitter = new EventEmitter();
+const mainEventBus = new EventEmitter();
+const stepEventBus = new EventEmitter();
+
+const getContext = () => {
+  const ctx = Storage.load();
+  if ( ctx ) {
+    const { outputActivityKind, activityInfo, workflowDetails } = ctx;
+    return { outputActivityKind, activityInfo, workflowDetails };
+  }
+  return {};
+};
 
 /**
- * Every object payload emitted through `messageBus` is stamped with a UUID v4 `eventId`.
+ * Attaches information and filter out events from the bus by proxying .emit().
+ *
+ * If createEnvelope=true, wrap payload:
+ * ```js
+ * {
+ *   eventId,
+ *   eventDate,
+ *   outputActivityKind,
+ *   activityInfo,
+ *   workflowDetails,
+ *   payload: <original payload>
+ * }
+ * ```
+ *
+ * if createEnvelope=false, adds eventId and eventDate to the original payload object
+ *
+ * @param {object} args
+ * @param {object} args.bus The event emitter to proxy
+ * @param {boolean} args.createEnvelope Whether to wrap event around an envelope
+ * @param {function} args.filter Filter function to drop events
  */
-emitter.emit = new Proxy( emitter.emit, {
-  apply( target, thisArg, args ) {
-    const [ eventName, payload, ...extras ] = args;
-    const newArguments = [];
+const proxyBus = ( { bus, createEnvelope = false, filter } ) => {
+  bus.emit = new Proxy( bus.emit, {
+    apply( target, thisArg, args ) {
+      const [ eventName, payload, ...rest ] = args;
 
-    // do now push arguments that dont exist. if payload is undefined with len=1, means it was never defined
-    // if payload is undefined with len>1, means user passed 'undefined' as argument
-    if ( args.length > 1 ) {
-      newArguments.push( isPlainObject( payload ) ? {
+      const shouldEmit = filter?.( eventName, payload ) ?? true;
+      if ( !shouldEmit ) {
+        return false;
+      }
+
+      const eventFields = {
         eventId: randomUUID(),
-        eventDate: Date.now(),
-        ...payload
-      } : payload );
-      newArguments.push( ...extras );
+        eventDate: Date.now()
+      };
+
+      const newPayload = createEnvelope ? { ...eventFields, ...getContext(), payload } : { ...eventFields, ...payload };
+      return Reflect.apply( target, thisArg, [ eventName, newPayload, ...rest ] );
     }
+  } );
+};
 
-    return Reflect.apply( target, thisArg, [ eventName, ...newArguments ] );
-  }
-} );
+const catalogWfFilter = ( _, payload ) => payload?.workflowDetails?.workflowType !== WORKFLOW_CATALOG;
 
-export const messageBus = emitter;
+// Main bus is not used inside steps, so it doesn't need context
+proxyBus( { bus: mainEventBus, createEnvelope: false, filter: catalogWfFilter } );
+// This receives SDK and user events from within steps, so add context to it
+proxyBus( { bus: stepEventBus, createEnvelope: true } );
+
+export { mainEventBus, stepEventBus };

--- a/sdk/core/src/bus.spec.js
+++ b/sdk/core/src/bus.spec.js
@@ -9,6 +9,11 @@ vi.mock( '#async_storage', () => ( {
 import { mainEventBus, stepEventBus } from './bus.js';
 
 const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const ACTIVITY_CONTEXT = {
+  activityInfo: { activityId: 'activity-id' },
+  workflowDetails: { workflowId: 'workflow-id' },
+  outputActivityKind: 'step'
+};
 
 describe( 'event buses', () => {
   beforeEach( () => {
@@ -94,15 +99,13 @@ describe( 'event buses', () => {
   } );
 
   describe( 'stepEventBus', () => {
+    beforeEach( () => {
+      loadMock.mockReturnValue( ACTIVITY_CONTEXT );
+    } );
+
     it( 'wraps payloads with event metadata and activity context', () => {
       const handler = vi.fn();
       const payload = { foo: 'bar' };
-      const context = {
-        activityInfo: { activityId: 'activity-id' },
-        workflowDetails: { workflowId: 'workflow-id' },
-        outputActivityKind: 'step'
-      };
-      loadMock.mockReturnValue( context );
       stepEventBus.on( 'test:event', handler );
 
       stepEventBus.emit( 'test:event', payload );
@@ -110,8 +113,22 @@ describe( 'event buses', () => {
       expect( handler ).toHaveBeenCalledWith( {
         eventId: expect.stringMatching( UUID_V4_REGEX ),
         eventDate: expect.any( Number ),
-        ...context,
+        ...ACTIVITY_CONTEXT,
         payload
+      } );
+    } );
+
+    it( 'omits activity fields outside activity context', () => {
+      const handler = vi.fn();
+      loadMock.mockReturnValue( undefined );
+      stepEventBus.on( 'test:event', handler );
+
+      stepEventBus.emit( 'test:event', { foo: 'bar' } );
+
+      expect( handler ).toHaveBeenCalledWith( {
+        eventId: expect.stringMatching( UUID_V4_REGEX ),
+        eventDate: expect.any( Number ),
+        payload: { foo: 'bar' }
       } );
     } );
 

--- a/sdk/core/src/bus.spec.js
+++ b/sdk/core/src/bus.spec.js
@@ -1,32 +1,157 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { messageBus } from './bus.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const loadMock = vi.hoisted( () => vi.fn() );
+
+vi.mock( '#async_storage', () => ( {
+  Storage: { load: loadMock }
+} ) );
+
+import { mainEventBus, stepEventBus } from './bus.js';
 
 const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-describe( 'messageBus', () => {
+describe( 'event buses', () => {
   beforeEach( () => {
-    messageBus.removeAllListeners();
+    mainEventBus.removeAllListeners();
+    stepEventBus.removeAllListeners();
+    loadMock.mockReset();
   } );
 
-  describe( 'eventId stamping', () => {
-    it( 'stamps a UUID v4 eventId on every object payload', () => {
+  afterEach( () => {
+    vi.useRealTimers();
+  } );
+
+  describe( 'mainEventBus', () => {
+    it( 'adds event metadata to payload fields', () => {
       const handler = vi.fn();
-      messageBus.on( 'test:event', handler );
+      const now = new Date( '2026-06-02T12:00:00.000Z' );
+      vi.useFakeTimers();
+      vi.setSystemTime( now );
+      mainEventBus.on( 'test:event', handler );
 
-      messageBus.emit( 'test:event', { foo: 'bar' } );
+      mainEventBus.emit( 'test:event', { foo: 'bar' } );
 
-      expect( handler ).toHaveBeenCalledWith( expect.objectContaining( {
-        foo: 'bar',
-        eventId: expect.stringMatching( UUID_V4_REGEX )
+      expect( handler ).toHaveBeenCalledWith( {
+        eventId: expect.stringMatching( UUID_V4_REGEX ),
+        eventDate: now.getTime(),
+        foo: 'bar'
+      } );
+    } );
+
+    it( 'preserves caller-supplied event metadata', () => {
+      const handler = vi.fn();
+      mainEventBus.on( 'test:event', handler );
+
+      mainEventBus.emit( 'test:event', { eventId: 'fixed-id', eventDate: 1234 } );
+
+      expect( handler ).toHaveBeenCalledWith( {
+        eventId: 'fixed-id',
+        eventDate: 1234
+      } );
+    } );
+
+    it( 'does not mutate the caller-supplied payload', () => {
+      const handler = vi.fn();
+      const payload = { foo: 'bar' };
+      mainEventBus.on( 'test:event', handler );
+
+      mainEventBus.emit( 'test:event', payload );
+
+      expect( handler.mock.calls[0][0] ).not.toBe( payload );
+      expect( payload ).toEqual( { foo: 'bar' } );
+    } );
+
+    it( 'does not attach activity context', () => {
+      const handler = vi.fn();
+      loadMock.mockReturnValue( {
+        activityInfo: { activityId: 'activity-id' },
+        workflowDetails: { workflowId: 'workflow-id' },
+        outputActivityKind: 'step'
+      } );
+      mainEventBus.on( 'test:event', handler );
+
+      mainEventBus.emit( 'test:event', { foo: 'bar' } );
+
+      expect( handler ).toHaveBeenCalledWith( expect.not.objectContaining( {
+        activityInfo: expect.anything(),
+        workflowDetails: expect.anything(),
+        outputActivityKind: expect.anything()
       } ) );
+      expect( loadMock ).not.toHaveBeenCalled();
+    } );
+
+    it( 'filters catalog workflow events', () => {
+      const handler = vi.fn();
+      mainEventBus.on( 'workflow:start', handler );
+
+      const emitted = mainEventBus.emit( 'workflow:start', {
+        workflowDetails: { workflowType: '$catalog' }
+      } );
+
+      expect( emitted ).toBe( false );
+      expect( handler ).not.toHaveBeenCalled();
+    } );
+  } );
+
+  describe( 'stepEventBus', () => {
+    it( 'wraps payloads with event metadata and activity context', () => {
+      const handler = vi.fn();
+      const payload = { foo: 'bar' };
+      const context = {
+        activityInfo: { activityId: 'activity-id' },
+        workflowDetails: { workflowId: 'workflow-id' },
+        outputActivityKind: 'step'
+      };
+      loadMock.mockReturnValue( context );
+      stepEventBus.on( 'test:event', handler );
+
+      stepEventBus.emit( 'test:event', payload );
+
+      expect( handler ).toHaveBeenCalledWith( {
+        eventId: expect.stringMatching( UUID_V4_REGEX ),
+        eventDate: expect.any( Number ),
+        ...context,
+        payload
+      } );
+    } );
+
+    it( 'preserves arbitrary payloads unchanged inside the envelope', () => {
+      const handler = vi.fn();
+      const array = [ 1, 2, 3 ];
+      const instance = new Date();
+      stepEventBus.on( 'test:event', handler );
+
+      stepEventBus.emit( 'test:event', 'value' );
+      stepEventBus.emit( 'test:event', array );
+      stepEventBus.emit( 'test:event', instance );
+      stepEventBus.emit( 'test:event' );
+
+      expect( handler.mock.calls[0][0].payload ).toBe( 'value' );
+      expect( handler.mock.calls[1][0].payload ).toBe( array );
+      expect( handler.mock.calls[2][0].payload ).toBe( instance );
+      expect( handler.mock.calls[3][0] ).toHaveProperty( 'payload', undefined );
+    } );
+
+    it( 'keeps payload metadata separate from envelope metadata', () => {
+      const handler = vi.fn();
+      const payload = { eventId: 'payload-id', eventDate: 1234 };
+      stepEventBus.on( 'test:event', handler );
+
+      stepEventBus.emit( 'test:event', payload );
+
+      const envelope = handler.mock.calls[0][0];
+      expect( envelope.eventId ).toMatch( UUID_V4_REGEX );
+      expect( envelope.eventId ).not.toBe( payload.eventId );
+      expect( envelope.eventDate ).not.toBe( payload.eventDate );
+      expect( envelope.payload ).toBe( payload );
     } );
 
     it( 'gives distinct emits distinct eventIds', () => {
       const handler = vi.fn();
-      messageBus.on( 'test:event', handler );
+      stepEventBus.on( 'test:event', handler );
 
-      messageBus.emit( 'test:event', { i: 1 } );
-      messageBus.emit( 'test:event', { i: 2 } );
+      stepEventBus.emit( 'test:event', { i: 1 } );
+      stepEventBus.emit( 'test:event', { i: 2 } );
 
       const first = handler.mock.calls[0][0].eventId;
       const second = handler.mock.calls[1][0].eventId;
@@ -35,101 +160,17 @@ describe( 'messageBus', () => {
       expect( first ).not.toBe( second );
     } );
 
-    it( 'preserves a caller-supplied eventId (deterministic retry case)', () => {
+    it( 'forwards additional positional arguments unchanged', () => {
       const handler = vi.fn();
-      messageBus.on( 'test:event', handler );
+      stepEventBus.on( 'test:event', handler );
 
-      messageBus.emit( 'test:event', { eventId: 'fixed-id', foo: 'bar' } );
-
-      expect( handler ).toHaveBeenCalledWith( expect.objectContaining( {
-        eventId: 'fixed-id',
-        foo: 'bar'
-      } ) );
-    } );
-
-    it( 'stamps eventDate on every object payload', () => {
-      const handler = vi.fn();
-      const now = new Date( '2026-06-02T12:00:00.000Z' );
-      vi.useFakeTimers();
-      vi.setSystemTime( now );
-      messageBus.on( 'test:event', handler );
-
-      messageBus.emit( 'test:event', { foo: 'bar' } );
-
-      expect( handler ).toHaveBeenCalledWith( expect.objectContaining( {
-        eventDate: now.getTime(),
-        foo: 'bar'
-      } ) );
-
-      vi.useRealTimers();
-    } );
-
-    it( 'preserves a caller-supplied eventDate', () => {
-      const handler = vi.fn();
-      messageBus.on( 'test:event', handler );
-
-      messageBus.emit( 'test:event', { eventDate: 1234, foo: 'bar' } );
-
-      expect( handler ).toHaveBeenCalledWith( expect.objectContaining( {
-        eventDate: 1234,
-        foo: 'bar'
-      } ) );
-    } );
-
-    it( 'does not mutate the caller-supplied payload object', () => {
-      const handler = vi.fn();
-      messageBus.on( 'test:event', handler );
-
-      const payload = { foo: 'bar' };
-      messageBus.emit( 'test:event', payload );
-
-      expect( payload ).not.toHaveProperty( 'eventId' );
-      expect( payload ).not.toHaveProperty( 'eventDate' );
-    } );
-  } );
-
-  describe( 'pass-through behavior', () => {
-    it( 'passes primitive payloads through unchanged', () => {
-      const handler = vi.fn();
-      messageBus.on( 'test:event', handler );
-
-      messageBus.emit( 'test:event', 'a-string' );
-      messageBus.emit( 'test:event', 42 );
-      messageBus.emit( 'test:event', true );
-
-      expect( handler ).toHaveBeenNthCalledWith( 1, 'a-string' );
-      expect( handler ).toHaveBeenNthCalledWith( 2, 42 );
-      expect( handler ).toHaveBeenNthCalledWith( 3, true );
-    } );
-
-    it( 'passes null and undefined payloads through unchanged', () => {
-      const handler = vi.fn();
-      messageBus.on( 'test:event', handler );
-
-      messageBus.emit( 'test:event', null );
-      messageBus.emit( 'test:event' );
-
-      expect( handler ).toHaveBeenNthCalledWith( 1, null );
-      expect( handler ).toHaveBeenNthCalledWith( 2 );
-    } );
-
-    it( 'passes array payloads through unchanged (no key injection)', () => {
-      const handler = vi.fn();
-      messageBus.on( 'test:event', handler );
-
-      messageBus.emit( 'test:event', [ 1, 2, 3 ] );
-
-      expect( handler ).toHaveBeenCalledWith( [ 1, 2, 3 ] );
-    } );
-
-    it( 'forwards additional positional args untouched', () => {
-      const handler = vi.fn();
-      messageBus.on( 'test:event', handler );
-
-      messageBus.emit( 'test:event', { foo: 'bar' }, 'extra', 99 );
+      stepEventBus.emit( 'test:event', { foo: 'bar' }, 'extra', 99 );
 
       expect( handler ).toHaveBeenCalledWith(
-        expect.objectContaining( { foo: 'bar', eventId: expect.stringMatching( UUID_V4_REGEX ) } ),
+        expect.objectContaining( {
+          eventId: expect.stringMatching( UUID_V4_REGEX ),
+          payload: { foo: 'bar' }
+        } ),
         'extra',
         99
       );

--- a/sdk/core/src/hooks/index.d.ts
+++ b/sdk/core/src/hooks/index.d.ts
@@ -116,7 +116,7 @@ export interface HookPayloadBase {
 export interface ActivityPayloadBase extends HookPayloadBase {
   /** Temporal's activityInfo(). */
   activityInfo: Info;
-  /** Output component kind for the activity, e.g. step or evaluator. */
+  /** Output component kind for the activity, e.g. step, evaluator, or internal_step. */
   outputActivityKind: string;
 }
 
@@ -233,8 +233,6 @@ export declare function onWorkflowError( handler: ( payload: WorkflowErrorHookPa
 /**
  * Register a handler to be invoked when an activity starts.
  *
- * Excludes internal activities.
- *
  * @param handler - Function called with the activity start payload.
  */
 export declare function onActivityStart( handler: ( payload: ActivityStartHookPayload ) => void ): void;
@@ -242,16 +240,12 @@ export declare function onActivityStart( handler: ( payload: ActivityStartHookPa
 /**
  * Register a handler to be invoked when an activity completes successfully.
  *
- * Excludes internal activities.
- *
  * @param handler - Function called with the activity end payload.
  */
 export declare function onActivityEnd( handler: ( payload: ActivityEndHookPayload ) => void ): void;
 
 /**
  * Register a handler to be invoked when an activity fails.
- *
- * Excludes internal activities.
  *
  * @param handler - Function called with the activity error payload.
  */
@@ -264,11 +258,25 @@ export interface OnHookEnvelope extends HookPayloadBase {
   /** Temporal's activityInfo(). */
   activityInfo: Info;
   /** Output component kind for the activity, e.g. step, evaluator, or internal_step. */
-  outputActivityKind?: string;
+  outputActivityKind: string;
 }
 
-export type OnHookPayload<TAttributes extends Record<string, unknown> = Record<string, unknown>> =
-  OnHookEnvelope & TAttributes;
+export type OnHookPayload<TPayload = unknown> =
+  OnHookEnvelope & {
+    /** Event-specific payload supplied by the SDK or emit(). */
+    payload: TPayload | undefined;
+  };
+
+/**
+ * Emit a custom event from the current activity.
+ *
+ * @param eventName - The name of the event to emit.
+ * @param payload - Optional value forwarded to on() handlers.
+ */
+export declare function emit(
+  eventName: string,
+  payload?: unknown
+): boolean;
 
 /**
  * Register a handler to be invoked when a given event happens
@@ -276,7 +284,7 @@ export type OnHookPayload<TAttributes extends Record<string, unknown> = Record<s
  * @param eventName - The name of the event to subscribe
  * @param handler - Function called with the event payload
  */
-export declare function on<TAttributes extends Record<string, unknown> = Record<string, unknown>>(
+export declare function on<TPayload = unknown>(
   eventName: string,
-  handler: ( payload: OnHookPayload<TAttributes> ) => void
+  handler: ( event: OnHookPayload<TPayload> ) => void
 ): void;

--- a/sdk/core/src/hooks/index.d.ts
+++ b/sdk/core/src/hooks/index.d.ts
@@ -99,35 +99,19 @@ export interface Aggregations {
 }
 
 /**
- * Common lifecycle hook payload fields for events associated with a workflow.
+ * Common hook payload fields
  */
 export interface HookPayloadBase {
   /** UUID v4 stamped per emit. Stable per-emit idempotency key. */
   eventId: string;
   /** Timestamp of the event */
   eventDate: number;
-  /** Information about the current workflow execution */
-  workflowDetails: WorkflowDetails;
-}
-
-/**
- * Common hook payload fields for events associated with an activity.
- */
-export interface ActivityPayloadBase extends HookPayloadBase {
-  /** Temporal's activityInfo(). */
-  activityInfo: Info;
-  /** Output component kind for the activity, e.g. step, evaluator, or internal_step. */
-  outputActivityKind: string;
 }
 
 /**
  * Payload passed to the onError() handler when a workflow, activity or runtime error occurs.
  */
-export interface ErrorHookPayload {
-  /** UUID v4 stamped per emit. Stable per-emit idempotency key. */
-  eventId: string;
-  /** Timestamp of the event */
-  eventDate: number;
+export interface ErrorHookPayload extends HookPayloadBase {
   /** Origin of the error: workflow execution, activity execution, or runtime. */
   source: 'workflow' | 'activity' | 'runtime';
   /** Information about the current workflow execution */
@@ -143,37 +127,52 @@ export interface ErrorHookPayload {
 }
 
 /**
+ * Common hook payload fields for events associated with an workflow.
+ */
+export interface WorkflowPayloadBase extends HookPayloadBase {
+  /** Information about the current workflow execution */
+  workflowDetails: WorkflowDetails;
+}
+
+/**
  * Payload passed to the onWorkflowStart() handler when a workflow run begins.
  */
-export type WorkflowStartHookPayload = HookPayloadBase;
+export type WorkflowStartHookPayload = WorkflowPayloadBase;
 
 /**
  * Payload passed to the onWorkflowEnd() handler when a workflow run completes successfully.
  */
-export type WorkflowEndHookPayload = HookPayloadBase;
+export type WorkflowEndHookPayload = WorkflowPayloadBase;
 
 /**
  * Payload passed to the onWorkflowError() handler when a workflow run fails.
  */
-export interface WorkflowErrorHookPayload extends HookPayloadBase {
+export interface WorkflowErrorHookPayload extends WorkflowPayloadBase {
   /** The error thrown. */
   error: Error;
 }
 
 /**
- * Common activity lifecycle hook payload fields.
+ * Common hook payload fields for events associated with an activity.
  */
-export type ActivityHookPayload = ActivityPayloadBase;
+export interface ActivityPayloadBase extends HookPayloadBase {
+  /** Information about the current workflow execution */
+  workflowDetails: WorkflowDetails;
+  /** Temporal's activityInfo(). */
+  activityInfo: Info;
+  /** Output component kind for the activity, e.g. step, evaluator, or internal_step. */
+  outputActivityKind: string;
+}
 
 /**
  * Payload passed to the onActivityStart() handler when an activity starts.
  */
-export type ActivityStartHookPayload = ActivityHookPayload;
+export type ActivityStartHookPayload = ActivityPayloadBase;
 
 /**
  * Payload passed to the onActivityEnd() handler when an activity completes successfully.
  */
-export interface ActivityEndHookPayload extends ActivityHookPayload {
+export interface ActivityEndHookPayload extends ActivityPayloadBase {
   /** Attribute totals collected during the activity execution. */
   aggregations: Aggregations | null;
 }
@@ -181,7 +180,7 @@ export interface ActivityEndHookPayload extends ActivityHookPayload {
 /**
  * Payload passed to the onActivityError() handler when an activity fails.
  */
-export interface ActivityErrorHookPayload extends ActivityHookPayload {
+export interface ActivityErrorHookPayload extends ActivityPayloadBase {
   /** Attribute totals collected during the activity execution. */
   aggregations: Aggregations | null;
   /** The error thrown. */
@@ -251,21 +250,17 @@ export declare function onActivityEnd( handler: ( payload: ActivityEndHookPayloa
  */
 export declare function onActivityError( handler: ( payload: ActivityErrorHookPayload ) => void ): void;
 
-/**
- * Framework-managed envelope added to payloads passed to on() handlers.
- */
-export interface OnHookEnvelope extends HookPayloadBase {
-  /** Temporal's activityInfo(). */
-  activityInfo: Info;
-  /** Output component kind for the activity, e.g. step, evaluator, or internal_step. */
-  outputActivityKind: string;
-}
-
-export type OnHookPayload<TPayload = unknown> =
-  OnHookEnvelope & {
-    /** Event-specific payload supplied by the SDK or emit(). */
-    payload: TPayload | undefined;
-  };
+/** Framework metadata, optional activity context, and the emitted payload. */
+export type ExternalHookPayload<TPayload = unknown> = HookPayloadBase & {
+  /** Information about the current workflow execution, when emitted from an activity. */
+  workflowDetails?: WorkflowDetails;
+  /** Temporal's activityInfo(), when emitted from an activity. */
+  activityInfo?: Info;
+  /** Output component kind, when emitted from an activity. */
+  outputActivityKind?: string;
+  /** The emitted payload */
+  payload: TPayload | undefined;
+};
 
 /**
  * Emit a custom event from the current activity.
@@ -286,5 +281,5 @@ export declare function emit(
  */
 export declare function on<TPayload = unknown>(
   eventName: string,
-  handler: ( event: OnHookPayload<TPayload> ) => void
+  handler: ( event: ExternalHookPayload<TPayload> ) => void
 ): void;

--- a/sdk/core/src/hooks/index.d.ts
+++ b/sdk/core/src/hooks/index.d.ts
@@ -135,7 +135,7 @@ export interface ErrorHookPayload {
   /** Temporal's activityInfo(). If source is activity */
   activityInfo?: Info;
   /** Output component kind for the activity, e.g. step, evaluator, or internal_step. */
-  outputActivityKind?: string;
+  outputActivityKind: string;
   /** Attribute totals collected during the activity execution. */
   aggregations?: Aggregations | null;
   /** The error thrown. */

--- a/sdk/core/src/hooks/index.js
+++ b/sdk/core/src/hooks/index.js
@@ -1,17 +1,17 @@
-import { messageBus } from '#bus';
-import { BusEventType, ComponentType, WORKFLOW_CATALOG } from '#consts';
+import { mainEventBus, stepEventBus } from '#bus';
+import { BusEventType } from '#consts';
 import { createChildLogger } from '#logger';
 
 const log = createChildLogger( 'Hooks' );
 
 /**
- * Invokes an external hook handler function with a try catch around it
+ * Invokes a function within a try catch and log the error
  *
  * @param {Function} fn
  * @param {any} args - Args to invoke the function with
  * @param {string} hookName - hookName to identify this hook function in the logs
  */
-const safeInvoke = async ( fn, args, hookName ) => {
+const callHookCb = async ( fn, args, hookName ) => {
   try {
     await fn( args );
   } catch ( error ) {
@@ -19,50 +19,55 @@ const safeInvoke = async ( fn, args, hookName ) => {
   }
 };
 
-/** Triggers on any errors: workflow, activity and runtime */
-export const onError = handler => {
-  messageBus.on( BusEventType.ACTIVITY_ERROR, async payload =>
-    safeInvoke( handler, { source: 'activity', ...payload }, 'onError' ) );
-  messageBus.on( BusEventType.WORKFLOW_ERROR, async payload =>
-    safeInvoke( handler, { source: 'workflow', ...payload }, 'onError' ) );
-  messageBus.on( BusEventType.RUNTIME_ERROR, async payload =>
-    safeInvoke( handler, { source: 'runtime', ...payload }, 'onError' ) );
+// General Life-cycle
+// --------------------------------------
+const onError = cb => {
+  mainEventBus.on( BusEventType.ACTIVITY_ERROR, async payload =>
+    callHookCb( cb, { source: 'activity', ...payload }, 'onError' ) );
+  mainEventBus.on( BusEventType.WORKFLOW_ERROR, async payload =>
+    callHookCb( cb, { source: 'workflow', ...payload }, 'onError' ) );
+  mainEventBus.on( BusEventType.RUNTIME_ERROR, async payload =>
+    callHookCb( cb, { source: 'runtime', ...payload }, 'onError' ) );
 };
 
-/** Listen to worker before start events */
-export const onBeforeWorkerStart = handler => messageBus.on( BusEventType.WORKER_BEFORE_START, () =>
-  safeInvoke( handler, undefined, 'onBeforeWorkerStart' ) );
+const onBeforeWorkerStart = cb => mainEventBus.on( BusEventType.WORKER_BEFORE_START, () => callHookCb( cb, undefined, 'onBeforeWorkerStart' ) );
 
-/** Catalog workflow events should not be emitted */
-const shouldEmitWorkflowEvent = workflowDetails => WORKFLOW_CATALOG !== workflowDetails.workflowType;
+// Workflow Life-cycle
+// --------------------------------------
+const onWorkflowStart = cb => mainEventBus.on( BusEventType.WORKFLOW_START, payload => callHookCb( cb, payload, 'onWorkflowStart' ) );
+const onWorkflowEnd = cb => mainEventBus.on( BusEventType.WORKFLOW_END, payload => callHookCb( cb, payload, 'onWorkflowEnd' ) );
+const onWorkflowError = cb => mainEventBus.on( BusEventType.WORKFLOW_ERROR, payload => callHookCb( cb, payload, 'onWorkflowError' ) );
 
-/** Listen to workflow start events, excludes catalog workflow */
-export const onWorkflowStart = handler => messageBus.on( BusEventType.WORKFLOW_START, ( { workflowDetails, ...eventFields } ) =>
-  shouldEmitWorkflowEvent( workflowDetails ) ? safeInvoke( handler, { workflowDetails, ...eventFields }, 'onWorkflowStart' ) : null );
+// Activity Life-cycle
+// --------------------------------------
+const onActivityStart = cb => mainEventBus.on( BusEventType.ACTIVITY_START, fields => callHookCb( cb, fields, 'onActivityStart' ) );
+const onActivityEnd = cb => mainEventBus.on( BusEventType.ACTIVITY_END, fields => callHookCb( cb, fields, 'onActivityEnd' ) );
+const onActivityError = cb => mainEventBus.on( BusEventType.ACTIVITY_ERROR, fields => callHookCb( cb, fields, 'onActivityError' ) );
 
-/** Listen to workflow end events, excludes catalog workflow */
-export const onWorkflowEnd = handler => messageBus.on( BusEventType.WORKFLOW_END, ( { workflowDetails, ...eventFields } ) =>
-  shouldEmitWorkflowEvent( workflowDetails ) ? safeInvoke( handler, { workflowDetails, ...eventFields }, 'onWorkflowEnd' ) : null );
+// Generic Events
+// --------------------------------------
+/** Listen to both sdk and custom events */
+const on = ( eventName, cb ) => {
+  stepEventBus.on( `sdk:${eventName}`, payload => callHookCb( cb, payload, eventName ) );
+  stepEventBus.on( `usr:${eventName}`, payload => callHookCb( cb, payload, eventName ) );
+};
 
-/** Listen to workflow error events, excludes catalog workflow */
-export const onWorkflowError = handler => messageBus.on( BusEventType.WORKFLOW_ERROR, ( { workflowDetails, ...eventFields } ) =>
-  shouldEmitWorkflowEvent( workflowDetails ) ? safeInvoke( handler, { workflowDetails, ...eventFields }, 'onWorkflowError' ) : null );
+/**
+ * Emits a custom event
+ * @param {string} eventName
+ * @param {any} payload
+ */
+const emit = ( eventName, payload ) => stepEventBus.emit( `usr:${eventName}`, payload );
 
-/** Internal activities do not trigger hooks */
-const shouldEmitActivityEvent = outputActivityKind => outputActivityKind !== ComponentType.INTERNAL_STEP;
-
-/** Listen to workflow start events, excludes catalog workflow */
-export const onActivityStart = handler => messageBus.on( BusEventType.ACTIVITY_START, ( { outputActivityKind, ...eventFields } ) =>
-  shouldEmitActivityEvent( outputActivityKind ) ? safeInvoke( handler, { outputActivityKind, ...eventFields }, 'onActivityStart' ) : null );
-
-/** Listen to workflow end events, excludes catalog workflow */
-export const onActivityEnd = handler => messageBus.on( BusEventType.ACTIVITY_END, ( { outputActivityKind, ...eventFields } ) =>
-  shouldEmitActivityEvent( outputActivityKind ) ? safeInvoke( handler, { outputActivityKind, ...eventFields }, 'onActivityEnd' ) : null );
-
-/** Listen to workflow error events, excludes catalog workflow */
-export const onActivityError = handler => messageBus.on( BusEventType.ACTIVITY_ERROR, ( { outputActivityKind, ...eventFields } ) =>
-  shouldEmitActivityEvent( outputActivityKind ) ? safeInvoke( handler, { outputActivityKind, ...eventFields }, 'onActivityError' ) : null );
-
-/** Generic listener for events emitted elsewhere (outside core) */
-export const on = ( eventName, handler ) => messageBus.on( `external:${eventName}`, payload =>
-  safeInvoke( handler, payload, eventName ) );
+export {
+  emit,
+  on,
+  onActivityEnd,
+  onActivityError,
+  onActivityStart,
+  onBeforeWorkerStart,
+  onError,
+  onWorkflowEnd,
+  onWorkflowError,
+  onWorkflowStart
+};

--- a/sdk/core/src/hooks/index.spec.js
+++ b/sdk/core/src/hooks/index.spec.js
@@ -1,22 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { BusEventType, ComponentType, WORKFLOW_CATALOG } from '#consts';
+import { BusEventType } from '#consts';
 
 const logErrorMock = vi.hoisted( () => vi.fn() );
 const createChildLoggerMock = vi.hoisted( () =>
   vi.fn( () => ( { error: logErrorMock } ) )
 );
 
-const onHandlers = vi.hoisted( () => ( {} ) );
-const messageBusMock = vi.hoisted( () => ( {
+const mainOnHandlers = vi.hoisted( () => ( {} ) );
+const stepOnHandlers = vi.hoisted( () => ( {} ) );
+const mainEventBusMock = vi.hoisted( () => ( {
   on: vi.fn( ( eventType, handler ) => {
-    onHandlers[eventType] = handler;
+    mainOnHandlers[eventType] = handler;
+  } )
+} ) );
+const stepEventBusMock = vi.hoisted( () => ( {
+  emit: vi.fn( () => true ),
+  on: vi.fn( ( eventType, handler ) => {
+    stepOnHandlers[eventType] = handler;
   } )
 } ) );
 
 vi.mock( '#logger', () => ( { createChildLogger: createChildLoggerMock } ) );
-vi.mock( '#bus', () => ( { messageBus: messageBusMock } ) );
+vi.mock( '#bus', () => ( {
+  mainEventBus: mainEventBusMock,
+  stepEventBus: stepEventBusMock
+} ) );
 
 import {
+  emit,
   on,
   onActivityEnd,
   onActivityError,
@@ -38,11 +49,6 @@ const workflowDetails = {
   attempt: 1
 };
 
-const catalogWorkflowDetails = {
-  ...workflowDetails,
-  workflowType: WORKFLOW_CATALOG
-};
-
 const activityInfo = {
   activityId: 'act-1',
   activityType: 'wf#step',
@@ -61,8 +67,11 @@ const aggregations = {
 describe( 'hooks/index', () => {
   beforeEach( () => {
     vi.clearAllMocks();
-    Object.keys( onHandlers ).forEach( k => {
-      delete onHandlers[k];
+    Object.keys( mainOnHandlers ).forEach( k => {
+      delete mainOnHandlers[k];
+    } );
+    Object.keys( stepOnHandlers ).forEach( k => {
+      delete stepOnHandlers[k];
     } );
   } );
 
@@ -71,9 +80,9 @@ describe( 'hooks/index', () => {
       const handler = vi.fn().mockResolvedValue( undefined );
       onError( handler );
 
-      expect( messageBusMock.on ).toHaveBeenCalledWith( BusEventType.ACTIVITY_ERROR, expect.any( Function ) );
-      expect( messageBusMock.on ).toHaveBeenCalledWith( BusEventType.WORKFLOW_ERROR, expect.any( Function ) );
-      expect( messageBusMock.on ).toHaveBeenCalledWith( BusEventType.RUNTIME_ERROR, expect.any( Function ) );
+      expect( mainEventBusMock.on ).toHaveBeenCalledWith( BusEventType.ACTIVITY_ERROR, expect.any( Function ) );
+      expect( mainEventBusMock.on ).toHaveBeenCalledWith( BusEventType.WORKFLOW_ERROR, expect.any( Function ) );
+      expect( mainEventBusMock.on ).toHaveBeenCalledWith( BusEventType.RUNTIME_ERROR, expect.any( Function ) );
     } );
 
     it( 'invokes handler with activity-shaped payload, forwarding bus fields', async () => {
@@ -81,7 +90,7 @@ describe( 'hooks/index', () => {
       onError( handler );
 
       const err = new Error( 'act-fail' );
-      await onHandlers[BusEventType.ACTIVITY_ERROR]( {
+      await mainOnHandlers[BusEventType.ACTIVITY_ERROR]( {
         eventId: 'evt-act-1',
         eventDate,
         activityInfo,
@@ -108,7 +117,7 @@ describe( 'hooks/index', () => {
       onError( handler );
 
       const err = new Error( 'wf-fail' );
-      await onHandlers[BusEventType.WORKFLOW_ERROR]( {
+      await mainOnHandlers[BusEventType.WORKFLOW_ERROR]( {
         eventId: 'evt-wf-1',
         eventDate,
         workflowDetails,
@@ -131,7 +140,7 @@ describe( 'hooks/index', () => {
       onError( handler );
 
       const error = new Error( 'rt' );
-      await onHandlers[BusEventType.RUNTIME_ERROR]( { eventId: 'evt-rt-1', eventDate, error } );
+      await mainOnHandlers[BusEventType.RUNTIME_ERROR]( { eventId: 'evt-rt-1', eventDate, error } );
 
       expect( handler ).toHaveBeenCalledWith( { eventId: 'evt-rt-1', eventDate, source: 'runtime', error } );
     } );
@@ -142,68 +151,35 @@ describe( 'hooks/index', () => {
       const handler = vi.fn().mockResolvedValue( undefined );
       onBeforeWorkerStart( handler );
 
-      expect( messageBusMock.on ).toHaveBeenCalledWith( BusEventType.WORKER_BEFORE_START, expect.any( Function ) );
-      await onHandlers[BusEventType.WORKER_BEFORE_START]();
+      expect( mainEventBusMock.on ).toHaveBeenCalledWith( BusEventType.WORKER_BEFORE_START, expect.any( Function ) );
+      await mainOnHandlers[BusEventType.WORKER_BEFORE_START]();
 
       expect( handler ).toHaveBeenCalledWith( undefined );
     } );
   } );
 
-  describe( 'onWorkflowStart', () => {
-    it( 'skips catalog workflow and forwards bus fields for real workflows', async () => {
+  describe( 'workflow lifecycle hooks', () => {
+    const cases = [
+      [ 'onWorkflowStart', onWorkflowStart, BusEventType.WORKFLOW_START, {} ],
+      [ 'onWorkflowEnd', onWorkflowEnd, BusEventType.WORKFLOW_END, {} ],
+      [ 'onWorkflowError', onWorkflowError, BusEventType.WORKFLOW_ERROR, { error: new Error( 'workflow failed' ) } ]
+    ];
+
+    it.each( cases )( '%s forwards bus fields', async ( _name, registerHook, eventType, extraFields ) => {
       const handler = vi.fn().mockResolvedValue( undefined );
-      onWorkflowStart( handler );
+      const payload = {
+        eventId: 'evt-workflow-1',
+        eventDate,
+        workflowDetails,
+        extra: 'passthrough',
+        ...extraFields
+      };
+      registerHook( handler );
 
-      await Promise.resolve( onHandlers[BusEventType.WORKFLOW_START]( {
-        eventId: 'evt-ignored', eventDate, workflowDetails: catalogWorkflowDetails
-      } ) );
-      expect( handler ).not.toHaveBeenCalled();
+      expect( mainEventBusMock.on ).toHaveBeenCalledWith( eventType, expect.any( Function ) );
+      await mainOnHandlers[eventType]( payload );
 
-      await Promise.resolve( onHandlers[BusEventType.WORKFLOW_START]( {
-        eventId: 'evt-start-1', eventDate, workflowDetails, extra: 'passthrough'
-      } ) );
-      expect( handler ).toHaveBeenCalledWith( {
-        eventId: 'evt-start-1', eventDate, workflowDetails, extra: 'passthrough'
-      } );
-    } );
-  } );
-
-  describe( 'onWorkflowEnd', () => {
-    it( 'skips catalog workflow and forwards bus fields for real workflows', async () => {
-      const handler = vi.fn().mockResolvedValue( undefined );
-      onWorkflowEnd( handler );
-
-      await Promise.resolve( onHandlers[BusEventType.WORKFLOW_END]( {
-        eventId: 'evt-ignored', eventDate, workflowDetails: catalogWorkflowDetails
-      } ) );
-      expect( handler ).not.toHaveBeenCalled();
-
-      await Promise.resolve( onHandlers[BusEventType.WORKFLOW_END]( {
-        eventId: 'evt-end-1', eventDate, workflowDetails, extra: 'passthrough'
-      } ) );
-      expect( handler ).toHaveBeenCalledWith( {
-        eventId: 'evt-end-1', eventDate, workflowDetails, extra: 'passthrough'
-      } );
-    } );
-  } );
-
-  describe( 'onWorkflowError', () => {
-    it( 'skips catalog workflow and forwards bus fields for real workflows', async () => {
-      const handler = vi.fn().mockResolvedValue( undefined );
-      const err = new Error( 'wf' );
-      onWorkflowError( handler );
-
-      await Promise.resolve( onHandlers[BusEventType.WORKFLOW_ERROR]( {
-        eventId: 'evt-ignored', eventDate, workflowDetails: catalogWorkflowDetails, error: err
-      } ) );
-      expect( handler ).not.toHaveBeenCalled();
-
-      await Promise.resolve( onHandlers[BusEventType.WORKFLOW_ERROR]( {
-        eventId: 'evt-err-1', eventDate, workflowDetails, error: err, extra: 'passthrough'
-      } ) );
-      expect( handler ).toHaveBeenCalledWith( {
-        eventId: 'evt-err-1', eventDate, workflowDetails, error: err, extra: 'passthrough'
-      } );
+      expect( handler ).toHaveBeenCalledWith( payload );
     } );
   } );
 
@@ -214,53 +190,49 @@ describe( 'hooks/index', () => {
       [ 'onActivityError', onActivityError, BusEventType.ACTIVITY_ERROR, { error: new Error( 'activity failed' ) } ]
     ];
 
-    it.each( cases )( '%s skips internal activities and forwards bus fields', async ( _name, registerHook, eventType, extraFields = {} ) => {
+    it.each( cases )( '%s forwards internal activity bus fields', async ( _name, registerHook, eventType, extraFields = {} ) => {
       const handler = vi.fn().mockResolvedValue( undefined );
+      const payload = {
+        eventId: 'evt-activity-1',
+        eventDate,
+        activityInfo,
+        workflowDetails,
+        outputActivityKind: 'internal_step',
+        extra: 'passthrough',
+        ...extraFields
+      };
       registerHook( handler );
 
-      expect( messageBusMock.on ).toHaveBeenCalledWith( eventType, expect.any( Function ) );
+      expect( mainEventBusMock.on ).toHaveBeenCalledWith( eventType, expect.any( Function ) );
+      await mainOnHandlers[eventType]( payload );
 
-      await Promise.resolve( onHandlers[eventType]( {
-        eventId: 'evt-ignored',
-        eventDate,
-        activityInfo,
-        workflowDetails,
-        outputActivityKind: ComponentType.INTERNAL_STEP,
-        ...extraFields
-      } ) );
-      expect( handler ).not.toHaveBeenCalled();
-
-      await Promise.resolve( onHandlers[eventType]( {
-        eventId: 'evt-activity-1',
-        eventDate,
-        activityInfo,
-        workflowDetails,
-        outputActivityKind: ComponentType.STEP,
-        extra: 'passthrough',
-        ...extraFields
-      } ) );
-
-      expect( handler ).toHaveBeenCalledWith( {
-        eventId: 'evt-activity-1',
-        eventDate,
-        activityInfo,
-        workflowDetails,
-        outputActivityKind: ComponentType.STEP,
-        extra: 'passthrough',
-        ...extraFields
-      } );
+      expect( handler ).toHaveBeenCalledWith( payload );
     } );
   } );
 
   describe( 'on', () => {
-    it( 'subscribes to external event channel and forwards payload', async () => {
+    it( 'subscribes to SDK and user event channels and forwards payloads', async () => {
       const handler = vi.fn().mockResolvedValue( undefined );
       on( 'myEvent', handler );
 
-      expect( messageBusMock.on ).toHaveBeenCalledWith( 'external:myEvent', expect.any( Function ) );
-      await onHandlers['external:myEvent']( { foo: 1 } );
+      expect( stepEventBusMock.on ).toHaveBeenCalledWith( 'sdk:myEvent', expect.any( Function ) );
+      expect( stepEventBusMock.on ).toHaveBeenCalledWith( 'usr:myEvent', expect.any( Function ) );
+      await stepOnHandlers['sdk:myEvent']( { payload: { source: 'sdk' } } );
+      await stepOnHandlers['usr:myEvent']( { payload: { source: 'user' } } );
 
-      expect( handler ).toHaveBeenCalledWith( { foo: 1 } );
+      expect( handler ).toHaveBeenNthCalledWith( 1, { payload: { source: 'sdk' } } );
+      expect( handler ).toHaveBeenNthCalledWith( 2, { payload: { source: 'user' } } );
+    } );
+  } );
+
+  describe( 'emit', () => {
+    it( 'emits payloads on the user event channel', () => {
+      const payload = { foo: 1 };
+
+      const emitted = emit( 'myEvent', payload );
+
+      expect( stepEventBusMock.emit ).toHaveBeenCalledWith( 'usr:myEvent', payload );
+      expect( emitted ).toBe( true );
     } );
   } );
 } );

--- a/sdk/core/src/sdk/runtime/events.d.ts
+++ b/sdk/core/src/sdk/runtime/events.d.ts
@@ -9,5 +9,5 @@ export declare const Event: {
    * @param eventName - The name of the event to emit
    * @param payload - An optional payload to send to the event.
    */
-  emit( eventName: string, payload?: object ): void;
+  emit( eventName: string, payload?: object ): boolean;
 };

--- a/sdk/core/src/sdk/runtime/events.d.ts
+++ b/sdk/core/src/sdk/runtime/events.d.ts
@@ -2,14 +2,12 @@
  * Tools to interact with Events
  */
 export declare const Event: {
+
   /**
-   * Emits a custom event on the in-process message bus.
-   *
-   * When called inside an Output activity context, the framework automatically
-   * attaches `activityInfo`, `workflowDetails`, and `outputActivityKind` onto the emitted payload.
+   * Emits an event on step message bus.
    *
    * @param eventName - The name of the event to emit
-   * @param payload - An optional payload to send to the event
+   * @param payload - An optional payload to send to the event.
    */
   emit( eventName: string, payload?: object ): void;
 };

--- a/sdk/core/src/sdk/runtime/events.js
+++ b/sdk/core/src/sdk/runtime/events.js
@@ -1,18 +1,5 @@
-import { messageBus } from '#bus';
-import { Storage } from '#async_storage';
+import { stepEventBus } from '#bus';
 
 export const Event = {
-  emit: ( eventName, payload ) => {
-    const ctx = Storage.load();
-
-    messageBus.emit( `external:${eventName}`, {
-      ...payload ?? {},
-      ...( ctx && {
-        activityInfo: ctx.activityInfo,
-        workflowDetails: ctx.workflowDetails,
-        outputActivityKind: ctx.outputActivityKind
-      } )
-    } );
-  }
+  emit: ( eventName, payload ) => stepEventBus.emit( `sdk:${eventName}`, payload )
 };
-

--- a/sdk/core/src/sdk/runtime/events.spec.js
+++ b/sdk/core/src/sdk/runtime/events.spec.js
@@ -1,118 +1,40 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const loadMock = vi.hoisted( () => vi.fn() );
 const emitMock = vi.hoisted( () => vi.fn() );
 
-vi.mock( '#async_storage', () => ( {
-  Storage: { load: loadMock }
-} ) );
-
 vi.mock( '#bus', () => ( {
-  messageBus: { emit: emitMock }
+  stepEventBus: { emit: emitMock }
 } ) );
 
 import { Event } from './events.js';
 
-// `eventId` stamping is the bus layer's responsibility (see bus.spec.js).
-// Assertions here use `objectContaining` so they don't have to know about that enrichment.
 describe( 'Event.emit', () => {
   beforeEach( () => {
     vi.clearAllMocks();
   } );
 
-  it( 'forwards activityInfo, workflowDetails, and outputActivityKind from storage', () => {
-    const activityInfo = {
-      activityId: 'act-1',
-      activityType: 'step',
-      workflowExecution: { workflowId: 'wf-1', runId: 'run-1' },
-      workflowType: 'workflow'
-    };
-    const workflowDetails = {
-      workflowId: 'wf-1',
-      runId: 'run-1',
-      workflowType: 'workflow'
-    };
-    loadMock.mockReturnValue( {
-      activityInfo,
-      workflowDetails,
-      outputActivityKind: 'step'
-    } );
+  it( 'forwards class instance payloads unchanged', () => {
+    class Payload {
+      value = 'test';
+    }
+    const payload = new Payload();
 
-    Event.emit( 'cost:llm:request', { modelId: 'gpt-4o' } );
+    Event.emit( 'test:event', payload );
 
-    expect( emitMock ).toHaveBeenCalledWith( 'external:cost:llm:request', expect.objectContaining( {
-      activityInfo,
-      workflowDetails,
-      outputActivityKind: 'step',
-      modelId: 'gpt-4o'
-    } ) );
+    expect( emitMock ).toHaveBeenCalledWith( 'sdk:test:event', payload );
   } );
 
-  it( 'emits payload without context when storage is missing', () => {
-    loadMock.mockReturnValue( undefined );
+  it( 'emits plain object payloads on the SDK event channel', () => {
+    const payload = { modelId: 'gpt-4o' };
 
-    Event.emit( 'foo:bar', { x: 1 } );
+    Event.emit( 'cost:llm:request', payload );
 
-    expect( emitMock ).toHaveBeenCalledWith( 'external:foo:bar', { x: 1 } );
+    expect( emitMock ).toHaveBeenCalledWith( 'sdk:cost:llm:request', payload );
   } );
 
-  it( 'handles missing payload', () => {
-    const activityInfo = {
-      activityId: 'act-2',
-      activityType: 'step',
-      workflowExecution: { workflowId: 'wf-2', runId: 'run-2' },
-      workflowType: 'workflow'
-    };
-    const workflowDetails = {
-      workflowId: 'wf-2',
-      runId: 'run-2',
-      workflowType: 'workflow'
-    };
-    loadMock.mockReturnValue( {
-      activityInfo,
-      workflowDetails,
-      outputActivityKind: 'step'
-    } );
-
+  it( 'forwards a missing payload as undefined', () => {
     Event.emit( 'lifecycle:start' );
 
-    expect( emitMock ).toHaveBeenCalledWith( 'external:lifecycle:start', expect.objectContaining( {
-      activityInfo,
-      workflowDetails,
-      outputActivityKind: 'step'
-    } ) );
-  } );
-
-  it( 'does not let payload override activityInfo, workflowDetails, or outputActivityKind', () => {
-    const activityInfo = {
-      activityId: 'act-3',
-      activityType: 'step',
-      workflowExecution: { workflowId: 'wf-3', runId: 'run-3' },
-      workflowType: 'workflow'
-    };
-    const workflowDetails = {
-      workflowId: 'wf-3',
-      runId: 'run-3',
-      workflowType: 'workflow'
-    };
-    loadMock.mockReturnValue( {
-      activityInfo,
-      workflowDetails,
-      outputActivityKind: 'step'
-    } );
-
-    Event.emit( 'cost:http:request', {
-      activityInfo: { activityId: 'should-be-overridden' },
-      workflowDetails: { workflowId: 'should-be-overridden' },
-      outputActivityKind: 'should-be-overridden',
-      url: 'https://example.com'
-    } );
-
-    expect( emitMock ).toHaveBeenCalledWith( 'external:cost:http:request', expect.objectContaining( {
-      activityInfo,
-      workflowDetails,
-      outputActivityKind: 'step',
-      url: 'https://example.com'
-    } ) );
+    expect( emitMock ).toHaveBeenCalledWith( 'sdk:lifecycle:start', undefined );
   } );
 } );

--- a/sdk/core/src/worker/global_functions.js
+++ b/sdk/core/src/worker/global_functions.js
@@ -1,4 +1,4 @@
-import { messageBus } from '#bus';
+import { mainEventBus } from '#bus';
 import { ACTIVITY_LOGGER_SYMBOL, BusEventType } from '#consts';
 import { activityInfo as activityInfoFn } from '@temporalio/activity';
 import { assignImmutableProperty } from '#helpers/object';
@@ -9,6 +9,6 @@ import { assignImmutableProperty } from '#helpers/object';
 export const bindGlobalFunctions = () => {
   /** Defines the activity logger function, accessible in activity context via logger interface */
   assignImmutableProperty( globalThis, ACTIVITY_LOGGER_SYMBOL, ( { level, message, metadata } ) =>
-    messageBus.emit( BusEventType.ACTIVITY_LOG, { level, message, metadata, activityInfo: activityInfoFn() } )
+    mainEventBus.emit( BusEventType.ACTIVITY_LOG, { level, message, metadata, activityInfo: activityInfoFn() } )
   );
 };

--- a/sdk/core/src/worker/global_functions.spec.js
+++ b/sdk/core/src/worker/global_functions.spec.js
@@ -10,7 +10,7 @@ const {
   }
 } ) );
 
-const messageBusMock = vi.hoisted( () => ( {
+const mainEventBusMock = vi.hoisted( () => ( {
   emit: vi.fn()
 } ) );
 const activityInfoMock = vi.hoisted( () => vi.fn( () => ( {
@@ -19,7 +19,7 @@ const activityInfoMock = vi.hoisted( () => vi.fn( () => ( {
 } ) ) );
 
 vi.mock( '#consts', () => ( { ACTIVITY_LOGGER_SYMBOL, BusEventType } ) );
-vi.mock( '#bus', () => ( { messageBus: messageBusMock } ) );
+vi.mock( '#bus', () => ( { mainEventBus: mainEventBusMock } ) );
 vi.mock( '@temporalio/activity', () => ( {
   activityInfo: activityInfoMock
 } ) );
@@ -42,7 +42,7 @@ describe( 'worker/global_functions', () => {
     } );
 
     expect( activityInfoMock ).toHaveBeenCalledTimes( 1 );
-    expect( messageBusMock.emit ).toHaveBeenCalledWith( BusEventType.ACTIVITY_LOG, {
+    expect( mainEventBusMock.emit ).toHaveBeenCalledWith( BusEventType.ACTIVITY_LOG, {
       level: 'debug',
       message: 'activity detail',
       metadata,

--- a/sdk/core/src/worker/index.js
+++ b/sdk/core/src/worker/index.js
@@ -13,7 +13,7 @@ import { createChildLogger } from '#logger';
 import { setupInterruptionHandler } from './interruption.js';
 import { CatalogJob } from './catalog_workflow/catalog_job.js';
 import { bootstrapFetchProxy } from './proxy.js';
-import { messageBus } from '#bus';
+import { mainEventBus } from '#bus';
 import { BusEventType } from '#consts';
 import { setupTelemetry } from './telemetry.js';
 import { TemporalConnectionMonitor } from './connection_monitor.js';
@@ -60,7 +60,7 @@ const execute = async () => {
   log.info( 'Loading activities...', { callerDir } );
   const { activities } = await loadActivities( callerDir, workflows );
 
-  messageBus.emit( BusEventType.WORKER_BEFORE_START );
+  mainEventBus.emit( BusEventType.WORKER_BEFORE_START );
   bootstrapFetchProxy();
 
   log.info( 'Initializing tracing...' );
@@ -218,7 +218,7 @@ execute()
   .catch( error => {
     log.error( 'Fatal error', { error: error.message, stack: error.stack } );
 
-    messageBus.emit( BusEventType.RUNTIME_ERROR, { error } );
+    mainEventBus.emit( BusEventType.RUNTIME_ERROR, { error } );
 
     const timeToFlushEvent = configs.processFailureShutdownDelay;
     log.info( `Exiting in ${timeToFlushEvent}ms` );

--- a/sdk/core/src/worker/index.spec.js
+++ b/sdk/core/src/worker/index.spec.js
@@ -7,7 +7,7 @@ const {
   connectionMonitorInstance,
   createCatalogMock,
   initInterceptorsMock,
-  messageBusMock,
+  mainEventBusMock,
   mockConnection,
   mockLog,
   mockWorker,
@@ -110,7 +110,7 @@ const {
     loadActivitiesMock: vi.fn().mockResolvedValue( {} ),
     loadHooksMock: vi.fn().mockResolvedValue( undefined ),
     loadWorkflowsMock: vi.fn().mockResolvedValue( [] ),
-    messageBusMock: { emit: vi.fn(), on: vi.fn() },
+    mainEventBusMock: { emit: vi.fn(), on: vi.fn() },
     mockConnection: { close: vi.fn().mockResolvedValue( undefined ) },
     mockLog: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
     mockWorker,
@@ -128,7 +128,7 @@ vi.mock( '#consts', async importOriginal => {
 } );
 const initTracing = vi.fn().mockResolvedValue( undefined );
 vi.mock( '#tracing', () => ( { init: initTracing } ) );
-vi.mock( '#bus', () => ( { messageBus: messageBusMock } ) );
+vi.mock( '#bus', () => ( { mainEventBus: mainEventBusMock } ) );
 
 const loadWorkflowsMock = vi.fn().mockResolvedValue( { workflows: [], entrypoint: '/fake/workflows/path.js' } );
 const loadActivitiesMock = vi.fn().mockResolvedValue( { activities: {} } );
@@ -357,7 +357,7 @@ describe( 'worker/index', () => {
         error: 'Big Failure'
       } ) );
     } );
-    expect( messageBusMock.emit ).toHaveBeenCalledWith( expect.any( String ), { error } );
+    expect( mainEventBusMock.emit ).toHaveBeenCalledWith( expect.any( String ), { error } );
     await vi.waitFor( () => expect( exitMock ).toHaveBeenCalledWith( 1 ) );
   } );
 
@@ -378,7 +378,7 @@ describe( 'worker/index', () => {
     } );
     expect( mockWorker.shutdown ).toHaveBeenCalledOnce();
     expect( catalogJobInstance.interrupt ).toHaveBeenCalledOnce();
-    expect( messageBusMock.emit ).toHaveBeenCalledWith( expect.any( String ), { error } );
+    expect( mainEventBusMock.emit ).toHaveBeenCalledWith( expect.any( String ), { error } );
   } );
 
   it( 'throws catalog job errors after graceful shutdown', async () => {
@@ -398,7 +398,7 @@ describe( 'worker/index', () => {
     } );
     expect( mockWorker.shutdown ).toHaveBeenCalledOnce();
     expect( connectionMonitorInstance.stop ).toHaveBeenCalledOnce();
-    expect( messageBusMock.emit ).toHaveBeenCalledWith( expect.any( String ), { error } );
+    expect( mainEventBusMock.emit ).toHaveBeenCalledWith( expect.any( String ), { error } );
   } );
 
   it( 'cleans up partial startup failures after connecting', async () => {

--- a/sdk/core/src/worker/interceptors/activity.js
+++ b/sdk/core/src/worker/interceptors/activity.js
@@ -4,7 +4,7 @@ import * as Tracing from '#tracing';
 import { headersToObject } from './headers.js';
 import { ACTIVITY_WRAPPER_VERSION_FIELD, BusEventType, METADATA_ACCESS_SYMBOL } from '#consts';
 import { activityHeartbeatEnabled, activityHeartbeatIntervalMs } from '../configs.js';
-import { messageBus } from '#bus';
+import { mainEventBus } from '#bus';
 import { aggregateAttributes } from '#helpers/aggregations';
 import { buildApplicationFailureWithDetails } from '#helpers/errors';
 
@@ -68,7 +68,7 @@ export class ActivityExecutionInterceptor {
       addAttribute
     };
 
-    messageBus.emit( BusEventType.ACTIVITY_START, { activityInfo, workflowDetails, outputActivityKind } );
+    mainEventBus.emit( BusEventType.ACTIVITY_START, { activityInfo, workflowDetails, outputActivityKind } );
     Tracing.addEventStart( { id: activityId, name: activityType, kind: outputActivityKind, parentId: runId, details: input.args[0], traceInfo } );
 
     try {
@@ -79,14 +79,14 @@ export class ActivityExecutionInterceptor {
 
       const aggregations = state.attributes.length > 0 ? aggregateAttributes( state.attributes ) : null;
 
-      messageBus.emit( BusEventType.ACTIVITY_END, { activityInfo, aggregations, workflowDetails, outputActivityKind } );
+      mainEventBus.emit( BusEventType.ACTIVITY_END, { activityInfo, aggregations, workflowDetails, outputActivityKind } );
       Tracing.addEventEnd( { id: activityId, details: output, traceInfo } );
 
       return { [ACTIVITY_WRAPPER_VERSION_FIELD]: 1, output, aggregations };
 
     } catch ( error ) {
       const aggregations = state.attributes.length > 0 ? aggregateAttributes( state.attributes ) : null;
-      messageBus.emit( BusEventType.ACTIVITY_ERROR, { activityInfo, aggregations, workflowDetails, outputActivityKind, error } );
+      mainEventBus.emit( BusEventType.ACTIVITY_ERROR, { activityInfo, aggregations, workflowDetails, outputActivityKind, error } );
       Tracing.addEventError( { id: activityId, details: error, traceInfo } );
 
       throw aggregations ? buildApplicationFailureWithDetails( error, { aggregations } ) : error;

--- a/sdk/core/src/worker/interceptors/activity.spec.js
+++ b/sdk/core/src/worker/interceptors/activity.spec.js
@@ -61,8 +61,8 @@ vi.mock( './headers.js', () => ( {
   headersToObject: () => ( { traceInfo: traceInfoMock, workflowDetails: workflowDetailsMock } )
 } ) );
 
-const messageBusEmitMock = vi.fn();
-vi.mock( '#bus', () => ( { messageBus: { emit: messageBusEmitMock } } ) );
+const mainEventBusEmitMock = vi.fn();
+vi.mock( '#bus', () => ( { mainEventBus: { emit: mainEventBusEmitMock } } ) );
 
 vi.mock( '#consts', async importOriginal => {
   const actual = await importOriginal();
@@ -135,11 +135,11 @@ describe( 'ActivityExecutionInterceptor', () => {
       aggregations: null,
       [ACTIVITY_WRAPPER_VERSION_FIELD]: 1
     } );
-    expect( messageBusEmitMock ).toHaveBeenCalledWith(
+    expect( mainEventBusEmitMock ).toHaveBeenCalledWith(
       BusEventType.ACTIVITY_START,
       { activityInfo: activityInfoMock, workflowDetails: workflowDetailsMock, outputActivityKind: 'step' }
     );
-    expect( messageBusEmitMock ).toHaveBeenCalledWith(
+    expect( mainEventBusEmitMock ).toHaveBeenCalledWith(
       BusEventType.ACTIVITY_END,
       { activityInfo: activityInfoMock, aggregations: null, workflowDetails: workflowDetailsMock, outputActivityKind: 'step' }
     );
@@ -178,7 +178,7 @@ describe( 'ActivityExecutionInterceptor', () => {
       [ACTIVITY_WRAPPER_VERSION_FIELD]: 1
     } );
 
-    expect( messageBusEmitMock ).toHaveBeenCalledWith( BusEventType.ACTIVITY_END, expect.any( Object ) );
+    expect( mainEventBusEmitMock ).toHaveBeenCalledWith( BusEventType.ACTIVITY_END, expect.any( Object ) );
     expect( addEventEndMock ).toHaveBeenCalledWith( { id: 'act-1', details: { result: 'sync' }, traceInfo: traceInfoMock } );
     expect( addEventErrorMock ).not.toHaveBeenCalled();
   } );
@@ -198,7 +198,7 @@ describe( 'ActivityExecutionInterceptor', () => {
       [ACTIVITY_WRAPPER_VERSION_FIELD]: 1
     } );
 
-    expect( messageBusEmitMock ).toHaveBeenCalledWith( BusEventType.ACTIVITY_END, {
+    expect( mainEventBusEmitMock ).toHaveBeenCalledWith( BusEventType.ACTIVITY_END, {
       activityInfo: activityInfoMock,
       aggregations: httpRequestAggregations,
       workflowDetails: workflowDetailsMock,
@@ -226,7 +226,7 @@ describe( 'ActivityExecutionInterceptor', () => {
       } ],
       cause: error
     } );
-    expect( messageBusEmitMock ).toHaveBeenCalledWith( BusEventType.ACTIVITY_ERROR, {
+    expect( mainEventBusEmitMock ).toHaveBeenCalledWith( BusEventType.ACTIVITY_ERROR, {
       activityInfo: activityInfoMock,
       aggregations: httpRequestAggregations,
       workflowDetails: workflowDetailsMock,
@@ -318,8 +318,8 @@ describe( 'ActivityExecutionInterceptor', () => {
     vi.advanceTimersByTime( 0 );
 
     await expect( promise ).rejects.toThrow( 'step failed' );
-    expect( messageBusEmitMock ).toHaveBeenCalledWith( BusEventType.ACTIVITY_START, expect.any( Object ) );
-    expect( messageBusEmitMock ).toHaveBeenCalledWith( BusEventType.ACTIVITY_ERROR, {
+    expect( mainEventBusEmitMock ).toHaveBeenCalledWith( BusEventType.ACTIVITY_START, expect.any( Object ) );
+    expect( mainEventBusEmitMock ).toHaveBeenCalledWith( BusEventType.ACTIVITY_ERROR, {
       activityInfo: activityInfoMock,
       aggregations: null,
       workflowDetails: workflowDetailsMock,

--- a/sdk/core/src/worker/log_hooks.js
+++ b/sdk/core/src/worker/log_hooks.js
@@ -1,4 +1,4 @@
-import { messageBus } from '#bus';
+import { mainEventBus } from '#bus';
 import { createChildLogger } from '#logger';
 import { ACTIVITY_GET_TRACE_DESTINATIONS, BusEventType, LifecycleEvent, WORKFLOW_CATALOG } from '#consts';
 
@@ -25,21 +25,21 @@ const serializedActivityFields = activityInfo => ( {
 
 const shouldLogActivity = activityInfo => activityInfo.activityType !== ACTIVITY_GET_TRACE_DESTINATIONS;
 
-messageBus.on( BusEventType.ACTIVITY_START, ( { activityInfo, outputActivityKind } ) =>
+mainEventBus.on( BusEventType.ACTIVITY_START, ( { activityInfo, outputActivityKind } ) =>
   shouldLogActivity( activityInfo ) && activityLog.info( `Started ${activityInfo.activityType} ${outputActivityKind}`, {
     event: LifecycleEvent.START,
     ...serializedActivityFields( activityInfo )
   } )
 );
 
-messageBus.on( BusEventType.ACTIVITY_END, ( { activityInfo, outputActivityKind } ) =>
+mainEventBus.on( BusEventType.ACTIVITY_END, ( { activityInfo, outputActivityKind } ) =>
   shouldLogActivity( activityInfo ) && activityLog.info( `Ended ${activityInfo.activityType} ${outputActivityKind}`, {
     event: LifecycleEvent.END,
     ...serializedActivityFields( activityInfo )
   } )
 );
 
-messageBus.on( BusEventType.ACTIVITY_ERROR, ( { activityInfo, outputActivityKind, error } ) =>
+mainEventBus.on( BusEventType.ACTIVITY_ERROR, ( { activityInfo, outputActivityKind, error } ) =>
   shouldLogActivity( activityInfo ) && activityLog.error( `Error ${activityInfo.activityType} ${outputActivityKind}: ${error.constructor.name}`, {
     event: LifecycleEvent.ERROR,
     ...serializedActivityFields( activityInfo ),
@@ -47,7 +47,7 @@ messageBus.on( BusEventType.ACTIVITY_ERROR, ( { activityInfo, outputActivityKind
   } )
 );
 
-messageBus.on( BusEventType.ACTIVITY_LOG, ( { level, message, metadata, activityInfo } ) =>
+mainEventBus.on( BusEventType.ACTIVITY_LOG, ( { level, message, metadata, activityInfo } ) =>
   activityLog[level]( message, {
     ...metadata ?? {},
     ...serializedActivityFields( activityInfo )
@@ -68,21 +68,21 @@ const serializeWorkflowFields = workflowDetails => ( {
 
 const shouldLogWorkflow = workflowDetails => workflowDetails.workflowType !== WORKFLOW_CATALOG;
 
-messageBus.on( BusEventType.WORKFLOW_START, ( { workflowDetails } ) =>
+mainEventBus.on( BusEventType.WORKFLOW_START, ( { workflowDetails } ) =>
   shouldLogWorkflow( workflowDetails ) && workflowLog.info( `Started ${workflowDetails.workflowType} workflow`, {
     event: LifecycleEvent.START,
     ...serializeWorkflowFields( workflowDetails )
   } )
 );
 
-messageBus.on( BusEventType.WORKFLOW_END, ( { workflowDetails } ) =>
+mainEventBus.on( BusEventType.WORKFLOW_END, ( { workflowDetails } ) =>
   shouldLogWorkflow( workflowDetails ) && workflowLog.info( `Ended ${workflowDetails.workflowType} workflow`, {
     event: LifecycleEvent.END,
     ...serializeWorkflowFields( workflowDetails )
   } )
 );
 
-messageBus.on( BusEventType.WORKFLOW_ERROR, ( { workflowDetails, error } ) =>
+mainEventBus.on( BusEventType.WORKFLOW_ERROR, ( { workflowDetails, error } ) =>
   shouldLogWorkflow( workflowDetails ) && workflowLog.error( `Error ${workflowDetails.workflowType} workflow: ${error.constructor.name}`, {
     event: LifecycleEvent.ERROR,
     ...serializeWorkflowFields( workflowDetails ),
@@ -90,7 +90,7 @@ messageBus.on( BusEventType.WORKFLOW_ERROR, ( { workflowDetails, error } ) =>
   } )
 );
 
-messageBus.on( BusEventType.WORKFLOW_LOG, ( { level, message, metadata, workflowDetails } ) =>
+mainEventBus.on( BusEventType.WORKFLOW_LOG, ( { level, message, metadata, workflowDetails } ) =>
   workflowLog[level]( message, {
     ...metadata ?? {},
     ...serializeWorkflowFields( workflowDetails )

--- a/sdk/core/src/worker/log_hooks.spec.js
+++ b/sdk/core/src/worker/log_hooks.spec.js
@@ -22,14 +22,14 @@ const createChildLoggerMock = vi.hoisted( () =>
 );
 
 const onHandlers = vi.hoisted( () => ( {} ) );
-const messageBusMock = vi.hoisted( () => ( {
+const mainEventBusMock = vi.hoisted( () => ( {
   on: vi.fn( ( eventType, handler ) => {
     onHandlers[eventType] = handler;
   } )
 } ) );
 
 vi.mock( '#logger', () => ( { createChildLogger: createChildLoggerMock } ) );
-vi.mock( '#bus', () => ( { messageBus: messageBusMock } ) );
+vi.mock( '#bus', () => ( { mainEventBus: mainEventBusMock } ) );
 
 import './log_hooks.js';
 

--- a/sdk/core/src/worker/sinks.js
+++ b/sdk/core/src/worker/sinks.js
@@ -1,6 +1,6 @@
 import { BusEventType, ComponentType } from '#consts';
 import * as Tracing from '#tracing';
-import { messageBus } from '#bus';
+import { mainEventBus } from '#bus';
 import { createWorkflowDetails } from '#helpers/temporal_context';
 
 // This sink allow for sandbox Temporal environment to send trace logs back to the main thread.
@@ -12,15 +12,15 @@ export const sinks = {
   workflow: {
     log: {
       fn: ( workflowInfo, { level, message, metadata } ) => {
-        messageBus.emit( BusEventType.WORKFLOW_LOG, { level, message, metadata, workflowDetails: createWorkflowDetails( workflowInfo ) } );
+        mainEventBus.emit( BusEventType.WORKFLOW_LOG, { level, message, metadata, workflowDetails: createWorkflowDetails( workflowInfo ) } );
       },
       callDuringReplay: false
     },
     start: {
       fn: ( workflowInfo, input ) => {
         const { runId, workflowType, memo: { traceInfo }, parent } = workflowInfo;
-        messageBus.emit( BusEventType.WORKFLOW_START, { workflowDetails: createWorkflowDetails( workflowInfo ) } );
-        if ( traceInfo ) { // internal workflows (catalog) do not have this info
+        mainEventBus.emit( BusEventType.WORKFLOW_START, { workflowDetails: createWorkflowDetails( workflowInfo ) } );
+        if ( traceInfo ) {
           Tracing.addEventStart( {
             id: runId,
             kind: ComponentType.WORKFLOW,
@@ -37,8 +37,8 @@ export const sinks = {
     end: {
       fn: ( workflowInfo, output ) => {
         const { runId, memo: { traceInfo } } = workflowInfo;
-        messageBus.emit( BusEventType.WORKFLOW_END, { workflowDetails: createWorkflowDetails( workflowInfo ) } );
-        if ( traceInfo ) { // internal workflows (catalog) do not have this info
+        mainEventBus.emit( BusEventType.WORKFLOW_END, { workflowDetails: createWorkflowDetails( workflowInfo ) } );
+        if ( traceInfo ) {
           Tracing.addEventEnd( { id: runId, details: output, traceInfo } );
         }
       },
@@ -48,8 +48,8 @@ export const sinks = {
     error: {
       fn: ( workflowInfo, error ) => {
         const { runId, memo: { traceInfo } } = workflowInfo;
-        messageBus.emit( BusEventType.WORKFLOW_ERROR, { workflowDetails: createWorkflowDetails( workflowInfo ), error } );
-        if ( traceInfo ) { // internal workflows (catalog) do not have this info
+        mainEventBus.emit( BusEventType.WORKFLOW_ERROR, { workflowDetails: createWorkflowDetails( workflowInfo ), error } );
+        if ( traceInfo ) {
           Tracing.addEventError( { id: runId, details: error, traceInfo } );
         }
       },

--- a/sdk/core/src/worker/sinks.spec.js
+++ b/sdk/core/src/worker/sinks.spec.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BusEventType, ComponentType } from '#consts';
 
-const messageBusMock = vi.hoisted( () => ( {
+const mainEventBusMock = vi.hoisted( () => ( {
   emit: vi.fn()
 } ) );
 
@@ -15,7 +15,7 @@ const createWorkflowDetailsMock = vi.hoisted( () => vi.fn( workflowInfo => ( {
   runId: workflowInfo.runId
 } ) ) );
 
-vi.mock( '#bus', () => ( { messageBus: messageBusMock } ) );
+vi.mock( '#bus', () => ( { mainEventBus: mainEventBusMock } ) );
 vi.mock( '#tracing', () => ( {
   addEventStart: addEventStartMock,
   addEventEnd: addEventEndMock,
@@ -69,7 +69,7 @@ describe( 'worker/sinks', () => {
     } );
 
     expect( createWorkflowDetailsMock ).toHaveBeenCalledWith( workflowInfo );
-    expect( messageBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_LOG, {
+    expect( mainEventBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_LOG, {
       level: 'info',
       message: 'workflow detail',
       metadata,
@@ -83,7 +83,7 @@ describe( 'worker/sinks', () => {
 
     sinks.workflow.start.fn( workflowInfo, input );
 
-    expect( messageBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_START, { workflowDetails } );
+    expect( mainEventBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_START, { workflowDetails } );
     expect( addEventStartMock ).toHaveBeenCalledWith( {
       id: 'run-1',
       kind: ComponentType.WORKFLOW,
@@ -99,7 +99,7 @@ describe( 'worker/sinks', () => {
 
     sinks.workflow.start.fn( { ...workflowInfo, memo: {} }, { value: 'input' } );
 
-    expect( messageBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_START, { workflowDetails } );
+    expect( mainEventBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_START, { workflowDetails } );
     expect( addEventStartMock ).not.toHaveBeenCalled();
   } );
 
@@ -109,7 +109,7 @@ describe( 'worker/sinks', () => {
 
     sinks.workflow.end.fn( workflowInfo, output );
 
-    expect( messageBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_END, { workflowDetails } );
+    expect( mainEventBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_END, { workflowDetails } );
     expect( addEventEndMock ).toHaveBeenCalledWith( {
       id: 'run-1',
       details: output,
@@ -122,7 +122,7 @@ describe( 'worker/sinks', () => {
 
     sinks.workflow.end.fn( { ...workflowInfo, memo: {} }, { value: 'output' } );
 
-    expect( messageBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_END, { workflowDetails } );
+    expect( mainEventBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_END, { workflowDetails } );
     expect( addEventEndMock ).not.toHaveBeenCalled();
   } );
 
@@ -132,7 +132,7 @@ describe( 'worker/sinks', () => {
 
     sinks.workflow.error.fn( workflowInfo, error );
 
-    expect( messageBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_ERROR, { workflowDetails, error } );
+    expect( mainEventBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_ERROR, { workflowDetails, error } );
     expect( addEventErrorMock ).toHaveBeenCalledWith( {
       id: 'run-1',
       details: error,
@@ -146,7 +146,7 @@ describe( 'worker/sinks', () => {
 
     sinks.workflow.error.fn( { ...workflowInfo, memo: {} }, error );
 
-    expect( messageBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_ERROR, { workflowDetails, error } );
+    expect( mainEventBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_ERROR, { workflowDetails, error } );
     expect( addEventErrorMock ).not.toHaveBeenCalled();
   } );
 

--- a/test_workflows/src/hooks.js
+++ b/test_workflows/src/hooks.js
@@ -1,6 +1,7 @@
 // import {
 //   onError,
 //   on,
+//   emit,
 //   onBeforeWorkerStart,
 //   onWorkflowStart,
 //   onWorkflowEnd,
@@ -16,17 +17,23 @@
 // on( 'http:request', async payload => console.log( colorize( 'on(http:request)' ), payload ) );
 // on( 'cost:llm:request', payload => console.log( colorize( 'on(cost:llm:request)' ), payload ) );
 // on( 'cost:http:request', payload => console.log( colorize( 'on(cost:llm:request)' ), payload ) );
+// on( 'test', payload => console.log( colorize( 'on(test)' ), payload ) );
 
 // // Generic on error
 // onError( payload => console.log( colorize( 'onError()' ), payload ) );
 
 // // Worker start
-// onBeforeWorkerStart( () => console.log( colorize( 'onBeforeWorkerStart()' ) ) );
+// onBeforeWorkerStart( () => {
+//   console.log( colorize( 'onBeforeWorkerStart()' ) )
+//   emit( 'test', { message: 'foo' } );
+// } );
 
 // // Workflow lifecycle
 // onWorkflowStart( payload => console.log( colorize( 'onWorkflowStart()' ), payload ) );
 // onWorkflowEnd( payload => console.log( colorize( 'onWorkflowEnd()' ), payload ) );
 // onWorkflowError( payload => console.log( colorize( 'onWorkflowError()' ), payload ) );
 
-// onActivityStart( ( { activityInfo, outputActivityKind } ) => console.log( colorize( 'onActivityStart()' ), { activityInfo, outputActivityKind } ) );
-// onActivityEnd( ( { aggregations } ) => console.log( colorize( 'onActivityStart()' ), { aggregations } ) );
+// // Activity lifecycle
+// onActivityStart( payload => console.log( colorize( 'onActivityStart()' ), payload ) );
+// onActivityEnd( payload => console.log( colorize( 'onActivityStart()' ), payload ) );
+// onActivityError( payload => console.log( colorize( 'onActivityError()' ), payload ) );


### PR DESCRIPTION
## Summary

- Added `emit()` to `@outputai/core/hooks` endpoint, so users can emit custom events to be listened to with `on()`. It is designed to be used within steps and will not work inside a workflow since the `/hooks` endpoint is not sandbox safe to be imported, if used elsewhere, context fields will be omitted;
- Refactored event emission to have two buses, one for worker, workflow and activity lifecycle and one for in-step events, like those from other SDK modules and user events. Simplified event emission and handling;
- Refactored events shape, all events listened using `on()` now have an envelope wrapper that adds the step/workflow info without risks of collision and are independent of the payload type:
  ```js
  emit( 'foo', 'bar' );
  
  on( 'foo', event => {
    console.log( event );
    assert( event, {
      eventId: "string", // uuid
      eventDate: number, // epoch
      activityInfo: {}, // result of Temporal's activityInfo() fn
      outputActivityKind: "string", // step, evaluator, internal_step, etc
      workflowDetails: {}, // serialization of some fields from Temporal's workflowInfo() fn
      payload: [original emitted event payload] // in this case "bar" 
    } );
  } );
  ```
   This includes events from SDK, like: `http:request`, `cost:llm:request`, `cost:http:request`;
- Added internal activity events to activity lifecycle hooks: `onActivityStart`, `onActivityEnd`, `onActivityError`;
- Removed `$catalog` workflow errors from `onError()`;
- 

## Test plan

- [x] Manually tested
- [x] Refactored/added unit tests
