### PR TITLE
refactor(cli): Removing install during hot-reload (OUT-476)

### DIFF
--- a/.changeset/stale-crabs-kiss.md
+++ b/.changeset/stale-crabs-kiss.md
@@ -1,0 +1,7 @@
+---
+"@outputai/cli": patch
+---
+
+- Removed install step from hot-reload when developing workflows (`output dev`). Nodemon (hot-reload daemon) re-installs (`npm install`) the dependencies on every reload, which is slow, even with cache. Also remove package.json from watched files.
+
+- Changed `npm install` to `npm ci`. After scaffolding, when the projects runs, it already has a lock file, so full install isn't necessary. This increases speed and predictability on dependencies resolution.

--- a/.changeset/stale-crabs-kiss.md
+++ b/.changeset/stale-crabs-kiss.md
@@ -3,4 +3,4 @@
 ---
 
 - Removed install from hot-reload when developing workflows (`output dev`): nodemon no longer runs `npm install` on every reload, and `package.json` is no longer watched. After dependency changes, run `npm install`, bring the stack down (`output dev down` if it is still running), and start `output dev` again.
-- `npm run output:worker` also no longer installs first — run `output:worker:install` (or rely on `output dev`, which still installs on worker start) before build/start. `output:fix` will rewrite `output:worker` in existing projects when you apply it.
+- `npm run output:worker` also no longer installs first — run `npm run output:worker:install` (or rely on `output dev`, which still installs on worker start) before build/start. `npx output fix` rewrites `output:worker` in existing projects when you apply it.

--- a/.changeset/stale-crabs-kiss.md
+++ b/.changeset/stale-crabs-kiss.md
@@ -2,4 +2,5 @@
 "@outputai/cli": patch
 ---
 
-- Removed install step from hot-reload when developing workflows (`output dev`). Nodemon (hot-reload daemon) re-installs (`npm install`) the dependencies on every reload, which is slow, even with cache. Also remove package.json from watched files.
+- Removed install from hot-reload when developing workflows (`output dev`): nodemon no longer runs `npm install` on every reload, and `package.json` is no longer watched. After dependency changes, run `npm install`, then `output dev down` and `output dev` again.
+- `npm run output:worker` also no longer installs first — run `output:worker:install` (or rely on `output dev`, which still installs on worker start) before build/start. `output:fix` will rewrite `output:worker` in existing projects when you apply it.

--- a/.changeset/stale-crabs-kiss.md
+++ b/.changeset/stale-crabs-kiss.md
@@ -3,5 +3,3 @@
 ---
 
 - Removed install step from hot-reload when developing workflows (`output dev`). Nodemon (hot-reload daemon) re-installs (`npm install`) the dependencies on every reload, which is slow, even with cache. Also remove package.json from watched files.
-
-- Changed `npm install` to `npm ci`. After scaffolding, when the projects runs, it already has a lock file, so full install isn't necessary. This increases speed and predictability on dependencies resolution.

--- a/.changeset/stale-crabs-kiss.md
+++ b/.changeset/stale-crabs-kiss.md
@@ -2,5 +2,5 @@
 "@outputai/cli": patch
 ---
 
-- Removed install from hot-reload when developing workflows (`output dev`): nodemon no longer runs `npm install` on every reload, and `package.json` is no longer watched. After dependency changes, run `npm install`, then `output dev down` and `output dev` again.
+- Removed install from hot-reload when developing workflows (`output dev`): nodemon no longer runs `npm install` on every reload, and `package.json` is no longer watched. After dependency changes, run `npm install`, bring the stack down (`output dev down` if it is still running), and start `output dev` again.
 - `npm run output:worker` also no longer installs first — run `output:worker:install` (or rely on `output dev`, which still installs on worker start) before build/start. `output:fix` will rewrite `output:worker` in existing projects when you apply it.

--- a/docs/guides/packages/cli.mdx
+++ b/docs/guides/packages/cli.mdx
@@ -82,13 +82,15 @@ This starts:
 | **Redis** | — | Caching layer (container-internal) |
 | **Temporal Server** | — | gRPC endpoint (container-internal) |
 
-Worker hot-reload does not watch `package.json`. After adding or changing dependencies, run `npm install`, then stop `output dev` and start it again so the worker container reinstalls into its `node_modules` volume. A nodemon reload or `output dev -d` against an already-running stack is not enough.
-
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--compose-file, -f` | — | Path to custom docker-compose file |
 | `--detached, -d` | false | Start services in the background and exit immediately |
 | `--image-pull-policy` | `always` | Image pull policy: `always`, `missing`, or `never` |
+
+<Note>
+Worker hot-reload does not watch `package.json`. After adding or changing dependencies, run `npm install`, then `output dev down` and `output dev` again so the worker container reinstalls into its `node_modules` volume. Stopping an attached session or running `output dev -d` is not enough — the stack must be brought down and started again.
+</Note>
 
 #### Running multiple dev stacks
 

--- a/docs/guides/packages/cli.mdx
+++ b/docs/guides/packages/cli.mdx
@@ -82,7 +82,7 @@ This starts:
 | **Redis** | — | Caching layer (container-internal) |
 | **Temporal Server** | — | gRPC endpoint (container-internal) |
 
-Worker hot-reload does not watch `package.json`. After adding or changing dependencies, run `npm install` and restart `output:dev`.
+Worker hot-reload does not watch `package.json`. After adding or changing dependencies, run `npm install` and restart `output dev`.
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/docs/guides/packages/cli.mdx
+++ b/docs/guides/packages/cli.mdx
@@ -77,10 +77,12 @@ This starts:
 |---------|-----|-------------|
 | **Temporal UI** | [http://localhost:8080](http://localhost:8080) | Monitor and debug workflows |
 | **API Server** | [http://localhost:3001](http://localhost:3001) | REST API for running workflows |
-| **Worker** | — | Processes workflows with auto-reload |
+| **Worker** | — | Processes workflows with auto-reload on `src/` changes |
 | **PostgreSQL** | — | Temporal persistence (container-internal) |
 | **Redis** | — | Caching layer (container-internal) |
 | **Temporal Server** | — | gRPC endpoint (container-internal) |
+
+Worker hot-reload does not watch `package.json`. After adding or changing dependencies, run `npm install` and restart `output:dev`.
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/docs/guides/packages/cli.mdx
+++ b/docs/guides/packages/cli.mdx
@@ -89,7 +89,7 @@ This starts:
 | `--image-pull-policy` | `always` | Image pull policy: `always`, `missing`, or `never` |
 
 <Note>
-Worker hot-reload does not watch `package.json`. After adding or changing dependencies, run `npm install`, then `output dev down` and `output dev` again so the worker container reinstalls into its `node_modules` volume. Stopping an attached session or running `output dev -d` is not enough — the stack must be brought down and started again.
+Worker hot-reload does not watch `package.json`. After adding or changing dependencies, run `npm install`, then bring the stack down and start `output dev` again so the worker container reinstalls into its `node_modules` volume. Quitting a foreground `output dev` that owns the stack tears it down and is enough; if the stack is still running (an attached session, or one started with `output dev -d`), run `output dev down` first, then `output dev` again.
 </Note>
 
 #### Running multiple dev stacks

--- a/docs/guides/packages/cli.mdx
+++ b/docs/guides/packages/cli.mdx
@@ -82,7 +82,7 @@ This starts:
 | **Redis** | — | Caching layer (container-internal) |
 | **Temporal Server** | — | gRPC endpoint (container-internal) |
 
-Worker hot-reload does not watch `package.json`. After adding or changing dependencies, run `npm install` and restart `output dev`.
+Worker hot-reload does not watch `package.json`. After adding or changing dependencies, run `npm install`, then stop `output dev` and start it again so the worker container reinstalls into its `node_modules` volume. A nodemon reload or `output dev -d` against an already-running stack is not enough.
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/sdk/cli/src/templates/agent_instructions/CLAUDE.md.template
+++ b/sdk/cli/src/templates/agent_instructions/CLAUDE.md.template
@@ -21,7 +21,7 @@ npm run output:worker:watch  # Build + restart on src/ file changes
 npm run output:worker        # Build and start worker
 ```
 
-Hot-reload watches `src/` only. After changing dependencies (`package.json` / lockfile), run `npm install` and restart `output:dev`.
+Hot-reload watches `src/` only. After changing dependencies (`package.json` / lockfile), run `npm install`, then stop and re-run `npm run output:dev` so the worker container reinstalls. A hot-reload alone is not enough.
 
 ## Project Structure
 

--- a/sdk/cli/src/templates/agent_instructions/CLAUDE.md.template
+++ b/sdk/cli/src/templates/agent_instructions/CLAUDE.md.template
@@ -21,7 +21,7 @@ npm run output:worker:watch  # Build + restart on src/ file changes
 npm run output:worker        # Build and start worker
 ```
 
-Hot-reload watches `src/` only. After changing dependencies (`package.json` / lockfile), run `npm install`, then stop and re-run `npm run output:dev` so the worker container reinstalls. A hot-reload alone is not enough.
+Hot-reload watches `src/` only. After changing dependencies (`package.json` / lockfile), run `npm install`, then `output dev down` and `npm run output:dev` again so the worker container reinstalls. A hot-reload or detach alone is not enough.
 
 ## Project Structure
 

--- a/sdk/cli/src/templates/agent_instructions/CLAUDE.md.template
+++ b/sdk/cli/src/templates/agent_instructions/CLAUDE.md.template
@@ -17,9 +17,11 @@ claude plugin install outputai@outputai --scope project
 npm run output:dev           # Start dev environment (worker + Temporal)
 npm run output:worker:build  # Build TypeScript to dist/
 npm run output:worker:check  # Optional: bundle-check workflows for bad imports (node: built-ins)
-npm run output:worker:watch  # Build + restart on file changes
-npm run output:worker        # Install, build, and start worker
+npm run output:worker:watch  # Build + restart on src/ file changes
+npm run output:worker        # Build and start worker
 ```
+
+Hot-reload watches `src/` only. After changing dependencies (`package.json` / lockfile), run `npm install` and restart `output:dev`.
 
 ## Project Structure
 

--- a/sdk/cli/src/templates/agent_instructions/CLAUDE.md.template
+++ b/sdk/cli/src/templates/agent_instructions/CLAUDE.md.template
@@ -21,7 +21,7 @@ npm run output:worker:watch  # Build + restart on src/ file changes
 npm run output:worker        # Build and start worker
 ```
 
-Hot-reload watches `src/` only. After changing dependencies (`package.json` / lockfile), run `npm install`, then `output dev down` and `npm run output:dev` again so the worker container reinstalls. A hot-reload or detach alone is not enough.
+Hot-reload watches `src/` only. After changing dependencies (`package.json` / lockfile), run `npm install`, then `npx output dev down` and `npm run output:dev` again so the worker container reinstalls. A hot-reload alone is not enough; if the stack is still running, `npx output dev down` is required.
 
 ## Project Structure
 

--- a/sdk/cli/src/templates/project/README.md.template
+++ b/sdk/cli/src/templates/project/README.md.template
@@ -81,7 +81,7 @@ This starts:
 - Output.ai API server (http://localhost:3001)
 - Worker process for executing workflows (auto-reloads on `src/` changes)
 
-Dependency changes (`package.json` / lockfile) are not picked up by hot-reload. Run `npm install`, then `output dev down` and `npm run output:dev` again so the worker container reinstalls. A hot-reload or detach alone is not enough.
+Dependency changes (`package.json` / lockfile) are not picked up by hot-reload. Run `npm install`, then `npx output dev down` and `npm run output:dev` again so the worker container reinstalls. A hot-reload alone is not enough; if the stack is still running, `npx output dev down` is required.
 
 ### 4. Run a workflow
 

--- a/sdk/cli/src/templates/project/README.md.template
+++ b/sdk/cli/src/templates/project/README.md.template
@@ -79,7 +79,9 @@ This starts:
 - Temporal server and UI (http://localhost:8080)
 - PostgreSQL and Redis databases
 - Output.ai API server (http://localhost:3001)
-- Worker process for executing workflows
+- Worker process for executing workflows (auto-reloads on `src/` changes)
+
+Dependency changes (`package.json` / lockfile) are not picked up by hot-reload. Run `npm install` and restart `output:dev`.
 
 ### 4. Run a workflow
 

--- a/sdk/cli/src/templates/project/README.md.template
+++ b/sdk/cli/src/templates/project/README.md.template
@@ -81,7 +81,7 @@ This starts:
 - Output.ai API server (http://localhost:3001)
 - Worker process for executing workflows (auto-reloads on `src/` changes)
 
-Dependency changes (`package.json` / lockfile) are not picked up by hot-reload. Run `npm install` and restart `output:dev`.
+Dependency changes (`package.json` / lockfile) are not picked up by hot-reload. Run `npm install`, then stop and re-run `npm run output:dev` so the worker container reinstalls. A hot-reload alone is not enough.
 
 ### 4. Run a workflow
 

--- a/sdk/cli/src/templates/project/README.md.template
+++ b/sdk/cli/src/templates/project/README.md.template
@@ -81,7 +81,7 @@ This starts:
 - Output.ai API server (http://localhost:3001)
 - Worker process for executing workflows (auto-reloads on `src/` changes)
 
-Dependency changes (`package.json` / lockfile) are not picked up by hot-reload. Run `npm install`, then stop and re-run `npm run output:dev` so the worker container reinstalls. A hot-reload alone is not enough.
+Dependency changes (`package.json` / lockfile) are not picked up by hot-reload. Run `npm install`, then `output dev down` and `npm run output:dev` again so the worker container reinstalls. A hot-reload or detach alone is not enough.
 
 ### 4. Run a workflow
 

--- a/sdk/cli/src/templates/project/package.json.template
+++ b/sdk/cli/src/templates/project/package.json.template
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/worker.js",
   "scripts": {
-    "output:worker:install": "npm install",
+    "output:worker:install": "npm ci",
     "output:worker:build": "rm -rf dist/* && tsc -p ./ && output-copy-assets",
     "output:worker:start": "output-worker",
     "output:worker:check": "output-worker --check",

--- a/sdk/cli/src/templates/project/package.json.template
+++ b/sdk/cli/src/templates/project/package.json.template
@@ -9,8 +9,8 @@
     "output:worker:build": "rm -rf dist/* && tsc -p ./ && output-copy-assets",
     "output:worker:start": "output-worker",
     "output:worker:check": "output-worker --check",
-    "output:worker": "npm run output:worker:install && npm run output:worker:build && npm run output:worker:start",
-    "output:worker:watch": "npx nodemon --watch src --watch package.json --ext ts,js,json,prompt,md --ignore 'dist/**' --ignore '**/*.spec.*' --ignore '**/*.test.*' --exec 'npm run output:worker'",
+    "output:worker": "npm run output:worker:build && npm run output:worker:start",
+    "output:worker:watch": "npx nodemon --watch src --ext ts,js,json,prompt,md --ignore 'dist/**' --ignore '**/*.spec.*' --ignore '**/*.test.*' --exec 'npm run output:worker'",
     "output:dev": "output dev"
   },
   "dependencies": {

--- a/sdk/cli/src/templates/project/package.json.template
+++ b/sdk/cli/src/templates/project/package.json.template
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/worker.js",
   "scripts": {
-    "output:worker:install": "npm ci",
+    "output:worker:install": "npm install",
     "output:worker:build": "rm -rf dist/* && tsc -p ./ && output-copy-assets",
     "output:worker:start": "output-worker",
     "output:worker:check": "output-worker --check",

--- a/test_workflows/package.json
+++ b/test_workflows/package.json
@@ -13,7 +13,7 @@
     "output:worker:start": "output-worker",
     "output:worker:check": "output-worker --check",
     "output:worker": "npm run output:worker:build && npm run output:worker:start",
-    "output:worker:watch": "npx nodemon --watch src --watch package.json --ext ts,js,json,prompt,md --ignore 'dist/**' --ignore '**/*.test.*' --exec 'npm run output:worker'"
+    "output:worker:watch": "npx nodemon --watch src --ext ts,js,json,prompt,md --ignore 'dist/**' --ignore '**/*.test.*' --exec 'npm run output:worker'"
   },
   "dependencies": {
     "@growthxlabs/workflows_catalog": "0.0.13",


### PR DESCRIPTION
## Summary

Remove install from worker hot-reload under `output:dev`. Nodemon no longer runs `npm install` on every reload, and `package.json` is no longer watched. After dependency changes, run `npm install`, then `output:dev down` and `output:dev` again.

Also drops the install step from `npm run output:worker` itself. Run `output:worker:install` first when invoking that script directly (`output:dev` still installs on worker start), `output:fix` rewrites `output:worker` in existing projects when applied.


## Test plan

- [x] Manually tested
