### PR TITLE
fix: add --json support to workflow start|run when running scenarios

### DIFF
--- a/.changeset/petite-rivers-melt.md
+++ b/.changeset/petite-rivers-melt.md
@@ -2,5 +2,5 @@
 "@outputai/cli": patch
 ---
 
-Fix `--json` output on the `workflow start` and `workflow run` commands. `workflow start` did not support `--json` at all and errored on the flag; it now emits the workflow result as JSON. `workflow run --json` corrupted its JSON output when given a scenario argument, because the "Using scenario:" notice was written to stdout; that notice now goes to stderr.
+Fix `--json` output on the `workflow start` and `workflow run` commands. `workflow start` did not support `--json` at all and errored on the flag; it now emits the workflow result as JSON. `workflow run --json` corrupted its JSON output when given a scenario argument, because the "Using scenario:" notice was written to stdout. That notice now goes to stderr, and is suppressed entirely under `--json` so that on success both commands write exactly one JSON object to stdout and nothing else.
 

--- a/.changeset/petite-rivers-melt.md
+++ b/.changeset/petite-rivers-melt.md
@@ -1,0 +1,6 @@
+---
+"@outputai/cli": patch
+---
+
+Fix `--json` output on the `workflow start` and `workflow run` commands. `workflow start` did not support `--json` at all and errored on the flag; it now emits the workflow result as JSON. `workflow run --json` corrupted its JSON output when given a scenario argument, because the "Using scenario:" notice was written to stdout; that notice now goes to stderr.
+

--- a/sdk/cli/src/commands/workflow/run.spec.ts
+++ b/sdk/cli/src/commands/workflow/run.spec.ts
@@ -77,7 +77,12 @@ describe( 'workflow run command', () => {
 
       await cmd.run();
 
-      expect( resolveInput ).toHaveBeenCalledWith( 'my_workflow', undefined, undefined, 'run', undefined );
+      expect( resolveInput ).toHaveBeenCalledWith( expect.objectContaining( {
+        workflowName: 'my_workflow',
+        commandName: 'run',
+        catalog: undefined,
+        json: false
+      } ) );
       expect( postWorkflowRun ).toHaveBeenCalledTimes( 1 );
       expect( postWorkflowRun ).toHaveBeenCalledWith(
         { workflowName: 'my_workflow', input: { key: 'value' }, catalog: undefined },
@@ -102,7 +107,12 @@ describe( 'workflow run command', () => {
 
       await cmd.run();
 
-      expect( resolveInput ).toHaveBeenCalledWith( 'my_workflow', 'basic', undefined, 'run', 'my-catalog' );
+      expect( resolveInput ).toHaveBeenCalledWith( expect.objectContaining( {
+        workflowName: 'my_workflow',
+        scenario: 'basic',
+        commandName: 'run',
+        catalog: 'my-catalog'
+      } ) );
       expect( postWorkflowRun ).toHaveBeenCalledWith(
         expect.objectContaining( { catalog: 'my-catalog' } ),
         expect.anything()

--- a/sdk/cli/src/commands/workflow/run.ts
+++ b/sdk/cli/src/commands/workflow/run.ts
@@ -81,7 +81,14 @@ export default class WorkflowRun extends Command {
   async run(): Promise<WorkflowResultResponse> {
     const { args, flags } = await this.parse( WorkflowRun );
 
-    const input = await resolveInput( args.workflowName, args.scenario, flags.input, 'run', flags.catalog );
+    const input = await resolveInput( {
+      workflowName: args.workflowName,
+      scenario: args.scenario,
+      inputFlag: flags.input,
+      commandName: 'run',
+      catalog: flags.catalog,
+      json: this.jsonEnabled()
+    } );
 
     this.log( `Executing workflow: ${args.workflowName}...` );
 

--- a/sdk/cli/src/commands/workflow/start.spec.ts
+++ b/sdk/cli/src/commands/workflow/start.spec.ts
@@ -51,12 +51,12 @@ describe( 'workflow start command', () => {
   } );
 
   describe( 'run()', () => {
-    const createCommand = async ( flagOverrides: Record<string, unknown> = {} ) => {
+    const createCommand = async ( flagOverrides: Record<string, unknown> = {}, argv = [ 'my_workflow' ] ) => {
       const WorkflowStart = ( await import( './start.js' ) ).default;
       const { postWorkflowStart } = await import( '#api/generated/api.js' );
       const { resolveInput } = await import( '#utils/resolve_input.js' );
 
-      const cmd = new WorkflowStart( [ 'my_workflow' ], {} as any );
+      const cmd = new WorkflowStart( argv, {} as any );
       cmd.log = vi.fn();
       cmd.error = vi.fn( () => {
         throw new Error( 'error called' );
@@ -80,7 +80,12 @@ describe( 'workflow start command', () => {
 
       const result = await cmd.run();
 
-      expect( resolveInput ).toHaveBeenCalledWith( 'my_workflow', undefined, undefined, 'start', 'my-catalog' );
+      expect( resolveInput ).toHaveBeenCalledWith( expect.objectContaining( {
+        workflowName: 'my_workflow',
+        commandName: 'start',
+        catalog: 'my-catalog',
+        json: false
+      } ) );
       expect( postWorkflowStart ).toHaveBeenCalledWith(
         expect.objectContaining( { workflowName: 'my_workflow', catalog: 'my-catalog' } )
       );
@@ -98,7 +103,25 @@ describe( 'workflow start command', () => {
 
       await cmd.run();
 
-      expect( resolveInput ).toHaveBeenCalledWith( 'my_workflow', undefined, undefined, 'start', undefined );
+      expect( resolveInput ).toHaveBeenCalledWith( expect.objectContaining( {
+        workflowName: 'my_workflow',
+        commandName: 'start',
+        catalog: undefined
+      } ) );
+    } );
+
+    it( 'tells resolveInput to stay quiet when --json is set', async () => {
+      const { cmd, postWorkflowStart, resolveInput } = await createCommand( {}, [ 'my_workflow', 'basic', '--json' ] );
+      resolveInput.mockResolvedValue( {} );
+      postWorkflowStart.mockResolvedValue( {
+        data: { workflowId: 'wf-123' },
+        status: 200,
+        headers: new Headers()
+      } as any );
+
+      await cmd.run();
+
+      expect( resolveInput ).toHaveBeenCalledWith( expect.objectContaining( { json: true } ) );
     } );
   } );
 } );

--- a/sdk/cli/src/commands/workflow/start.spec.ts
+++ b/sdk/cli/src/commands/workflow/start.spec.ts
@@ -43,6 +43,11 @@ describe( 'workflow start command', () => {
       expect( WorkflowStart.flags.catalog.env ).toBe( 'OUTPUT_CATALOG_ID' );
       expect( WorkflowStart.flags.catalog.char ).toBe( 'c' );
     } );
+
+    it( 'enables the built-in --json flag', async () => {
+      const WorkflowStart = ( await import( './start.js' ) ).default;
+      expect( WorkflowStart.enableJsonFlag ).toBe( true );
+    } );
   } );
 
   describe( 'run()', () => {
@@ -73,12 +78,13 @@ describe( 'workflow start command', () => {
         headers: new Headers()
       } as any );
 
-      await cmd.run();
+      const result = await cmd.run();
 
       expect( resolveInput ).toHaveBeenCalledWith( 'my_workflow', undefined, undefined, 'start', 'my-catalog' );
       expect( postWorkflowStart ).toHaveBeenCalledWith(
         expect.objectContaining( { workflowName: 'my_workflow', catalog: 'my-catalog' } )
       );
+      expect( result ).toEqual( { workflowId: 'wf-123' } );
     } );
 
     it( 'passes undefined catalog through when none is set', async () => {

--- a/sdk/cli/src/commands/workflow/start.ts
+++ b/sdk/cli/src/commands/workflow/start.ts
@@ -6,11 +6,14 @@ import { resolveInput } from '#utils/resolve_input.js';
 export default class WorkflowStart extends Command {
   static override description = 'Start a workflow asynchronously without waiting for completion';
 
+  static override enableJsonFlag = true;
+
   static override examples = [
     '<%= config.bin %> <%= command.id %> simple basic_input',
     '<%= config.bin %> <%= command.id %> simple --input \'{"values":[1,2,3]}\'',
     '<%= config.bin %> <%= command.id %> simple --input input.json',
-    '<%= config.bin %> <%= command.id %> simple --input \'{"key":"value"}\' --catalog my-catalog'
+    '<%= config.bin %> <%= command.id %> simple --input \'{"key":"value"}\' --catalog my-catalog',
+    '<%= config.bin %> <%= command.id %> simple --json'
   ];
 
   static override args = {
@@ -40,7 +43,7 @@ export default class WorkflowStart extends Command {
     } )
   };
 
-  async run(): Promise<void> {
+  async run(): Promise<PostWorkflowStart200> {
     const { args, flags } = await this.parse( WorkflowStart );
 
     const input = await resolveInput( args.workflowName, args.scenario, flags.input, 'start', flags.catalog );
@@ -68,6 +71,8 @@ export default class WorkflowStart extends Command {
     ].join( '\n' );
 
     this.log( `\n${output}` );
+
+    return result;
   }
 
   async catch( error: Error ): Promise<void> {

--- a/sdk/cli/src/commands/workflow/start.ts
+++ b/sdk/cli/src/commands/workflow/start.ts
@@ -46,7 +46,14 @@ export default class WorkflowStart extends Command {
   async run(): Promise<PostWorkflowStart200> {
     const { args, flags } = await this.parse( WorkflowStart );
 
-    const input = await resolveInput( args.workflowName, args.scenario, flags.input, 'start', flags.catalog );
+    const input = await resolveInput( {
+      workflowName: args.workflowName,
+      scenario: args.scenario,
+      inputFlag: flags.input,
+      commandName: 'start',
+      catalog: flags.catalog,
+      json: this.jsonEnabled()
+    } );
 
     this.log( `Starting workflow: ${args.workflowName}...` );
 

--- a/sdk/cli/src/utils/resolve_input.spec.ts
+++ b/sdk/cli/src/utils/resolve_input.spec.ts
@@ -37,10 +37,38 @@ describe( 'resolveInput', () => {
     } as any );
     vi.mocked( parseInputFlag ).mockReturnValue( { key: 'value' } );
 
-    const result = await resolveInput( 'web_search', 'happy_path', undefined, 'start' );
+    const result = await resolveInput( {
+      workflowName: 'web_search',
+      scenario: 'happy_path',
+      commandName: 'start'
+    } );
 
     expect( result ).toEqual( { key: 'value' } );
-    expect( ux.stderr ).toHaveBeenCalledWith( 'Using scenario: /scenarios/happy_path.json\n' );
+    expect( ux.stderr ).toHaveBeenCalledWith( 'Using scenario: /scenarios/happy_path.json' );
+    expect( ux.stdout ).not.toHaveBeenCalled();
+  } );
+
+  it( 'suppresses the scenario notice entirely under --json', async () => {
+    const { ux } = await import( '@oclif/core' );
+    const { parseInputFlag } = await import( '#utils/input_parser.js' );
+    const { resolveScenarioPath } = await import( '#utils/scenario_resolver.js' );
+    const { resolveInput } = await import( './resolve_input.js' );
+
+    vi.mocked( resolveScenarioPath ).mockResolvedValue( {
+      found: true,
+      path: '/scenarios/happy_path.json'
+    } as any );
+    vi.mocked( parseInputFlag ).mockReturnValue( { key: 'value' } );
+
+    const result = await resolveInput( {
+      workflowName: 'web_search',
+      scenario: 'happy_path',
+      commandName: 'start',
+      json: true
+    } );
+
+    expect( result ).toEqual( { key: 'value' } );
+    expect( ux.stderr ).not.toHaveBeenCalled();
     expect( ux.stdout ).not.toHaveBeenCalled();
   } );
 
@@ -51,7 +79,11 @@ describe( 'resolveInput', () => {
 
     vi.mocked( parseInputFlag ).mockReturnValue( { key: 'value' } );
 
-    await resolveInput( 'web_search', undefined, '{"key":"value"}', 'start' );
+    await resolveInput( {
+      workflowName: 'web_search',
+      inputFlag: '{"key":"value"}',
+      commandName: 'start'
+    } );
 
     expect( ux.stderr ).not.toHaveBeenCalled();
     expect( ux.stdout ).not.toHaveBeenCalled();

--- a/sdk/cli/src/utils/resolve_input.spec.ts
+++ b/sdk/cli/src/utils/resolve_input.spec.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock( '@oclif/core', () => ( {
+  ux: {
+    stdout: vi.fn(),
+    stderr: vi.fn(),
+    error: vi.fn( () => {
+      throw new Error( 'ux.error called' );
+    } )
+  }
+} ) );
+
+vi.mock( '#utils/input_parser.js', () => ( {
+  parseInputFlag: vi.fn()
+} ) );
+
+vi.mock( '#utils/scenario_resolver.js', () => ( {
+  resolveScenarioPath: vi.fn(),
+  getScenarioNotFoundMessage: vi.fn()
+} ) );
+
+describe( 'resolveInput', () => {
+  beforeEach( () => {
+    vi.clearAllMocks();
+  } );
+
+  it( 'emits the scenario notice on stderr so --json stdout stays clean', async () => {
+    const { ux } = await import( '@oclif/core' );
+    const { parseInputFlag } = await import( '#utils/input_parser.js' );
+    const { resolveScenarioPath } = await import( '#utils/scenario_resolver.js' );
+    const { resolveInput } = await import( './resolve_input.js' );
+
+    vi.mocked( resolveScenarioPath ).mockResolvedValue( {
+      found: true,
+      path: '/scenarios/happy_path.json'
+    } as any );
+    vi.mocked( parseInputFlag ).mockReturnValue( { key: 'value' } );
+
+    const result = await resolveInput( 'web_search', 'happy_path', undefined, 'start' );
+
+    expect( result ).toEqual( { key: 'value' } );
+    expect( ux.stderr ).toHaveBeenCalledWith( 'Using scenario: /scenarios/happy_path.json\n' );
+    expect( ux.stdout ).not.toHaveBeenCalled();
+  } );
+
+  it( 'does not emit the scenario notice when input comes from --input', async () => {
+    const { ux } = await import( '@oclif/core' );
+    const { parseInputFlag } = await import( '#utils/input_parser.js' );
+    const { resolveInput } = await import( './resolve_input.js' );
+
+    vi.mocked( parseInputFlag ).mockReturnValue( { key: 'value' } );
+
+    await resolveInput( 'web_search', undefined, '{"key":"value"}', 'start' );
+
+    expect( ux.stderr ).not.toHaveBeenCalled();
+    expect( ux.stdout ).not.toHaveBeenCalled();
+  } );
+} );

--- a/sdk/cli/src/utils/resolve_input.ts
+++ b/sdk/cli/src/utils/resolve_input.ts
@@ -2,13 +2,18 @@ import { ux } from '@oclif/core';
 import { parseInputFlag } from '#utils/input_parser.js';
 import { resolveScenarioPath, getScenarioNotFoundMessage } from '#utils/scenario_resolver.js';
 
-export async function resolveInput(
-  workflowName: string,
-  scenario: string | undefined,
-  inputFlag: string | undefined,
-  commandName: string,
-  catalog?: string
-): Promise<unknown> {
+export type ResolveInputOptions = {
+  workflowName: string;
+  scenario?: string;
+  inputFlag?: string;
+  commandName: string;
+  catalog?: string;
+  json?: boolean;
+};
+
+export async function resolveInput( options: ResolveInputOptions ): Promise<unknown> {
+  const { workflowName, scenario, inputFlag, commandName, catalog, json } = options;
+
   if ( inputFlag && scenario ) {
     return ux.error(
       'Cannot use both scenario argument and --input flag. Choose one.',
@@ -28,7 +33,12 @@ export async function resolveInput(
         { exit: 1 }
       );
     }
-    ux.stderr( `Using scenario: ${resolution.path}\n` );
+    // Advisory notice goes to stderr so stdout stays clean for piping, and is
+    // skipped entirely under --json where even stderr is noise to a script
+    // consuming the structured output (same rule as the init hook's banner).
+    if ( !json ) {
+      ux.stderr( `Using scenario: ${resolution.path}` );
+    }
     return parseInputFlag( resolution.path! );
   }
 

--- a/sdk/cli/src/utils/resolve_input.ts
+++ b/sdk/cli/src/utils/resolve_input.ts
@@ -28,7 +28,7 @@ export async function resolveInput(
         { exit: 1 }
       );
     }
-    ux.stdout( `Using scenario: ${resolution.path}\n` );
+    ux.stderr( `Using scenario: ${resolution.path}\n` );
     return parseInputFlag( resolution.path! );
   }
 


### PR DESCRIPTION
## Summary

Running scenarios does not support the `--json` flag that was recently updated/added in https://github.com/growthxai/output/pull/281 , and the `workflow start` command was missing support completely. 

Examples:

<details>

**Workflow start (with scenario):**

```
❯ npx output workflow start simple basic
Using scenario: /[..]/simple/scenarios/basic.json

Starting workflow: simple...

Workflow started successfully

Workflow ID: K-h-IHkeg82BQH6DGgg7F

Use "workflow status K-h-IHkeg82BQH6DGgg7F" to check the workflow status
Use "workflow result K-h-IHkeg82BQH6DGgg7F" to get the workflow result when complete

❯ npx output workflow start simple basic --json
 ›   Error: Nonexistent flag: --json
 ›   See more help with --help
```

**Workflow start (without scenario):**

```
❯ npx output workflow start simple --input '{"values":[1,2,3]}'
Starting workflow: simple...

Workflow started successfully

Workflow ID: obU6uMRuTXFRBUBtr6N8W

Use "workflow status obU6uMRuTXFRBUBtr6N8W" to check the workflow status
Use "workflow result obU6uMRuTXFRBUBtr6N8W" to get the workflow result when complete

❯ npx output workflow start simple --input '{"values":[1,2,3]}' --json
 ›   Error: Nonexistent flag: --json
 ›   See more help with --help
```

**Workflow run (with scenario):**

*Note the `Using scenario:` output when using the `--json` flag*

```
❯ npx output workflow run simple basic --json 
Using scenario: /[..]/simple/scenarios/basic.json

{
  "workflowId": "P8o8i7iEZS8BuoFCXZ6xx",
  "runId": "019fae8c-883e-7e87-957f-96077c42420f",
  "status": "completed",
  "input": {
    "values": [
      1,
      2,
      3
    ]
  },
  "output": {
    "result": 6,
    "workflowId": "P8o8i7iEZS8BuoFCXZ6xx"
  },
  "trace": {
    "destinations": {
      "local": "/[...]/simple/2026-07-29-15-44-33-342Z_P8o8i7iEZS8BuoFCXZ6xx.json"
    }
  },
  "error": null,
  "errorDetails": null
}

❯ npx output workflow run simple basic --json | jq
jq: parse error: Invalid numeric literal at line 1, column 6
```

**Workflow run (without scenario):**

```
❯ npx output workflow run simple --input '{"values":[1,2,3]}'
Executing workflow: simple...

Workflow ID: uRxO-wJN-J557th0LNQsT

Output:
{
  "result": 6,
  "workflowId": "uRxO-wJN-J557th0LNQsT"
}

❯ npx output workflow run simple --input '{"values":[1,2,3]}' --json | jq
{
  "workflowId": "ZVk3jEhtejItBzKbN80L_",
  "runId": "019fae90-e5dc-75ef-8101-c72ebc6cd86b",
  "status": "completed",
  "input": {
    "values": [
      1,
      2,
      3
    ]
  },
  "output": {
    "result": 6,
    "workflowId": "ZVk3jEhtejItBzKbN80L_"
  },
  "trace": {
    "destinations": {
      "local": "/[...]/simple/2026-07-29-15-49-19-452Z_ZVk3jEhtejItBzKbN80L_.json"
    }
  },
  "error": null,
  "errorDetails": null
}
```

</details>

In this PR we remove the "Using scenario: /[..]/simple/scenarios/basic.json" output when the `--json` flag is present. We also add support for `--json` to the `start` command, which was mistakenly omitted from a previous PR.
