### PR TITLE
refactor(cli): Remove test_eval alias command list (OUT-335)

### DIFF
--- a/.changeset/short-keys-begin.md
+++ b/.changeset/short-keys-begin.md
@@ -1,5 +1,5 @@
 ---
-"@outputai/cli": patch
+"@outputai/cli": minor
 ---
 
 Renamed the workflow eval CLI command to `output workflow test` (was `output workflow test_eval`). The short `test` name is now the only command id; the `test_eval` name is removed.

--- a/.changeset/short-keys-begin.md
+++ b/.changeset/short-keys-begin.md
@@ -1,0 +1,5 @@
+---
+"@outputai/cli": patch
+---
+
+Renamed the workflow eval CLI command to `output workflow test` (was `output workflow test_eval`). The short `test` name is now the only command id; the `test_eval` name is removed.

--- a/docs/guides/migrations/index.mdx
+++ b/docs/guides/migrations/index.mdx
@@ -46,6 +46,6 @@ It reads the `@outputai/*` version in your `package.json`, finds the matching gu
     Trace destinations omit unavailable `local` and `remote` keys instead of returning `null`.
   </Card>
   <Card title="v0.10.0 → v0.11.0" href="/migrations/v0.10.0-to-v0.11.0">
-    HTTP clients, hook event envelopes, API request logging, Temporal workflow runtime changes, Temporal TypeScript SDK v1.20.3, and strict prompt Liquid rendering.
+    HTTP clients, hook event envelopes, API request logging, Temporal workflow runtime changes, Temporal TypeScript SDK v1.20.3, CLI `workflow test` rename, and strict prompt Liquid rendering.
   </Card>
 </CardGroup>

--- a/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
+++ b/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
@@ -1,9 +1,9 @@
 ---
 title: "v0.10.0 → v0.11.0"
-description: "Upgrading Output.ai projects from v0.10.0 to v0.11.0: HTTP clients, hook event envelopes, API request logging, Temporal rollout safety, shared activity names, child workflow activity-option precedence, Temporal TypeScript SDK v1.20.3, and strict prompt Liquid rendering."
+description: "Upgrading Output.ai projects from v0.10.0 to v0.11.0: HTTP clients, hook event envelopes, API request logging, Temporal rollout safety, shared activity names, child workflow activity-option precedence, Temporal TypeScript SDK v1.20.3, CLI workflow test rename, and strict prompt Liquid rendering."
 ---
 
-This guide covers customer-facing changes to `@outputai/http`, hooks and workflow execution in `@outputai/core`, prompt rendering in `@outputai/llm`, and API request logging in `output-api`.
+This guide covers customer-facing changes to `@outputai/http`, hooks and workflow execution in `@outputai/core`, prompt rendering in `@outputai/llm`, the `@outputai/cli` workflow test command name, and API request logging in `output-api`.
 
 ## API HTTP request logging
 
@@ -647,6 +647,25 @@ Step-level `options.activityOptions` still have final precedence. Review step de
 ## Temporal TypeScript SDK version
 
 Output now ships the Temporal TypeScript SDK (`@temporalio/*`) at **v1.20.3** (previously **v1.17.0**). Re-test any project code that imports `@temporalio/*` directly against that version.
+
+## CLI: `workflow test_eval` renamed to `workflow test`
+
+The workflow evaluation command id is now `workflow:test`. The previous primary id `workflow:test_eval` is removed (it was only the filename-derived id; published docs already used `output workflow test`).
+
+```bash
+# Before
+npx output workflow test_eval <workflowName>
+
+# After
+npx output workflow test <workflowName>
+```
+
+`output workflow test` continues to work the same way; only the `test_eval` name stops resolving.
+
+### CLI rename checklist
+
+- Replace any scripts, CI steps, or aliases that call `output workflow test_eval` with `output workflow test`.
+- No change if you already use `output workflow test`.
 
 ## Prompt Liquid rendering is strict
 

--- a/sdk/cli/src/commands/workflow/test.spec.ts
+++ b/sdk/cli/src/commands/workflow/test.spec.ts
@@ -57,12 +57,12 @@ describe( 'workflow test command', () => {
 
   describe( 'command definition', () => {
     it( 'enables the built-in --json flag', async () => {
-      const WorkflowTest = ( await import( './test_eval.js' ) ).default;
+      const WorkflowTest = ( await import( './test.js' ) ).default;
       expect( WorkflowTest.enableJsonFlag ).toBe( true );
     } );
 
     it( 'binds the catalog flag to OUTPUT_CATALOG_ID', async () => {
-      const WorkflowTest = ( await import( './test_eval.js' ) ).default;
+      const WorkflowTest = ( await import( './test.js' ) ).default;
       expect( WorkflowTest.flags ).toHaveProperty( 'catalog' );
       expect( WorkflowTest.flags.catalog.env ).toBe( 'OUTPUT_CATALOG_ID' );
       expect( WorkflowTest.flags.catalog.char ).toBe( 'c' );
@@ -71,7 +71,7 @@ describe( 'workflow test command', () => {
 
   describe( 'run()', () => {
     const createCommand = async ( jsonEnabled: boolean ) => {
-      const WorkflowTest = ( await import( './test_eval.js' ) ).default;
+      const WorkflowTest = ( await import( './test.js' ) ).default;
       const { postWorkflowRun } = await import( '#api/generated/api.js' );
 
       const cmd = new WorkflowTest( [ 'simple' ], {} as any );
@@ -128,7 +128,7 @@ describe( 'workflow test command', () => {
     } );
 
     it( 'routes registration, dataset runs, and the eval run to the resolved catalog', async () => {
-      const WorkflowTest = ( await import( './test_eval.js' ) ).default;
+      const WorkflowTest = ( await import( './test.js' ) ).default;
       const { postWorkflowRun } = await import( '#api/generated/api.js' );
       const { fetchWorkflowCatalog } = await import( '#api/workflow_catalog.js' );
 

--- a/sdk/cli/src/commands/workflow/test.ts
+++ b/sdk/cli/src/commands/workflow/test.ts
@@ -15,9 +15,7 @@ import {
 import type { Dataset, EvalOutput } from '@outputai/evals';
 
 export default class WorkflowTest extends Command {
-  static override hiddenAliases = [ 'workflow:test' ];
-
-  static override description = 'Run evaluations against a workflow using its datasets (alias: workflow test)';
+  static override description = 'Run evaluations against a workflow using its datasets';
 
   static override enableJsonFlag = true;
 

--- a/sdk/cli/src/commands/workflow/test_eval.ts
+++ b/sdk/cli/src/commands/workflow/test_eval.ts
@@ -15,9 +15,9 @@ import {
 import type { Dataset, EvalOutput } from '@outputai/evals';
 
 export default class WorkflowTest extends Command {
-  static override aliases = [ 'workflow:test' ];
+  static override hiddenAliases = [ 'workflow:test' ];
 
-  static override description = 'Run evaluations against a workflow using its datasets';
+  static override description = 'Run evaluations against a workflow using its datasets (alias: workflow test)';
 
   static override enableJsonFlag = true;
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -7,7 +7,7 @@ export default defineConfig( {
   test: {
     silent: true,
     environment: 'node',
-    include: [ '**/?(*.)+(spec|test).(ts|js)' ],
+    include: [ '**/*.{spec,test}.{ts,js}' ],
     exclude: [ 'node_modules/**', '**/node_modules/**', '**/*.integration.test.(ts|js)', '**/dist/**' ],
     globals: true,
     sourcemap: true // Enable source maps for debugging


### PR DESCRIPTION
## Summary

- Renamed the workflow eval CLI command to `output workflow test` (was `output workflow test_eval`). The short `test` name is now the only command id; the `test_eval` name is removed.
- Fixed vitest capture string was matching `*test|spec.js|ts`, meaning it would capture: `test.js`, `vitest.js`, etc. I was updated to `*.test|spec.js|ts`.

### Before
<img width="1442" height="890" alt="image" src="https://github.com/user-attachments/assets/e1032efe-532b-4947-9d2b-4e16406dabd5" />

### After
<img width="1436" height="838" alt="image" src="https://github.com/user-attachments/assets/22c5af68-d6e9-41cf-b3cb-ea630df03869" />
