### PR TITLE
feat: enable TUI to reattach to existing dev sessions

### DIFF
--- a/.changeset/true-parents-worry.md
+++ b/.changeset/true-parents-worry.md
@@ -3,3 +3,19 @@
 ---
 
 Add TUI attaching and re-attaching and `dev down` teardown command
+
+`output dev` now detects an existing stack with `docker compose ps` instead of an
+unconditional host-port probe, so a re-run attaches to a running project stack
+rather than aborting on a collision with its own containers. Attached sessions
+leave the stack up on quit; `output dev down` stops it.
+
+A stack whose containers are all stopped counts as a fresh start, not an attach —
+`output dev` restarts it in the foreground and still tears it down on quit.
+
+`output dev -d` gained the pre-flight port probe the foreground path has. This
+matters on Docker Desktop, where a non-container process holding a published port
+does not fail `compose up -d`: the container starts and the port keeps answering
+the other process, with no error from Docker.
+
+Note: `-d` now pipes Docker's output rather than inheriting the terminal, so
+Docker drops its redrawing progress bars for plain scrolling lines.

--- a/.changeset/true-parents-worry.md
+++ b/.changeset/true-parents-worry.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": minor
+---
+
+Add TUI attaching and re-attaching and `dev down` teardown command

--- a/coding_assistants/claude/plugins/outputai/skills/output-services-check/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-services-check/SKILL.md
@@ -62,9 +62,16 @@ Wait 30-60 seconds for all services to initialize, then re-run the checks.
 
 ### If only some services are down:
 ```bash
-# Restart all services using Docker Compose
-docker compose down
-docker compose up -d
+# `output dev` reconciles a partially-up stack itself — it runs `up -d` for the
+# missing containers, then attaches to monitor. Prefer it over raw compose so
+# the project name and compose file match what the CLI uses.
+npx output dev
+```
+
+To stop everything first and start clean:
+```bash
+npx output dev down
+npx output dev
 ```
 
 ### If services fail to start:

--- a/docs/guides/packages/cli.mdx
+++ b/docs/guides/packages/cli.mdx
@@ -25,6 +25,7 @@ npx output workflow run lead_enrichment acme
 |---------|-------------|
 | `output init` | Create a new project |
 | `output dev` | Start development services |
+| `output dev down` | Stop development services |
 | `output update` | Update CLI and agent configuration |
 | `output workflow plan` | Generate a workflow plan from a description |
 | `output workflow generate` | Generate workflow code from a plan |
@@ -84,7 +85,8 @@ This starts:
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--compose-file, -f` | — | Path to custom docker-compose file |
-| `--no-watch` | false | Disable file watching |
+| `--detached, -d` | false | Start services in the background and exit immediately |
+| `--image-pull-policy` | `always` | Image pull policy: `always`, `missing`, or `never` |
 
 #### Running multiple dev stacks
 
@@ -107,6 +109,37 @@ OUTPUT_TEMPORAL_HOST_PORT=7234
 `DOCKER_SERVICE_NAME` isolates Docker networks, volumes, and container names so the stacks don't interfere with each other. `OUTPUT_CATALOG_ID` keeps each stack's workflow catalog separate. The three `OUTPUT_*_HOST_PORT` vars control which ports are exposed on your machine — the container-internal ports are unchanged, so workers in either stack still reach Temporal at `temporal:7233`.
 
 Run `npx output dev` in each project directory. Project A's API is at `http://localhost:3001` and Project B's at `http://localhost:3002`. If a port is already in use, `output dev` names the conflicting port and the env var to override.
+
+#### Attaching to a running stack
+
+If services are already running for this project, `output dev` attaches and
+monitors them instead of reporting a port collision on our own containers.
+
+An attached session does not own the stack: quitting the dashboard leaves the
+services running. The footer reads `ctrl+c detach (keeps running)` so you can
+tell which mode you're in. Stop an attached stack explicitly:
+
+```bash
+output dev down
+```
+
+A stack whose containers are all stopped is not an attach — `output dev` starts
+it in the foreground and tears it down on quit, as a fresh start would.
+
+### output dev down
+
+Stop the development services started by `output dev`:
+
+```bash
+output dev down
+```
+
+Use this after `output dev -d`, or when an attached `output dev` session left
+the services running on quit.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--compose-file, -f` | — | Path to custom docker-compose file |
 
 ### output dev eject
 

--- a/sdk/cli/src/commands/dev/down.spec.ts
+++ b/sdk/cli/src/commands/dev/down.spec.ts
@@ -58,11 +58,19 @@ describe( 'dev down command', () => {
       expect( cmd.error ).not.toHaveBeenCalled();
     } );
 
-    it( 'errors when the compose file is missing', async () => {
+    it( 'errors with the command formatter when the compose file is missing', async () => {
       vi.mocked( dockerService.resolveDockerComposePath ).mockRejectedValue( new Error( 'File not found' ) );
 
       const cmd = makeCmd();
+      cmd.error = vi.fn( () => {
+        throw new Error( 'oclif-error-thrown' );
+      } ) as any;
+
       await expect( cmd.run() ).rejects.toThrow();
+      expect( cmd.error ).toHaveBeenCalledWith(
+        expect.stringContaining( 'File not found' ),
+        { exit: 1 }
+      );
       expect( dockerService.stopDockerCompose ).not.toHaveBeenCalled();
     } );
 

--- a/sdk/cli/src/commands/dev/down.spec.ts
+++ b/sdk/cli/src/commands/dev/down.spec.ts
@@ -1,0 +1,83 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as dockerService from '#services/docker.js';
+import DevDown from './down.js';
+
+vi.mock( '#services/docker.js', () => ( {
+  validateDockerEnvironment: vi.fn(),
+  stopDockerCompose: vi.fn().mockResolvedValue( undefined ),
+  resolveDockerComposePath: vi.fn().mockResolvedValue( '/path/to/docker-compose-dev.yml' )
+} ) );
+
+const makeCmd = (): DevDown => {
+  const cmd = new DevDown( [], {} as any );
+  cmd.log = vi.fn() as any;
+  cmd.error = vi.fn() as any;
+  Object.defineProperty( cmd, 'parse', {
+    value: vi.fn().mockResolvedValue( { flags: { 'compose-file': undefined }, args: {} } ),
+    configurable: true
+  } );
+  return cmd;
+};
+
+describe( 'dev down command', () => {
+  beforeEach( () => {
+    vi.clearAllMocks();
+    vi.mocked( dockerService.validateDockerEnvironment ).mockReturnValue( undefined );
+    vi.mocked( dockerService.stopDockerCompose ).mockResolvedValue( undefined );
+    vi.mocked( dockerService.resolveDockerComposePath ).mockResolvedValue( '/path/to/docker-compose-dev.yml' );
+  } );
+
+  afterEach( () => {
+    vi.restoreAllMocks();
+  } );
+
+  describe( 'command structure', () => {
+    it( 'should have a description mentioning stopping services', () => {
+      expect( DevDown.description ).toBeDefined();
+      expect( DevDown.description ).toContain( 'Stop' );
+    } );
+
+    it( 'should have no required arguments', () => {
+      expect( Object.keys( DevDown.args ) ).toHaveLength( 0 );
+    } );
+
+    it( 'should have a compose-file flag', () => {
+      expect( DevDown.flags['compose-file'] ).toBeDefined();
+      expect( DevDown.flags['compose-file'].char ).toBe( 'f' );
+    } );
+  } );
+
+  describe( 'run', () => {
+    it( 'validates docker and stops the default stack', async () => {
+      const cmd = makeCmd();
+      await cmd.run();
+
+      expect( dockerService.validateDockerEnvironment ).toHaveBeenCalled();
+      expect( dockerService.stopDockerCompose ).toHaveBeenCalledWith( '/path/to/docker-compose-dev.yml' );
+      expect( cmd.error ).not.toHaveBeenCalled();
+    } );
+
+    it( 'errors when the compose file is missing', async () => {
+      vi.mocked( dockerService.resolveDockerComposePath ).mockRejectedValue( new Error( 'File not found' ) );
+
+      const cmd = makeCmd();
+      await expect( cmd.run() ).rejects.toThrow();
+      expect( dockerService.stopDockerCompose ).not.toHaveBeenCalled();
+    } );
+
+    it( 'surfaces a teardown failure as an actionable error', async () => {
+      vi.mocked( dockerService.stopDockerCompose ).mockRejectedValue( new Error( 'compose down failed' ) );
+      const cmd = makeCmd();
+      cmd.error = vi.fn( () => {
+        throw new Error( 'oclif-error-thrown' );
+      } ) as any;
+
+      await expect( cmd.run() ).rejects.toThrow();
+      expect( cmd.error ).toHaveBeenCalledWith(
+        expect.stringContaining( 'compose down failed' ),
+        { exit: 1 }
+      );
+    } );
+  } );
+} );

--- a/sdk/cli/src/commands/dev/down.ts
+++ b/sdk/cli/src/commands/dev/down.ts
@@ -34,9 +34,8 @@ export default class DevDown extends Command {
 
     validateDockerEnvironment();
 
-    const dockerComposePath = await resolveDockerComposePath( flags['compose-file'] );
-
     try {
+      const dockerComposePath = await resolveDockerComposePath( flags['compose-file'] );
       await stopDockerCompose( dockerComposePath );
     } catch ( error ) {
       this.error( getErrorMessage( error ), { exit: 1 } );

--- a/sdk/cli/src/commands/dev/down.ts
+++ b/sdk/cli/src/commands/dev/down.ts
@@ -1,0 +1,45 @@
+import { Command, Flags } from '@oclif/core';
+import {
+  validateDockerEnvironment,
+  stopDockerCompose,
+  resolveDockerComposePath
+} from '#services/docker.js';
+import { getErrorMessage } from '#utils/error_utils.js';
+
+export default class DevDown extends Command {
+  static description = [
+    'Stop Output development services started by `output dev`',
+    '',
+    'Useful after `output dev -d`, or when an attached `output dev` session',
+    'left the services running on quit.'
+  ].join( '\n' );
+
+  static examples = [
+    '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --compose-file ./custom-docker-compose.yml'
+  ];
+
+  static args = {};
+
+  static flags = {
+    'compose-file': Flags.string( {
+      description: 'Path to a custom docker-compose file',
+      required: false,
+      char: 'f'
+    } )
+  };
+
+  async run(): Promise<void> {
+    const { flags } = await this.parse( DevDown );
+
+    validateDockerEnvironment();
+
+    const dockerComposePath = await resolveDockerComposePath( flags['compose-file'] );
+
+    try {
+      await stopDockerCompose( dockerComposePath );
+    } catch ( error ) {
+      this.error( getErrorMessage( error ), { exit: 1 } );
+    }
+  }
+}

--- a/sdk/cli/src/commands/dev/index.spec.ts
+++ b/sdk/cli/src/commands/dev/index.spec.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import fs from 'node:fs/promises';
 import type { ChildProcess } from 'node:child_process';
 import { render } from 'ink';
 import * as dockerService from '#services/docker.js';
@@ -17,37 +16,23 @@ vi.mock( '#utils/port_availability.js', () => ( {
   findUnavailablePorts: vi.fn().mockResolvedValue( [] )
 } ) );
 
-vi.mock( '#services/docker.js', () => ( {
-  validateDockerEnvironment: vi.fn(),
-  startDockerCompose: vi.fn(),
-  stopDockerCompose: vi.fn().mockResolvedValue( undefined ),
-  getServiceStatus: vi.fn().mockResolvedValue( [
-    { name: 'redis', state: 'running', health: 'healthy', ports: [ '6379:6379' ] },
-    { name: 'temporal', state: 'running', health: 'healthy', ports: [ '7233:7233' ] }
-  ] ),
-  isServiceFailed: vi.fn( ( s: { state: string; health: string } ) =>
-    s.state === 'exited' || s.health === 'unhealthy'
-  ),
-  DockerComposeConfigNotFoundError: Error,
-  DockerValidationError: Error,
-  getDefaultDockerComposePath: vi.fn( () => '/path/to/docker-compose-dev.yml' ),
-  SERVICE_HEALTH: {
-    HEALTHY: 'healthy',
-    UNHEALTHY: 'unhealthy',
-    STARTING: 'starting',
-    NONE: 'none'
-  },
-  SERVICE_STATE: {
-    RUNNING: 'running',
-    EXITED: 'exited'
-  }
-} ) );
-
-vi.mock( 'node:fs/promises', () => ( {
-  default: {
-    access: vi.fn()
-  }
-} ) );
+vi.mock( '#services/docker.js', async importActual => {
+  const actual = await importActual<typeof import( '#services/docker.js' )>();
+  return {
+    ...actual,
+    // Override only the IO surface. Pure helpers (classifyStackState,
+    // isServiceHealthy, STACK_STATE, error classes) come from the real module,
+    // so branch selection here exercises the same logic production runs.
+    validateDockerEnvironment: vi.fn(),
+    startDockerCompose: vi.fn(),
+    startDockerComposeDetached: vi.fn(),
+    stopDockerCompose: vi.fn().mockResolvedValue( undefined ),
+    // Default: nothing running — a fresh start. Individual tests opt into an
+    // existing stack by overriding this to drive attach / reconcile branches.
+    getServiceStatus: vi.fn().mockResolvedValue( [] ),
+    resolveDockerComposePath: vi.fn().mockResolvedValue( '/path/to/docker-compose-dev.yml' )
+  };
+} );
 
 vi.mock( 'ink', () => ( {
   render: vi.fn().mockReturnValue( {
@@ -105,12 +90,22 @@ describe( 'dev command', () => {
     vi.mocked( dockerService.validateDockerEnvironment ).mockResolvedValue( undefined );
     // By default, no host port is taken — individual tests opt in.
     vi.mocked( portAvailability.findUnavailablePorts ).mockResolvedValue( [] );
+    // By default, no stack is running — a fresh start. Tests opt into the
+    // attach / reconcile branches by overriding getServiceStatus.
+    vi.mocked( dockerService.getServiceStatus ).mockResolvedValue( [] );
+    vi.mocked( dockerService.startDockerComposeDetached ).mockReturnValue( undefined );
     // By default, startDockerCompose returns a mock process
     vi.mocked( dockerService.startDockerCompose ).mockResolvedValue( createMockDockerProcess() );
-    // By default, fs.access succeeds (file exists)
-    vi.mocked( fs ).access.mockResolvedValue( undefined );
+    // By default, the compose file resolves and exists.
+    vi.mocked( dockerService.resolveDockerComposePath ).mockResolvedValue( '/path/to/docker-compose-dev.yml' );
     // By default, ensureClaudePlugin succeeds
     vi.mocked( codingAgentsService.ensureClaudePlugin ).mockResolvedValue( undefined );
+    // By default, render returns an instance that exits immediately. Tests
+    // needing a controllable lifecycle override this.
+    vi.mocked( render ).mockReturnValue( {
+      waitUntilExit: vi.fn().mockResolvedValue( undefined ),
+      unmount: vi.fn()
+    } as any );
   } );
 
   afterEach( () => {
@@ -277,7 +272,9 @@ describe( 'dev command', () => {
     } );
 
     it( 'should handle docker compose configuration not found', async () => {
-      vi.mocked( fs ).access.mockRejectedValue( new Error( 'File not found' ) );
+      vi.mocked( dockerService.resolveDockerComposePath ).mockRejectedValue(
+        new dockerService.DockerComposeConfigNotFoundError( '/path/to/docker-compose-dev.yml' )
+      );
 
       const cmd = new Dev( [], {} as any );
       cmd.log = vi.fn() as any;
@@ -424,6 +421,105 @@ describe( 'dev command', () => {
 
       expect( inkInstance.unmount ).not.toHaveBeenCalledWith( expect.any( Error ) );
       expect( cmd.error ).not.toHaveBeenCalled();
+    } );
+  } );
+
+  describe( 'attach and reconcile behavior', () => {
+    const runningStack = [
+      { name: 'redis', state: 'running', health: 'healthy', ports: [] },
+      { name: 'temporal', state: 'running', health: 'healthy', ports: [ '7233:7233' ] },
+      { name: 'api', state: 'running', health: 'none', ports: [ '3001:3001' ] }
+    ];
+
+    const makeCmd = (): Dev => {
+      const cmd = new Dev( [], {} as any );
+      cmd.log = vi.fn() as any;
+      cmd.error = vi.fn() as any;
+      Object.defineProperty( cmd, 'parse', {
+        value: vi.fn().mockResolvedValue( {
+          flags: { 'compose-file': undefined, 'image-pull-policy': 'always', detached: false },
+          args: {}
+        } ),
+        configurable: true
+      } );
+      return cmd;
+    };
+
+    const lastRenderedProps = <T>(): T => {
+      const appElement = vi.mocked( render ).mock.calls.at( -1 )?.[0];
+      if ( !React.isValidElement<T>( appElement ) ) {
+        throw new Error( 'Expected render to receive a React element' );
+      }
+      return appElement.props;
+    };
+
+    it( 'attaches to a healthy running stack without a foreground up or port probe', async () => {
+      vi.mocked( dockerService.getServiceStatus ).mockResolvedValue( runningStack );
+
+      const cmd = makeCmd();
+      await cmd.run();
+
+      expect( portAvailability.findUnavailablePorts ).not.toHaveBeenCalled();
+      expect( dockerService.startDockerCompose ).not.toHaveBeenCalled();
+      expect( dockerService.startDockerComposeDetached ).not.toHaveBeenCalled();
+      expect( cmd.error ).not.toHaveBeenCalled();
+      expect( lastRenderedProps<{ attached: boolean }>().attached ).toBe( true );
+    } );
+
+    it( 'leaves an attached stack running on cleanup (no teardown)', async () => {
+      vi.mocked( dockerService.getServiceStatus ).mockResolvedValue( runningStack );
+
+      const cmd = makeCmd();
+      await cmd.run();
+
+      await lastRenderedProps<{ onCleanup: () => Promise<void> }>().onCleanup();
+
+      expect( dockerService.stopDockerCompose ).not.toHaveBeenCalled();
+    } );
+
+    it( 'does not port-probe or error when our own stack already holds the ports', async () => {
+      vi.mocked( dockerService.getServiceStatus ).mockResolvedValue( runningStack );
+      vi.mocked( portAvailability.findUnavailablePorts ).mockResolvedValue( [ 3001 ] );
+
+      const cmd = makeCmd();
+      await cmd.run();
+
+      expect( portAvailability.findUnavailablePorts ).not.toHaveBeenCalled();
+      expect( cmd.error ).not.toHaveBeenCalled();
+    } );
+
+    it( 'reconciles a partially-failed stack with a detached up, then monitors', async () => {
+      vi.mocked( dockerService.getServiceStatus ).mockResolvedValue( [
+        { name: 'temporal', state: 'running', health: 'healthy', ports: [ '7233:7233' ] },
+        { name: 'worker', state: 'exited', health: 'none', ports: [] }
+      ] );
+
+      const cmd = makeCmd();
+      await cmd.run();
+
+      expect( dockerService.startDockerComposeDetached ).toHaveBeenCalledWith(
+        '/path/to/docker-compose-dev.yml',
+        'always'
+      );
+      // Reconcile monitors via ps polling, not a foreground up.
+      expect( dockerService.startDockerCompose ).not.toHaveBeenCalled();
+      expect( portAvailability.findUnavailablePorts ).not.toHaveBeenCalled();
+      expect( lastRenderedProps<{ attached: boolean }>().attached ).toBe( true );
+    } );
+
+    it( 'falls back to a fresh foreground start when no stack is running', async () => {
+      vi.mocked( dockerService.getServiceStatus ).mockResolvedValue( [] );
+
+      const cmd = makeCmd();
+      const runPromise = cmd.run();
+      await new Promise( resolve => setImmediate( resolve ) );
+
+      expect( portAvailability.findUnavailablePorts ).toHaveBeenCalled();
+      expect( dockerService.startDockerCompose ).toHaveBeenCalled();
+      expect( dockerService.startDockerComposeDetached ).not.toHaveBeenCalled();
+      expect( lastRenderedProps<{ attached: boolean }>().attached ).toBe( false );
+
+      runPromise.catch( () => {} );
     } );
   } );
 

--- a/sdk/cli/src/commands/dev/index.spec.ts
+++ b/sdk/cli/src/commands/dev/index.spec.ts
@@ -25,7 +25,7 @@ vi.mock( '#services/docker.js', async importActual => {
     // so branch selection here exercises the same logic production runs.
     validateDockerEnvironment: vi.fn(),
     startDockerCompose: vi.fn(),
-    startDockerComposeDetached: vi.fn(),
+    runDockerComposeUpDetached: vi.fn().mockResolvedValue( { code: 0, output: '' } ),
     stopDockerCompose: vi.fn().mockResolvedValue( undefined ),
     // Default: nothing running — a fresh start. Individual tests opt into an
     // existing stack by overriding this to drive attach / reconcile branches.
@@ -93,7 +93,7 @@ describe( 'dev command', () => {
     // By default, no stack is running — a fresh start. Tests opt into the
     // attach / reconcile branches by overriding getServiceStatus.
     vi.mocked( dockerService.getServiceStatus ).mockResolvedValue( [] );
-    vi.mocked( dockerService.startDockerComposeDetached ).mockReturnValue( undefined );
+    vi.mocked( dockerService.runDockerComposeUpDetached ).mockResolvedValue( { code: 0, output: '' } );
     // By default, startDockerCompose returns a mock process
     vi.mocked( dockerService.startDockerCompose ).mockResolvedValue( createMockDockerProcess() );
     // By default, the compose file resolves and exists.
@@ -461,7 +461,7 @@ describe( 'dev command', () => {
 
       expect( portAvailability.findUnavailablePorts ).not.toHaveBeenCalled();
       expect( dockerService.startDockerCompose ).not.toHaveBeenCalled();
-      expect( dockerService.startDockerComposeDetached ).not.toHaveBeenCalled();
+      expect( dockerService.runDockerComposeUpDetached ).not.toHaveBeenCalled();
       expect( cmd.error ).not.toHaveBeenCalled();
       expect( lastRenderedProps<{ attached: boolean }>().attached ).toBe( true );
     } );
@@ -497,14 +497,38 @@ describe( 'dev command', () => {
       const cmd = makeCmd();
       await cmd.run();
 
-      expect( dockerService.startDockerComposeDetached ).toHaveBeenCalledWith(
+      expect( dockerService.runDockerComposeUpDetached ).toHaveBeenCalledWith(
         '/path/to/docker-compose-dev.yml',
         'always'
       );
       // Reconcile monitors via ps polling, not a foreground up.
       expect( dockerService.startDockerCompose ).not.toHaveBeenCalled();
       expect( portAvailability.findUnavailablePorts ).not.toHaveBeenCalled();
+      expect( cmd.error ).not.toHaveBeenCalled();
       expect( lastRenderedProps<{ attached: boolean }>().attached ).toBe( true );
+    } );
+
+    it( 'aborts with a port-collision hint when the reconcile up fails to bind', async () => {
+      vi.mocked( dockerService.getServiceStatus ).mockResolvedValue( [
+        { name: 'temporal', state: 'running', health: 'healthy', ports: [ '7233:7233' ] },
+        { name: 'worker', state: 'exited', health: 'none', ports: [] }
+      ] );
+      vi.mocked( dockerService.runDockerComposeUpDetached ).mockResolvedValue( {
+        code: 1,
+        output: 'Error: ports are not available: exposing port TCP 0.0.0.0:3001 -> bind: address already in use'
+      } );
+
+      const cmd = makeCmd();
+      // this.error throws in oclif; emulate so the flow stops at the abort.
+      const errorMock = vi.fn( ( _message?: string ) => {
+        throw new Error( 'aborted' );
+      } );
+      cmd.error = errorMock as any;
+      await expect( cmd.run() ).rejects.toThrow( 'aborted' );
+
+      const message = errorMock.mock.calls.at( -1 )?.[0] as unknown as string;
+      expect( message ).toContain( '3001' );
+      expect( render ).not.toHaveBeenCalled();
     } );
 
     it( 'falls back to a fresh foreground start when no stack is running', async () => {
@@ -516,10 +540,56 @@ describe( 'dev command', () => {
 
       expect( portAvailability.findUnavailablePorts ).toHaveBeenCalled();
       expect( dockerService.startDockerCompose ).toHaveBeenCalled();
-      expect( dockerService.startDockerComposeDetached ).not.toHaveBeenCalled();
+      expect( dockerService.runDockerComposeUpDetached ).not.toHaveBeenCalled();
       expect( lastRenderedProps<{ attached: boolean }>().attached ).toBe( false );
 
       runPromise.catch( () => {} );
+    } );
+  } );
+
+  describe( 'detached flag', () => {
+    const makeDetachedCmd = (): Dev => {
+      const cmd = new Dev( [], {} as any );
+      cmd.log = vi.fn() as any;
+      cmd.error = vi.fn() as any;
+      Object.defineProperty( cmd, 'parse', {
+        value: vi.fn().mockResolvedValue( {
+          flags: { 'compose-file': undefined, 'image-pull-policy': 'always', detached: true },
+          args: {}
+        } ),
+        configurable: true
+      } );
+      return cmd;
+    };
+
+    it( 'brings the stack up detached and exits without mounting the TUI', async () => {
+      const cmd = makeDetachedCmd();
+      await cmd.run();
+
+      expect( dockerService.runDockerComposeUpDetached ).toHaveBeenCalledWith(
+        '/path/to/docker-compose-dev.yml',
+        'always'
+      );
+      expect( dockerService.getServiceStatus ).not.toHaveBeenCalled();
+      expect( render ).not.toHaveBeenCalled();
+      expect( cmd.error ).not.toHaveBeenCalled();
+    } );
+
+    it( 'aborts with a port-collision hint when the detached up fails to bind', async () => {
+      vi.mocked( dockerService.runDockerComposeUpDetached ).mockResolvedValue( {
+        code: 1,
+        output: 'Error: ports are not available: exposing port TCP 0.0.0.0:7233 -> bind: address already in use'
+      } );
+
+      const cmd = makeDetachedCmd();
+      const errorMock = vi.fn( ( _message?: string ) => {
+        throw new Error( 'aborted' );
+      } );
+      cmd.error = errorMock as any;
+
+      await expect( cmd.run() ).rejects.toThrow( 'aborted' );
+      const message = errorMock.mock.calls.at( -1 )?.[0] as unknown as string;
+      expect( message ).toContain( '7233' );
     } );
   } );
 

--- a/sdk/cli/src/commands/dev/index.spec.ts
+++ b/sdk/cli/src/commands/dev/index.spec.ts
@@ -25,7 +25,7 @@ vi.mock( '#services/docker.js', async importActual => {
     // so branch selection here exercises the same logic production runs.
     validateDockerEnvironment: vi.fn(),
     startDockerCompose: vi.fn(),
-    runDockerComposeUpDetached: vi.fn().mockResolvedValue( { code: 0, output: '' } ),
+    runDockerComposeUpDetached: vi.fn().mockResolvedValue( { code: 0, signal: null, output: '' } ),
     stopDockerCompose: vi.fn().mockResolvedValue( undefined ),
     // Default: nothing running — a fresh start. Individual tests opt into an
     // existing stack by overriding this to drive attach / reconcile branches.
@@ -93,7 +93,7 @@ describe( 'dev command', () => {
     // By default, no stack is running — a fresh start. Tests opt into the
     // attach / reconcile branches by overriding getServiceStatus.
     vi.mocked( dockerService.getServiceStatus ).mockResolvedValue( [] );
-    vi.mocked( dockerService.runDockerComposeUpDetached ).mockResolvedValue( { code: 0, output: '' } );
+    vi.mocked( dockerService.runDockerComposeUpDetached ).mockResolvedValue( { code: 0, signal: null, output: '' } );
     // By default, startDockerCompose returns a mock process
     vi.mocked( dockerService.startDockerCompose ).mockResolvedValue( createMockDockerProcess() );
     // By default, the compose file resolves and exists.
@@ -179,21 +179,21 @@ describe( 'dev command', () => {
       await expect( cmd.run() ).rejects.toThrow( 'Docker is not installed' );
     } );
 
-    it( 'should call validateDockerEnvironment', async () => {
+    it( 'should call validateDockerEnvironment before doing any work', async () => {
       const cmd = new Dev( [], {} as any );
       cmd.log = vi.fn() as any;
       cmd.error = vi.fn() as any;
+      Object.defineProperty( cmd, 'parse', {
+        value: vi.fn().mockResolvedValue( {
+          flags: { 'compose-file': undefined, 'image-pull-policy': 'always', detached: true },
+          args: {}
+        } ),
+        configurable: true
+      } );
 
-      // Mock the subprocess spawn to prevent actual execution
-      vi.doMock( 'node:child_process', () => ( {
-        spawn: vi.fn().mockReturnValue( {
-          on: vi.fn(),
-          kill: vi.fn()
-        } )
-      } ) );
+      await cmd.run();
 
-      // This test just verifies the function is called
-      expect( vi.mocked( dockerService.validateDockerEnvironment ) ).toBeDefined();
+      expect( dockerService.validateDockerEnvironment ).toHaveBeenCalled();
     } );
   } );
 
@@ -422,6 +422,68 @@ describe( 'dev command', () => {
       expect( inkInstance.unmount ).not.toHaveBeenCalledWith( expect.any( Error ) );
       expect( cmd.error ).not.toHaveBeenCalled();
     } );
+
+    // Without this, mutating teardownIfOwned to return unconditionally leaves
+    // every test green while each session leaks containers holding ports.
+    it( 'stops compose and kills the foreground process when it owns the stack', async () => {
+      const dockerProcess = createMockDockerProcess();
+      vi.mocked( dockerService.startDockerCompose ).mockResolvedValue( dockerProcess );
+
+      const cmd = new Dev( [], {} as any );
+      cmd.log = vi.fn() as any;
+      cmd.error = vi.fn() as any;
+      Object.defineProperty( cmd, 'parse', {
+        value: vi.fn().mockResolvedValue( {
+          flags: { 'compose-file': undefined, 'image-pull-policy': 'always', detached: false },
+          args: {}
+        } ),
+        configurable: true
+      } );
+
+      const runPromise = cmd.run();
+      await new Promise( resolve => setImmediate( resolve ) );
+
+      const appElement = vi.mocked( render ).mock.calls.at( -1 )?.[0];
+      if ( !React.isValidElement<{ onCleanup: () => Promise<void> }>( appElement ) ) {
+        throw new Error( 'Expected render to receive a React element' );
+      }
+      await appElement.props.onCleanup();
+
+      expect( dockerService.stopDockerCompose ).toHaveBeenCalledWith( '/path/to/docker-compose-dev.yml' );
+      expect( dockerProcess.kill ).toHaveBeenCalledWith( 'SIGTERM' );
+
+      runPromise.catch( () => {} );
+    } );
+
+    // The abnormal-exit route (health timeout, compose crash) resolves outside
+    // the signal path and has its own teardown call.
+    it( 'tears down an owned stack when the TUI exits abnormally', async () => {
+      const dockerProcess = createMockDockerProcess();
+      vi.mocked( dockerService.startDockerCompose ).mockResolvedValue( dockerProcess );
+      const inkInstance = createControllableInkInstance();
+      vi.mocked( render ).mockReturnValue( inkInstance as any );
+
+      const cmd = new Dev( [], {} as any );
+      cmd.log = vi.fn() as any;
+      cmd.error = vi.fn( () => {
+        throw new Error( 'aborted' );
+      } ) as any;
+      Object.defineProperty( cmd, 'parse', {
+        value: vi.fn().mockResolvedValue( {
+          flags: { 'compose-file': undefined, 'image-pull-policy': 'always', detached: false },
+          args: {}
+        } ),
+        configurable: true
+      } );
+
+      const runPromise = cmd.run();
+      await new Promise( resolve => setImmediate( resolve ) );
+
+      inkInstance.unmount( new Error( 'Timeout waiting for services to become healthy' ) );
+      await expect( runPromise ).rejects.toThrow( 'aborted' );
+
+      expect( dockerService.stopDockerCompose ).toHaveBeenCalledWith( '/path/to/docker-compose-dev.yml' );
+    } );
   } );
 
   describe( 'attach and reconcile behavior', () => {
@@ -515,7 +577,10 @@ describe( 'dev command', () => {
       ] );
       vi.mocked( dockerService.runDockerComposeUpDetached ).mockResolvedValue( {
         code: 1,
-        output: 'Error: ports are not available: exposing port TCP 0.0.0.0:3001 -> bind: address already in use'
+        signal: null,
+        output: 'Error response from daemon: failed to set up container networking: driver failed ' +
+          'programming external connectivity on endpoint out-api-1 (a1b2c3): ' +
+          'Bind for 0.0.0.0:3001 failed: port is already allocated'
       } );
 
       const cmd = makeCmd();
@@ -527,7 +592,8 @@ describe( 'dev command', () => {
       await expect( cmd.run() ).rejects.toThrow( 'aborted' );
 
       const message = errorMock.mock.calls.at( -1 )?.[0] as unknown as string;
-      expect( message ).toContain( '3001' );
+      expect( message ).toContain( 'Port 3001 is already in use.' );
+      expect( message ).toContain( 'OUTPUT_API_HOST_PORT=' );
       expect( render ).not.toHaveBeenCalled();
     } );
 
@@ -542,6 +608,92 @@ describe( 'dev command', () => {
       expect( dockerService.startDockerCompose ).toHaveBeenCalled();
       expect( dockerService.runDockerComposeUpDetached ).not.toHaveBeenCalled();
       expect( lastRenderedProps<{ attached: boolean }>().attached ).toBe( false );
+
+      runPromise.catch( () => {} );
+    } );
+
+    // A stopped stack (reboot, `docker compose stop`, failed teardown) leaves
+    // exited rows in `ps --all`. Before the classifier keyed on "is anything
+    // live", these reconciled and then disowned themselves: a plain `output dev`
+    // started every container and left them running on quit.
+    it( 'treats an all-exited stack as an owned fresh start, not an attach', async () => {
+      vi.mocked( dockerService.getServiceStatus ).mockResolvedValue( [
+        { name: 'temporal', state: 'exited', health: 'none', ports: [] },
+        { name: 'worker', state: 'exited', health: 'none', ports: [] }
+      ] );
+
+      const cmd = makeCmd();
+      const runPromise = cmd.run();
+      await new Promise( resolve => setImmediate( resolve ) );
+
+      expect( portAvailability.findUnavailablePorts ).toHaveBeenCalled();
+      expect( dockerService.startDockerCompose ).toHaveBeenCalled();
+      expect( dockerService.runDockerComposeUpDetached ).not.toHaveBeenCalled();
+      expect( lastRenderedProps<{ attached: boolean }>().attached ).toBe( false );
+
+      runPromise.catch( () => {} );
+    } );
+
+    it( 'tears down an all-exited stack it restarted, since it owns it', async () => {
+      vi.mocked( dockerService.getServiceStatus ).mockResolvedValue( [
+        { name: 'temporal', state: 'exited', health: 'none', ports: [] }
+      ] );
+
+      const cmd = makeCmd();
+      const runPromise = cmd.run();
+      await new Promise( resolve => setImmediate( resolve ) );
+
+      await lastRenderedProps<{ onCleanup: () => Promise<void> }>().onCleanup();
+
+      expect( dockerService.stopDockerCompose ).toHaveBeenCalledWith( '/path/to/docker-compose-dev.yml' );
+
+      runPromise.catch( () => {} );
+    } );
+
+    // The `ps` query absorbs a broken compose file, a dead daemon, EACCES on the
+    // socket, and any JSON.parse throw. Falling back to a fresh start is right;
+    // doing it silently is what reproduced OUT-477 with the wrong remedy.
+    it( 'falls back to a fresh start and warns when the state query fails', async () => {
+      vi.mocked( dockerService.getServiceStatus ).mockRejectedValue(
+        new Error( 'no configuration file provided: not found' )
+      );
+
+      const cmd = makeCmd();
+      cmd.warn = vi.fn() as any;
+      const runPromise = cmd.run();
+      await new Promise( resolve => setImmediate( resolve ) );
+
+      expect( portAvailability.findUnavailablePorts ).toHaveBeenCalled();
+      expect( dockerService.startDockerCompose ).toHaveBeenCalled();
+      expect( lastRenderedProps<{ attached: boolean }>().attached ).toBe( false );
+
+      const warned = vi.mocked( cmd.warn ).mock.calls.map( c => String( c[0] ) ).join( '\n' );
+      expect( warned ).toContain( 'no configuration file provided: not found' );
+      expect( warned ).toContain( 'output dev down' );
+
+      runPromise.catch( () => {} );
+    } );
+
+    it( 'warns that quitting leaves the stack up when attaching', async () => {
+      vi.mocked( dockerService.getServiceStatus ).mockResolvedValue( runningStack );
+
+      const cmd = makeCmd();
+      await cmd.run();
+
+      const logged = vi.mocked( cmd.log ).mock.calls.map( c => c[0] ).join( '\n' );
+      expect( logged ).toContain( 'Quitting leaves these services running' );
+      expect( logged ).toContain( 'output dev down' );
+    } );
+
+    it( 'does not claim the stack survives quitting on an owned fresh start', async () => {
+      vi.mocked( dockerService.getServiceStatus ).mockResolvedValue( [] );
+
+      const cmd = makeCmd();
+      const runPromise = cmd.run();
+      await new Promise( resolve => setImmediate( resolve ) );
+
+      const logged = vi.mocked( cmd.log ).mock.calls.map( c => c[0] ).join( '\n' );
+      expect( logged ).not.toContain( 'Quitting leaves these services running' );
 
       runPromise.catch( () => {} );
     } );
@@ -570,15 +722,68 @@ describe( 'dev command', () => {
         '/path/to/docker-compose-dev.yml',
         'always'
       );
-      expect( dockerService.getServiceStatus ).not.toHaveBeenCalled();
       expect( render ).not.toHaveBeenCalled();
+      expect( cmd.error ).not.toHaveBeenCalled();
+    } );
+
+    // The -d path lost its probe when the state check moved inside the NONE
+    // branch. It matters more than it looks: a non-container process holding a
+    // published port does NOT fail `compose up -d` on Docker Desktop — the
+    // container starts and the port keeps answering the other process.
+    it( 'probes host ports before starting a fresh detached stack', async () => {
+      const cmd = makeDetachedCmd();
+      await cmd.run();
+
+      expect( portAvailability.findUnavailablePorts ).toHaveBeenCalled();
+      expect( dockerService.runDockerComposeUpDetached ).toHaveBeenCalled();
+    } );
+
+    it( 'aborts before compose when a foreign process holds a port', async () => {
+      vi.mocked( portAvailability.findUnavailablePorts ).mockResolvedValue( [ 3001 ] );
+
+      const cmd = makeDetachedCmd();
+      const errorMock = vi.fn( ( _message?: string ) => {
+        throw new Error( 'aborted' );
+      } );
+      cmd.error = errorMock as any;
+
+      await expect( cmd.run() ).rejects.toThrow( 'aborted' );
+      expect( errorMock.mock.calls.at( -1 )?.[0] ).toContain( 'Port 3001 is already in use.' );
+      expect( dockerService.runDockerComposeUpDetached ).not.toHaveBeenCalled();
+    } );
+
+    it( 'warns rather than silently assuming a fresh start when the query fails', async () => {
+      vi.mocked( dockerService.getServiceStatus ).mockRejectedValue( new Error( 'daemon not running' ) );
+
+      const cmd = makeDetachedCmd();
+      cmd.warn = vi.fn() as any;
+      await cmd.run();
+
+      const warned = vi.mocked( cmd.warn ).mock.calls.map( c => String( c[0] ) ).join( '\n' );
+      expect( warned ).toContain( 'daemon not running' );
+      expect( portAvailability.findUnavailablePorts ).toHaveBeenCalled();
+    } );
+
+    it( 'does not probe when our own stack is already running', async () => {
+      vi.mocked( dockerService.getServiceStatus ).mockResolvedValue( [
+        { name: 'api', state: 'running', health: 'healthy', ports: [ '3001:3001' ] }
+      ] );
+      vi.mocked( portAvailability.findUnavailablePorts ).mockResolvedValue( [ 3001 ] );
+
+      const cmd = makeDetachedCmd();
+      await cmd.run();
+
+      expect( portAvailability.findUnavailablePorts ).not.toHaveBeenCalled();
       expect( cmd.error ).not.toHaveBeenCalled();
     } );
 
     it( 'aborts with a port-collision hint when the detached up fails to bind', async () => {
       vi.mocked( dockerService.runDockerComposeUpDetached ).mockResolvedValue( {
         code: 1,
-        output: 'Error: ports are not available: exposing port TCP 0.0.0.0:7233 -> bind: address already in use'
+        signal: null,
+        output: 'Error response from daemon: failed to set up container networking: driver failed ' +
+          'programming external connectivity on endpoint out-temporal-1 (d4e5f6): ' +
+          'Bind for 0.0.0.0:7233 failed: port is already allocated'
       } );
 
       const cmd = makeDetachedCmd();
@@ -589,7 +794,8 @@ describe( 'dev command', () => {
 
       await expect( cmd.run() ).rejects.toThrow( 'aborted' );
       const message = errorMock.mock.calls.at( -1 )?.[0] as unknown as string;
-      expect( message ).toContain( '7233' );
+      expect( message ).toContain( 'Port 7233 is already in use.' );
+      expect( message ).toContain( 'OUTPUT_TEMPORAL_HOST_PORT=' );
     } );
   } );
 

--- a/sdk/cli/src/commands/dev/index.spec.ts
+++ b/sdk/cli/src/commands/dev/index.spec.ts
@@ -652,7 +652,7 @@ describe( 'dev command', () => {
 
     // The `ps` query absorbs a broken compose file, a dead daemon, EACCES on the
     // socket, and any JSON.parse throw. Falling back to a fresh start is right;
-    // doing it silently is what reproduced OUT-477 with the wrong remedy.
+    // doing it silently is what reported a port collision with the wrong remedy.
     it( 'falls back to a fresh start and warns when the state query fails', async () => {
       vi.mocked( dockerService.getServiceStatus ).mockRejectedValue(
         new Error( 'no configuration file provided: not found' )

--- a/sdk/cli/src/commands/dev/index.ts
+++ b/sdk/cli/src/commands/dev/index.ts
@@ -109,7 +109,7 @@ export default class Dev extends Command {
       // Reconcile: converge a stack that's up but incomplete to the compose
       // spec, then monitor. Inspected (not fire-and-forget) so a failed bind
       // surfaces the same actionable port-collision hint the fresh-start path
-      // gives. Recovers the OUT-477 orphaned-stack case.
+      // gives. Recovers the orphaned stack a crashed session leaves behind.
       this.log( '🔄 Existing services detected — reconciling before attaching...\n' );
       await this.upDetachedOrError( dockerComposePath, pullPolicy );
     } else {
@@ -243,8 +243,8 @@ export default class Dev extends Command {
       exitAltScreenOnce();
       // An abnormal exit (health timeout, docker crash) resolves outside the
       // signal path. Tear down here only if cleanup hasn't already run, so an
-      // owned stack never leaks containers holding ports — the OUT-477 root
-      // cause. teardownIfOwned no-ops for attach/reconcile sessions.
+      // owned stack never leaks containers that keep holding published ports.
+      // teardownIfOwned no-ops for attach/reconcile sessions.
       if ( !state.cleaningUp ) {
         await teardownIfOwned().catch( teardownError => {
           // Don't mask the original failure, but the stack may still be up
@@ -271,8 +271,8 @@ export default class Dev extends Command {
   }
 
   // Probe only when no container of ours is live — otherwise our own stack is
-  // legitimately holding the ports and a probe would abort on it, which is the
-  // OUT-477 failure this detection replaced.
+  // legitimately holding the ports and the probe would abort on it, which is
+  // the failure this detection replaced.
   private async probePortsIfFreshStart( dockerComposePath: string ): Promise<void> {
     const services = await this.getServiceStatusOrWarn( dockerComposePath );
     if ( classifyStackState( services ) === STACK_STATE.NONE ) {
@@ -282,12 +282,11 @@ export default class Dev extends Command {
 
   // Query the stack, falling back to "nothing running" when the query itself
   // fails. A fresh start is the right recovery, but [] is not a neutral default
-  // — it asserts "no containers exist", which every caller acts on. Announce it,
-  // or a broken `ps` silently port-probes onto the user's own containers and
-  // reproduces the exact OUT-477 message this detection replaced, with a remedy
-  // (change the port) that is wrong for the actual cause.
-  private async getServiceStatusOrWarn( dockerComposePath: string ): Promise<ServiceStatus[]> {
-    return getServiceStatus( dockerComposePath ).catch( ( error: unknown ) => {
+  // — it asserts "no containers exist", which every caller acts on. Warn, or a
+  // broken `ps` silently port-probes onto the user's own containers and reports
+  // a port collision whose remedy (change the port) is wrong for the cause.
+  private getServiceStatusOrWarn = ( dockerComposePath: string ): Promise<ServiceStatus[]> =>
+    getServiceStatus( dockerComposePath ).catch( ( error: unknown ) => {
       this.warn(
         `Could not query existing services (${getErrorMessage( error )}). ` +
         'Continuing as a fresh start — if services are already running, stop them ' +
@@ -295,7 +294,6 @@ export default class Dev extends Command {
       );
       return [];
     } );
-  }
 
   // Bring the stack up detached and fail with an actionable message if compose
   // couldn't launch it (most often a foreign process holding a published

--- a/sdk/cli/src/commands/dev/index.ts
+++ b/sdk/cli/src/commands/dev/index.ts
@@ -12,7 +12,7 @@ import {
   STACK_STATE,
   resolveDockerComposePath
 } from '#services/docker.js';
-import type { PullPolicy } from '#services/docker.js';
+import type { PullPolicy, ServiceStatus } from '#services/docker.js';
 import { getErrorMessage } from '#utils/error_utils.js';
 import { formatComposeFailure, formatPortCollisionsHint } from '#utils/port_collision.js';
 import { findUnavailablePorts } from '#utils/port_availability.js';
@@ -25,11 +25,15 @@ export default class Dev extends Command {
     'Start Output development services (auto-restarts worker on file changes)',
     '',
     'If services are already running (e.g. after `output dev -d`), this attaches',
-    'to monitor them instead of failing on a port collision. Quitting an attached',
-    'session leaves the services running — stop them with `output dev down`.',
+    'to monitor them rather than treating our own containers as a port collision.',
+    'Quitting an attached session leaves the services running — stop them with',
+    '`output dev down`.',
     '',
-    'To run a second dev stack concurrently, override host ports in .env:',
+    'To run a second dev stack concurrently, give it its own compose project and',
+    'host ports in .env — without DOCKER_SERVICE_NAME both checkouts share one',
+    'stack, and the second will attach to the first instead of starting:',
     '',
+    '  DOCKER_SERVICE_NAME=output-sdk-two',
     '  OUTPUT_API_HOST_PORT=3002',
     '  OUTPUT_TEMPORAL_UI_HOST_PORT=8081',
     '  OUTPUT_TEMPORAL_HOST_PORT=7234'
@@ -80,55 +84,59 @@ export default class Dev extends Command {
     const pullPolicy = flags['image-pull-policy'] as PullPolicy;
     if ( flags.detached ) {
       this.log( '🐳 Starting services in detached mode...\n' );
+      // Probe only for a fresh start, same rule as the foreground path — our own
+      // running containers must not read as a collision. Compose alone isn't
+      // enough of a check: on Docker Desktop for macOS (verified on 29.4.0) a
+      // non-container process holding a published port doesn't fail `up -d` at
+      // all — the container starts and that port keeps answering the other
+      // process. The probe is the only thing that catches it there.
+      await this.probePortsIfFreshStart( dockerComposePath );
       await this.upDetachedOrError( dockerComposePath, pullPolicy );
       this.log( '✅ Services started. Run `output dev` without --detached to monitor status.\n' );
       return;
     }
 
-    // Detect an existing stack for this project (scoped by compose project
-    // name) so a re-run attaches instead of colliding. A raw port probe can't
-    // tell our own running containers from a foreign process; `docker compose
-    // ps` can. Fall back to a fresh start if the query itself fails.
-    const existingServices = await getServiceStatus( dockerComposePath ).catch( () => [] );
+    // Detect an existing stack for this project so a re-run attaches instead of
+    // colliding. A raw port probe can't tell our own running containers from a
+    // foreign process; `docker compose ps` can — though only within the shared
+    // compose project name, which doesn't separate one checkout from another.
+    const existingServices = await this.getServiceStatusOrWarn( dockerComposePath );
     const stackState = classifyStackState( existingServices );
 
     if ( stackState === STACK_STATE.NONE ) {
-      // Fresh start: probe each published host port before docker runs.
-      // Compose won't collide with its own containers, but a foreign process
-      // on one of these ports would leave the Ink TUI in limbo, so surface it
-      // now with an actionable hint.
-      const takenPorts = await findUnavailablePorts( Object.values( config.ports ) );
-      if ( takenPorts.length > 0 ) {
-        this.error( formatPortCollisionsHint( takenPorts, config.ports ), { exit: 1 } );
-      }
+      await this.probePorts();
     } else if ( stackState === STACK_STATE.PARTIAL ) {
-      // Reconcile: recreate failed or missing containers in the background,
-      // then monitor. `up -d` is idempotent and leaves healthy containers
-      // untouched, so this cleanly recovers the OUT-477 orphaned-stack case.
-      // Inspected (not fire-and-forget) so a failed bind surfaces the same
-      // actionable port-collision hint the fresh-start path gives.
+      // Reconcile: converge a stack that's up but incomplete to the compose
+      // spec, then monitor. Inspected (not fire-and-forget) so a failed bind
+      // surfaces the same actionable port-collision hint the fresh-start path
+      // gives. Recovers the OUT-477 orphaned-stack case.
       this.log( '🔄 Existing services detected — reconciling before attaching...\n' );
       await this.upDetachedOrError( dockerComposePath, pullPolicy );
     } else {
       this.log( '🔗 Services already running — attaching to monitor.\n' );
     }
 
-    // True whenever we didn't start the stack ourselves — an attach or a
-    // reconcile of a stack the user backgrounded. Drives teardown ownership,
-    // the foreground `up`, and the UI hint.
-    const attachOnly = stackState !== STACK_STATE.NONE;
+    // We own the stack only when we started it ourselves. Attaching to (or
+    // reconciling) a stack the user already had running leaves it up on quit.
+    const ownsStack = stackState === STACK_STATE.NONE;
+
+    if ( !ownsStack ) {
+      // The stack outliving this session is the surprising half of attach mode,
+      // and neither log line above says so. State the consequence plainly —
+      // container state alone can't tell a backgrounded `-d` stack from a
+      // crashed foreground session, so we can't infer intent, only report it.
+      this.log( 'Quitting leaves these services running — stop them with `output dev down`.\n' );
+    }
 
     const state = {
       cleaningUp: false
     };
 
-    // Only an invocation that started the stack in the foreground owns its
-    // teardown; attach/reconcile sessions leave it running (`output dev down`
-    // stops it). A foreground `up` stops the whole project on exit, so attach
-    // mode never runs one. Both the signal-driven cleanup and the abnormal-exit
-    // catch route through here so the ownership rule lives in one place.
+    // Only an invocation that started the stack owns its teardown; attach and
+    // reconcile sessions leave it running. Both the signal-driven cleanup and
+    // the abnormal-exit catch route through here so the rule lives in one place.
     const teardownIfOwned = async () => {
-      if ( attachOnly ) {
+      if ( !ownsStack ) {
         return;
       }
       if ( this.dockerProcess ) {
@@ -195,15 +203,14 @@ export default class Dev extends Command {
       enterAltScreen();
 
       const instance = render(
-        React.createElement( DevApp, { dockerComposePath, onCleanup: cleanup, attached: attachOnly } ),
+        React.createElement( DevApp, { dockerComposePath, onCleanup: cleanup, attached: !ownsStack } ),
         { exitOnCtrlC: false }
       );
       instanceRef.current = instance;
 
-      // Attach mode monitors an existing stack via `docker compose ps` polling
-      // (handled inside DevApp) — it must not own a foreground `up`, which
-      // would stop the whole project on exit.
-      if ( !attachOnly ) {
+      // Attach mode monitors via `docker compose ps` polling (inside DevApp) —
+      // it must not own a foreground `up`, which stops the whole project on exit.
+      if ( ownsStack ) {
         const dockerProc = await startDockerCompose( {
           dockerComposePath,
           pullPolicy,
@@ -252,19 +259,61 @@ export default class Dev extends Command {
     }
   }
 
+  // Probe each published host port before docker runs. Compose won't collide
+  // with its own containers, but a foreign process on one of these ports would
+  // leave the Ink TUI in limbo (or, detached, produce a container nobody can
+  // reach), so surface it now with an actionable hint.
+  private async probePorts(): Promise<void> {
+    const takenPorts = await findUnavailablePorts( Object.values( config.ports ) );
+    if ( takenPorts.length > 0 ) {
+      this.error( formatPortCollisionsHint( takenPorts, config.ports ), { exit: 1 } );
+    }
+  }
+
+  // Probe only when no container of ours is live — otherwise our own stack is
+  // legitimately holding the ports and a probe would abort on it, which is the
+  // OUT-477 failure this detection replaced.
+  private async probePortsIfFreshStart( dockerComposePath: string ): Promise<void> {
+    const services = await this.getServiceStatusOrWarn( dockerComposePath );
+    if ( classifyStackState( services ) === STACK_STATE.NONE ) {
+      await this.probePorts();
+    }
+  }
+
+  // Query the stack, falling back to "nothing running" when the query itself
+  // fails. A fresh start is the right recovery, but [] is not a neutral default
+  // — it asserts "no containers exist", which every caller acts on. Announce it,
+  // or a broken `ps` silently port-probes onto the user's own containers and
+  // reproduces the exact OUT-477 message this detection replaced, with a remedy
+  // (change the port) that is wrong for the actual cause.
+  private async getServiceStatusOrWarn( dockerComposePath: string ): Promise<ServiceStatus[]> {
+    return getServiceStatus( dockerComposePath ).catch( ( error: unknown ) => {
+      this.warn(
+        `Could not query existing services (${getErrorMessage( error )}). ` +
+        'Continuing as a fresh start — if services are already running, stop them ' +
+        'with `output dev down` first.'
+      );
+      return [];
+    } );
+  }
+
   // Bring the stack up detached and fail with an actionable message if compose
   // couldn't launch it (most often a foreign process holding a published
   // port). Shared by the `--detached` flag and the PARTIAL reconcile branch so
   // both surface the port-collision hint instead of a raw compose error.
   private async upDetachedOrError( dockerComposePath: string, pullPolicy: PullPolicy ): Promise<void> {
-    const { code, output } = await runDockerComposeUpDetached( dockerComposePath, pullPolicy );
+    const { code, signal, output } = await runDockerComposeUpDetached( dockerComposePath, pullPolicy );
     if ( code === 0 ) {
       return;
     }
 
+    // A signalled compose (an OOM-killed pull, a SIGKILL) has no exit code —
+    // report the signal rather than "unknown", which discards a known cause.
+    const reason = signal ? `signal ${signal}` : `exit code ${code ?? 'unknown'}`;
     this.error(
       formatComposeFailure(
-        `Docker compose failed to start services (exit code ${code ?? 'unknown'}).`,
+        `Docker compose failed to start services (${reason}). ` +
+        'Some containers may have started — stop them with `output dev down`.',
         output,
         config.ports
       ),

--- a/sdk/cli/src/commands/dev/index.ts
+++ b/sdk/cli/src/commands/dev/index.ts
@@ -1,6 +1,4 @@
 import { Command, Flags } from '@oclif/core';
-import fs from 'node:fs/promises';
-import path from 'node:path';
 import type { ChildProcess } from 'node:child_process';
 import { render } from 'ink';
 import React from 'react';
@@ -9,8 +7,10 @@ import {
   startDockerCompose,
   startDockerComposeDetached,
   stopDockerCompose,
-  DockerComposeConfigNotFoundError,
-  getDefaultDockerComposePath
+  getServiceStatus,
+  classifyStackState,
+  STACK_STATE,
+  resolveDockerComposePath
 } from '#services/docker.js';
 import type { PullPolicy } from '#services/docker.js';
 import { getErrorMessage } from '#utils/error_utils.js';
@@ -24,6 +24,10 @@ export default class Dev extends Command {
   static description = [
     'Start Output development services (auto-restarts worker on file changes)',
     '',
+    'If services are already running (e.g. after `output dev -d`), this attaches',
+    'to monitor them instead of failing on a port collision. Quitting an attached',
+    'session leaves the services running — stop them with `output dev down`.',
+    '',
     'To run a second dev stack concurrently, override host ports in .env:',
     '',
     '  OUTPUT_API_HOST_PORT=3002',
@@ -33,6 +37,7 @@ export default class Dev extends Command {
 
   static examples = [
     '<%= config.bin %> <%= command.id %>',
+    '<%= config.bin %> <%= command.id %> --detached',
     '<%= config.bin %> <%= command.id %> --compose-file ./custom-docker-compose.yml',
     '<%= config.bin %> <%= command.id %> --image-pull-policy missing'
   ];
@@ -70,23 +75,7 @@ export default class Dev extends Command {
     // Eagerly resolve ports so InvalidPortError surfaces before Ink mounts.
     void config.ports;
 
-    // Probe each published host port before docker runs. docker compose up
-    // doesn't exit on partial container failure, so a bind collision would
-    // otherwise leave the Ink TUI in limbo with no actionable feedback.
-    const takenPorts = await findUnavailablePorts( Object.values( config.ports ) );
-    if ( takenPorts.length > 0 ) {
-      this.error( formatPortCollisionsHint( takenPorts, config.ports ), { exit: 1 } );
-    }
-
-    const dockerComposePath = flags['compose-file'] ?
-      path.resolve( process.cwd(), flags['compose-file'] ) :
-      getDefaultDockerComposePath();
-
-    try {
-      await fs.access( dockerComposePath );
-    } catch {
-      throw new DockerComposeConfigNotFoundError( dockerComposePath );
-    }
+    const dockerComposePath = await resolveDockerComposePath( flags['compose-file'] );
 
     const pullPolicy = flags['image-pull-policy'] as PullPolicy;
     if ( flags.detached ) {
@@ -96,17 +85,60 @@ export default class Dev extends Command {
       return;
     }
 
+    // Detect an existing stack for this project (scoped by compose project
+    // name) so a re-run attaches instead of colliding. A raw port probe can't
+    // tell our own running containers from a foreign process; `docker compose
+    // ps` can. Fall back to a fresh start if the query itself fails.
+    const existingServices = await getServiceStatus( dockerComposePath ).catch( () => [] );
+    const stackState = classifyStackState( existingServices );
+
+    if ( stackState === STACK_STATE.NONE ) {
+      // Fresh start: probe each published host port before docker runs.
+      // Compose won't collide with its own containers, but a foreign process
+      // on one of these ports would leave the Ink TUI in limbo, so surface it
+      // now with an actionable hint.
+      const takenPorts = await findUnavailablePorts( Object.values( config.ports ) );
+      if ( takenPorts.length > 0 ) {
+        this.error( formatPortCollisionsHint( takenPorts, config.ports ), { exit: 1 } );
+      }
+    } else if ( stackState === STACK_STATE.PARTIAL ) {
+      // Reconcile: recreate failed or missing containers in the background,
+      // then monitor. `up -d` is idempotent and leaves healthy containers
+      // untouched, so this cleanly recovers the OUT-477 orphaned-stack case.
+      this.log( '🔄 Existing services detected — reconciling before attaching...\n' );
+      startDockerComposeDetached( dockerComposePath, pullPolicy );
+    } else {
+      this.log( '🔗 Services already running — attaching to monitor.\n' );
+    }
+
+    // True whenever we didn't start the stack ourselves — an attach or a
+    // reconcile of a stack the user backgrounded. Drives teardown ownership,
+    // the foreground `up`, and the UI hint.
+    const attachOnly = stackState !== STACK_STATE.NONE;
+
     const state = {
       cleaningUp: false
+    };
+
+    // Only an invocation that started the stack in the foreground owns its
+    // teardown; attach/reconcile sessions leave it running (`output dev down`
+    // stops it). A foreground `up` stops the whole project on exit, so attach
+    // mode never runs one. Both the signal-driven cleanup and the abnormal-exit
+    // catch route through here so the ownership rule lives in one place.
+    const teardownIfOwned = async () => {
+      if ( attachOnly ) {
+        return;
+      }
+      if ( this.dockerProcess ) {
+        this.dockerProcess.kill( 'SIGTERM' );
+      }
+      await stopDockerCompose( dockerComposePath );
     };
 
     const cleanup = async () => {
       state.cleaningUp = true;
       this.log( '\n' );
-      if ( this.dockerProcess ) {
-        this.dockerProcess.kill( 'SIGTERM' );
-      }
-      await stopDockerCompose( dockerComposePath );
+      await teardownIfOwned();
     };
 
     // INK paints onto the alternate screen buffer so log-update has a
@@ -161,41 +193,53 @@ export default class Dev extends Command {
       enterAltScreen();
 
       const instance = render(
-        React.createElement( DevApp, { dockerComposePath, onCleanup: cleanup } ),
+        React.createElement( DevApp, { dockerComposePath, onCleanup: cleanup, attached: attachOnly } ),
         { exitOnCtrlC: false }
       );
       instanceRef.current = instance;
 
-      const dockerProc = await startDockerCompose( {
-        dockerComposePath,
-        pullPolicy,
-        onError: error => {
-          instance.unmount( new Error( `Docker process error: ${getErrorMessage( error )}` ) );
-        },
-        onExit: ( code, signal, output ) => {
-          if ( state.cleaningUp ) {
-            return;
-          }
-          if ( code === 0 ) {
-            instance.unmount();
-            return;
-          }
+      // Attach mode monitors an existing stack via `docker compose ps` polling
+      // (handled inside DevApp) — it must not own a foreground `up`, which
+      // would stop the whole project on exit.
+      if ( !attachOnly ) {
+        const dockerProc = await startDockerCompose( {
+          dockerComposePath,
+          pullPolicy,
+          onError: error => {
+            instance.unmount( new Error( `Docker process error: ${getErrorMessage( error )}` ) );
+          },
+          onExit: ( code, signal, output ) => {
+            if ( state.cleaningUp ) {
+              return;
+            }
+            if ( code === 0 ) {
+              instance.unmount();
+              return;
+            }
 
-          const exitReason = signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`;
-          const hint = formatPortCollisionHint( output, config.ports );
-          const prefix = hint ? `${hint}\n\n` : '';
-          const detail = output ? `\n\nRecent Docker output:\n${output}` : '';
-          instance.unmount( new Error( `${prefix}Docker compose exited with ${exitReason}.${detail}` ) );
-        }
-      } );
+            const exitReason = signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`;
+            const hint = formatPortCollisionHint( output, config.ports );
+            const prefix = hint ? `${hint}\n\n` : '';
+            const detail = output ? `\n\nRecent Docker output:\n${output}` : '';
+            instance.unmount( new Error( `${prefix}Docker compose exited with ${exitReason}.${detail}` ) );
+          }
+        } );
 
-      this.dockerProcess = dockerProc;
+        this.dockerProcess = dockerProc;
+      }
 
       await instance.waitUntilExit();
       exitAltScreenOnce();
     } catch ( error ) {
       instanceRef.current?.unmount();
       exitAltScreenOnce();
+      // An abnormal exit (health timeout, docker crash) resolves outside the
+      // signal path. Tear down here only if cleanup hasn't already run, so an
+      // owned stack never leaks containers holding ports — the OUT-477 root
+      // cause. teardownIfOwned no-ops for attach/reconcile sessions.
+      if ( !state.cleaningUp ) {
+        await teardownIfOwned().catch( () => {} );
+      }
       this.error( getErrorMessage( error ), { exit: 1 } );
     }
   }

--- a/sdk/cli/src/commands/dev/index.ts
+++ b/sdk/cli/src/commands/dev/index.ts
@@ -5,7 +5,7 @@ import React from 'react';
 import {
   validateDockerEnvironment,
   startDockerCompose,
-  startDockerComposeDetached,
+  runDockerComposeUpDetached,
   stopDockerCompose,
   getServiceStatus,
   classifyStackState,
@@ -80,7 +80,7 @@ export default class Dev extends Command {
     const pullPolicy = flags['image-pull-policy'] as PullPolicy;
     if ( flags.detached ) {
       this.log( '🐳 Starting services in detached mode...\n' );
-      startDockerComposeDetached( dockerComposePath, pullPolicy );
+      await this.upDetachedOrError( dockerComposePath, pullPolicy );
       this.log( '✅ Services started. Run `output dev` without --detached to monitor status.\n' );
       return;
     }
@@ -105,8 +105,10 @@ export default class Dev extends Command {
       // Reconcile: recreate failed or missing containers in the background,
       // then monitor. `up -d` is idempotent and leaves healthy containers
       // untouched, so this cleanly recovers the OUT-477 orphaned-stack case.
+      // Inspected (not fire-and-forget) so a failed bind surfaces the same
+      // actionable port-collision hint the fresh-start path gives.
       this.log( '🔄 Existing services detected — reconciling before attaching...\n' );
-      startDockerComposeDetached( dockerComposePath, pullPolicy );
+      await this.upDetachedOrError( dockerComposePath, pullPolicy );
     } else {
       this.log( '🔗 Services already running — attaching to monitor.\n' );
     }
@@ -238,9 +240,35 @@ export default class Dev extends Command {
       // owned stack never leaks containers holding ports — the OUT-477 root
       // cause. teardownIfOwned no-ops for attach/reconcile sessions.
       if ( !state.cleaningUp ) {
-        await teardownIfOwned().catch( () => {} );
+        await teardownIfOwned().catch( teardownError => {
+          // Don't mask the original failure, but the stack may still be up
+          // holding ports — tell the user how to stop it.
+          this.warn(
+            'Failed to stop services during cleanup — they may still be running. ' +
+            `Stop them with \`output dev down\`.\n${getErrorMessage( teardownError )}`
+          );
+        } );
       }
       this.error( getErrorMessage( error ), { exit: 1 } );
     }
+  }
+
+  // Bring the stack up detached and fail with an actionable message if compose
+  // couldn't launch it (most often a foreign process holding a published
+  // port). Shared by the `--detached` flag and the PARTIAL reconcile branch so
+  // both surface the port-collision hint instead of a raw compose error.
+  private async upDetachedOrError( dockerComposePath: string, pullPolicy: PullPolicy ): Promise<void> {
+    const { code, output } = await runDockerComposeUpDetached( dockerComposePath, pullPolicy );
+    if ( code === 0 ) {
+      return;
+    }
+
+    const hint = formatPortCollisionHint( output, config.ports );
+    const prefix = hint ? `${hint}\n\n` : '';
+    const detail = output ? `\n\nRecent Docker output:\n${output}` : '';
+    this.error(
+      `${prefix}Docker compose failed to start services (exit code ${code ?? 'unknown'}).${detail}`,
+      { exit: 1 }
+    );
   }
 }

--- a/sdk/cli/src/commands/dev/index.ts
+++ b/sdk/cli/src/commands/dev/index.ts
@@ -14,7 +14,7 @@ import {
 } from '#services/docker.js';
 import type { PullPolicy } from '#services/docker.js';
 import { getErrorMessage } from '#utils/error_utils.js';
-import { formatPortCollisionHint, formatPortCollisionsHint } from '#utils/port_collision.js';
+import { formatComposeFailure, formatPortCollisionsHint } from '#utils/port_collision.js';
 import { findUnavailablePorts } from '#utils/port_availability.js';
 import { ensureClaudePlugin } from '#services/coding_agents.js';
 import { DevApp } from '#views/dev/dev_app.js';
@@ -220,10 +220,9 @@ export default class Dev extends Command {
             }
 
             const exitReason = signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`;
-            const hint = formatPortCollisionHint( output, config.ports );
-            const prefix = hint ? `${hint}\n\n` : '';
-            const detail = output ? `\n\nRecent Docker output:\n${output}` : '';
-            instance.unmount( new Error( `${prefix}Docker compose exited with ${exitReason}.${detail}` ) );
+            instance.unmount( new Error(
+              formatComposeFailure( `Docker compose exited with ${exitReason}.`, output, config.ports )
+            ) );
           }
         } );
 
@@ -263,11 +262,12 @@ export default class Dev extends Command {
       return;
     }
 
-    const hint = formatPortCollisionHint( output, config.ports );
-    const prefix = hint ? `${hint}\n\n` : '';
-    const detail = output ? `\n\nRecent Docker output:\n${output}` : '';
     this.error(
-      `${prefix}Docker compose failed to start services (exit code ${code ?? 'unknown'}).${detail}`,
+      formatComposeFailure(
+        `Docker compose failed to start services (exit code ${code ?? 'unknown'}).`,
+        output,
+        config.ports
+      ),
       { exit: 1 }
     );
   }

--- a/sdk/cli/src/services/docker.spec.ts
+++ b/sdk/cli/src/services/docker.spec.ts
@@ -3,7 +3,8 @@ import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
 import {
   parseServiceStatus, getServiceStatus,
   startDockerCompose, startDockerComposeDetached, stopDockerCompose,
-  waitForServicesHealthy, isServiceHealthy, isServiceFailed
+  waitForServicesHealthy, isServiceHealthy, isServiceFailed,
+  classifyStackState, STACK_STATE, type ServiceStatus
 } from './docker.js';
 
 vi.mock( 'node:child_process', () => ( {
@@ -355,6 +356,43 @@ describe( 'docker service', () => {
 
     it( 'should return false for a service with health: starting — not a failure, just in progress', () => {
       expect( isServiceFailed( { name: 'temporal', state: 'running', health: 'starting', ports: [] } ) ).toBe( false );
+    } );
+  } );
+
+  describe( 'classifyStackState', () => {
+    const svc = ( state: string, health: string ): ServiceStatus =>
+      ( { name: 's', state, health, ports: [] } );
+
+    it( 'returns NONE for an empty stack (fresh start)', () => {
+      expect( classifyStackState( [] ) ).toBe( STACK_STATE.NONE );
+    } );
+
+    it( 'returns RUNNING when every service is up and healthy', () => {
+      expect( classifyStackState( [
+        svc( 'running', 'healthy' ),
+        svc( 'running', 'none' )
+      ] ) ).toBe( STACK_STATE.RUNNING );
+    } );
+
+    it( 'returns PARTIAL when any service has failed (OUT-477 orphan)', () => {
+      expect( classifyStackState( [
+        svc( 'running', 'healthy' ),
+        svc( 'exited', 'none' )
+      ] ) ).toBe( STACK_STATE.PARTIAL );
+    } );
+
+    it( 'returns PARTIAL when services exist but some are still coming up', () => {
+      expect( classifyStackState( [
+        svc( 'running', 'healthy' ),
+        svc( 'created', 'none' )
+      ] ) ).toBe( STACK_STATE.PARTIAL );
+    } );
+
+    it( 'treats an unhealthy service as PARTIAL, not RUNNING', () => {
+      expect( classifyStackState( [
+        svc( 'running', 'healthy' ),
+        svc( 'running', 'unhealthy' )
+      ] ) ).toBe( STACK_STATE.PARTIAL );
     } );
   } );
 

--- a/sdk/cli/src/services/docker.spec.ts
+++ b/sdk/cli/src/services/docker.spec.ts
@@ -475,7 +475,7 @@ describe( 'docker service', () => {
       ] ) ).toBe( STACK_STATE.RUNNING );
     } );
 
-    it( 'returns PARTIAL when any service has failed (OUT-477 orphan)', () => {
+    it( 'returns PARTIAL when any service has failed (orphaned stack)', () => {
       expect( classifyStackState( [
         svc( 'running', 'healthy' ),
         svc( 'exited', 'none' )

--- a/sdk/cli/src/services/docker.spec.ts
+++ b/sdk/cli/src/services/docker.spec.ts
@@ -1,16 +1,23 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { execFileSync, spawn, type ChildProcess } from 'node:child_process';
+import path from 'node:path';
+import fs from 'node:fs/promises';
 import {
   parseServiceStatus, getServiceStatus,
-  startDockerCompose, startDockerComposeDetached, stopDockerCompose,
+  startDockerCompose, runDockerComposeUpDetached, stopDockerCompose,
   waitForServicesHealthy, isServiceHealthy, isServiceFailed,
-  classifyStackState, STACK_STATE, type ServiceStatus
+  classifyStackState, STACK_STATE, type ServiceStatus,
+  resolveDockerComposePath, getDefaultDockerComposePath, DockerComposeConfigNotFoundError
 } from './docker.js';
 
 vi.mock( 'node:child_process', () => ( {
   execSync: vi.fn(),
   execFileSync: vi.fn(),
   spawn: vi.fn()
+} ) );
+
+vi.mock( 'node:fs/promises', () => ( {
+  default: { access: vi.fn() }
 } ) );
 
 const mockChildProcess = ( process: unknown ): ChildProcess => process as ChildProcess;
@@ -230,11 +237,48 @@ describe( 'docker service', () => {
     } );
   } );
 
-  describe( 'startDockerComposeDetached', () => {
-    it( 'should pass --project-name and -d to docker compose up', () => {
-      vi.mocked( execFileSync ).mockReturnValue( '' );
-      startDockerComposeDetached( '/path/to/docker-compose.yml' );
-      expect( execFileSync ).toHaveBeenCalledWith(
+  describe( 'runDockerComposeUpDetached', () => {
+    const makeProcess = () => {
+      const handlers: {
+        error?: ( error: Error ) => void;
+        exit?: ( code: number | null ) => void;
+        stdout?: ( chunk: Buffer ) => void;
+        stderr?: ( chunk: Buffer ) => void;
+      } = {};
+      const proc = {
+        on: vi.fn( ( event: 'error' | 'exit',
+          handler: ( ( error: Error ) => void ) | ( ( code: number | null ) => void ) ) => {
+          if ( event === 'error' ) {
+            handlers.error = handler as ( error: Error ) => void;
+          } else {
+            handlers.exit = handler as ( code: number | null ) => void;
+          }
+          return proc;
+        } ),
+        stdout: {
+          on: vi.fn( ( event: 'data', handler: ( chunk: Buffer ) => void ) => {
+            handlers.stdout = handler;
+            return proc.stdout;
+          } )
+        },
+        stderr: {
+          on: vi.fn( ( event: 'data', handler: ( chunk: Buffer ) => void ) => {
+            handlers.stderr = handler;
+            return proc.stderr;
+          } )
+        }
+      };
+      return { proc, handlers };
+    };
+
+    it( 'passes --project-name and -d, tees output, and resolves with the exit code', async () => {
+      const { proc, handlers } = makeProcess();
+      vi.mocked( spawn ).mockReturnValue( mockChildProcess( proc ) );
+      const stdoutSpy = vi.spyOn( process.stdout, 'write' ).mockReturnValue( true );
+
+      const promise = runDockerComposeUpDetached( '/path/to/docker-compose.yml' );
+
+      expect( spawn ).toHaveBeenCalledWith(
         'docker',
         [
           'compose', '-f', '/path/to/docker-compose.yml',
@@ -242,14 +286,27 @@ describe( 'docker service', () => {
           '--project-name', 'output-sdk',
           'up', '-d'
         ],
-        expect.objectContaining( { stdio: 'inherit', cwd: process.cwd() } )
+        expect.objectContaining( { cwd: process.cwd(), stdio: [ 'ignore', 'pipe', 'pipe' ] } )
       );
+
+      handlers.stdout?.( Buffer.from( 'pulling images\n' ) );
+      handlers.exit?.( 0 );
+
+      expect( await promise ).toEqual( { code: 0, output: 'pulling images' } );
+      expect( stdoutSpy ).toHaveBeenCalledWith( Buffer.from( 'pulling images\n' ) );
+      stdoutSpy.mockRestore();
     } );
 
-    it( 'should append --pull when pullPolicy is provided', () => {
-      vi.mocked( execFileSync ).mockReturnValue( '' );
-      startDockerComposeDetached( '/path/to/docker-compose.yml', 'missing' );
-      expect( execFileSync ).toHaveBeenCalledWith(
+    it( 'appends --pull when pullPolicy is provided', async () => {
+      const { proc, handlers } = makeProcess();
+      vi.mocked( spawn ).mockReturnValue( mockChildProcess( proc ) );
+      vi.spyOn( process.stdout, 'write' ).mockReturnValue( true );
+
+      const promise = runDockerComposeUpDetached( '/path/to/docker-compose.yml', 'missing' );
+      handlers.exit?.( 0 );
+      await promise;
+
+      expect( spawn ).toHaveBeenCalledWith(
         'docker',
         [
           'compose', '-f', '/path/to/docker-compose.yml',
@@ -257,8 +314,52 @@ describe( 'docker service', () => {
           '--project-name', 'output-sdk',
           'up', '-d', '--pull', 'missing'
         ],
-        expect.objectContaining( { stdio: 'inherit', cwd: process.cwd() } )
+        expect.objectContaining( { cwd: process.cwd() } )
       );
+    } );
+
+    it( 'resolves with a non-zero code and captured stderr so the caller can hint the collision', async () => {
+      const { proc, handlers } = makeProcess();
+      vi.mocked( spawn ).mockReturnValue( mockChildProcess( proc ) );
+      vi.spyOn( process.stderr, 'write' ).mockReturnValue( true );
+
+      const promise = runDockerComposeUpDetached( '/path/to/docker-compose.yml' );
+      handlers.stderr?.( Buffer.from( 'Error: address already in use\n' ) );
+      handlers.exit?.( 1 );
+
+      expect( await promise ).toEqual( { code: 1, output: 'Error: address already in use' } );
+    } );
+
+    it( 'rejects when the docker process fails to spawn', async () => {
+      const { proc, handlers } = makeProcess();
+      vi.mocked( spawn ).mockReturnValue( mockChildProcess( proc ) );
+
+      const promise = runDockerComposeUpDetached( '/path/to/docker-compose.yml' );
+      handlers.error?.( new Error( 'spawn ENOENT' ) );
+
+      await expect( promise ).rejects.toThrow( 'spawn ENOENT' );
+    } );
+  } );
+
+  describe( 'resolveDockerComposePath', () => {
+    it( 'resolves a custom path against cwd and returns it when it exists', async () => {
+      vi.mocked( fs.access ).mockResolvedValue( undefined );
+      const result = await resolveDockerComposePath( 'custom/compose.yml' );
+      const expected = path.resolve( process.cwd(), 'custom/compose.yml' );
+      expect( result ).toBe( expected );
+      expect( fs.access ).toHaveBeenCalledWith( expected );
+    } );
+
+    it( 'throws DockerComposeConfigNotFoundError when the path does not exist', async () => {
+      vi.mocked( fs.access ).mockRejectedValue( new Error( 'ENOENT' ) );
+      await expect( resolveDockerComposePath( 'missing.yml' ) )
+        .rejects.toBeInstanceOf( DockerComposeConfigNotFoundError );
+    } );
+
+    it( 'falls back to the bundled default when no custom path is given', async () => {
+      vi.mocked( fs.access ).mockResolvedValue( undefined );
+      const result = await resolveDockerComposePath();
+      expect( result ).toBe( getDefaultDockerComposePath() );
     } );
   } );
 

--- a/sdk/cli/src/services/docker.spec.ts
+++ b/sdk/cli/src/services/docker.spec.ts
@@ -191,7 +191,7 @@ describe( 'docker service', () => {
         stderr?: ( chunk: Buffer ) => void;
       } = {};
       const process = {
-        on: vi.fn( ( event: 'error' | 'exit',
+        on: vi.fn( ( event: 'error' | 'close',
           handler: ( ( error: Error ) => void ) | ( ( code: number | null, signal: NodeJS.Signals | null ) => void ) ) => {
           if ( event === 'error' ) {
             processHandlers.error = handler as ( error: Error ) => void;
@@ -223,7 +223,7 @@ describe( 'docker service', () => {
       } );
 
       expect( dockerProcess.on ).toHaveBeenCalledWith( 'error', expect.any( Function ) );
-      expect( dockerProcess.on ).toHaveBeenCalledWith( 'exit', expect.any( Function ) );
+      expect( dockerProcess.on ).toHaveBeenCalledWith( 'close', expect.any( Function ) );
 
       streamHandlers.stdout?.( Buffer.from( 'starting services\n' ) );
       streamHandlers.stderr?.( Buffer.from( 'compose failed\n' ) );
@@ -246,7 +246,7 @@ describe( 'docker service', () => {
         stderr?: ( chunk: Buffer ) => void;
       } = {};
       const proc = {
-        on: vi.fn( ( event: 'error' | 'exit',
+        on: vi.fn( ( event: 'error' | 'close',
           handler: ( ( error: Error ) => void ) | ( ( code: number | null ) => void ) ) => {
           if ( event === 'error' ) {
             handlers.error = handler as ( error: Error ) => void;
@@ -493,6 +493,31 @@ describe( 'docker service', () => {
       expect( classifyStackState( [
         svc( 'running', 'healthy' ),
         svc( 'running', 'unhealthy' )
+      ] ) ).toBe( STACK_STATE.PARTIAL );
+    } );
+
+    // `ps --all` reports exited containers, so a stack stopped by a reboot, a
+    // `docker compose stop`, or a failed teardown still has rows. Nothing is
+    // live, so this invocation would be the one starting it — that makes it an
+    // owned fresh start, not an attach.
+    it( 'returns NONE when every service is exited — an owned fresh start, not an attach', () => {
+      expect( classifyStackState( [
+        svc( 'exited', 'none' ),
+        svc( 'exited', 'none' )
+      ] ) ).toBe( STACK_STATE.NONE );
+    } );
+
+    it( 'returns NONE when containers are created but none have started', () => {
+      expect( classifyStackState( [
+        svc( 'created', 'none' ),
+        svc( 'created', 'none' )
+      ] ) ).toBe( STACK_STATE.NONE );
+    } );
+
+    it( 'still returns PARTIAL when at least one service is live', () => {
+      expect( classifyStackState( [
+        svc( 'running', 'healthy' ),
+        svc( 'exited', 'none' )
       ] ) ).toBe( STACK_STATE.PARTIAL );
     } );
   } );

--- a/sdk/cli/src/services/docker.ts
+++ b/sdk/cli/src/services/docker.ts
@@ -5,6 +5,8 @@ import { fileURLToPath } from 'node:url';
 import { ux } from '@oclif/core';
 import semver from 'semver';
 import { config } from '#config.js';
+import { getErrorMessage } from '#utils/error_utils.js';
+import { formatComposeFailure } from '#utils/port_collision.js';
 
 const DEFAULT_COMPOSE_PATH = '../assets/docker/docker-compose-dev.yml';
 
@@ -187,11 +189,11 @@ export function isServiceFailed( service: ServiceStatus ): boolean {
 }
 
 export const STACK_STATE = {
-  /** No containers exist for this project — a fresh start. */
+  /** Nothing live for this project — a fresh start we own. */
   NONE: 'none',
-  /** Every container is up and healthy — safe to attach and monitor. */
+  /** Every container found is running and healthy (or has no healthcheck). */
   RUNNING: 'running',
-  /** Containers exist but some failed or are still coming up — reconcile. */
+  /** Something is live but not everything is healthy — reconcile. */
   PARTIAL: 'partial'
 } as const;
 
@@ -200,19 +202,21 @@ export type StackState = typeof STACK_STATE[keyof typeof STACK_STATE];
 /**
  * Classify the current state of a project's stack from `docker compose ps`.
  *
- * This is the detection signal `output dev` branches on: an empty result means
- * nothing is running (fresh start); an all-healthy result means we can attach
- * and monitor without touching the stack; anything in between (an exited
- * container, or services still booting) is reconciled with an idempotent
- * `up -d`. Scoped to the project name, so it never mistakes a foreign process
- * for one of ours the way a raw port probe does.
+ * This is the detection signal `output dev` branches on: nothing live means a
+ * fresh start; an all-healthy result means we can attach and monitor without
+ * touching the stack; anything in between is reconciled with `up -d`.
+ *
+ * Scoped to the shared `output-sdk` compose project, which distinguishes our
+ * containers from unrelated processes — but not one Output checkout from
+ * another, since the project name defaults to a machine-global constant.
  */
 export function classifyStackState( services: ServiceStatus[] ): StackState {
-  if ( services.length === 0 ) {
+  // No container is live. `ps --all` also reports exited ones, so a stack left
+  // behind by a reboot, a `docker compose stop`, or a failed teardown lands
+  // here — that's an owned fresh start, not something to attach to.
+  if ( !services.some( service => service.state === SERVICE_STATE.RUNNING ) ) {
     return STACK_STATE.NONE;
   }
-  // Anything short of every service being healthy — a failed container or one
-  // still booting — is PARTIAL and gets reconciled.
   if ( services.every( isServiceHealthy ) ) {
     return STACK_STATE.RUNNING;
   }
@@ -297,7 +301,9 @@ export async function startDockerCompose( {
     dockerProcess.on( 'error', error => onError( error, output.read() ) );
   }
   if ( onExit ) {
-    dockerProcess.on( 'exit', ( code, signal ) => onExit( code, signal, output.read() ) );
+    // `close` rather than `exit` so stdio has drained — the buffered output is
+    // what formatComposeFailure greps for a bind failure.
+    dockerProcess.on( 'close', ( code, signal ) => onExit( code, signal, output.read() ) );
   }
 
   return dockerProcess;
@@ -305,14 +311,18 @@ export async function startDockerCompose( {
 
 export interface DetachedUpResult {
   code: number | null;
+  signal: NodeJS.Signals | null;
   output: string;
 }
 
 // Run `docker compose up -d` to completion, teeing Docker's progress to the
-// user's terminal while retaining recent output. Unlike a fire-and-forget
-// spawn, the caller can inspect the exit code and surface a port-collision
-// hint when the bind fails. Async (not execFileSync) so the event loop — and
-// any TUI about to mount — stays responsive during image pulls.
+// user's terminal while retaining recent output. The predecessor used
+// execFileSync with inherited stdio, which threw a raw compose error the caller
+// couldn't inspect; returning the exit code and output lets it surface a
+// port-collision hint instead. Async so image pulls don't block the event loop.
+//
+// Trade-off: piping means Docker sees a non-TTY and drops its redrawing
+// progress bars for plain scrolling lines.
 export function runDockerComposeUpDetached(
   dockerComposePath: string,
   pullPolicy?: PullPolicy
@@ -348,8 +358,17 @@ export function runDockerComposeUpDetached(
       output.append( chunk );
     } );
 
-    child.on( 'error', reject );
-    child.on( 'exit', code => resolve( { code, output: output.read() } ) );
+    // `error` fires when the spawn itself failed (docker missing, EACCES).
+    // Reject with the buffered output attached so the caller keeps the context
+    // rather than surfacing a bare `spawn docker ENOENT`.
+    child.on( 'error', error => {
+      reject( new Error( formatComposeFailure( getErrorMessage( error ), output.read(), config.ports ) ) );
+    } );
+    // `close`, not `exit`: exit fires while stdio may still be draining, and on
+    // a fast-failing `up -d` — exactly the bind-collision case — the stderr
+    // chunk carrying the bind error can land after it. Resolving early makes
+    // the port-collision hint disappear intermittently.
+    child.on( 'close', ( code, signal ) => resolve( { code, signal, output: output.read() } ) );
   } );
 }
 

--- a/sdk/cli/src/services/docker.ts
+++ b/sdk/cli/src/services/docker.ts
@@ -239,6 +239,19 @@ export async function waitForServicesHealthy(
   throw new Error( 'Timeout waiting for services to become healthy' );
 }
 
+// A rolling buffer that retains the last ~20k chars of a spawned process's
+// combined output, so a startup failure can surface recent Docker logs without
+// holding the whole stream. Shared by the two compose spawn sites.
+function createOutputBuffer(): { append: ( chunk: Buffer ) => void; read: () => string } {
+  const buffer = { value: '' };
+  return {
+    append: ( chunk: Buffer ): void => {
+      buffer.value = `${buffer.value}${chunk.toString()}`.slice( -20000 ).trimStart();
+    },
+    read: (): string => buffer.value.trimEnd()
+  };
+}
+
 export interface DockerComposeHandlers {
   onError?: ( error: Error, output: string ) => void;
   onExit?: ( code: number | null, signal: NodeJS.Signals | null, output: string ) => void;
@@ -269,12 +282,7 @@ export async function startDockerCompose( {
     args.push( '--pull', pullPolicy );
   }
 
-  const output = {
-    value: ''
-  };
-  const appendOutput = ( chunk: Buffer ): void => {
-    output.value = `${output.value}${chunk.toString()}`.slice( -20000 ).trimStart();
-  };
+  const output = createOutputBuffer();
 
   const dockerProcess = spawn( 'docker', args, {
     cwd: process.cwd(),
@@ -283,13 +291,13 @@ export async function startDockerCompose( {
     stdio: [ 'ignore', 'pipe', 'pipe' ]
   } );
 
-  dockerProcess.stdout?.on( 'data', appendOutput );
-  dockerProcess.stderr?.on( 'data', appendOutput );
+  dockerProcess.stdout?.on( 'data', output.append );
+  dockerProcess.stderr?.on( 'data', output.append );
   if ( onError ) {
-    dockerProcess.on( 'error', error => onError( error, output.value.trimEnd() ) );
+    dockerProcess.on( 'error', error => onError( error, output.read() ) );
   }
   if ( onExit ) {
-    dockerProcess.on( 'exit', ( code, signal ) => onExit( code, signal, output.value.trimEnd() ) );
+    dockerProcess.on( 'exit', ( code, signal ) => onExit( code, signal, output.read() ) );
   }
 
   return dockerProcess;
@@ -321,12 +329,7 @@ export function runDockerComposeUpDetached(
     args.push( '--pull', pullPolicy );
   }
 
-  const output = {
-    value: ''
-  };
-  const appendOutput = ( chunk: Buffer ): void => {
-    output.value = `${output.value}${chunk.toString()}`.slice( -20000 ).trimStart();
-  };
+  const output = createOutputBuffer();
 
   return new Promise( ( resolve, reject ) => {
     // Pipe rather than inherit so we can both echo Docker's progress and keep
@@ -338,15 +341,15 @@ export function runDockerComposeUpDetached(
 
     child.stdout?.on( 'data', ( chunk: Buffer ) => {
       process.stdout.write( chunk );
-      appendOutput( chunk );
+      output.append( chunk );
     } );
     child.stderr?.on( 'data', ( chunk: Buffer ) => {
       process.stderr.write( chunk );
-      appendOutput( chunk );
+      output.append( chunk );
     } );
 
     child.on( 'error', reject );
-    child.on( 'exit', code => resolve( { code, output: output.value.trimEnd() } ) );
+    child.on( 'exit', code => resolve( { code, output: output.read() } ) );
   } );
 }
 

--- a/sdk/cli/src/services/docker.ts
+++ b/sdk/cli/src/services/docker.ts
@@ -295,10 +295,20 @@ export async function startDockerCompose( {
   return dockerProcess;
 }
 
-export function startDockerComposeDetached(
+export interface DetachedUpResult {
+  code: number | null;
+  output: string;
+}
+
+// Run `docker compose up -d` to completion, teeing Docker's progress to the
+// user's terminal while retaining recent output. Unlike a fire-and-forget
+// spawn, the caller can inspect the exit code and surface a port-collision
+// hint when the bind fails. Async (not execFileSync) so the event loop — and
+// any TUI about to mount — stays responsive during image pulls.
+export function runDockerComposeUpDetached(
   dockerComposePath: string,
   pullPolicy?: PullPolicy
-): void {
+): Promise<DetachedUpResult> {
   const args = [
     'compose',
     '-f', dockerComposePath,
@@ -311,7 +321,33 @@ export function startDockerComposeDetached(
     args.push( '--pull', pullPolicy );
   }
 
-  execFileSync( 'docker', args, { stdio: 'inherit', cwd: process.cwd() } );
+  const output = {
+    value: ''
+  };
+  const appendOutput = ( chunk: Buffer ): void => {
+    output.value = `${output.value}${chunk.toString()}`.slice( -20000 ).trimStart();
+  };
+
+  return new Promise( ( resolve, reject ) => {
+    // Pipe rather than inherit so we can both echo Docker's progress and keep
+    // recent output for a startup-failure hint.
+    const child = spawn( 'docker', args, {
+      cwd: process.cwd(),
+      stdio: [ 'ignore', 'pipe', 'pipe' ]
+    } );
+
+    child.stdout?.on( 'data', ( chunk: Buffer ) => {
+      process.stdout.write( chunk );
+      appendOutput( chunk );
+    } );
+    child.stderr?.on( 'data', ( chunk: Buffer ) => {
+      process.stderr.write( chunk );
+      appendOutput( chunk );
+    } );
+
+    child.on( 'error', reject );
+    child.on( 'exit', code => resolve( { code, output: output.value.trimEnd() } ) );
+  } );
 }
 
 export async function stopDockerCompose( dockerComposePath: string ): Promise<void> {

--- a/sdk/cli/src/services/docker.ts
+++ b/sdk/cli/src/services/docker.ts
@@ -1,4 +1,5 @@
 import { execFileSync, execSync, spawn, type ChildProcess } from 'node:child_process';
+import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { ux } from '@oclif/core';
@@ -122,6 +123,24 @@ export function getDefaultDockerComposePath(): string {
   );
 }
 
+// Resolve the compose file a `dev` command should act on — a caller-supplied
+// path (relative to cwd) or the bundled default — and verify it exists. Shared
+// by `dev` and `dev down` so the resolution rule and not-found error stay in
+// one place.
+export async function resolveDockerComposePath( customPath?: string ): Promise<string> {
+  const dockerComposePath = customPath ?
+    path.resolve( process.cwd(), customPath ) :
+    getDefaultDockerComposePath();
+
+  try {
+    await fs.access( dockerComposePath );
+  } catch {
+    throw new DockerComposeConfigNotFoundError( dockerComposePath );
+  }
+
+  return dockerComposePath;
+}
+
 export function parseServiceStatus( jsonOutput: string ): ServiceStatus[] {
   if ( !jsonOutput.trim() ) {
     return [];
@@ -165,6 +184,39 @@ export function isServiceHealthy( service: ServiceStatus ): boolean {
 
 export function isServiceFailed( service: ServiceStatus ): boolean {
   return service.state === SERVICE_STATE.EXITED || service.health === SERVICE_HEALTH.UNHEALTHY;
+}
+
+export const STACK_STATE = {
+  /** No containers exist for this project — a fresh start. */
+  NONE: 'none',
+  /** Every container is up and healthy — safe to attach and monitor. */
+  RUNNING: 'running',
+  /** Containers exist but some failed or are still coming up — reconcile. */
+  PARTIAL: 'partial'
+} as const;
+
+export type StackState = typeof STACK_STATE[keyof typeof STACK_STATE];
+
+/**
+ * Classify the current state of a project's stack from `docker compose ps`.
+ *
+ * This is the detection signal `output dev` branches on: an empty result means
+ * nothing is running (fresh start); an all-healthy result means we can attach
+ * and monitor without touching the stack; anything in between (an exited
+ * container, or services still booting) is reconciled with an idempotent
+ * `up -d`. Scoped to the project name, so it never mistakes a foreign process
+ * for one of ours the way a raw port probe does.
+ */
+export function classifyStackState( services: ServiceStatus[] ): StackState {
+  if ( services.length === 0 ) {
+    return STACK_STATE.NONE;
+  }
+  // Anything short of every service being healthy — a failed container or one
+  // still booting — is PARTIAL and gets reconciled.
+  if ( services.every( isServiceHealthy ) ) {
+    return STACK_STATE.RUNNING;
+  }
+  return STACK_STATE.PARTIAL;
 }
 
 export async function waitForServicesHealthy(

--- a/sdk/cli/src/utils/port_collision.spec.ts
+++ b/sdk/cli/src/utils/port_collision.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { extractCollidedPort, formatPortCollisionHint, formatPortCollisionsHint } from './port_collision.js';
+import {
+  extractCollidedPort, formatPortCollisionHint, formatPortCollisionsHint, formatComposeFailure
+} from './port_collision.js';
 
 const DEFAULT_PORTS = { api: 3001, temporalUi: 8080, temporal: 7233 };
 
@@ -27,6 +29,27 @@ describe( 'extractCollidedPort', () => {
 
   it( 'returns null when no bind failure is present', () => {
     expect( extractCollidedPort( 'some unrelated stderr line' ) ).toBeNull();
+  } );
+
+  // Captured verbatim from Docker 29.4.0 on macOS. The bind failure is nested
+  // three wrappers deep; matching whole message shapes missed it.
+  it( 'extracts the port from Docker 29\'s nested container-networking wrapper', () => {
+    const stderr = 'Error response from daemon: failed to set up container networking: ' +
+      'driver failed programming external connectivity on endpoint out-api-1 ' +
+      '(e72baf85643fb5dc19000acf62c1ad0d11bffc653cabe1fc8861387ec1ebd629): ' +
+      'Bind for 0.0.0.0:3001 failed: port is already allocated';
+    expect( extractCollidedPort( stderr ) ).toBe( 3001 );
+  } );
+
+  it( 'extracts the port from the "ports are not available" wrapper', () => {
+    const stderr = 'Error: ports are not available: exposing port TCP 0.0.0.0:3001 -> 0.0.0.0:0: ' +
+      'listen tcp 0.0.0.0:3001: bind: address already in use';
+    expect( extractCollidedPort( stderr ) ).toBe( 3001 );
+  } );
+
+  it( 'ignores an IP-like prefix and takes the port nearest the failure phrase', () => {
+    const stderr = 'container 172.17.0.2:5432 started\nBind for 0.0.0.0:8080 failed: port is already allocated';
+    expect( extractCollidedPort( stderr ) ).toBe( 8080 );
   } );
 
   it( 'returns null for empty input', () => {
@@ -111,5 +134,34 @@ describe( 'formatPortCollisionsHint', () => {
     const hint = formatPortCollisionsHint( [ 3001, 5432 ], DEFAULT_PORTS );
     expect( hint ).toContain( '• Port 3001 — override with OUTPUT_API_HOST_PORT=<other port>' );
     expect( hint ).toContain( '• Port 5432 — stop the process holding it' );
+  } );
+} );
+
+describe( 'formatComposeFailure', () => {
+  const reason = 'Docker compose failed to start services (exit code 1).';
+
+  it( 'prepends the actionable hint when the output names a collision', () => {
+    const message = formatComposeFailure(
+      reason,
+      'Bind for 0.0.0.0:3001 failed: port is already allocated',
+      DEFAULT_PORTS
+    );
+    expect( message.startsWith( 'Port 3001 is already in use.' ) ).toBe( true );
+    expect( message ).toContain( 'OUTPUT_API_HOST_PORT=<other port>' );
+    expect( message ).toContain( reason );
+    expect( message ).toContain( 'Recent Docker output:' );
+  } );
+
+  it( 'omits the output section entirely when nothing was captured', () => {
+    const message = formatComposeFailure( reason, '', DEFAULT_PORTS );
+    expect( message ).toBe( reason );
+    expect( message ).not.toContain( 'Recent Docker output:' );
+  } );
+
+  it( 'returns reason plus raw output, with no hint, for an unrecognized failure', () => {
+    const message = formatComposeFailure( reason, 'no such image: outputai/api:dev', DEFAULT_PORTS );
+    expect( message.startsWith( reason ) ).toBe( true );
+    expect( message ).toContain( 'Recent Docker output:\nno such image' );
+    expect( message ).not.toContain( 'is already in use' );
   } );
 } );

--- a/sdk/cli/src/utils/port_collision.ts
+++ b/sdk/cli/src/utils/port_collision.ts
@@ -3,21 +3,27 @@
  * an actionable hint that names the conflicting port and the env var to
  * override.
  *
- * Docker compose surfaces port collisions through two common error shapes:
- *   - "Bind for 0.0.0.0:3001 failed: port is already allocated"
- *   - "failed to bind host port for 0.0.0.0:7233:.../tcp: address already in use"
+ * Docker wraps the same failure differently across versions and platforms —
+ * Docker 29 on macOS nests it three deep:
  *
- * We match both, extract the host port, then map it back to the env var that
- * sets it. The map prefers a runtime lookup of resolved ports (so a user who
- * already set OUTPUT_API_HOST_PORT=3050 sees that var named when 3050
- * collides) and falls back to a default-port table for the unresolved case.
+ *   Error response from daemon: failed to set up container networking: driver
+ *   failed programming external connectivity on endpoint out-api-1 (a1b2…):
+ *   Bind for 0.0.0.0:3001 failed: port is already allocated
+ *
+ * Matching whole message shapes means a new wrapper silently drops the hint, so
+ * we anchor on the terminal phrase instead and take the host port nearest to it.
+ * That survives wrappers we haven't seen.
+ *
+ * The port is then mapped back to the env var that sets it. The map prefers a
+ * runtime lookup of resolved ports (so a user who already set
+ * OUTPUT_API_HOST_PORT=3050 sees that var named when 3050 collides) and falls
+ * back to a default-port table for the unresolved case.
  */
 
-const PORT_BIND_PATTERNS: RegExp[] = [
-  /Bind for [^:\s]+:(\d+) failed: port is already allocated/,
-  /failed to bind host port for [^:\s]+:(\d+)[^]*?address already in use/,
-  /listen tcp [^:\s]+:(\d+):\s*bind: address already in use/
-];
+const COLLISION_PHRASES = [ 'port is already allocated', 'address already in use' ];
+
+/** Trailing `:<port>` in a fragment — the host port a bind failure names. */
+const TRAILING_PORT = /:(\d+)(?!.*:\d)/s;
 
 const DEFAULT_PORT_TO_ENV_VAR: Record<number, string> = {
   3001: 'OUTPUT_API_HOST_PORT',
@@ -39,8 +45,16 @@ export function extractCollidedPort( stderr: string ): number | null {
   if ( !stderr ) {
     return null;
   }
-  for ( const pattern of PORT_BIND_PATTERNS ) {
-    const match = stderr.match( pattern );
+
+  for ( const phrase of COLLISION_PHRASES ) {
+    const phraseIndex = stderr.indexOf( phrase );
+    if ( phraseIndex === -1 ) {
+      continue;
+    }
+    // The host port is the last one named before the phrase — every shape puts
+    // it there ("Bind for 0.0.0.0:3001 failed: port is already allocated",
+    // "listen tcp 0.0.0.0:3001: bind: address already in use").
+    const match = stderr.slice( 0, phraseIndex ).match( TRAILING_PORT );
     if ( match ) {
       return parseInt( match[1], 10 );
     }

--- a/sdk/cli/src/utils/port_collision.ts
+++ b/sdk/cli/src/utils/port_collision.ts
@@ -105,6 +105,24 @@ export function formatPortCollisionHint(
 }
 
 /**
+ * Compose a docker-failure message from a caller-supplied core sentence and the
+ * process's recent output: an actionable port-collision hint (when one is
+ * detected) is prepended, and the raw recent output is appended. Shared by the
+ * foreground exit handler and the detached/reconcile path so both surface the
+ * same failure shape.
+ */
+export function formatComposeFailure(
+  reason: string,
+  output: string,
+  resolvedPorts: Record<string, number>
+): string {
+  const hint = formatPortCollisionHint( output, resolvedPorts );
+  const prefix = hint ? `${hint}\n\n` : '';
+  const detail = output ? `\n\nRecent Docker output:\n${output}` : '';
+  return `${prefix}${reason}${detail}`;
+}
+
+/**
  * Build a hint from a known list of colliding ports. For a single collision
  * the output matches `formatPortCollisionHint` exactly so callers stay
  * symmetric. For multiple collisions a bulleted list is rendered, each line

--- a/sdk/cli/src/views/dev/chrome/footer.tsx
+++ b/sdk/cli/src/views/dev/chrome/footer.tsx
@@ -16,15 +16,17 @@ export interface FooterState {
   hints?: CommandHint[];
   itemCount?: number;
   itemLabel?: string;
+  /** Attached to a pre-existing stack — quitting leaves services running. */
+  attached?: boolean;
 }
 
-const GLOBAL_HINTS: CommandHint[] = [
+const globalHints = ( attached: boolean ): CommandHint[] => [
   { key: 'tab', label: 'next tab' },
   { key: 'shift-tab', label: 'prev tab' },
   { key: '1-4', label: 'tabs' },
   { key: '/', label: 'search' },
   { key: '?', label: 'help' },
-  { key: 'ctrl+c', label: 'quit' }
+  { key: 'ctrl+c', label: attached ? 'detach (keeps running)' : 'quit' }
 ];
 
 const VERSION = packageJson.version;
@@ -43,11 +45,11 @@ const HintRow: React.FC<{ hints: CommandHint[] }> = ( { hints } ) => (
   </Box>
 );
 
-export const Footer: React.FC<FooterState> = ( { hints = [], itemCount, itemLabel } ) => {
+export const Footer: React.FC<FooterState> = ( { hints = [], itemCount, itemLabel, attached = false } ) => {
   return (
     <Box flexDirection="column">
       <Box flexDirection="row" justifyContent="space-between">
-        <HintRow hints={GLOBAL_HINTS} />
+        <HintRow hints={globalHints( attached )} />
         {typeof itemCount === 'number' && itemLabel && (
           <Box>
             <Text dimColor>{itemCount} {itemLabel}</Text>

--- a/sdk/cli/src/views/dev/dev_app.tsx
+++ b/sdk/cli/src/views/dev/dev_app.tsx
@@ -218,7 +218,8 @@ const overlayFor = ( opts: {
 const Shell: React.FC<{
   dockerComposePath: string;
   onCleanup: () => Promise<void>;
-}> = ( { dockerComposePath, onCleanup } ) => {
+  attached: boolean;
+}> = ( { dockerComposePath, onCleanup, attached } ) => {
   const { exit } = useApp();
   const ui = useUiState();
   const [ phase, setPhase ] = useState<Phase>( 'waiting' );
@@ -335,7 +336,7 @@ const Shell: React.FC<{
         {ui.tab === 'help' && <HelpPanel />}
       </Box>
       <Toasts />
-      <Footer hints={footer.hints} itemCount={footer.itemCount} itemLabel={footer.itemLabel} />
+      <Footer hints={footer.hints} itemCount={footer.itemCount} itemLabel={footer.itemLabel} attached={attached} />
     </Box>
   );
 };
@@ -343,8 +344,9 @@ const Shell: React.FC<{
 export const DevApp: React.FC<{
   dockerComposePath: string;
   onCleanup: () => Promise<void>;
-}> = ( { dockerComposePath, onCleanup } ) => (
+  attached?: boolean;
+}> = ( { dockerComposePath, onCleanup, attached = false } ) => (
   <UiStateProvider>
-    <Shell dockerComposePath={dockerComposePath} onCleanup={onCleanup} />
+    <Shell dockerComposePath={dockerComposePath} onCleanup={onCleanup} attached={attached} />
   </UiStateProvider>
 );

--- a/sdk/cli/src/views/dev/dev_app.tsx
+++ b/sdk/cli/src/views/dev/dev_app.tsx
@@ -230,7 +230,16 @@ const Shell: React.FC<{
     onServices: setServices,
     onAllHealthy: () => setPhase( 'running' ),
     onFailure: () => setPhase( 'failed' ),
-    onTimeout: () => exit( new Error( 'Timeout waiting for services to become healthy' ) )
+    // An attach/reconcile session monitors a stack it doesn't own, so a slow
+    // health check must not be fatal — drop into the dashboard and keep
+    // polling status. Only an owned fresh start treats the timeout as an error.
+    onTimeout: () => {
+      if ( attached ) {
+        setPhase( 'running' );
+        return;
+      }
+      exit( new Error( 'Timeout waiting for services to become healthy' ) );
+    }
   } );
 
   useStatusRefresh( dockerComposePath, phase !== 'waiting', setServices );


### PR DESCRIPTION
## Summary

Enable the CLI TUI to re-attach to an existing `output dev` session. When attaching to a `dev` session that was started in a detached state (`output dev -d`), the CLI will attach to the existing session and start the TUI. Exiting the TUI will then **detach**, and not shut down the `dev` setup.

To teardown a detached session, use the new `output dev down` command.

### Would you like to know more? 

`output dev` now classifies the project's stack with `docker compose ps` rather than probing host ports unconditionally:

| Stack state | Behavior | Owns teardown? |
|---|---|---|
| Nothing live (incl. all containers exited) | Probe ports, start in foreground | Yes — quitting tears down |
| Some live, not all healthy | `up -d` to converge, then monitor | No — quitting leaves it up |
| All live and healthy | Attach and monitor | No — quitting leaves it up |

When the session does not own the stack, startup prints `Quitting leaves these services running — stop them with 'output dev down'.` and the footer reads `ctrl+c detach (keeps running)`.

Teardown for a stack this session doesn't own is explicit: **`output dev down`**.

### Other details

- `output dev -d` now does pre-flight port probe - we can detect if a non-container process is holding a port we expect
- `-d` is now an "inspected async spawn" rather than _fire-and-forget_. A failed _bind_ now gives an actionable hint instead of a raw compose error
- failed `docker compose ps` now warns instead of silently assuming "no containers exist"

## Test plan

- [ ] `npx output dev -d`, then `npx output dev` from the same project — TUI attaches
- [ ] Footer reads `detach (keeps running)`; startup prints the "Quitting leaves…" line
- [ ] Exit with `ctrl+c` — services still up (`http://localhost:8080`, run a workflow)
- [ ] `npx output dev down` — services stop
- [ ] `npx output dev` with nothing running — foreground start, quitting tears down
- [ ] `docker compose stop` the stack, then `npx output dev` — treated as a fresh start (foreground, tears down on quit), **not** an attach
- [ ] Hold port 3001 with a non-Docker process, then `npx output dev -d` — aborts with a hint naming `OUTPUT_API_HOST_PORT` instead of starting an unreachable container
