### PR TITLE
refactor(cli): Removing dotenv

### DIFF
--- a/.changeset/calm-lions-env.md
+++ b/.changeset/calm-lions-env.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+CLI env loading now uses Node's `process.loadEnvFile` instead of the `dotenv` package.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,9 +199,6 @@ importers:
       debug:
         specifier: 4.4.3
         version: 4.4.3(supports-color@5.5.0)
-      dotenv:
-        specifier: 17.4.2
-        version: 17.4.2
       handlebars:
         specifier: 4.7.9
         version: 4.7.9
@@ -4152,10 +4149,6 @@ packages:
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
-
-  dotenv@17.4.2:
-    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
-    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -12730,8 +12723,6 @@ snapshots:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
-
-  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/sdk/cli/package.json
+++ b/sdk/cli/package.json
@@ -38,7 +38,6 @@
     "cli-table3": "0.6.5",
     "date-fns": "4.1.0",
     "debug": "4.4.3",
-    "dotenv": "17.4.2",
     "handlebars": "4.7.9",
     "ink": "7.0.1",
     "ink-spinner": "5.0.0",

--- a/sdk/cli/src/utils/env_loader.spec.ts
+++ b/sdk/cli/src/utils/env_loader.spec.ts
@@ -1,55 +1,51 @@
-/**
- * Tests for the env loader utility
- */
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
-import * as dotenv from 'dotenv';
-
-vi.mock( 'node:fs' );
-vi.mock( 'dotenv' );
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadEnvironment } from './env_loader.js';
 
 describe( 'loadEnvironment', () => {
-  const originalEnv = { ...process.env };
-  const mockCwd = '/mock/project';
+  const originalCwd = process.cwd();
+  const mockCwd = mkdtempSync( join( tmpdir(), 'output-env-loader-' ) );
+  const mockApiUrl = 'https://mock.api.com';
+  const mockToken = 'mock-token';
+  const mockEnvironment = [
+    `OUTPUT_API_URL=${mockApiUrl}`,
+    `OUTPUT_API_TOKEN=${mockToken}`
+  ].join( '\n' );
 
   beforeEach( () => {
-    vi.resetModules();
-    vi.clearAllMocks();
-    vi.spyOn( process, 'cwd' ).mockReturnValue( mockCwd );
-    vi.spyOn( console, 'log' ).mockImplementation( () => {} );
-    vi.spyOn( console, 'warn' ).mockImplementation( () => {} );
+    process.chdir( mockCwd );
+    vi.stubEnv( 'OUTPUT_CLI_ENV', undefined );
+    vi.stubEnv( 'OUTPUT_API_URL', undefined );
+    vi.stubEnv( 'OUTPUT_API_TOKEN', undefined );
   } );
 
   afterEach( () => {
-    process.env = { ...originalEnv };
-    vi.restoreAllMocks();
+    process.chdir( originalCwd );
+    vi.unstubAllEnvs();
   } );
 
-  it( 'should load from OUTPUT_CLI_ENV when set and file exists', async () => {
-    process.env.OUTPUT_CLI_ENV = '.env.prod';
-    const expectedPath = resolve( mockCwd, '.env.prod' );
-
-    vi.mocked( existsSync ).mockReturnValue( true );
-    vi.mocked( dotenv.config ).mockReturnValue( { parsed: { OUTPUT_API_URL: 'https://prod.api.com' } } );
-
-    const { loadEnvironment } = await import( './env_loader.js' );
-    loadEnvironment();
-
-    expect( dotenv.config ).toHaveBeenCalledWith( { path: expectedPath, quiet: true } );
+  afterAll( () => {
+    rmSync( mockCwd, { recursive: true, force: true } );
   } );
 
-  it( 'should load .env by default and log', async () => {
-    delete process.env.OUTPUT_CLI_ENV;
-    const envPath = resolve( mockCwd, '.env' );
+  it( 'loads variables from OUTPUT_CLI_ENV', () => {
+    writeFileSync( join( mockCwd, '.env.mock' ), mockEnvironment );
+    process.env.OUTPUT_CLI_ENV = '.env.mock';
 
-    vi.mocked( existsSync ).mockImplementation( p => p === envPath );
-    vi.mocked( dotenv.config ).mockReturnValue( { parsed: {} } );
-
-    const { loadEnvironment } = await import( './env_loader.js' );
     loadEnvironment();
 
-    expect( dotenv.config ).toHaveBeenCalledTimes( 1 );
-    expect( dotenv.config ).toHaveBeenCalledWith( { path: envPath, quiet: true } );
+    expect( process.env.OUTPUT_API_URL ).toBe( mockApiUrl );
+    expect( process.env.OUTPUT_API_TOKEN ).toBe( mockToken );
+  } );
+
+  it( 'loads variables from .env by default', () => {
+    writeFileSync( join( mockCwd, '.env' ), mockEnvironment );
+
+    loadEnvironment();
+
+    expect( process.env.OUTPUT_API_URL ).toBe( mockApiUrl );
+    expect( process.env.OUTPUT_API_TOKEN ).toBe( mockToken );
   } );
 } );

--- a/sdk/cli/src/utils/env_loader.spec.ts
+++ b/sdk/cli/src/utils/env_loader.spec.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, readdirSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { loadEnvironment } from './env_loader.js';
@@ -9,7 +9,7 @@ describe( 'loadEnvironment', () => {
 
   beforeEach( () => {
     for ( const name of readdirSync( mockCwd ) ) {
-      unlinkSync( join( mockCwd, name ) );
+      rmSync( join( mockCwd, name ), { recursive: true, force: true } );
     }
     vi.spyOn( process, 'cwd' ).mockReturnValue( mockCwd );
     vi.stubEnv( 'OUTPUT_CLI_ENV', undefined );
@@ -63,5 +63,26 @@ describe( 'loadEnvironment', () => {
     expect( () => loadEnvironment() ).not.toThrow();
     expect( process.env.OUTPUT_API_URL ).toBeUndefined();
     expect( process.env.OUTPUT_API_TOKEN ).toBeUndefined();
+  } );
+
+  it( 'does not throw when the env path is not a readable file', () => {
+    mkdirSync( join( mockCwd, 'not-a-file.env' ) );
+    process.env.OUTPUT_CLI_ENV = 'not-a-file.env';
+
+    expect( () => loadEnvironment() ).not.toThrow();
+    expect( process.env.OUTPUT_API_URL ).toBeUndefined();
+  } );
+
+  it( 'does not overwrite already-set process.env values', () => {
+    vi.stubEnv( 'OUTPUT_API_URL', 'https://ambient.api.com' );
+    writeFileSync( join( mockCwd, '.env' ), [
+      'OUTPUT_API_URL=https://file.api.com',
+      'OUTPUT_API_TOKEN=file-token'
+    ].join( '\n' ) );
+
+    loadEnvironment();
+
+    expect( process.env.OUTPUT_API_URL ).toBe( 'https://ambient.api.com' );
+    expect( process.env.OUTPUT_API_TOKEN ).toBe( 'file-token' );
   } );
 } );

--- a/sdk/cli/src/utils/env_loader.spec.ts
+++ b/sdk/cli/src/utils/env_loader.spec.ts
@@ -1,28 +1,24 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readdirSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { loadEnvironment } from './env_loader.js';
 
 describe( 'loadEnvironment', () => {
-  const originalCwd = process.cwd();
   const mockCwd = mkdtempSync( join( tmpdir(), 'output-env-loader-' ) );
-  const mockApiUrl = 'https://mock.api.com';
-  const mockToken = 'mock-token';
-  const mockEnvironment = [
-    `OUTPUT_API_URL=${mockApiUrl}`,
-    `OUTPUT_API_TOKEN=${mockToken}`
-  ].join( '\n' );
 
   beforeEach( () => {
-    process.chdir( mockCwd );
+    for ( const name of readdirSync( mockCwd ) ) {
+      unlinkSync( join( mockCwd, name ) );
+    }
+    vi.spyOn( process, 'cwd' ).mockReturnValue( mockCwd );
     vi.stubEnv( 'OUTPUT_CLI_ENV', undefined );
     vi.stubEnv( 'OUTPUT_API_URL', undefined );
     vi.stubEnv( 'OUTPUT_API_TOKEN', undefined );
   } );
 
   afterEach( () => {
-    process.chdir( originalCwd );
+    vi.restoreAllMocks();
     vi.unstubAllEnvs();
   } );
 
@@ -31,21 +27,41 @@ describe( 'loadEnvironment', () => {
   } );
 
   it( 'loads variables from OUTPUT_CLI_ENV', () => {
-    writeFileSync( join( mockCwd, '.env.mock' ), mockEnvironment );
+    writeFileSync( join( mockCwd, '.env' ), [
+      'OUTPUT_API_URL=https://default.api.com',
+      'OUTPUT_API_TOKEN=default-token'
+    ].join( '\n' ) );
+    writeFileSync( join( mockCwd, '.env.mock' ), [
+      'OUTPUT_API_URL=https://mock.api.com',
+      'OUTPUT_API_TOKEN=mock-token'
+    ].join( '\n' ) );
     process.env.OUTPUT_CLI_ENV = '.env.mock';
 
     loadEnvironment();
 
-    expect( process.env.OUTPUT_API_URL ).toBe( mockApiUrl );
-    expect( process.env.OUTPUT_API_TOKEN ).toBe( mockToken );
+    expect( process.env.OUTPUT_API_URL ).toBe( 'https://mock.api.com' );
+    expect( process.env.OUTPUT_API_TOKEN ).toBe( 'mock-token' );
   } );
 
   it( 'loads variables from .env by default', () => {
-    writeFileSync( join( mockCwd, '.env' ), mockEnvironment );
+    writeFileSync( join( mockCwd, '.env' ), [
+      'OUTPUT_API_URL=https://default.api.com',
+      'OUTPUT_API_TOKEN=default-token'
+    ].join( '\n' ) );
+    writeFileSync( join( mockCwd, '.env.mock' ), [
+      'OUTPUT_API_URL=https://mock.api.com',
+      'OUTPUT_API_TOKEN=mock-token'
+    ].join( '\n' ) );
 
     loadEnvironment();
 
-    expect( process.env.OUTPUT_API_URL ).toBe( mockApiUrl );
-    expect( process.env.OUTPUT_API_TOKEN ).toBe( mockToken );
+    expect( process.env.OUTPUT_API_URL ).toBe( 'https://default.api.com' );
+    expect( process.env.OUTPUT_API_TOKEN ).toBe( 'default-token' );
+  } );
+
+  it( 'does nothing when the env file is missing', () => {
+    expect( () => loadEnvironment() ).not.toThrow();
+    expect( process.env.OUTPUT_API_URL ).toBeUndefined();
+    expect( process.env.OUTPUT_API_TOKEN ).toBeUndefined();
   } );
 } );

--- a/sdk/cli/src/utils/env_loader.ts
+++ b/sdk/cli/src/utils/env_loader.ts
@@ -5,7 +5,6 @@
  */
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
-import * as dotenv from 'dotenv';
 import debugFactory from 'debug';
 
 const debug = debugFactory( 'output-cli:env-loader' );
@@ -21,5 +20,5 @@ export function loadEnvironment(): void {
   }
 
   debug( `Loading env from: ${envPath}` );
-  dotenv.config( { path: envPath, quiet: true } );
+  process.loadEnvFile( envPath );
 }

--- a/sdk/cli/src/utils/env_loader.ts
+++ b/sdk/cli/src/utils/env_loader.ts
@@ -20,5 +20,9 @@ export function loadEnvironment(): void {
   }
 
   debug( `Loading env from: ${envPath}` );
-  process.loadEnvFile( envPath );
+  try {
+    process.loadEnvFile( envPath );
+  } catch ( err ) {
+    debug( `Warning: Failed to load env file ${envPath}: ${err}` );
+  }
 }


### PR DESCRIPTION
## Summary

The dep `dotenv` had a single usage in the CLI, and that could be replaced (drop-in) with a native feature from Node 24.

## Test plan

- [x] Refactored unit tests
- [x] Manual test
