### PR TITLE
DRAFT: inject maxTokens defaults from models.dev when prompts omit 

### DIFF
--- a/sdk/llm/src/ai_sdk_options.js
+++ b/sdk/llm/src/ai_sdk_options.js
@@ -1,7 +1,54 @@
 import { loadImageModel, loadTextModel, loadTools } from './ai_model.js';
 import { resolveMessageProviderOptions } from './prompt/block_options.js';
 import { ROLE, isRole } from './utils/message.js';
-import { FatalError } from '@outputai/core';
+import { resolveModelMaxOutputTokens } from './cost/fetch_models_pricing.js';
+import { FatalError, Logger } from '@outputai/core';
+
+const logger = Logger.createLogger( 'LLM' );
+
+// Warn at most once per model to avoid log spam in hot generation loops.
+const warnedUnknownModels = new Set();
+
+// Upper bound on the max output ceiling we inject. models.dev ceilings can be very large
+// (e.g. 64000); a provider already recognizes such models and picks a sane default, so we
+// only need to lift the low unknown-model fallback (often 4096). Capping keeps us from
+// pushing a provider-recognized model above a size that is unsafe for non-streaming calls.
+const MAX_OUTPUT_TOKENS_CAP = 32000;
+
+/**
+ * When a prompt does not set `maxTokens`, default the AI SDK's `maxOutputTokens` to the
+ * model's ceiling from models.dev, capped at MAX_OUTPUT_TOKENS_CAP. Without this, models
+ * the provider does not recognize fall back to its low default (often 4096) and silently
+ * truncate output. Only a limit models.dev actually knows is injected; genuinely unknown
+ * models are left to the provider (a warning is emitted), and a cold/stale table injects
+ * nothing (a background refresh is in flight).
+ *
+ * @param {object} options - AI SDK options being assembled (mutated in place)
+ * @param {object} config - Loaded prompt config ({ provider, model })
+ */
+const applyModelMaxOutputDefault = ( options, config ) => {
+  const { provider, model } = config;
+  const { status, maxOutputTokens } = resolveModelMaxOutputTokens( { provider, model } );
+
+  if ( status === 'known' ) {
+    options.maxOutputTokens = Math.min( maxOutputTokens, MAX_OUTPUT_TOKENS_CAP );
+    return;
+  }
+
+  // status 'cold': the models.dev table is not warmed yet, so we cannot know the limit for
+  // this call; a background refresh is already in flight. Skip the warning to avoid a
+  // false positive on a known model whose limit simply is not cached yet.
+  if ( status === 'unknown' ) {
+    const modelKey = `${provider}/${model}`;
+    if ( !warnedUnknownModels.has( modelKey ) ) {
+      warnedUnknownModels.add( modelKey );
+      logger.warn(
+        `No max output token limit known for model "${modelKey}"; the provider may cap output ` +
+        'at a low default (often 4096). Set "maxTokens" in the prompt to control output length.'
+      );
+    }
+  }
+};
 
 /**
  * Convert a loaded prompt into AI SDK text generation options.
@@ -34,6 +81,8 @@ export const loadAiSdkTextOptions = prompt => {
 
   if ( prompt.config.maxTokens ) {
     options.maxOutputTokens = prompt.config.maxTokens;
+  } else {
+    applyModelMaxOutputDefault( options, prompt.config );
   }
 
   const tools = loadTools( prompt );

--- a/sdk/llm/src/ai_sdk_options.spec.js
+++ b/sdk/llm/src/ai_sdk_options.spec.js
@@ -3,12 +3,26 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const loadModelImpl = vi.fn();
 const loadImageModelImpl = vi.fn();
 const loadToolsImpl = vi.fn();
+const resolveModelMaxOutputTokensImpl = vi.fn();
+const warnImpl = vi.fn();
 
 vi.mock( './ai_model.js', () => ( {
   loadTextModel: ( ...args ) => loadModelImpl( ...args ),
   loadImageModel: ( ...args ) => loadImageModelImpl( ...args ),
   loadTools: ( ...args ) => loadToolsImpl( ...args )
 } ) );
+
+vi.mock( './cost/fetch_models_pricing.js', () => ( {
+  resolveModelMaxOutputTokens: ( ...args ) => resolveModelMaxOutputTokensImpl( ...args )
+} ) );
+
+vi.mock( '@outputai/core', async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    Logger: { ...actual.Logger, createLogger: () => ( { warn: ( ...args ) => warnImpl( ...args ) } ) }
+  };
+} );
 
 const importSut = async () => import( './ai_sdk_options.js' );
 
@@ -44,6 +58,8 @@ describe( 'ai_sdk_options', () => {
     loadModelImpl.mockReturnValue( 'MODEL' );
     loadImageModelImpl.mockReturnValue( 'IMAGE_MODEL' );
     loadToolsImpl.mockReturnValue( null );
+    resolveModelMaxOutputTokensImpl.mockReturnValue( { status: 'cold', maxOutputTokens: null } );
+    warnImpl.mockReset();
   } );
 
   it( 'maps loaded prompts to AI SDK text options', async () => {
@@ -86,6 +102,66 @@ describe( 'ai_sdk_options', () => {
     const result = loadAiSdkTextOptions( prompt );
 
     expect( result.tools ).toBe( tools );
+  } );
+
+  it( 'defaults maxOutputTokens to the model limit from models.dev when maxTokens is unset', async () => {
+    resolveModelMaxOutputTokensImpl.mockReturnValue( { status: 'known', maxOutputTokens: 8000 } );
+    const prompt = makeTextPrompt();
+
+    const { loadAiSdkTextOptions } = await importSut();
+    const result = loadAiSdkTextOptions( prompt );
+
+    expect( resolveModelMaxOutputTokensImpl ).toHaveBeenCalledWith( {
+      provider: 'anthropic',
+      model: 'claude-haiku-4-5'
+    } );
+    expect( result.maxOutputTokens ).toBe( 8000 );
+    expect( warnImpl ).not.toHaveBeenCalled();
+  } );
+
+  it( 'caps the injected model limit at 32000', async () => {
+    resolveModelMaxOutputTokensImpl.mockReturnValue( { status: 'known', maxOutputTokens: 64000 } );
+    const prompt = makeTextPrompt();
+
+    const { loadAiSdkTextOptions } = await importSut();
+    const result = loadAiSdkTextOptions( prompt );
+
+    expect( result.maxOutputTokens ).toBe( 32000 );
+  } );
+
+  it( 'prefers an explicit maxTokens over the model limit and skips the resolver', async () => {
+    const prompt = makeTextPrompt( { maxTokens: 1000 } );
+
+    const { loadAiSdkTextOptions } = await importSut();
+    const result = loadAiSdkTextOptions( prompt );
+
+    expect( result.maxOutputTokens ).toBe( 1000 );
+    expect( resolveModelMaxOutputTokensImpl ).not.toHaveBeenCalled();
+  } );
+
+  it( 'leaves maxOutputTokens unset and does not warn when the models table is cold', async () => {
+    resolveModelMaxOutputTokensImpl.mockReturnValue( { status: 'cold', maxOutputTokens: null } );
+    const prompt = makeTextPrompt();
+
+    const { loadAiSdkTextOptions } = await importSut();
+    const result = loadAiSdkTextOptions( prompt );
+
+    expect( result.maxOutputTokens ).toBeUndefined();
+    expect( warnImpl ).not.toHaveBeenCalled();
+  } );
+
+  it( 'warns once per model when the limit is unknown and leaves maxOutputTokens unset', async () => {
+    resolveModelMaxOutputTokensImpl.mockReturnValue( { status: 'unknown', maxOutputTokens: null } );
+    const prompt = makeTextPrompt( { model: 'claude-sonnet-5' } );
+
+    const { loadAiSdkTextOptions } = await importSut();
+    const first = loadAiSdkTextOptions( prompt );
+    const second = loadAiSdkTextOptions( prompt );
+
+    expect( first.maxOutputTokens ).toBeUndefined();
+    expect( second.maxOutputTokens ).toBeUndefined();
+    expect( warnImpl ).toHaveBeenCalledTimes( 1 );
+    expect( warnImpl ).toHaveBeenCalledWith( expect.stringContaining( 'anthropic/claude-sonnet-5' ) );
   } );
 
   it( 'throws when text options receive a prompt without message blocks', async () => {

--- a/sdk/llm/src/cost/fetch_models_pricing.js
+++ b/sdk/llm/src/cost/fetch_models_pricing.js
@@ -4,32 +4,48 @@ import { EnvHttpProxyAgent, fetch } from 'undici';
 const logger = Logger.createLogger( 'LLM' );
 const costTableUrl = 'https://models.dev/api.json';
 const cacheTTL = 1000 * 60 * 60 * 24; // 1 day
+const failureBackoffTTL = 1000 * 60; // 1 minute — negative-cache window after a failed fetch
 
 /* Ignore HTTP/2. Check: https://github.com/growthxai/output/issues/299 */
 const dispatcher = new EnvHttpProxyAgent( { allowH2: false } );
 
 export const cache = {
   content: null,
+  limits: null,
   expiresAt: 0
 };
 
-const buildModelMap = data => {
-  const map = new Map();
+const buildModelMaps = data => {
+  const costs = new Map();
+  const limits = new Map();
+  // fetchModelsPricing validates `data` is a non-null object before calling; the inner
+  // guards below still cover malformed nested providers/models.
   for ( const provider of Object.values( data ) ) {
-    for ( const [ modelName, { cost } ] of Object.entries( provider.models ?? {} ) ) {
-      if ( cost ) { // some models don't have cost
-        map.set( modelName, cost );
-        map.set( `${provider.id}/${modelName}`, cost );
+    for ( const [ modelName, model ] of Object.entries( provider?.models ?? {} ) ) {
+      const keys = [ modelName, `${provider.id}/${modelName}` ];
+      if ( model?.cost ) { // some models don't have cost
+        for ( const key of keys ) {
+          costs.set( key, model.cost );
+        }
+      }
+      const outputLimit = model?.limit?.output;
+      if ( Number.isFinite( outputLimit ) && outputLimit > 0 ) {
+        for ( const key of keys ) {
+          limits.set( key, outputLimit );
+        }
       }
     }
   }
-  return map;
+  return { costs, limits };
 };
 
 const buildErrorMessage = cause => `Error "${cause}" when fetching models pricing at ${costTableUrl}`;
 
 export const fetchModelsPricing = async () => {
-  if ( cache.content && cache.expiresAt > Date.now() ) {
+  // A future expiry covers a fresh success, a stale-serve window, and a negative-cache
+  // window after a failure; in every case skip the fetch and return whatever is cached
+  // (which may be null during a negative-cache window).
+  if ( cache.expiresAt > Date.now() ) {
     return cache.content;
   }
 
@@ -46,7 +62,14 @@ export const fetchModelsPricing = async () => {
     state.errorMessage = buildErrorMessage( error.code ?? error.name ?? error.constructor.name );
   }
 
+  if ( !state.errorMessage && ( state.table === null || typeof state.table !== 'object' ) ) {
+    state.errorMessage = buildErrorMessage( 'malformed response body' );
+  }
+
   if ( state.errorMessage ) {
+    // Back off before retrying so a persistent outage does not trigger a fetch on every
+    // resolve/warm; serve stale content within the window if we have any.
+    cache.expiresAt = Date.now() + failureBackoffTTL;
     if ( cache.content ) {
       logger.warn( state.errorMessage + ', falling back to stale cache' );
       return cache.content;
@@ -55,7 +78,63 @@ export const fetchModelsPricing = async () => {
     return null;
   }
 
-  cache.content = buildModelMap( state.table );
+  const { costs, limits } = buildModelMaps( state.table );
+  cache.content = costs;
+  cache.limits = limits;
   cache.expiresAt = Date.now() + cacheTTL;
   return cache.content;
+};
+
+const warmState = { promise: null };
+
+/**
+ * Trigger a background refresh of the models table without awaiting it. Called by
+ * resolveModelMaxOutputTokens when the cache is cold/stale so the table warms for
+ * subsequent calls; the resolve itself is synchronous, so the first call on a cold cache
+ * is best-effort and self-heals from the next call. Concurrent invocations share one
+ * in-flight fetch.
+ */
+export const warmModelsPricing = () => {
+  if ( !warmState.promise ) {
+    warmState.promise = fetchModelsPricing()
+      .catch( () => null )
+      .finally( () => {
+        warmState.promise = null;
+      } );
+  }
+  return warmState.promise;
+};
+
+/**
+ * Resolve a model's max output token limit synchronously from the cached models.dev
+ * table. Sourcing the ceiling here (rather than relying on the AI SDK provider's
+ * per-model fallback) prevents the silent 4096 cap for models the provider build does
+ * not yet recognize: models.dev tracks new models faster, and when the provider treats
+ * a model as unknown it does NOT clamp, so the injected limit is authoritative.
+ *
+ * @param {object} config
+ * @param {string} config.provider - Provider id, e.g. "anthropic"
+ * @param {string} config.model - Model id
+ * @returns {{ status: 'known'|'unknown'|'cold', maxOutputTokens: number|null }}
+ *   `known` when a limit was found; `unknown` when a fresh table has no entry for the
+ *   model; `cold` when the table is unfetched or stale (a background warm is triggered and
+ *   the caller should not warn, since the model may appear once the refresh lands).
+ */
+export const resolveModelMaxOutputTokens = ( { provider, model } = {} ) => {
+  const isStale = cache.expiresAt <= Date.now();
+  if ( isStale ) {
+    warmModelsPricing(); // refresh in the background; read stale limits below meanwhile
+  }
+  if ( !cache.limits ) {
+    return { status: 'cold', maxOutputTokens: null };
+  }
+  const maxOutputTokens =
+    cache.limits.get( `${provider}/${model}` ) ??
+    cache.limits.get( model );
+  if ( maxOutputTokens !== undefined ) {
+    return { status: 'known', maxOutputTokens };
+  }
+  // Absent from the table. If the table is stale a refresh is in flight and the model may
+  // appear once it lands, so report 'cold' (no warning) rather than a false 'unknown'.
+  return { status: isStale ? 'cold' : 'unknown', maxOutputTokens: null };
 };

--- a/sdk/llm/src/cost/fetch_models_pricing.spec.js
+++ b/sdk/llm/src/cost/fetch_models_pricing.spec.js
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
-import { fetchModelsPricing, cache } from './fetch_models_pricing.js';
+import { fetchModelsPricing, resolveModelMaxOutputTokens, warmModelsPricing, cache } from './fetch_models_pricing.js';
 
 const fetchMock = vi.hoisted( () => vi.fn() );
 const EnvHttpProxyAgentMock = vi.hoisted( () => vi.fn( function EnvHttpProxyAgent( options ) {
@@ -31,6 +31,7 @@ const stubFetch = response => {
 describe( 'fetchModelsPricing', () => {
   beforeEach( () => {
     cache.content = null;
+    cache.limits = null;
     cache.expiresAt = 0;
     fetchMock.mockReset();
   } );
@@ -151,5 +152,144 @@ describe( 'fetchModelsPricing', () => {
 
     expect( result.get( 'withCost' ) ).toEqual( { input: 1, output: 2 } );
     expect( result.get( 'noCost' ) ).toBeUndefined();
+  } );
+
+  it( 'treats a non-object response body as an error without throwing', async () => {
+    stubFetch( okResponse( null ) );
+
+    const result = await fetchModelsPricing();
+
+    expect( result ).toBeNull();
+  } );
+
+  it( 'negative-caches after a failure so a subsequent call does not refetch', async () => {
+    stubFetch( { ok: false, status: 503 } );
+
+    const first = await fetchModelsPricing();
+    const second = await fetchModelsPricing();
+
+    expect( first ).toBeNull();
+    expect( second ).toBeNull();
+    expect( fetchMock ).toHaveBeenCalledTimes( 1 );
+  } );
+} );
+
+describe( 'resolveModelMaxOutputTokens', () => {
+  const knownModel = 'claude-opus-4-5-20251101';
+  const knownLimit = fixture.anthropic.models[knownModel].limit.output;
+
+  beforeEach( () => {
+    cache.content = null;
+    cache.limits = null;
+    cache.expiresAt = 0;
+    fetchMock.mockReset();
+  } );
+
+  it( 'returns status "cold" and triggers a warm when the table has never been fetched', async () => {
+    stubFetch( okResponse( fixture ) );
+
+    const result = resolveModelMaxOutputTokens( { provider: 'anthropic', model: knownModel } );
+
+    expect( result ).toEqual( { status: 'cold', maxOutputTokens: null } );
+    expect( fetchMock ).toHaveBeenCalled();
+
+    // Flush the background warm so it does not leak into later tests.
+    await warmModelsPricing();
+  } );
+
+  it( 'returns the model output limit once the table is warm', async () => {
+    stubFetch( okResponse( fixture ) );
+    await fetchModelsPricing();
+
+    expect( resolveModelMaxOutputTokens( { provider: 'anthropic', model: knownModel } ) )
+      .toEqual( { status: 'known', maxOutputTokens: knownLimit } );
+  } );
+
+  it( 'resolves a provider-prefixed model id', async () => {
+    stubFetch( okResponse( fixture ) );
+    await fetchModelsPricing();
+
+    // The bare model key and the provider/model key both resolve.
+    expect( resolveModelMaxOutputTokens( { provider: 'anthropic', model: knownModel } ).maxOutputTokens )
+      .toBe( knownLimit );
+  } );
+
+  it( 'returns status "unknown" for a model absent from the warm table', async () => {
+    stubFetch( okResponse( fixture ) );
+    await fetchModelsPricing();
+
+    expect( resolveModelMaxOutputTokens( { provider: 'anthropic', model: 'claude-sonnet-5' } ) )
+      .toEqual( { status: 'unknown', maxOutputTokens: null } );
+  } );
+
+  it( 'ignores models whose limit has no output value', async () => {
+    const data = {
+      p1: {
+        id: 'p1',
+        models: {
+          noOutput: { cost: { input: 1, output: 2 }, limit: { context: 100 } }
+        }
+      }
+    };
+    stubFetch( okResponse( data ) );
+    await fetchModelsPricing();
+
+    expect( resolveModelMaxOutputTokens( { provider: 'p1', model: 'noOutput' } ) )
+      .toEqual( { status: 'unknown', maxOutputTokens: null } );
+  } );
+
+  it( 'treats a zero output limit as unknown rather than a known limit of 0', async () => {
+    const data = {
+      p1: {
+        id: 'p1',
+        models: {
+          zero: { cost: { input: 1, output: 2 }, limit: { output: 0 } }
+        }
+      }
+    };
+    stubFetch( okResponse( data ) );
+    await fetchModelsPricing();
+
+    expect( resolveModelMaxOutputTokens( { provider: 'p1', model: 'zero' } ) )
+      .toEqual( { status: 'unknown', maxOutputTokens: null } );
+  } );
+
+  it( 'reports "cold" (not "unknown") for an absent model when the table is stale', async () => {
+    stubFetch( okResponse( fixture ) );
+    await fetchModelsPricing();
+    cache.expiresAt = 0; // table is now stale
+    stubFetch( okResponse( fixture ) ); // the background warm triggered by the resolve
+
+    const result = resolveModelMaxOutputTokens( { provider: 'anthropic', model: 'brand-new-model' } );
+
+    expect( result ).toEqual( { status: 'cold', maxOutputTokens: null } );
+    expect( fetchMock ).toHaveBeenCalled();
+
+    await warmModelsPricing(); // flush the background warm so it does not leak
+  } );
+} );
+
+describe( 'warmModelsPricing', () => {
+  beforeEach( () => {
+    cache.content = null;
+    cache.limits = null;
+    cache.expiresAt = 0;
+    fetchMock.mockReset();
+  } );
+
+  it( 'fetches and warms the cache without throwing on failure', async () => {
+    fetchMock.mockRejectedValueOnce( new Error( 'network failure' ) );
+
+    await expect( warmModelsPricing() ).resolves.toBeNull();
+  } );
+
+  it( 'warms the limits cache so a later resolve returns known', async () => {
+    stubFetch( okResponse( fixture ) );
+
+    await warmModelsPricing();
+
+    const knownModel = 'claude-opus-4-5-20251101';
+    expect( resolveModelMaxOutputTokens( { provider: 'anthropic', model: knownModel } ).status )
+      .toBe( 'known' );
   } );
 } );

--- a/sdk/llm/src/max_output_tokens.integration.spec.js
+++ b/sdk/llm/src/max_output_tokens.integration.spec.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { loadAiSdkTextOptions } from './ai_sdk_options.js';
+import { fetchModelsPricing, cache } from './cost/fetch_models_pricing.js';
+
+// Integration seam: the real resolveModelMaxOutputTokens -> real applyModelMaxOutputDefault
+// -> capped maxOutputTokens. Only the network (undici) and provider model loading
+// (ai_model.js) are mocked, so a key-format divergence between buildModelMaps
+// (`${provider.id}/${modelName}`) and resolveModelMaxOutputTokens (`${provider}/${model}`)
+// would surface here where the unit specs mock one side of the seam.
+const fetchMock = vi.hoisted( () => vi.fn() );
+const EnvHttpProxyAgentMock = vi.hoisted( () => vi.fn() );
+
+vi.mock( 'undici', () => ( {
+  EnvHttpProxyAgent: EnvHttpProxyAgentMock,
+  fetch: fetchMock
+} ) );
+
+vi.mock( './ai_model.js', () => ( {
+  loadTextModel: () => 'MODEL',
+  loadImageModel: () => 'IMAGE_MODEL',
+  loadTools: () => null
+} ) );
+
+const __dirname = dirname( fileURLToPath( import.meta.url ) );
+const fixture = JSON.parse( readFileSync( join( __dirname, 'cost', 'fixtures', 'models_api_light.json' ), 'utf8' ) );
+
+const makePrompt = config => ( {
+  name: 'test@v1',
+  config: { provider: 'anthropic', model: 'claude-opus-4-5-20251101', ...config },
+  messages: [ { role: 'user', content: 'Hello' } ],
+  instructions: null
+} );
+
+describe( 'max output tokens default (integration)', () => {
+  beforeEach( () => {
+    cache.content = null;
+    cache.limits = null;
+    cache.expiresAt = 0;
+    fetchMock.mockReset().mockResolvedValue( { ok: true, json: () => Promise.resolve( fixture ) } );
+  } );
+
+  it( 'injects the models.dev ceiling, capped at 32000, through the real resolver', async () => {
+    // Fixture limit.output for this model is 64000; the cap must bring it to 32000.
+    await fetchModelsPricing();
+
+    const result = loadAiSdkTextOptions( makePrompt() );
+
+    expect( result.maxOutputTokens ).toBe( 32000 );
+  } );
+
+  it( 'lets an explicit maxTokens win over the models.dev default', async () => {
+    await fetchModelsPricing();
+
+    const result = loadAiSdkTextOptions( makePrompt( { maxTokens: 500 } ) );
+
+    expect( result.maxOutputTokens ).toBe( 500 );
+  } );
+} );


### PR DESCRIPTION
# DRAFT

## Summary

Use models.dev information to add defaults if no `maxTokens` is provided.

This is still a draft though

