### PR TITLE
fix: preserve terminal scroll if TUI crashes

### DIFF
--- a/.changeset/honest-years-smash.md
+++ b/.changeset/honest-years-smash.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Restore the terminal on abnormal `output dev` exit. Uncaught exceptions and unhandled rejections now leave the alternate-screen buffer and unmount the TUI before exiting, so scrollback and the error stack stay readable.

--- a/sdk/cli/src/commands/dev/index.spec.ts
+++ b/sdk/cli/src/commands/dev/index.spec.ts
@@ -427,6 +427,75 @@ describe( 'dev command', () => {
     } );
   } );
 
+  describe( 'fatal error handling', () => {
+    it( 'restores the terminal and exits non-zero on an uncaught exception', async () => {
+      const inkInstance = createControllableInkInstance();
+      vi.mocked( render ).mockReturnValue( inkInstance as any );
+
+      // Capture the registered handlers instead of letting them attach to the
+      // real process, and neutralize process.exit so firing one doesn't kill
+      // the test runner.
+      const handlers: Record<string, ( err: unknown ) => void> = {};
+      const onSpy = vi.spyOn( process, 'on' ).mockImplementation( ( ( event: string, handler: any ) => {
+        handlers[event] = handler;
+        return process;
+      } ) as any );
+      const exitSpy = vi.spyOn( process, 'exit' ).mockImplementation( ( () => undefined ) as any );
+      const stdoutSpy = vi.spyOn( process.stdout, 'write' ).mockImplementation( () => true );
+      const errorSpy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+      const cmd = new Dev( [], {} as any );
+      cmd.log = vi.fn() as any;
+      cmd.error = vi.fn() as any;
+
+      Object.defineProperty( cmd, 'parse', {
+        value: vi.fn().mockResolvedValue( { flags: { 'compose-file': undefined, 'image-pull-policy': 'always' }, args: {} } ),
+        configurable: true
+      } );
+
+      const runPromise = cmd.run();
+      await new Promise( resolve => setImmediate( resolve ) );
+
+      expect( handlers.uncaughtException ).toBeInstanceOf( Function );
+      expect( handlers.unhandledRejection ).toBeInstanceOf( Function );
+
+      const crash = new Error( 'boom' );
+      handlers.uncaughtException( crash );
+
+      // Terminal restore, the crash print, and exit all run after docker
+      // teardown settles, so they land a tick later.
+      await new Promise( resolve => setImmediate( resolve ) );
+
+      // Docker is torn down before exit, so a crash doesn't orphan the
+      // compose stack.
+      expect( dockerService.stopDockerCompose ).toHaveBeenCalled();
+      expect( inkInstance.unmount ).toHaveBeenCalled();
+      expect( stdoutSpy ).toHaveBeenCalledWith( '\x1b[?1049l' );
+      expect( errorSpy ).toHaveBeenCalledWith( crash );
+      expect( exitSpy ).toHaveBeenCalledWith( 1 );
+
+      // Discriminating order: docker must be fully torn down BEFORE Ink
+      // unmounts. Unmounting resolves waitUntilExit() and resumes run(),
+      // which strips the signal listeners — so an unmount-first ordering
+      // would drop the SIGINT handler mid-teardown and risk orphaning the
+      // stack on a Ctrl+C.
+      expect( vi.mocked( dockerService.stopDockerCompose ).mock.invocationCallOrder[0] )
+        .toBeLessThan( inkInstance.unmount.mock.invocationCallOrder[0] );
+
+      // Within the restore, Ink unmounts before the alt-screen is left, and
+      // the crash prints only after — otherwise console.error paints into a
+      // buffer the user never sees.
+      const leaveAltScreenCall = stdoutSpy.mock.invocationCallOrder[
+        stdoutSpy.mock.calls.findIndex( ( [ seq ] ) => seq === '\x1b[?1049l' )
+      ];
+      expect( inkInstance.unmount.mock.invocationCallOrder[0] ).toBeLessThan( leaveAltScreenCall );
+      expect( leaveAltScreenCall ).toBeLessThan( errorSpy.mock.invocationCallOrder[0] );
+
+      onSpy.mockRestore();
+      runPromise.catch( () => {} );
+    } );
+  } );
+
   describe( 'image pull policy', () => {
     it( 'should pass pull policy to startDockerCompose', async () => {
       const cmd = new Dev( [], {} as any );

--- a/sdk/cli/src/commands/dev/index.ts
+++ b/sdk/cli/src/commands/dev/index.ts
@@ -187,9 +187,7 @@ export default class Dev extends Command {
     // mid-teardown and let a Ctrl+C orphan the stack. Print the raw error so
     // Node's stack trace survives, then re-exit non-zero. Fire-once: a second
     // catchable crash during teardown is a no-op. A hard V8 abort() (SIGABRT)
-    // is uncatchable and not covered here. The object wrapper holds the
-    // fire-once flag because the linter forbids `let` (same idiom as
-    // exitAltScreenOnce above).
+    // is uncatchable and not covered here.
     const fatalState = { handled: false };
     const handleFatalError = ( err: unknown ): void => {
       if ( fatalState.handled ) {

--- a/sdk/cli/src/commands/dev/index.ts
+++ b/sdk/cli/src/commands/dev/index.ts
@@ -136,7 +136,29 @@ export default class Dev extends Command {
     // signal handlers just stop docker and exit.
     const instanceRef: { current: ReturnType<typeof render> | null } = { current: null };
 
-    process.on( 'exit', exitAltScreenOnce );
+    // Single terminal-restore sequence shared by every exit path: stop Ink
+    // (frees raw mode) then leave the alt-screen. The `finally` guarantees
+    // the alt-screen is left even if `unmount()` throws — otherwise a crash
+    // could strand the user in the blank alt buffer. This is the one place
+    // the unmount → leave-alt-screen order lives, so the paths can't drift.
+    const restoreTerminal = (): void => {
+      try {
+        instanceRef.current?.unmount();
+      } finally {
+        exitAltScreenOnce();
+      }
+    };
+
+    // Collect a disposer for every process listener so registration and
+    // teardown can't drift: a handler added through `on` is always removed by
+    // the `finally` below, with no separate removeListener list to keep in sync.
+    const disposers: Array<() => void> = [];
+    const on = ( event: string, handler: ( ...args: unknown[] ) => void ): void => {
+      process.on( event, handler );
+      disposers.push( () => process.removeListener( event, handler ) );
+    };
+
+    on( 'exit', exitAltScreenOnce );
 
     // `process.on` doesn't await the handler, so the cleanup promise would
     // float and any rejection would surface as an unhandled rejection.
@@ -151,11 +173,40 @@ export default class Dev extends Command {
           exitAltScreenOnce();
           console.error( 'Cleanup failed:', getErrorMessage( err ) );
         } )
-        .finally( () => instanceRef.current?.unmount() );
+        .finally( restoreTerminal );
     };
 
-    process.on( 'SIGINT', handleSignal );
-    process.on( 'SIGTERM', handleSignal );
+    on( 'SIGINT', handleSignal );
+    on( 'SIGTERM', handleSignal );
+
+    // A fatal crash (uncaught exception / unhandled rejection) skips both the
+    // clean-exit path and the signal handlers. Tear docker down via cleanup()
+    // FIRST, then restore the terminal and print the crash: unmounting Ink
+    // resolves the awaited waitUntilExit(), which resumes run() and strips the
+    // signal listeners — so unmounting before cleanup would drop them
+    // mid-teardown and let a Ctrl+C orphan the stack. Print the raw error so
+    // Node's stack trace survives, then re-exit non-zero. Fire-once: a second
+    // catchable crash during teardown is a no-op. A hard V8 abort() (SIGABRT)
+    // is uncatchable and not covered here. The object wrapper holds the
+    // fire-once flag because the linter forbids `let` (same idiom as
+    // exitAltScreenOnce above).
+    const fatalState = { handled: false };
+    const handleFatalError = ( err: unknown ): void => {
+      if ( fatalState.handled ) {
+        return;
+      }
+      fatalState.handled = true;
+      cleanup()
+        .catch( cleanupErr => console.error( 'Cleanup failed:', getErrorMessage( cleanupErr ) ) )
+        .finally( () => {
+          restoreTerminal();
+          console.error( err );
+          process.exit( 1 );
+        } );
+    };
+
+    on( 'uncaughtException', handleFatalError );
+    on( 'unhandledRejection', handleFatalError );
 
     try {
       enterAltScreen();
@@ -194,9 +245,13 @@ export default class Dev extends Command {
       await instance.waitUntilExit();
       exitAltScreenOnce();
     } catch ( error ) {
-      instanceRef.current?.unmount();
-      exitAltScreenOnce();
+      restoreTerminal();
       this.error( getErrorMessage( error ), { exit: 1 } );
+    } finally {
+      // Remove every process-global listener registered above; otherwise each
+      // run() (test invocations included) leaks a live handler that force-
+      // exits the process on the next stray signal or rejection.
+      disposers.forEach( dispose => dispose() );
     }
   }
 }


### PR DESCRIPTION
## Summary

Fix issue in development when if the TUI should crash terminal scroll is lost and users likely cannot see the actual root issue, just the most recent lines of the crash.