### PR TITLE
feat(core): Using parsed data from zod schemas as input and return of workflows, steps and evals (OUT-536)

### DIFF
--- a/.changeset/swift-things-sort.md
+++ b/.changeset/swift-things-sort.md
@@ -1,0 +1,5 @@
+---
+"@outputai/core": minor
+---
+
+- `workflow()`, `step()`, and `evaluator()` now pass the value returned by the Zod `inputSchema` parser to their handler. Workflows and steps also return the value produced by their `outputSchema` parser. Zod transforms, coercions, defaults, and object-key stripping therefore affect the values handled and returned by these components instead of only validating them.

--- a/docs/guides/evaluators/evaluator-step.mdx
+++ b/docs/guides/evaluators/evaluator-step.mdx
@@ -108,6 +108,10 @@ Evaluators are called from workflows like regular async functions — `await jud
 
 Evaluator names must start with a letter or underscore, followed by letters, numbers, or underscores. Hyphens, spaces, dots, and other punctuation are not allowed.
 
+<Note>
+  The input schema parses evaluator input; it does not only validate it. The evaluator `fn` receives the value returned by `inputSchema`, so Zod transforms, coercions, defaults, and object-key stripping apply at runtime.
+</Note>
+
 ## EvaluationResult Types
 
 Evaluators must return an `EvaluationResult`. Three types are available depending on what you're scoring:

--- a/docs/guides/evaluators/evaluator-step.mdx
+++ b/docs/guides/evaluators/evaluator-step.mdx
@@ -102,7 +102,7 @@ Evaluators are called from workflows like regular async functions — `await jud
 |----------|------|-------------|
 | `name` | `string` | Unique identifier for the evaluator |
 | `description` | `string` | Human-readable description |
-| `inputSchema` | `ZodSchema` | Zod schema for input validation |
+| `inputSchema` | `ZodSchema` | Zod schema for input; values are **parsed** before `fn` runs |
 | `options` | `object` | Optional workflow options (see [Options](#options)) |
 | `fn` | `function` | The evaluator implementation (must return an `EvaluationResult`) |
 

--- a/docs/guides/migrations/index.mdx
+++ b/docs/guides/migrations/index.mdx
@@ -46,6 +46,6 @@ It reads the `@outputai/*` version in your `package.json`, finds the matching gu
     Trace destinations omit unavailable `local` and `remote` keys instead of returning `null`.
   </Card>
   <Card title="v0.10.0 → v0.11.0" href="/migrations/v0.10.0-to-v0.11.0">
-    HTTP clients, hook event envelopes, API request logging, Temporal workflow runtime changes, Temporal TypeScript SDK v1.20.3, CLI `workflow test` rename, and strict prompt Liquid rendering.
+    Parsed component schemas, HTTP clients, hook event envelopes, API request logging, Temporal workflow runtime changes, Temporal TypeScript SDK v1.20.3, CLI `workflow test` rename, and strict prompt Liquid rendering.
   </Card>
 </CardGroup>

--- a/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
+++ b/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
@@ -553,6 +553,12 @@ Because schemas run at the component boundary, `.transform()`, `z.coerce`, `.pre
 - **Idempotency (re-parse):** Every workflow run parses its Temporal args again — including runs started with `continueAsNew`. The next run does not know it is a continuation. If you pass values that were already transformed, a non-idempotent transform runs twice (for example appending a suffix on each continue-as-new). Prefer idempotent transforms, or pass wire-format input into `continueAsNew` (the same shape you would pass when starting the workflow).
 - **Catalog JSON Schema:** The worker catalog still converts Zod schemas with `z.toJSONSchema`. Bare `.transform()` often cannot be represented and may omit the schema from the catalog; `z.coerce` and `.pipe()` usually convert. Authors who control both the schema and catalog consumers should treat catalog JSON Schema as best-effort for advanced Zod features.
 
+### Published workflow package types
+
+`WorkflowFunctionWrapper`, `StepFunctionWrapper`, and `EvaluatorFunctionWrapper` are now typed as `Wrapper<InputSchema, OutputSchema>` (schema generics), not `Wrapper<Fn<In, Out>>`. Runtime is unchanged; TypeScript breaks for packages that still ship `.d.ts` built against the old arity (for example a published workflows catalog).
+
+Rebuild and republish those packages against `@outputai/core` v0.11.0 so their declarations match, or release them together with the core bump.
+
 ### Migration steps
 
 Review the `inputSchema` and `outputSchema` of every workflow, step, and evaluator:
@@ -562,6 +568,7 @@ Review the `inputSchema` and `outputSchema` of every workflow, step, and evaluat
 - Check object schemas for unknown properties that Zod strips by default. Use `z.looseObject( { ... } )` when those properties must be preserved.
 - Ensure transforms on **workflow** schemas are deterministic for Temporal replay.
 - Ensure workflow `inputSchema` transforms are idempotent if you `continueAsNew` with values that will be parsed again, or pass wire-format input instead.
+- Republish any package that exports workflow/step/evaluator wrappers so its `.d.ts` matches the new `Wrapper` arity.
 
 ## Workflow runtime changes
 

--- a/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
+++ b/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
@@ -516,14 +516,15 @@ In v0.10.x, workflow, step, and evaluator schemas validated values, but componen
 
 For example:
 
-```ts
+```js
 const calculateTotal = step( {
   name: 'calculate_total',
   inputSchema: z.object( {
     count: z.coerce.number().default( 1 )
   } ),
   outputSchema: z.object( {
-    total: z.number()
+    total: z.number(),
+    currency: z.string().default( 'USD' )
   } ),
   fn: async input => ( {
     total: input.count * 10,
@@ -535,9 +536,10 @@ const result = await calculateTotal( {
   count: '2',
   requestId: 'request-123'
 } );
+// result => { total: 20, currency: 'USD' }
 ```
 
-In v0.10.x, `input.count` was the string `'2'`, `input.requestId` remained available, and `result.internalNote` was returned. In v0.11.0, `input.count` is the number `2`, Zod's default object behavior removes `requestId`, and the returned result is `{ total: 20 }`.
+In v0.10.x, `input.count` was the string `'2'`, `input.requestId` remained available, `result.internalNote` was returned, and `currency` was absent because `fn` did not set it. In v0.11.0, `input.count` is the number `2`, Zod's default object behavior removes `requestId` from the handler input and `internalNote` from the caller result, and `outputSchema` fills `currency` with `'USD'`, so the returned result is `{ total: 20, currency: 'USD' }`.
 
 ### Migration steps
 
@@ -545,7 +547,7 @@ Review the `inputSchema` and `outputSchema` of every workflow, step, and evaluat
 
 - Update handlers and callers to use the parsed Zod input and output types.
 - Check schemas using `.transform()`, `z.coerce`, `.default()`, `.catch()`, or `.preprocess()` for values that now change at runtime.
-- Check object schemas for unknown properties that Zod strips by default. Use `.passthrough()` when those properties must be preserved.
+- Check object schemas for unknown properties that Zod strips by default. Use `z.looseObject( { ... } )` when those properties must be preserved.
 - Ensure transforms used by workflow schemas are deterministic because they run during Temporal workflow replay.
 
 ## Workflow runtime changes

--- a/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
+++ b/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
@@ -1,9 +1,9 @@
 ---
 title: "v0.10.0 → v0.11.0"
-description: "Upgrading Output.ai projects from v0.10.0 to v0.11.0: HTTP clients, hook event envelopes, API request logging, Temporal rollout safety, shared activity names, child workflow activity-option precedence, Temporal TypeScript SDK v1.20.3, CLI workflow test rename, and strict prompt Liquid rendering."
+description: "Upgrading Output.ai projects from v0.10.0 to v0.11.0: parsed component schemas, HTTP clients, hook event envelopes, API request logging, Temporal rollout safety, shared activity names, child workflow activity-option precedence, Temporal TypeScript SDK v1.20.3, CLI workflow test rename, and strict prompt Liquid rendering."
 ---
 
-This guide covers customer-facing changes to `@outputai/http`, hooks and workflow execution in `@outputai/core`, prompt rendering in `@outputai/llm`, the `@outputai/cli` workflow test command name, and API request logging in `output-api`.
+This guide covers customer-facing changes to `@outputai/http`, schemas, hooks and workflow execution in `@outputai/core`, prompt rendering in `@outputai/llm`, the `@outputai/cli` workflow test command name, and API request logging in `output-api`.
 
 ## API HTTP request logging
 
@@ -505,6 +505,48 @@ Audit libraries that receive a custom `fetch` callback. Ensure the callback uses
 - Check custom dispatchers and Fetch callbacks for reliance on `undici.install()`.
 - Configure proxy behavior for non-Output HTTP calls.
 - Run type checking and HTTP integration tests after regenerating the lockfile.
+
+## Component schemas now return parsed values
+
+In v0.10.x, workflow, step, and evaluator schemas validated values, but component handlers and callers continued to receive the original values. In v0.11.0, components use the values returned by Zod:
+
+- `inputSchema` parsing happens before `fn`, so the handler receives parsed input.
+- `outputSchema` parsing happens after `fn`, so workflow and step callers receive parsed output.
+- Zod coercions, transforms, defaults, and object-key handling now affect runtime values.
+
+For example:
+
+```ts
+const calculateTotal = step( {
+  name: 'calculate_total',
+  inputSchema: z.object( {
+    count: z.coerce.number().default( 1 )
+  } ),
+  outputSchema: z.object( {
+    total: z.number()
+  } ),
+  fn: async input => ( {
+    total: input.count * 10,
+    internalNote: 'not part of the public result'
+  } )
+} );
+
+const result = await calculateTotal( {
+  count: '2',
+  requestId: 'request-123'
+} );
+```
+
+In v0.10.x, `input.count` was the string `'2'`, `input.requestId` remained available, and `result.internalNote` was returned. In v0.11.0, `input.count` is the number `2`, Zod's default object behavior removes `requestId`, and the returned result is `{ total: 20 }`.
+
+### Migration steps
+
+Review the `inputSchema` and `outputSchema` of every workflow, step, and evaluator:
+
+- Update handlers and callers to use the parsed Zod input and output types.
+- Check schemas using `.transform()`, `z.coerce`, `.default()`, `.catch()`, or `.preprocess()` for values that now change at runtime.
+- Check object schemas for unknown properties that Zod strips by default. Use `.passthrough()` when those properties must be preserved.
+- Ensure transforms used by workflow schemas are deterministic because they run during Temporal workflow replay.
 
 ## Workflow runtime changes
 

--- a/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
+++ b/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
@@ -514,6 +514,8 @@ In v0.10.x, workflow, step, and evaluator schemas validated values, but componen
 - `outputSchema` parsing happens after `fn`, so workflow and step callers receive parsed output.
 - Zod coercions, transforms, defaults, and object-key handling now affect runtime values.
 
+TypeScript mirrors that split: handlers are typed with `z.infer` for input (post-parse) and `z.input` for what they return (pre-parse). Callers pass `z.input` and receive `z.infer`.
+
 For example:
 
 ```js
@@ -541,14 +543,25 @@ const result = await calculateTotal( {
 
 In v0.10.x, `input.count` was the string `'2'`, `input.requestId` remained available, `result.internalNote` was returned, and `currency` was absent because `fn` did not set it. In v0.11.0, `input.count` is the number `2`, Zod's default object behavior removes `requestId` from the handler input and `internalNote` from the caller result, and `outputSchema` fills `currency` with `'USD'`, so the returned result is `{ total: 20, currency: 'USD' }`.
 
+Trace files still record the **raw** Temporal workflow arguments at start (before `inputSchema` parse) and the **parsed** output at end (after `outputSchema` parse).
+
+### Transforms, replay, and continue-as-new
+
+Because schemas run at the component boundary, `.transform()`, `z.coerce`, `.preprocess()`, and similar helpers are no longer documentation-only:
+
+- **Determinism (workflow schemas):** Workflow code is replayed by Temporal. Any transform on a workflow `inputSchema` or `outputSchema` must be deterministic (no `Date.now()`, `Math.random()`, or other non-replay-safe sources). Prefer keeping workflow input as wire format (types, `.default()`, optional coerce) and putting one-shot shaping in a step or inside `fn` when possible.
+- **Idempotency (re-parse):** Every workflow run parses its Temporal args again — including runs started with `continueAsNew`. The next run does not know it is a continuation. If you pass values that were already transformed, a non-idempotent transform runs twice (for example appending a suffix on each continue-as-new). Prefer idempotent transforms, or pass wire-format input into `continueAsNew` (the same shape you would pass when starting the workflow).
+- **Catalog JSON Schema:** The worker catalog still converts Zod schemas with `z.toJSONSchema`. Bare `.transform()` often cannot be represented and may omit the schema from the catalog; `z.coerce` and `.pipe()` usually convert. Authors who control both the schema and catalog consumers should treat catalog JSON Schema as best-effort for advanced Zod features.
+
 ### Migration steps
 
 Review the `inputSchema` and `outputSchema` of every workflow, step, and evaluator:
 
-- Update handlers and callers to use the parsed Zod input and output types.
+- Update handlers and callers to use the parsed Zod input and output types (`z.infer` in handlers, `z.input` at call sites when schemas coerce or default).
 - Check schemas using `.transform()`, `z.coerce`, `.default()`, `.catch()`, or `.preprocess()` for values that now change at runtime.
 - Check object schemas for unknown properties that Zod strips by default. Use `z.looseObject( { ... } )` when those properties must be preserved.
-- Ensure transforms used by workflow schemas are deterministic because they run during Temporal workflow replay.
+- Ensure transforms on **workflow** schemas are deterministic for Temporal replay.
+- Ensure workflow `inputSchema` transforms are idempotent if you `continueAsNew` with values that will be parsed again, or pass wire-format input instead.
 
 ## Workflow runtime changes
 

--- a/docs/guides/steps/index.mdx
+++ b/docs/guides/steps/index.mdx
@@ -52,6 +52,10 @@ Steps are called from workflows like regular async functions — `await lookupCo
 
 Step names must start with a letter or underscore, followed by letters, numbers, or underscores. Hyphens, spaces, dots, and other punctuation are not allowed.
 
+<Note>
+  Schemas parse step values; they do not only validate them. The step `fn` receives the value returned by `inputSchema`, and the caller receives the value returned by `outputSchema`. Zod transforms, coercions, defaults, and object-key stripping therefore apply at runtime.
+</Note>
+
 ## Steps vs Workflows
 
 <CardGroup cols={2}>

--- a/docs/guides/steps/index.mdx
+++ b/docs/guides/steps/index.mdx
@@ -45,15 +45,15 @@ Steps are called from workflows like regular async functions — `await lookupCo
 |----------|------|-------------|
 | `name` | `string` | Unique identifier for the step |
 | `description` | `string` | Human-readable description |
-| `inputSchema` | `ZodSchema` | Zod schema for input validation |
-| `outputSchema` | `ZodSchema` | Zod schema for output validation |
+| `inputSchema` | `ZodSchema` | Zod schema for input; values are **parsed** before `fn` runs |
+| `outputSchema` | `ZodSchema` | Zod schema for output; values are **parsed** before returning to callers |
 | `options` | `object` | Optional workflow options (see [Options](#options)) |
 | `fn` | `function` | The step implementation |
 
 Step names must start with a letter or underscore, followed by letters, numbers, or underscores. Hyphens, spaces, dots, and other punctuation are not allowed.
 
 <Note>
-  Schemas parse step values; they do not only validate them. The step `fn` receives the value returned by `inputSchema`, and the caller receives the value returned by `outputSchema`. Zod transforms, coercions, defaults, and object-key stripping therefore apply at runtime.
+  Schemas parse step values; they do not only validate them. The step `fn` receives the value returned by `inputSchema`, and the caller receives the value returned by `outputSchema`. Zod transforms, coercions, defaults, and object-key stripping therefore apply at runtime. If you feed a step's parsed output back into the same (or another) schema as input, transforms run again — keep them idempotent or pass wire-format values when that round-trip matters.
 </Note>
 
 ## Steps vs Workflows

--- a/docs/guides/workflows/context.mdx
+++ b/docs/guides/workflows/context.mdx
@@ -87,6 +87,8 @@ fn: async (input, context) => {
 
 If your workflow has an `inputSchema`, pass the input object for the new execution. If it has no `inputSchema`, call without arguments: `context.control.continueAsNew()`.
 
+The new run parses that payload with `inputSchema` like any other workflow start — there is no “already parsed” shortcut. Pass wire-format input (what you would pass when starting the workflow), especially if `inputSchema` uses `.transform()` or other helpers that are not safe to apply twice.
+
 The function's return type matches your `outputSchema` for type-checking, but it never actually returns — the execution is replaced.
 
 See the [Temporal continue-as-new documentation](https://docs.temporal.io/develop/typescript/continue-as-new) for more details.

--- a/docs/guides/workflows/index.mdx
+++ b/docs/guides/workflows/index.mdx
@@ -47,8 +47,8 @@ The `fn` function is your workflow logic. It calls steps in sequence, and each s
 |--------|------|-------------|
 | `name` | `string` | Unique identifier for the workflow |
 | `description` | `string` | Human-readable description |
-| `inputSchema` | `ZodSchema` | Zod schema for input validation |
-| `outputSchema` | `ZodSchema` | Zod schema for output validation |
+| `inputSchema` | `ZodSchema` | Zod schema for input; values are **parsed** before `fn` runs |
+| `outputSchema` | `ZodSchema` | Zod schema for output; values are **parsed** before returning to callers |
 | `fn` | `function` | The workflow implementation |
 | `options` | `object` | Optional workflow options (see [Options](#options)) |
 | `aliases` | `string[]` | Optional alternative names for backward-compatible renaming (see [Aliases](#aliases)) |
@@ -56,8 +56,17 @@ The `fn` function is your workflow logic. It calls steps in sequence, and each s
 Workflow names must start with a letter or underscore, followed by letters, numbers, or underscores. Hyphens, spaces, dots, and other punctuation are not allowed.
 
 <Note>
-  Schemas parse workflow values; they do not only validate them. The workflow `fn` receives the value returned by `inputSchema`, and the workflow caller receives the value returned by `outputSchema`. Zod transforms, coercions, defaults, and object-key stripping therefore apply at runtime. Any schema transform used by a workflow must be deterministic so Temporal can replay it safely.
+  Schemas parse workflow values; they do not only validate them. The workflow `fn` receives the value returned by `inputSchema`, and the workflow caller receives the value returned by `outputSchema`. Zod transforms, coercions, defaults, and object-key stripping therefore apply at runtime.
 </Note>
+
+### Schema transforms and Temporal
+
+Workflow `inputSchema` / `outputSchema` run inside the Temporal workflow sandbox on every activation, including replay and every `continueAsNew` run (continuations are not special-cased — args are parsed like any other start).
+
+- Prefer wire-format schemas on workflows: types, `.default()`, and careful use of `z.coerce`.
+- Any `.transform()` / `.preprocess()` on a workflow schema must be **deterministic** (safe under Temporal replay).
+- Prefer **idempotent** transforms on workflow `inputSchema`, or pass wire-format payloads into `continueAsNew`. A non-idempotent transform applied to already-parsed values will run again on the next execution.
+- One-shot or non-idempotent shaping belongs in a [step](/steps) or inside `fn` after you have accepted wire input.
 
 ## Workflow Rules
 

--- a/docs/guides/workflows/index.mdx
+++ b/docs/guides/workflows/index.mdx
@@ -55,6 +55,10 @@ The `fn` function is your workflow logic. It calls steps in sequence, and each s
 
 Workflow names must start with a letter or underscore, followed by letters, numbers, or underscores. Hyphens, spaces, dots, and other punctuation are not allowed.
 
+<Note>
+  Schemas parse workflow values; they do not only validate them. The workflow `fn` receives the value returned by `inputSchema`, and the workflow caller receives the value returned by `outputSchema`. Zod transforms, coercions, defaults, and object-key stripping therefore apply at runtime. Any schema transform used by a workflow must be deterministic so Temporal can replay it safely.
+</Note>
+
 ## Workflow Rules
 
 Workflows must be **deterministic** — given the same input, they must always follow the same path. This is because Output (via Temporal) replays your workflow code to recover state after failures. If the code produces different results on replay, recovery breaks.

--- a/sdk/core/src/interface/evaluator.d.ts
+++ b/sdk/core/src/interface/evaluator.d.ts
@@ -16,7 +16,7 @@ export type EvaluatorOptions = {
 /**
  * The handler function of an evaluator.
  *
- * @param input - The evaluator input; it matches the schema defined by `inputSchema`.
+ * @param input - Parsed evaluator input (`z.infer<inputSchema>`).
  *
  * @returns The result of the evaluation.
  */
@@ -30,14 +30,15 @@ export type EvaluatorFunction<
 /**
  * A wrapper around the user defined `fn` handler function.
  *
- * It has the same signature and returns the same value, calling the user function inside.
- *
- * It adds input validation based on the `inputSchema`.
+ * Callers pass values accepted by `inputSchema` (`z.input`). The wrapper parses input
+ * and invokes `fn`.
  */
-export type EvaluatorFunctionWrapper<EvaluatorFunction extends ( ...args: any ) => any> = // eslint-disable-line @typescript-eslint/no-explicit-any
-  Parameters<EvaluatorFunction> extends [infer Input] ?
-    ( input: Input ) => ReturnType<EvaluatorFunction> :
-    () => ReturnType<EvaluatorFunction>;
+export type EvaluatorFunctionWrapper<
+  InputSchema extends AnyZodSchema | undefined = undefined,
+  Result extends EvaluationResult = EvaluationResult
+> = InputSchema extends AnyZodSchema ?
+  ( input: z.input<InputSchema> ) => Promise<Result> :
+  () => Promise<Result>;
 
 /**
  * Creates an evaluation function. It is similar to a step, but must return an EvaluationResult.
@@ -67,4 +68,4 @@ export declare function evaluator<
   inputSchema: InputSchema;
   fn: EvaluatorFunction<InputSchema, Result>;
   options?: EvaluatorOptions;
-} ): EvaluatorFunctionWrapper<EvaluatorFunction<InputSchema, Result>>;
+} ): EvaluatorFunctionWrapper<InputSchema, Result>;

--- a/sdk/core/src/interface/evaluator.js
+++ b/sdk/core/src/interface/evaluator.js
@@ -13,6 +13,6 @@ export function evaluator( { name, description, inputSchema, fn, options } ) {
     description,
     inputSchema,
     options,
-    handler: async input => validator.validateOutput( await fn( validator.validateInput( input ) ) )
+    handler: async input => validator.parseOutput( await fn( validator.parseInput( input ) ) )
   } );
 }

--- a/sdk/core/src/interface/evaluator.js
+++ b/sdk/core/src/interface/evaluator.js
@@ -13,11 +13,6 @@ export function evaluator( { name, description, inputSchema, fn, options } ) {
     description,
     inputSchema,
     options,
-    handler: async input => {
-      validator.validateInput( input );
-      const output = await fn( input );
-      validator.validateOutput( output );
-      return output;
-    }
+    handler: async input => validator.validateOutput( await fn( validator.validateInput( input ) ) )
   } );
 }

--- a/sdk/core/src/interface/evaluator.spec.js
+++ b/sdk/core/src/interface/evaluator.spec.js
@@ -9,8 +9,8 @@ import {
 import { ValidationError } from '#errors';
 
 const validateDefinitionMock = vi.hoisted( () => vi.fn() );
-const validateInputMock = vi.hoisted( () => vi.fn( input => input ) );
-const validateOutputMock = vi.hoisted( () => vi.fn( output => output ) );
+const parseInputMock = vi.hoisted( () => vi.fn( input => input ) );
+const parseOutputMock = vi.hoisted( () => vi.fn( output => output ) );
 const validatorConstructorMock = vi.hoisted( () => vi.fn() );
 const createEvaluatorMock = vi.hoisted( () => vi.fn( ( { handler } ) => handler ) );
 
@@ -22,8 +22,8 @@ vi.mock( './validations/index.js', () => {
 
     constructor( ...args ) {
       validatorConstructorMock( ...args );
-      this.validateInput = validateInputMock;
-      this.validateOutput = validateOutputMock;
+      this.parseInput = parseInputMock;
+      this.parseOutput = parseOutputMock;
     }
   }
 
@@ -87,15 +87,15 @@ describe( 'evaluator()', () => {
 
     await expect( wrapper( { value: 'input' } ) ).resolves.toBe( output );
 
-    expect( validateInputMock ).toHaveBeenCalledWith( { value: 'input' } );
+    expect( parseInputMock ).toHaveBeenCalledWith( { value: 'input' } );
     expect( fn ).toHaveBeenCalledWith( { value: 'input' } );
-    expect( validateOutputMock ).toHaveBeenCalledWith( output );
+    expect( parseOutputMock ).toHaveBeenCalledWith( output );
   } );
 
   it( 'does not call the evaluator function when input validation throws', async () => {
     const { evaluator } = await import( './evaluator.js' );
     const error = new ValidationError( 'invalid input' );
-    validateInputMock.mockImplementationOnce( () => {
+    parseInputMock.mockImplementationOnce( () => {
       throw error;
     } );
     const fn = vi.fn();
@@ -106,13 +106,13 @@ describe( 'evaluator()', () => {
 
     await expect( wrapper( { value: 'bad' } ) ).rejects.toBe( error );
     expect( fn ).not.toHaveBeenCalled();
-    expect( validateOutputMock ).not.toHaveBeenCalled();
+    expect( parseOutputMock ).not.toHaveBeenCalled();
   } );
 
   it( 'propagates output validation errors after the evaluator function runs', async () => {
     const { evaluator } = await import( './evaluator.js' );
     const error = new ValidationError( 'invalid output' );
-    validateOutputMock.mockImplementationOnce( () => {
+    parseOutputMock.mockImplementationOnce( () => {
       throw error;
     } );
     const output = { value: 'not-an-evaluation-result' };
@@ -124,7 +124,7 @@ describe( 'evaluator()', () => {
 
     await expect( wrapper( { value: 'input' } ) ).rejects.toBe( error );
     expect( fn ).toHaveBeenCalledOnce();
-    expect( validateOutputMock ).toHaveBeenCalledWith( output );
+    expect( parseOutputMock ).toHaveBeenCalledWith( output );
   } );
 } );
 

--- a/sdk/core/src/interface/evaluator.spec.js
+++ b/sdk/core/src/interface/evaluator.spec.js
@@ -9,8 +9,8 @@ import {
 import { ValidationError } from '#errors';
 
 const validateDefinitionMock = vi.hoisted( () => vi.fn() );
-const validateInputMock = vi.hoisted( () => vi.fn() );
-const validateOutputMock = vi.hoisted( () => vi.fn() );
+const validateInputMock = vi.hoisted( () => vi.fn( input => input ) );
+const validateOutputMock = vi.hoisted( () => vi.fn( output => output ) );
 const validatorConstructorMock = vi.hoisted( () => vi.fn() );
 const createEvaluatorMock = vi.hoisted( () => vi.fn( ( { handler } ) => handler ) );
 

--- a/sdk/core/src/interface/step.d.ts
+++ b/sdk/core/src/interface/step.d.ts
@@ -15,31 +15,32 @@ export type StepOptions = {
 /**
  * The handler function of a step.
  *
- * @param input - The step input; it matches the schema defined by `inputSchema`.
+ * @param input - Parsed step input (`z.infer<inputSchema>`).
  *
- * @returns A value matching the schema defined by `outputSchema`.
+ * @returns A value accepted by `outputSchema` before parse (`z.input<outputSchema>`).
  */
 export type StepFunction<
   InputSchema extends AnyZodSchema | undefined = undefined,
   OutputSchema extends AnyZodSchema | undefined = undefined
 > = InputSchema extends AnyZodSchema ?
-  ( input: z.infer<InputSchema> ) => Promise<OutputSchema extends AnyZodSchema ? z.infer<OutputSchema> : void> :
-  () => Promise<OutputSchema extends AnyZodSchema ? z.infer<OutputSchema> : void>;
+  ( input: z.infer<InputSchema> ) => Promise<OutputSchema extends AnyZodSchema ? z.input<OutputSchema> : void> :
+  () => Promise<OutputSchema extends AnyZodSchema ? z.input<OutputSchema> : void>;
 
 /**
  * A wrapper around the user defined `fn` handler function.
  *
- * It accepts the same input and returns the same value, calling the user function inside.
+ * Callers pass values accepted by `inputSchema` (`z.input`). The wrapper parses input,
+ * invokes `fn`, parses output, and returns `z.infer<outputSchema>`.
  *
- * It adds input and output validation based on the `inputSchema`, `outputSchema`.
- *
- * @param input - The Step input; it matches the schema defined by `inputSchema`.
- * @returns A value matching the schema defined by `outputSchema`.
+ * @param input - The step input before `inputSchema` parse.
+ * @returns The step output after `outputSchema` parse.
  */
-export type StepFunctionWrapper<StepFunction extends ( ...args: any ) => any> = // eslint-disable-line @typescript-eslint/no-explicit-any
-  Parameters<StepFunction> extends [infer Input] ?
-    ( input: Input ) => ReturnType<StepFunction> :
-    () => ReturnType<StepFunction>;
+export type StepFunctionWrapper<
+  InputSchema extends AnyZodSchema | undefined = undefined,
+  OutputSchema extends AnyZodSchema | undefined = undefined
+> = InputSchema extends AnyZodSchema ?
+  ( input: z.input<InputSchema> ) => Promise<OutputSchema extends AnyZodSchema ? z.infer<OutputSchema> : void> :
+  () => Promise<OutputSchema extends AnyZodSchema ? z.infer<OutputSchema> : void>;
 
 /**
  * Creates a step.
@@ -123,7 +124,7 @@ export type StepFunctionWrapper<StepFunction extends ( ...args: any ) => any> = 
  * @param params.outputSchema - Zod schema for the `fn` output
  * @param params.fn - A handler function containing the step code
  * @param params.options - Optional step options.
- * @returns The same handler function set at `fn`
+ * @returns A wrapper that parses input/output around `fn`
  */
 export declare function step<
   InputSchema extends AnyZodSchema | undefined = undefined,
@@ -135,4 +136,4 @@ export declare function step<
   outputSchema?: OutputSchema;
   fn: StepFunction<InputSchema, OutputSchema>;
   options?: StepOptions;
-} ): StepFunctionWrapper<StepFunction<InputSchema, OutputSchema>>;
+} ): StepFunctionWrapper<InputSchema, OutputSchema>;

--- a/sdk/core/src/interface/step.js
+++ b/sdk/core/src/interface/step.js
@@ -14,6 +14,6 @@ export function step( { name, description, inputSchema, outputSchema, fn, option
     inputSchema,
     outputSchema,
     options,
-    handler: async input => validator.validateOutput( await fn( validator.validateInput( input ) ) )
+    handler: async input => validator.parseOutput( await fn( validator.parseInput( input ) ) )
   } );
 }

--- a/sdk/core/src/interface/step.js
+++ b/sdk/core/src/interface/step.js
@@ -14,11 +14,6 @@ export function step( { name, description, inputSchema, outputSchema, fn, option
     inputSchema,
     outputSchema,
     options,
-    handler: async input => {
-      validator.validateInput( input );
-      const output = await fn( input );
-      validator.validateOutput( output );
-      return output;
-    }
+    handler: async input => validator.validateOutput( await fn( validator.validateInput( input ) ) )
   } );
 }

--- a/sdk/core/src/interface/step.spec.js
+++ b/sdk/core/src/interface/step.spec.js
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ValidationError } from '#errors';
 
 const validateDefinitionMock = vi.hoisted( () => vi.fn() );
-const validateInputMock = vi.hoisted( () => vi.fn() );
-const validateOutputMock = vi.hoisted( () => vi.fn() );
+const validateInputMock = vi.hoisted( () => vi.fn( input => input ) );
+const validateOutputMock = vi.hoisted( () => vi.fn( output => output ) );
 const validatorConstructorMock = vi.hoisted( () => vi.fn() );
 const createStepMock = vi.hoisted( () => vi.fn( ( { handler } ) => handler ) );
 

--- a/sdk/core/src/interface/step.spec.js
+++ b/sdk/core/src/interface/step.spec.js
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ValidationError } from '#errors';
 
 const validateDefinitionMock = vi.hoisted( () => vi.fn() );
-const validateInputMock = vi.hoisted( () => vi.fn( input => input ) );
-const validateOutputMock = vi.hoisted( () => vi.fn( output => output ) );
+const parseInputMock = vi.hoisted( () => vi.fn( input => input ) );
+const parseOutputMock = vi.hoisted( () => vi.fn( output => output ) );
 const validatorConstructorMock = vi.hoisted( () => vi.fn() );
 const createStepMock = vi.hoisted( () => vi.fn( ( { handler } ) => handler ) );
 
@@ -15,8 +15,8 @@ vi.mock( './validations/index.js', () => {
 
     constructor( ...args ) {
       validatorConstructorMock( ...args );
-      this.validateInput = validateInputMock;
-      this.validateOutput = validateOutputMock;
+      this.parseInput = parseInputMock;
+      this.parseOutput = parseOutputMock;
     }
   }
 
@@ -86,15 +86,15 @@ describe( 'step()', () => {
 
     await expect( wrapper( { value: 'input' } ) ).resolves.toBe( output );
 
-    expect( validateInputMock ).toHaveBeenCalledWith( { value: 'input' } );
+    expect( parseInputMock ).toHaveBeenCalledWith( { value: 'input' } );
     expect( fn ).toHaveBeenCalledWith( { value: 'input' } );
-    expect( validateOutputMock ).toHaveBeenCalledWith( output );
+    expect( parseOutputMock ).toHaveBeenCalledWith( output );
   } );
 
   it( 'does not call the step function when input validation throws', async () => {
     const { step } = await import( './step.js' );
     const error = new ValidationError( 'invalid input' );
-    validateInputMock.mockImplementationOnce( () => {
+    parseInputMock.mockImplementationOnce( () => {
       throw error;
     } );
     const fn = vi.fn();
@@ -105,13 +105,13 @@ describe( 'step()', () => {
 
     await expect( wrapper( { value: 'bad' } ) ).rejects.toBe( error );
     expect( fn ).not.toHaveBeenCalled();
-    expect( validateOutputMock ).not.toHaveBeenCalled();
+    expect( parseOutputMock ).not.toHaveBeenCalled();
   } );
 
   it( 'propagates output validation errors after the step function runs', async () => {
     const { step } = await import( './step.js' );
     const error = new ValidationError( 'invalid output' );
-    validateOutputMock.mockImplementationOnce( () => {
+    parseOutputMock.mockImplementationOnce( () => {
       throw error;
     } );
     const output = { ok: false };
@@ -123,6 +123,6 @@ describe( 'step()', () => {
 
     await expect( wrapper( { value: 'input' } ) ).rejects.toBe( error );
     expect( fn ).toHaveBeenCalledOnce();
-    expect( validateOutputMock ).toHaveBeenCalledWith( output );
+    expect( parseOutputMock ).toHaveBeenCalledWith( output );
   } );
 } );

--- a/sdk/core/src/interface/validations/index.js
+++ b/sdk/core/src/interface/validations/index.js
@@ -1,4 +1,5 @@
 import { ValidationError } from '#errors';
+import { ComponentType } from '#consts';
 import { prettifyError } from 'zod';
 import {
   evaluatorOutputSchema,
@@ -10,84 +11,63 @@ import {
   workflowSchema
 } from './schemas.js';
 
-/**
- * Validates data using a Zod schema
- * @param {unknown} data
- * @param {ZodType} schema
- * @param {string} prefix - Validation error prefix
- * @throws {ValidationError} If validation fails
- * @returns {void}
- */
-const validate = ( data, schema, prefix = '' ) => {
-  if ( !schema ) {
-    return;
-  }
+const capitalize = word => word.at( 0 ).toUpperCase() + word.slice( 1 );
 
+const validate = ( schema, data, prefix ) => {
+  if ( !schema ) {
+    return data;
+  }
   const result = schema.safeParse( data );
-  if ( !result.success ) {
+  if ( result.success === false ) {
     throw new ValidationError( `${prefix} validation failed: ${prettifyError( result.error ) }` );
   }
+  return result.data;
 };
 
-export class WorkflowValidator {
+export class Validator {
+  static label;
+  static definitionSchema;
+
   static validateDefinition( definition ) {
-    validate( definition, workflowSchema, 'Workflow' );
+    validate( this.definitionSchema, definition, this.label );
   }
 
   constructor( { name, inputSchema, outputSchema } ) {
     this.name = name;
     this.inputSchema = inputSchema;
     this.outputSchema = outputSchema;
+    this.prefix = `${this.constructor.label} "${this.name}"`;
   }
 
   validateInput( input ) {
-    validate( input, this.inputSchema, `Workflow "${this.name}" input` );
+    return validate( this.inputSchema, input, `${this.prefix} input` );
   }
 
   validateOutput( output ) {
-    validate( output, this.outputSchema, `Workflow "${this.name}" output` );
+    return validate( this.outputSchema, output, `${this.prefix} output` );
   }
+}
+
+export class WorkflowValidator extends Validator {
+  static label = capitalize( ComponentType.WORKFLOW );
+  static definitionSchema = workflowSchema;
 
   validateInvocationOptions( options ) {
-    validate( options, workflowInvocationOptionsSchema, `Workflow "${this.name}" invocation options` );
+    return validate( workflowInvocationOptionsSchema, options, `${this.prefix} invocation options` );
   }
 }
 
-export class StepValidator {
-  static validateDefinition( definition ) {
-    validate( definition, stepSchema, 'Step' );
-  }
-
-  constructor( { name, inputSchema, outputSchema } ) {
-    this.name = name;
-    this.inputSchema = inputSchema;
-    this.outputSchema = outputSchema;
-  }
-
-  validateInput( input ) {
-    validate( input, this.inputSchema, `Step "${this.name}" input` );
-  }
-
-  validateOutput( output ) {
-    validate( output, this.outputSchema, `Step "${this.name}" output` );
-  }
+export class StepValidator extends Validator {
+  static label = capitalize( ComponentType.STEP );
+  static definitionSchema = stepSchema;
 }
 
-export class EvaluatorValidator {
-  static validateDefinition( definition ) {
-    validate( definition, evaluatorSchema, 'Evaluator' );
-  }
+export class EvaluatorValidator extends Validator {
+  static label = capitalize( ComponentType.EVALUATOR );
+  static definitionSchema = evaluatorSchema;
+
   constructor( { name, inputSchema } ) {
-    this.name = name;
-    this.inputSchema = inputSchema;
-  }
-
-  validateInput( input ) {
-    validate( input, this.inputSchema, `Evaluator "${this.name}" input` );
-  }
-
-  validateOutput( output ) {
-    validate( output, evaluatorOutputSchema, `Evaluator "${this.name}" output` );
+    super( { name, inputSchema, outputSchema: evaluatorOutputSchema } );
   }
 }
 
@@ -96,7 +76,7 @@ export class EvaluatorValidator {
  * @param {object} args - The request arguments
  */
 export function validateRequestPayload( args ) {
-  validate( args, httpRequestSchema, 'Request payload' );
+  validate( httpRequestSchema, args, 'Request payload' );
 };
 
 /**
@@ -104,5 +84,5 @@ export function validateRequestPayload( args ) {
  * @param {object} args - The request arguments
  */
 export function validateExecuteInParallel( args ) {
-  validate( args, executeInParallelSchema, 'ExecuteInParallel' );
+  validate( executeInParallelSchema, args, 'ExecuteInParallel' );
 };

--- a/sdk/core/src/interface/validations/index.js
+++ b/sdk/core/src/interface/validations/index.js
@@ -39,11 +39,11 @@ export class Validator {
     this.prefix = `${this.constructor.label} "${this.name}"`;
   }
 
-  validateInput( input ) {
+  parseInput( input ) {
     return validate( this.inputSchema, input, `${this.prefix} input` );
   }
 
-  validateOutput( output ) {
+  parseOutput( output ) {
     return validate( this.outputSchema, output, `${this.prefix} output` );
   }
 }
@@ -52,7 +52,7 @@ export class WorkflowValidator extends Validator {
   static label = capitalize( ComponentType.WORKFLOW );
   static definitionSchema = workflowSchema;
 
-  validateInvocationOptions( options ) {
+  parseInvocationOptions( options ) {
     return validate( workflowInvocationOptionsSchema, options, `${this.prefix} invocation options` );
   }
 }

--- a/sdk/core/src/interface/validations/index.spec.js
+++ b/sdk/core/src/interface/validations/index.spec.js
@@ -56,9 +56,9 @@ describe( 'interface validators', () => {
       const input = { value: 'ok' };
       const output = { result: 'ok' };
 
-      expect( validator.validateInput( input ) ).toEqual( input );
-      expect( validator.validateOutput( output ) ).toEqual( output );
-      expect( () => validator.validateInvocationOptions( {
+      expect( validator.parseInput( input ) ).toEqual( input );
+      expect( validator.parseOutput( output ) ).toEqual( output );
+      expect( () => validator.parseInvocationOptions( {
         detached: true,
         activityOptions: { retry: { maximumAttempts: 1 } },
         context: { info: { workflowId: 'test-workflow' } }
@@ -73,10 +73,10 @@ describe( 'interface validators', () => {
 
       const validator = new WorkflowValidator( workflowArgs );
 
-      expect( () => validator.validateInput( { value: 1 } ) ).toThrow( ValidationError );
-      expect( () => validator.validateInput( { value: 1 } ) ).toThrow( /Workflow "valid_workflow" input validation failed/ );
-      expect( () => validator.validateOutput( { result: 1 } ) ).toThrow( /Workflow "valid_workflow" output validation failed/ );
-      expect( () => validator.validateInvocationOptions( {
+      expect( () => validator.parseInput( { value: 1 } ) ).toThrow( ValidationError );
+      expect( () => validator.parseInput( { value: 1 } ) ).toThrow( /Workflow "valid_workflow" input validation failed/ );
+      expect( () => validator.parseOutput( { result: 1 } ) ).toThrow( /Workflow "valid_workflow" output validation failed/ );
+      expect( () => validator.parseInvocationOptions( {
         options: { activityOptions: { retry: { maximumAttempts: 1 } } }
       } ) ).toThrow( /Workflow "valid_workflow" invocation options validation failed/ );
     } );
@@ -89,8 +89,8 @@ describe( 'interface validators', () => {
       const input = { anything: true };
       const output = { anything: true };
 
-      expect( validator.validateInput( input ) ).toBe( input );
-      expect( validator.validateOutput( output ) ).toBe( output );
+      expect( validator.parseInput( input ) ).toBe( input );
+      expect( validator.parseOutput( output ) ).toBe( output );
     } );
   } );
 
@@ -101,8 +101,8 @@ describe( 'interface validators', () => {
       const input = { value: 'ok' };
       const output = { result: 'ok' };
 
-      expect( validator.validateInput( input ) ).toEqual( input );
-      expect( validator.validateOutput( output ) ).toEqual( output );
+      expect( validator.parseInput( input ) ).toEqual( input );
+      expect( validator.parseOutput( output ) ).toEqual( output );
     } );
 
     it( 'throws ValidationError with useful prefixes for invalid step data', () => {
@@ -112,8 +112,8 @@ describe( 'interface validators', () => {
 
       const validator = new StepValidator( stepArgs );
 
-      expect( () => validator.validateInput( { value: 1 } ) ).toThrow( /Step "valid_step" input validation failed/ );
-      expect( () => validator.validateOutput( { result: 1 } ) ).toThrow( /Step "valid_step" output validation failed/ );
+      expect( () => validator.parseInput( { value: 1 } ) ).toThrow( /Step "valid_step" input validation failed/ );
+      expect( () => validator.parseOutput( { result: 1 } ) ).toThrow( /Step "valid_step" output validation failed/ );
     } );
   } );
 
@@ -124,8 +124,8 @@ describe( 'interface validators', () => {
       const input = { value: 'ok' };
       const output = new EvaluationResult( { value: 'pass', confidence: 1 } );
 
-      expect( validator.validateInput( input ) ).toEqual( input );
-      expect( validator.validateOutput( output ) ).toEqual( output );
+      expect( validator.parseInput( input ) ).toEqual( input );
+      expect( validator.parseOutput( output ) ).toEqual( output );
     } );
 
     it( 'throws ValidationError for output schemas and invalid evaluator output', () => {
@@ -136,8 +136,8 @@ describe( 'interface validators', () => {
 
       const validator = new EvaluatorValidator( evaluatorArgs );
 
-      expect( () => validator.validateInput( { value: 1 } ) ).toThrow( /Evaluator "valid_evaluator" input validation failed/ );
-      expect( () => validator.validateOutput( { value: 'pass', confidence: 1 } ) ).toThrow(
+      expect( () => validator.parseInput( { value: 1 } ) ).toThrow( /Evaluator "valid_evaluator" input validation failed/ );
+      expect( () => validator.parseOutput( { value: 'pass', confidence: 1 } ) ).toThrow(
         /Evaluator "valid_evaluator" output validation failed/
       );
     } );

--- a/sdk/core/src/interface/validations/index.spec.js
+++ b/sdk/core/src/interface/validations/index.spec.js
@@ -53,9 +53,11 @@ describe( 'interface validators', () => {
     it( 'validates workflow definitions, input, output, and invocation options', () => {
       expect( () => WorkflowValidator.validateDefinition( workflowArgs ) ).not.toThrow();
       const validator = new WorkflowValidator( workflowArgs );
+      const input = { value: 'ok' };
+      const output = { result: 'ok' };
 
-      expect( () => validator.validateInput( { value: 'ok' } ) ).not.toThrow();
-      expect( () => validator.validateOutput( { result: 'ok' } ) ).not.toThrow();
+      expect( validator.validateInput( input ) ).toEqual( input );
+      expect( validator.validateOutput( output ) ).toEqual( output );
       expect( () => validator.validateInvocationOptions( {
         detached: true,
         activityOptions: { retry: { maximumAttempts: 1 } },
@@ -84,9 +86,11 @@ describe( 'interface validators', () => {
         name: 'schema_less_workflow',
         fn
       } );
+      const input = { anything: true };
+      const output = { anything: true };
 
-      expect( () => validator.validateInput( { anything: true } ) ).not.toThrow();
-      expect( () => validator.validateOutput( { anything: true } ) ).not.toThrow();
+      expect( validator.validateInput( input ) ).toBe( input );
+      expect( validator.validateOutput( output ) ).toBe( output );
     } );
   } );
 
@@ -94,9 +98,11 @@ describe( 'interface validators', () => {
     it( 'validates step definitions, input, and output', () => {
       expect( () => StepValidator.validateDefinition( stepArgs ) ).not.toThrow();
       const validator = new StepValidator( stepArgs );
+      const input = { value: 'ok' };
+      const output = { result: 'ok' };
 
-      expect( () => validator.validateInput( { value: 'ok' } ) ).not.toThrow();
-      expect( () => validator.validateOutput( { result: 'ok' } ) ).not.toThrow();
+      expect( validator.validateInput( input ) ).toEqual( input );
+      expect( validator.validateOutput( output ) ).toEqual( output );
     } );
 
     it( 'throws ValidationError with useful prefixes for invalid step data', () => {
@@ -115,9 +121,11 @@ describe( 'interface validators', () => {
     it( 'validates evaluator definitions, input, and EvaluationResult output', () => {
       expect( () => EvaluatorValidator.validateDefinition( evaluatorArgs ) ).not.toThrow();
       const validator = new EvaluatorValidator( evaluatorArgs );
+      const input = { value: 'ok' };
+      const output = new EvaluationResult( { value: 'pass', confidence: 1 } );
 
-      expect( () => validator.validateInput( { value: 'ok' } ) ).not.toThrow();
-      expect( () => validator.validateOutput( new EvaluationResult( { value: 'pass', confidence: 1 } ) ) ).not.toThrow();
+      expect( validator.validateInput( input ) ).toEqual( input );
+      expect( validator.validateOutput( output ) ).toEqual( output );
     } );
 
     it( 'throws ValidationError for output schemas and invalid evaluator output', () => {

--- a/sdk/core/src/interface/workflow.d.ts
+++ b/sdk/core/src/interface/workflow.d.ts
@@ -21,6 +21,8 @@ export type WorkflowContext<
      * It acts as a checkpoint when the workflow gets too long or approaches certain scaling limits.
      *
      * It accepts input with the same schema as the parent workflow function (`inputSchema`).
+     * The next run parses that input like any other workflow start; pass wire-format values if
+     * `inputSchema` transforms are not safe to apply twice.
      *
      * Calling this function must be the last statement in the workflow, accompanied by a `return`:
      *

--- a/sdk/core/src/interface/workflow.d.ts
+++ b/sdk/core/src/interface/workflow.d.ts
@@ -38,7 +38,7 @@ export type WorkflowContext<
      * @returns The workflow output type for type-checking; never returns at runtime.
      */
     continueAsNew: InputSchema extends AnyZodSchema ?
-      ( input: z.infer<InputSchema> ) => ( OutputSchema extends AnyZodSchema ? z.infer<OutputSchema> : void ) :
+      ( input: z.input<InputSchema> ) => ( OutputSchema extends AnyZodSchema ? z.infer<OutputSchema> : void ) :
       () => ( OutputSchema extends AnyZodSchema ? z.infer<OutputSchema> : void ),
 
     /**
@@ -122,39 +122,44 @@ export type WorkflowOptions = {
 /**
  * The handler function of a workflow.
  *
- * @param input - The workflow input; it matches the schema defined by `inputSchema`.
+ * @param input - Parsed workflow input (`z.infer<inputSchema>`).
  * @param context - A context object with tools and information.
  *
- * @returns A value matching the schema defined by `outputSchema`.
+ * @returns A value accepted by `outputSchema` before parse (`z.input<outputSchema>`).
  */
 export type WorkflowFunction<
   InputSchema extends AnyZodSchema | undefined = undefined,
   OutputSchema extends AnyZodSchema | undefined = undefined
 > = InputSchema extends AnyZodSchema ?
   ( input: z.infer<InputSchema>, context: WorkflowContext<InputSchema, OutputSchema> ) =>
-  Promise<OutputSchema extends AnyZodSchema ? z.infer<OutputSchema> : void> :
+  Promise<OutputSchema extends AnyZodSchema ? z.input<OutputSchema> : void> :
   ( input: undefined | null, context: WorkflowContext<InputSchema, OutputSchema> ) =>
-  Promise<OutputSchema extends AnyZodSchema ? z.infer<OutputSchema> : void>;
+  Promise<OutputSchema extends AnyZodSchema ? z.input<OutputSchema> : void>;
 
 /**
  * A wrapper around the user defined `fn` handler function.
  *
- * It accepts the same input and returns the same value, calling the user function inside.
+ * Callers pass values accepted by `inputSchema` (`z.input`). The wrapper parses input,
+ * invokes `fn`, parses output, and returns `z.infer<outputSchema>`.
  *
  * The second argument is a WorkflowInvocationOptions object, allowing workflows configuration overwrite.
  *
- * It adds input and output validation based on the `inputSchema`, `outputSchema`.
- *
- * @param input - The workflow input; it matches the schema defined by `inputSchema`.
+ * @param input - The workflow input before `inputSchema` parse.
  * @param options - Additional options for the invocation.
- * @returns A value matching the schema defined by `outputSchema`.
+ * @returns The workflow output after `outputSchema` parse.
  */
-export type WorkflowFunctionWrapper<WorkflowFunction extends ( ...args: any ) => any> = // eslint-disable-line @typescript-eslint/no-explicit-any
-  [Parameters<WorkflowFunction>[0]] extends [undefined | null] ?
-    ( input?: undefined | null, options?: WorkflowInvocationOptions ) =>
-    ReturnType<WorkflowFunction> :
-    ( input: Parameters<WorkflowFunction>[0], options?: WorkflowInvocationOptions ) =>
-    ReturnType<WorkflowFunction>;
+export type WorkflowFunctionWrapper<
+  InputSchema extends AnyZodSchema | undefined = undefined,
+  OutputSchema extends AnyZodSchema | undefined = undefined
+> = InputSchema extends AnyZodSchema ?
+  (
+    input: z.input<InputSchema>,
+    options?: WorkflowInvocationOptions
+  ) => Promise<OutputSchema extends AnyZodSchema ? z.infer<OutputSchema> : void> :
+  (
+    input?: undefined | null,
+    options?: WorkflowInvocationOptions
+  ) => Promise<OutputSchema extends AnyZodSchema ? z.infer<OutputSchema> : void>;
 
 /**
  * Creates a workflow.
@@ -270,7 +275,7 @@ export type WorkflowFunctionWrapper<WorkflowFunction extends ( ...args: any ) =>
  * @param params.outputSchema - Zod schema for workflow output
  * @param params.fn - A function containing the workflow code
  * @param params.options - Optional workflow options.
- * @returns The same handler function set at `fn` with a different signature
+ * @returns A wrapper that parses input/output around `fn`
  */
 export declare function workflow<
   InputSchema extends AnyZodSchema | undefined = undefined,
@@ -288,4 +293,4 @@ export declare function workflow<
    * while maintaining backward compatibility with existing callers.
    */
   aliases?: string[];
-} ): WorkflowFunctionWrapper<WorkflowFunction<InputSchema, OutputSchema>>;
+} ): WorkflowFunctionWrapper<InputSchema, OutputSchema>;

--- a/sdk/core/src/interface/workflow.js
+++ b/sdk/core/src/interface/workflow.js
@@ -41,12 +41,12 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
   const validator = new WorkflowValidator( { name, inputSchema, outputSchema } );
 
   const handler = async ( input, rawInvocationOptions = {} ) => {
-    const invocationOptions = validator.validateInvocationOptions( rawInvocationOptions );
+    const invocationOptions = validator.parseInvocationOptions( rawInvocationOptions );
 
     // If called outside Temporal workflow context, just execute the handler function
     if ( !inWorkflowContext() ) {
-      return validator.validateOutput(
-        await fn( validator.validateInput( input ), deepMerge( WorkflowContext.build(), invocationOptions?.context ) )
+      return validator.parseOutput(
+        await fn( validator.parseInput( input ), deepMerge( WorkflowContext.build(), invocationOptions?.context ) )
       );
     }
 
@@ -90,7 +90,7 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
     };
 
     try {
-      const output = validator.validateOutput( await fn( validator.validateInput( input ), WorkflowContext.build() ) );
+      const output = validator.parseOutput( await fn( validator.parseInput( input ), WorkflowContext.build() ) );
 
       return { [C.WORKFLOW_WRAPPER_VERSION_FIELD]: 1, output, ...traceDestinations };
     } catch ( error ) {

--- a/sdk/core/src/interface/workflow.js
+++ b/sdk/core/src/interface/workflow.js
@@ -11,17 +11,6 @@ import { FatalError } from '#errors';
 import * as C from '#consts';
 
 /**
- * Execute the workflow without temporal, using the fn handler function.
- * This is important to allow for workflows to have unit tests
- */
-const executeWithoutTemporal = async ( { input, validator, handler, contextOverrides = {} } ) => {
-  validator.validateInput( input );
-  const output = await handler( input, deepMerge( WorkflowContext.build(), contextOverrides ) );
-  validator.validateOutput( output );
-  return output;
-};
-
-/**
  * Add a global dispatcher function to be used to invoke activities.
  * This will replace direct activity invocation in the user code by the webpack loader.
  *
@@ -51,12 +40,14 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
   const disableTrace = options.disableTrace ?? defaultOptions.disableTrace;
   const validator = new WorkflowValidator( { name, inputSchema, outputSchema } );
 
-  const handler = async ( input, invocationOptions = {} ) => {
-    validator.validateInvocationOptions( invocationOptions );
+  const handler = async ( input, rawInvocationOptions = {} ) => {
+    const invocationOptions = validator.validateInvocationOptions( rawInvocationOptions );
 
     // If called outside Temporal workflow context, just execute the handler function
     if ( !inWorkflowContext() ) {
-      return executeWithoutTemporal( { input, validator, handler: fn, contextOverrides: invocationOptions?.context } );
+      return validator.validateOutput(
+        await fn( validator.validateInput( input ), deepMerge( WorkflowContext.build(), invocationOptions?.context ) )
+      );
     }
 
     const { workflowId, runId, memo, root } = workflowInfo();
@@ -99,9 +90,7 @@ export function workflow( { name, description, inputSchema, outputSchema, fn, op
     };
 
     try {
-      validator.validateInput( input );
-      const output = await fn( input, WorkflowContext.build() );
-      validator.validateOutput( output );
+      const output = validator.validateOutput( await fn( validator.validateInput( input ), WorkflowContext.build() ) );
 
       return { [C.WORKFLOW_WRAPPER_VERSION_FIELD]: 1, output, ...traceDestinations };
     } catch ( error ) {

--- a/sdk/core/src/interface/workflow.spec.js
+++ b/sdk/core/src/interface/workflow.spec.js
@@ -15,9 +15,9 @@ const executeChildMock = vi.hoisted( () => vi.fn() );
 const workflowInfoMock = vi.hoisted( () => vi.fn() );
 const continueAsNewMock = vi.hoisted( () => vi.fn() );
 const validateDefinitionMock = vi.hoisted( () => vi.fn() );
-const validateInputMock = vi.hoisted( () => vi.fn() );
-const validateOutputMock = vi.hoisted( () => vi.fn() );
-const validateInvocationOptionsMock = vi.hoisted( () => vi.fn() );
+const validateInputMock = vi.hoisted( () => vi.fn( input => input ) );
+const validateOutputMock = vi.hoisted( () => vi.fn( output => output ) );
+const validateInvocationOptionsMock = vi.hoisted( () => vi.fn( options => options ) );
 const validatorConstructorMock = vi.hoisted( () => vi.fn() );
 const createWorkflowMock = vi.hoisted( () => vi.fn( ( { handler } ) => handler ) );
 

--- a/sdk/core/src/interface/workflow.spec.js
+++ b/sdk/core/src/interface/workflow.spec.js
@@ -15,9 +15,9 @@ const executeChildMock = vi.hoisted( () => vi.fn() );
 const workflowInfoMock = vi.hoisted( () => vi.fn() );
 const continueAsNewMock = vi.hoisted( () => vi.fn() );
 const validateDefinitionMock = vi.hoisted( () => vi.fn() );
-const validateInputMock = vi.hoisted( () => vi.fn( input => input ) );
-const validateOutputMock = vi.hoisted( () => vi.fn( output => output ) );
-const validateInvocationOptionsMock = vi.hoisted( () => vi.fn( options => options ) );
+const parseInputMock = vi.hoisted( () => vi.fn( input => input ) );
+const parseOutputMock = vi.hoisted( () => vi.fn( output => output ) );
+const parseInvocationOptionsMock = vi.hoisted( () => vi.fn( options => options ) );
 const validatorConstructorMock = vi.hoisted( () => vi.fn() );
 const createWorkflowMock = vi.hoisted( () => vi.fn( ( { handler } ) => handler ) );
 
@@ -29,9 +29,9 @@ vi.mock( './validations/index.js', () => {
 
     constructor( ...args ) {
       validatorConstructorMock( ...args );
-      this.validateInput = validateInputMock;
-      this.validateOutput = validateOutputMock;
-      this.validateInvocationOptions = validateInvocationOptionsMock;
+      this.parseInput = parseInputMock;
+      this.parseOutput = parseOutputMock;
+      this.parseInvocationOptions = parseInvocationOptionsMock;
     }
   }
 
@@ -210,9 +210,9 @@ describe( 'workflow()', () => {
         value: 'test-workflow-ok',
         extra: 'custom'
       } );
-      expect( validateInvocationOptionsMock ).toHaveBeenCalledWith( { context: { extra: 'custom' } } );
-      expect( validateInputMock ).toHaveBeenCalledWith( { suffix: '-ok' } );
-      expect( validateOutputMock ).toHaveBeenCalledWith( { value: 'test-workflow-ok', extra: 'custom' } );
+      expect( parseInvocationOptionsMock ).toHaveBeenCalledWith( { context: { extra: 'custom' } } );
+      expect( parseInputMock ).toHaveBeenCalledWith( { suffix: '-ok' } );
+      expect( parseOutputMock ).toHaveBeenCalledWith( { value: 'test-workflow-ok', extra: 'custom' } );
       expect( workflowInfoMock ).not.toHaveBeenCalled();
       expect( proxyActivitiesMock ).not.toHaveBeenCalled();
     } );
@@ -220,7 +220,7 @@ describe( 'workflow()', () => {
     it( 'does not run fn when plain function input validation fails', async () => {
       const { workflow } = await import( './workflow.js' );
       const error = new ValidationError( 'invalid input' );
-      validateInputMock.mockImplementationOnce( () => {
+      parseInputMock.mockImplementationOnce( () => {
         throw error;
       } );
       const fn = vi.fn();
@@ -234,13 +234,13 @@ describe( 'workflow()', () => {
 
       await expect( wf( { value: 1 } ) ).rejects.toBe( error );
       expect( fn ).not.toHaveBeenCalled();
-      expect( validateOutputMock ).not.toHaveBeenCalled();
+      expect( parseOutputMock ).not.toHaveBeenCalled();
     } );
 
     it( 'propagates plain function output validation errors after fn runs', async () => {
       const { workflow } = await import( './workflow.js' );
       const error = new ValidationError( 'invalid output' );
-      validateOutputMock.mockImplementationOnce( () => {
+      parseOutputMock.mockImplementationOnce( () => {
         throw error;
       } );
       const output = { result: 1 };
@@ -257,7 +257,7 @@ describe( 'workflow()', () => {
       expect( fn ).toHaveBeenCalledWith( { value: 'ok' }, expect.objectContaining( {
         info: { workflowId: 'test-workflow', runId: 'test-run' }
       } ) );
-      expect( validateOutputMock ).toHaveBeenCalledWith( output );
+      expect( parseOutputMock ).toHaveBeenCalledWith( output );
     } );
   } );
 
@@ -294,7 +294,7 @@ describe( 'workflow()', () => {
           retry: { maximumAttempts: 7 }
         }
       } ) ).resolves.toEqual( { child: 'ok' } );
-      expect( validateInvocationOptionsMock ).toHaveBeenCalledWith( {
+      expect( parseInvocationOptionsMock ).toHaveBeenCalledWith( {
         detached: true,
         context: { testOnly: true },
         activityOptions: {
@@ -543,7 +543,7 @@ describe( 'workflow()', () => {
         fn: async () => ( { result: 1 } )
       } ) );
 
-      validateInputMock.mockImplementationOnce( () => {
+      parseInputMock.mockImplementationOnce( () => {
         throw inputError;
       } );
       await expect( wf( { value: 1 } ) ).rejects.toBe( inputError );
@@ -551,7 +551,7 @@ describe( 'workflow()', () => {
 
       delete globalThis[INVOKE_ACTIVITY_SYMBOL];
       setWorkflowInfo( { workflowType: 'runtime_validation_wf', memo: {} } );
-      validateOutputMock.mockImplementationOnce( () => {
+      parseOutputMock.mockImplementationOnce( () => {
         throw outputError;
       } );
       await expect( wf( { value: 'ok' } ) ).rejects.toBe( outputError );

--- a/test_workflows/src/workflows/nested/external/workflow.ts
+++ b/test_workflows/src/workflows/nested/external/workflow.ts
@@ -1,6 +1,10 @@
 import { workflow, z } from '@outputai/core';
 import { processNumbers } from '@growthxlabs/workflows_catalog';
 
+// TEMP: catalog .d.ts still uses WorkflowFunctionWrapper<WorkflowFunction<...>>; cast until catalog is updated for core's Wrapper<In, Out>.
+type ProcessNumbers = ( input: { values: number[] } ) => Promise<{ summation: number; subtraction: number }>;
+const processNumbersCompat = processNumbers as unknown as ProcessNumbers;
+
 export default workflow( {
   name: 'nested_external',
   description: 'Calling nested external workflow',
@@ -12,7 +16,7 @@ export default workflow( {
   fn: async () => {
     const values = [ 3, 2, 1 ];
 
-    const { summation, subtraction } = await processNumbers( { values } );
+    const { summation, subtraction } = await processNumbersCompat( { values } );
 
     return { values, summation, subtraction };
   }

--- a/test_workflows/src/workflows/schema_parsing/scenarios/basic.json
+++ b/test_workflows/src/workflows/schema_parsing/scenarios/basic.json
@@ -1,0 +1,4 @@
+{
+  "count": "2",
+  "requestId": "req-123"
+}

--- a/test_workflows/src/workflows/schema_parsing/steps.spec.ts
+++ b/test_workflows/src/workflows/schema_parsing/steps.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { formatLabel, scaleValue } from './steps.js';
+
+describe( 'schema_parsing steps', () => {
+  describe( 'scaleValue', () => {
+    it( 'coerces input, applies defaults, strips unknown output fields, and fills output defaults', async () => {
+      // Cast: exercise runtime stripping of unknown input keys (not part of z.input).
+      const result = await scaleValue( {
+        value: '3',
+        extra: 'stripped-from-input'
+      } as { value: string } );
+
+      expect( result ).toEqual( { product: 30, unit: 'x' } );
+    } );
+
+    it( 'uses input defaults when fields are omitted', async () => {
+      const result = await scaleValue( {} );
+
+      expect( result ).toEqual( { product: 10, unit: 'x' } );
+    } );
+  } );
+
+  describe( 'formatLabel', () => {
+    it( 'transforms input then output', async () => {
+      const result = await formatLabel( '  Hello World  ' );
+
+      expect( result ).toBe( 'label:hello world' );
+    } );
+  } );
+} );

--- a/test_workflows/src/workflows/schema_parsing/steps.ts
+++ b/test_workflows/src/workflows/schema_parsing/steps.ts
@@ -1,0 +1,32 @@
+import { step, z } from '@outputai/core';
+
+/**
+ * Coerce/default on input; default + strip unknown keys on output.
+ */
+export const scaleValue = step( {
+  name: 'scale_value',
+  description: 'Scale a value with schema defaults and output field stripping',
+  inputSchema: z.object( {
+    value: z.coerce.number().default( 1 ),
+    factor: z.number().default( 10 )
+  } ),
+  outputSchema: z.object( {
+    product: z.number(),
+    unit: z.string().default( 'x' )
+  } ),
+  fn: async input => ( {
+    product: input.value * input.factor,
+    scratch: 'dropped-by-output-schema'
+  } )
+} );
+
+/**
+ * Deterministic string transforms on both input and output.
+ */
+export const formatLabel = step( {
+  name: 'format_label',
+  description: 'Normalize a label on input and prefix it on output',
+  inputSchema: z.string().transform( value => value.trim().toLowerCase() ),
+  outputSchema: z.string().transform( value => `label:${value}` ),
+  fn: async label => label
+} );

--- a/test_workflows/src/workflows/schema_parsing/workflow.spec.ts
+++ b/test_workflows/src/workflows/schema_parsing/workflow.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import schemaParsing from './workflow.js';
+
+describe( 'schema_parsing workflow', () => {
+  const context = {
+    info: {
+      workflowId: 'wf-schema-parsing'
+    }
+  };
+
+  it( 'coerces input, strips unknown keys, fills output defaults, and drops extra return fields', async () => {
+    // Cast: exercise runtime stripping of unknown workflow input keys (not part of z.input).
+    const result = await schemaParsing( {
+      count: '2',
+      requestId: 'req-123'
+    } as { count: string }, { context } );
+
+    expect( result ).toEqual( {
+      total: 20,
+      label: 'label:item',
+      currency: 'USD',
+      workflowId: 'wf-schema-parsing'
+    } );
+  } );
+
+  it( 'applies workflow input defaults when the payload is empty', async () => {
+    const result = await schemaParsing( {}, { context } );
+
+    expect( result ).toEqual( {
+      total: 10,
+      label: 'label:item',
+      currency: 'USD',
+      workflowId: 'wf-schema-parsing'
+    } );
+  } );
+
+  it( 'passes through an explicit label into the transform step', async () => {
+    const result = await schemaParsing( {
+      count: 5,
+      label: '  Custom  '
+    }, { context } );
+
+    expect( result ).toEqual( {
+      total: 50,
+      label: 'label:custom',
+      currency: 'USD',
+      workflowId: 'wf-schema-parsing'
+    } );
+  } );
+} );

--- a/test_workflows/src/workflows/schema_parsing/workflow.ts
+++ b/test_workflows/src/workflows/schema_parsing/workflow.ts
@@ -1,0 +1,33 @@
+import { workflow, z } from '@outputai/core';
+import { formatLabel, scaleValue } from './steps.js';
+
+export default workflow( {
+  name: 'schema_parsing',
+  description: 'Exercises Zod parse behavior on workflow and step schemas',
+  inputSchema: z.object( {
+    count: z.coerce.number().default( 1 ),
+    label: z.string().default( 'Item' )
+  } ),
+  outputSchema: z.object( {
+    total: z.number(),
+    label: z.string(),
+    currency: z.string().default( 'USD' ),
+    workflowId: z.string()
+  } ),
+  fn: async ( input, context ) => {
+    // Unknown keys are stripped by the step inputSchema (cast: TS rejects excess props on z.input).
+    const scaled = await scaleValue( {
+      value: input.count,
+      ignoredByStep: true
+    } as { value: number } );
+    const label = await formatLabel( `  ${input.label}  ` );
+
+    return {
+      total: scaled.product,
+      label,
+      workflowId: context.info.workflowId,
+      internalNote: 'dropped-by-workflow-output-schema'
+      // currency omitted -> workflow output default
+    };
+  }
+} );


### PR DESCRIPTION
## Summary

- `workflow()`, `step()`, and `evaluator()` now pass the value returned by the Zod `inputSchema` parser to their handler. Workflows and steps also return the value produced by their `outputSchema` parser. Zod transforms, coercions, defaults, and object-key stripping therefore affect the values handled and returned by these components instead of only validating them.
