### PR TITLE
chore: fix `output dev` TUI crash with unbounded cache

### DIFF
--- a/.changeset/swift-snails-bet.md
+++ b/.changeset/swift-snails-bet.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+fix `output dev` memory leak in TUI where workflow run details grew unbounded

--- a/sdk/cli/src/views/dev/hooks/use_run_detail.ts
+++ b/sdk/cli/src/views/dev/hooks/use_run_detail.ts
@@ -10,6 +10,7 @@ import {
 import type { TraceData, DebugNode } from '#types/trace.js';
 import { normalizeWorkflowStatus } from '#utils/normalize_workflow_status.js';
 import { TERMINAL_STATUSES } from '#utils/format_workflow_result.js';
+import { createBoundedCache } from '#views/dev/utils/bounded_cache.js';
 
 export interface RunStep {
   index: number;
@@ -35,7 +36,8 @@ const EMPTY_DETAIL: RunDetail = {
   steps: [],
   loading: false
 };
-const runDetailCache = new Map<string, RunDetail>();
+const RUN_DETAIL_CACHE_MAX = 50;
+const runDetailCache = createBoundedCache<string, RunDetail>( RUN_DETAIL_CACHE_MAX );
 
 const stepNameOf = ( node: DebugNode ): string => {
   if ( node.name ) {

--- a/sdk/cli/src/views/dev/hooks/use_step_graph.ts
+++ b/sdk/cli/src/views/dev/hooks/use_step_graph.ts
@@ -4,6 +4,7 @@ import type { Span } from '#services/workflow_history/correlator.js';
 import buildSpanLabels from '#utils/span_labels.js';
 import { isTerminalRunStatus } from '#views/dev/hooks/use_run_detail.js';
 import { usePoll, POLL_INTERVAL_MS } from '#views/dev/hooks/use_poll.js';
+import { createBoundedCache } from '#views/dev/utils/bounded_cache.js';
 
 export interface StepGraph {
   spans: Span[];
@@ -23,7 +24,8 @@ const EMPTY_GRAPH: StepGraph = {
   error: null
 };
 
-const stepGraphCache = new Map<string, StepGraph>();
+const STEP_GRAPH_CACHE_MAX = 50;
+const stepGraphCache = createBoundedCache<string, StepGraph>( STEP_GRAPH_CACHE_MAX );
 
 /**
  * Fetches a run's correlated step spans for the dev TUI's waterfall overlay,

--- a/sdk/cli/src/views/dev/utils/bounded_cache.spec.ts
+++ b/sdk/cli/src/views/dev/utils/bounded_cache.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { createBoundedCache } from './bounded_cache.js';
+
+describe( 'createBoundedCache', () => {
+  it( 'round-trips set and get', () => {
+    const cache = createBoundedCache<string, number>( 3 );
+    cache.set( 'a', 1 );
+    expect( cache.get( 'a' ) ).toBe( 1 );
+    expect( cache.get( 'missing' ) ).toBeUndefined();
+  } );
+
+  it( 'evicts the oldest entry once maxSize is exceeded', () => {
+    const cache = createBoundedCache<string, number>( 2 );
+    cache.set( 'a', 1 );
+    cache.set( 'b', 2 );
+    cache.set( 'c', 3 );
+    expect( cache.has( 'a' ) ).toBe( false );
+    expect( cache.get( 'b' ) ).toBe( 2 );
+    expect( cache.get( 'c' ) ).toBe( 3 );
+  } );
+
+  it( 'refreshes recency on get so the touched entry survives eviction', () => {
+    const cache = createBoundedCache<string, number>( 2 );
+    cache.set( 'a', 1 );
+    cache.set( 'b', 2 );
+    // Touch 'a' so 'b' becomes the least-recently-used entry.
+    expect( cache.get( 'a' ) ).toBe( 1 );
+    cache.set( 'c', 3 );
+    expect( cache.has( 'a' ) ).toBe( true );
+    expect( cache.has( 'b' ) ).toBe( false );
+    expect( cache.has( 'c' ) ).toBe( true );
+  } );
+
+  it( 'updates an existing key in place without growing', () => {
+    const cache = createBoundedCache<string, number>( 2 );
+    cache.set( 'a', 1 );
+    cache.set( 'a', 2 );
+    expect( cache.get( 'a' ) ).toBe( 2 );
+    expect( cache.size() ).toBe( 1 );
+  } );
+
+  it( 'supports has and clear', () => {
+    const cache = createBoundedCache<string, number>( 2 );
+    cache.set( 'a', 1 );
+    expect( cache.has( 'a' ) ).toBe( true );
+    cache.clear();
+    expect( cache.has( 'a' ) ).toBe( false );
+    expect( cache.size() ).toBe( 0 );
+  } );
+
+  it( 'never exceeds maxSize', () => {
+    const cache = createBoundedCache<string, number>( 3 );
+    Array.from( { length: 100 }, ( _, i ) => i ).forEach( i => {
+      cache.set( `key-${i}`, i );
+      expect( cache.size() ).toBeLessThanOrEqual( 3 );
+    } );
+    expect( cache.size() ).toBe( 3 );
+  } );
+} );

--- a/sdk/cli/src/views/dev/utils/bounded_cache.ts
+++ b/sdk/cli/src/views/dev/utils/bounded_cache.ts
@@ -1,0 +1,48 @@
+export interface BoundedCache<K, V> {
+  get( key: K ): V | undefined;
+  set( key: K, value: V ): void;
+  has( key: K ): boolean;
+  clear(): void;
+  size(): number;
+}
+
+/**
+ * A small LRU cache backed by an insertion-ordered `Map`, capped at `maxSize`
+ * entries. Reading a key refreshes its recency; once the cap is exceeded the
+ * least-recently-used entries are evicted. Drop-in compatible with the
+ * `Map.get` / `Map.set` calls it replaces.
+ */
+export const createBoundedCache = <K, V>( maxSize: number ): BoundedCache<K, V> => {
+  const entries = new Map<K, V>();
+
+  return {
+    get( key: K ): V | undefined {
+      const value = entries.get( key );
+      if ( value === undefined ) {
+        return value;
+      }
+      entries.delete( key );
+      entries.set( key, value );
+      return value;
+    },
+    set( key: K, value: V ): void {
+      entries.delete( key );
+      entries.set( key, value );
+      if ( entries.size > maxSize ) {
+        const oldest = entries.keys().next();
+        if ( !oldest.done ) {
+          entries.delete( oldest.value );
+        }
+      }
+    },
+    has( key: K ): boolean {
+      return entries.has( key );
+    },
+    clear(): void {
+      entries.clear();
+    },
+    size(): number {
+      return entries.size;
+    }
+  };
+};

--- a/sdk/cli/src/views/dev/utils/bounded_cache.ts
+++ b/sdk/cli/src/views/dev/utils/bounded_cache.ts
@@ -1,4 +1,4 @@
-export interface BoundedCache<K, V> {
+export interface BoundedCache<K, V extends {}> {
   get( key: K ): V | undefined;
   set( key: K, value: V ): void;
   has( key: K ): boolean;
@@ -12,7 +12,10 @@ export interface BoundedCache<K, V> {
  * least-recently-used entries are evicted. Drop-in compatible with the
  * `Map.get` / `Map.set` calls it replaces.
  */
-export const createBoundedCache = <K, V>( maxSize: number ): BoundedCache<K, V> => {
+export const createBoundedCache = <K, V extends {}>( maxSize: number ): BoundedCache<K, V> => {
+  if ( maxSize < 1 ) {
+    throw new Error( 'createBoundedCache: maxSize must be >= 1' );
+  }
   const entries = new Map<K, V>();
 
   return {


### PR DESCRIPTION
## Summary

The TUI from `output dev` cached workflow run information but never checked or flushed it, so it grew unbounded. Eventually that causes a crash because it consumes too much memory and hits limits from the underlying Node process.

In this change we introduce a Least Recently Used (LRU) cache instead, so we eventually purge old things. 