### PR TITLE
fix(llm): Cost calculated with wrong model pricing (OUT-548)

### DIFF
--- a/.changeset/wicked-ravens-stay.md
+++ b/.changeset/wicked-ravens-stay.md
@@ -1,0 +1,7 @@
+---
+"@outputai/llm": patch
+---
+
+- Added `'google-vertex'` provider name support to use the `@ai-sdk/google-vertex` provider, the previous `'vertex'` is still supported as an alias, and it is deprecated;
+- Added `'amazon-bedrock'` provider name support to use the `@ai-sdk/amazon-bedrock` provider, the previous `'bedrock'` is still supported as an alias, and it is deprecated;
+- Fixed a bug causing the wrong model to be used to calculate LLM costs when the model name was referenced by another provider.

--- a/.changeset/wicked-ravens-stay.md
+++ b/.changeset/wicked-ravens-stay.md
@@ -4,4 +4,4 @@
 
 - Added `'google-vertex'` provider name support to use the `@ai-sdk/google-vertex` provider, the previous `'vertex'` is still supported as an alias, and it is deprecated;
 - Added `'amazon-bedrock'` provider name support to use the `@ai-sdk/amazon-bedrock` provider, the previous `'bedrock'` is still supported as an alias, and it is deprecated;
-- Fixed a bug causing the wrong model to be used to calculate LLM costs when the model name was referenced by another provider.
+- Fixed a bug causing the wrong model to be used to calculate LLM costs when the model name was referenced by another provider. Cost lookup is now `provider` + `model` against the [models.dev](https://models.dev) catalog, so custom `registerProvider` names that are not models.dev ids correctly get `null` cost instead of an arbitrary provider's rates.

--- a/.changeset/wicked-ravens-stay.md
+++ b/.changeset/wicked-ravens-stay.md
@@ -4,4 +4,5 @@
 
 - Added `'google-vertex'` provider name support to use the `@ai-sdk/google-vertex` provider, the previous `'vertex'` is still supported as an alias, and it is deprecated;
 - Added `'amazon-bedrock'` provider name support to use the `@ai-sdk/amazon-bedrock` provider, the previous `'bedrock'` is still supported as an alias, and it is deprecated;
+- `registerProvider('vertex', …)` and `registerProvider('bedrock', …)` now throw — register under `'google-vertex'` or `'amazon-bedrock'` instead (see the v0.10 → v0.11 migration guide);
 - Fixed a bug causing the wrong model to be used to calculate LLM costs when the model name was referenced by another provider. Cost lookup is now `provider` + `model` against the [models.dev](https://models.dev) catalog, so custom `registerProvider` names that are not models.dev ids correctly get `null` cost instead of an arbitrary provider's rates.

--- a/.changeset/wicked-ravens-stay.md
+++ b/.changeset/wicked-ravens-stay.md
@@ -1,5 +1,5 @@
 ---
-"@outputai/llm": patch
+"@outputai/llm": minor
 ---
 
 - Added `'google-vertex'` provider name support to use the `@ai-sdk/google-vertex` provider, the previous `'vertex'` is still supported as an alias, and it is deprecated;

--- a/.claude/skills/prompt-file-provider-options/SKILL.md
+++ b/.claude/skills/prompt-file-provider-options/SKILL.md
@@ -54,9 +54,9 @@ providerOptions:
 
 ---
 
-❌ **Mistake 3: Wrong namespace for Vertex Gemini**
+❌ **Mistake 3: Wrong namespace for Google Vertex Gemini**
 ```yaml
-provider: vertex
+provider: google-vertex
 model: gemini-2.0-flash
 providerOptions:
   vertex:               # WRONG: Gemini uses 'google' namespace
@@ -65,7 +65,7 @@ providerOptions:
 
 ✅ **Correct:**
 ```yaml
-provider: vertex
+provider: google-vertex
 model: gemini-2.0-flash
 providerOptions:
   google:               # Correct: Gemini is a Google model
@@ -109,31 +109,31 @@ providerOptions:
     reasoningEffort: high
 ```
 
-**Vertex with Gemini**
+**Google Vertex with Gemini**
 ```yaml
-provider: vertex
+provider: google-vertex
 model: gemini-2.0-flash
 providerOptions:
-  google:               # Note: 'google', not 'vertex'
+  google:               # Note: 'google', not 'google-vertex'
     useSearchGrounding: true
 ```
 
-**Vertex with Claude**
+**Google Vertex with Claude**
 ```yaml
-provider: vertex
+provider: google-vertex
 model: claude-sonnet-4-20250514@vertex
 providerOptions:
-  anthropic:            # Note: 'anthropic', not 'vertex'
+  anthropic:            # Note: 'anthropic', not 'google-vertex'
     effort: medium
 ```
 
 **Amazon Bedrock**
 ```yaml
-provider: bedrock
+provider: amazon-bedrock
 model: anthropic.claude-sonnet-4-20250514-v1:0
 maxTokens: 64000              # Recommended: Bedrock has no client-side defaults
 providerOptions:
-  bedrock:                    # Note: 'bedrock', not 'anthropic'
+  bedrock:                    # Note: AI SDK 'bedrock' namespace, not 'anthropic'
     guardrailConfig:
       guardrailIdentifier: my-guardrail
       guardrailVersion: "1"

--- a/coding_assistants/claude/plugins/outputai/agents/workflow_prompt_writer.md
+++ b/coding_assistants/claude/plugins/outputai/agents/workflow_prompt_writer.md
@@ -44,7 +44,7 @@ maxTokens: 2000
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `provider` | string | LLM provider: `anthropic`, `openai`, `vertex`, `bedrock`, `azure`, `perplexity` |
+| `provider` | string | LLM provider: `anthropic`, `openai`, `google-vertex`, `amazon-bedrock`, `azure`, `perplexity` |
 | `model` | string | Model identifier (provider-specific) |
 | `temperature` | number | Creativity (0.0-1.0, lower = more deterministic) |
 | `maxTokens` | number | Maximum response length |

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-model-selection/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-model-selection/SKILL.md
@@ -93,9 +93,9 @@ Output SDK `provider:` values don't always line up with the snapshot keys, since
 |---|---|
 | `anthropic` | `anthropic` |
 | `openai` | `openai` |
-| `vertex` (Gemini models) | `google` |
-| `vertex` (Claude models) | `anthropic` (then re-add the `@vertex` suffix manually) |
-| `bedrock` | `anthropic` (then translate to bedrock namespace manually) |
+| `google-vertex` (Gemini models) | `google` |
+| `google-vertex` (Claude models) | `anthropic` (then re-add the `@vertex` suffix manually) |
+| `amazon-bedrock` | `anthropic` (then translate to bedrock namespace manually) |
 
 ### Step 4 — Pick a model from the provider's list
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
@@ -75,7 +75,7 @@ User message with {{ variable }} placeholders.
 
 ```yaml
 ---
-provider: anthropic    # LLM provider: anthropic, openai, vertex
+provider: anthropic    # LLM provider: anthropic, openai, google-vertex, amazon-bedrock, azure, perplexity
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: claude-sonnet-4-6
 ---
@@ -145,11 +145,11 @@ maxTokens: 4096
 ---
 ```
 
-#### Vertex (Gemini)
+#### Google Vertex (Gemini)
 
 ```yaml
 ---
-provider: vertex
+provider: google-vertex
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: gemini-3-pro
 temperature: 0.7

--- a/coding_assistants/claude/plugins/outputai/skills/output-meta-project-context/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-meta-project-context/SKILL.md
@@ -405,7 +405,7 @@ const { result } = await generateText( {
 } );
 ```
 
-**Provider & model selection:** the SDK supports `anthropic`, `openai`, `vertex`, `bedrock`, `azure`, and `perplexity` (the registered list lives in the SDK's model registry, `sdk/llm/src/ai_model.js`). Don't pin specific model IDs in docs — they drift. To pick a current model, run [`output-dev-model-selection`](../output-dev-model-selection/SKILL.md), which queries the AI Gateway model index live.
+**Provider & model selection:** the SDK supports `anthropic`, `openai`, `google-vertex`, `amazon-bedrock`, `azure`, and `perplexity` (the registered list lives in the SDK's provider registry, `sdk/llm/src/ai_provider.js`). Don't pin specific model IDs in docs — they drift. To pick a current model, run [`output-dev-model-selection`](../output-dev-model-selection/SKILL.md), which queries the AI Gateway model index live.
 
 See `output-dev-prompt-file` for comprehensive patterns.
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-plan-workflow/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-plan-workflow/SKILL.md
@@ -73,7 +73,7 @@ Clarify scope boundaries and technical considerations by asking numbered questio
     - integration points
   </technical>
   <llm_provider>
-    - Ask which LLM provider the user wants to use (anthropic, openai, or vertex)
+    - Ask which LLM provider the user wants to use (anthropic, openai, google-vertex, or amazon-bedrock)
     - Default to anthropic if the user has no preference
     - All prompt files in the workflow must use the same provider unless the user explicitly requests otherwise
     - Record the chosen provider so it flows through to prompt engineering (step 6) and implementation

--- a/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
+++ b/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
@@ -875,3 +875,70 @@ npx output workflow test <workflowName>
 - Grep prompts for `{{` and confirm each name is supplied by callers.
 - Run critical workflows once after upgrade and watch for `Prompt "…" could not be rendered` fatals.
 - Update any docs or tests that assumed empty-string rendering for missing variables.
+
+## LLM provider names: `google-vertex` and `amazon-bedrock`
+
+`@outputai/llm` renames the built-in Vertex and Bedrock prompt `provider` values to match the underlying AI SDK packages and the [models.dev](https://models.dev) catalog. LLM cost lookup is also keyed by `provider` + `model` in that catalog (not by model id alone).
+
+| Before (v0.10.x) | After (v0.11.0) |
+| --- | --- |
+| `provider: vertex` | `provider: google-vertex` (preferred). `vertex` still works as a deprecated alias and is rewritten at prompt load with a warning. |
+| `provider: bedrock` | `provider: amazon-bedrock` (preferred). `bedrock` still works as a deprecated alias and is rewritten at prompt load with a warning. |
+| `registerProvider('vertex', …)` / `registerProvider('bedrock', …)` | Throws `ValidationError`. Register under `google-vertex` or `amazon-bedrock` instead. |
+| Custom `registerProvider` name sharing a model id with another models.dev provider | Previously could pick that other provider’s rates. Now `response.cost` is `null` unless the registered name is a models.dev provider id. |
+
+Prompt files that still use the old names keep working. Overrides registered under the old names do **not**.
+
+### Custom providers and pricing
+
+If you registered a custom provider under a name that is **not** a [models.dev](https://models.dev) provider id (for example `my-proxy` or a private gateway), cost used to fall back to whatever catalog entry matched the model id alone — often the wrong vendor’s rates. That fallback is removed: those calls still run, but pricing is unavailable (`null`) instead of incorrect. To get catalog pricing again, register and reference a models.dev provider id (such as `openai`, `google-vertex`, or `amazon-bedrock`).
+
+### Before
+
+```ts
+import { createVertex } from '@ai-sdk/google-vertex';
+import { registerProvider } from '@outputai/llm';
+
+registerProvider('vertex', createVertex({
+  project: process.env.GOOGLE_VERTEX_PROJECT,
+  location: process.env.GOOGLE_VERTEX_LOCATION
+}));
+```
+
+```yaml
+---
+provider: vertex
+model: gemini-2.5-flash-lite
+---
+```
+
+### After
+
+```ts
+import { createVertex } from '@ai-sdk/google-vertex';
+import { registerProvider } from '@outputai/llm';
+
+registerProvider('google-vertex', createVertex({
+  project: process.env.GOOGLE_VERTEX_PROJECT,
+  location: process.env.GOOGLE_VERTEX_LOCATION
+}));
+```
+
+```yaml
+---
+provider: google-vertex
+model: gemini-2.5-flash-lite
+---
+```
+
+### Migration steps
+
+1. Replace `registerProvider('vertex', …)` with `registerProvider('google-vertex', …)` and `registerProvider('bedrock', …)` with `registerProvider('amazon-bedrock', …)`.
+2. Prefer updating prompt front matter to `google-vertex` / `amazon-bedrock` (aliases remain until they are removed in a later release).
+3. Grep for `registerProvider\(\s*['"]vertex['"]` and `registerProvider\(\s*['"]bedrock['"]` before upgrading.
+
+### Provider rename checklist
+
+- Update any `registerProvider` calls that used `vertex` or `bedrock`.
+- Optionally update `.prompt` files to the canonical names to silence deprecation warnings.
+- Expect `response.cost === null` (and no `cost:llm:request` event) for custom provider names that are not models.dev ids — they no longer inherit another provider’s pricing by model name alone.

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -693,6 +693,8 @@ model: claude-haiku-4-5
 
 Built-in providers use Output's default fetch configuration, including longer Undici response timeouts for LLM calls that take time before returning headers or body chunks. Custom registered providers are used exactly as you register them; they do not automatically receive that custom fetch. If your custom provider also needs longer network timeouts, configure its provider instance directly.
 
+LLM cost estimation looks up rates by `provider` + `model` in the [models.dev](https://models.dev) catalog. Built-in provider names match that catalog. A custom `registerProvider` name (such as `vertex-anthropic` above) will not match, so `response.cost` is `null` and a missing-cost warning is logged — register under a models.dev provider id if you need automatic pricing.
+
 ## Prompt Caching
 
 When a prompt sends the same large prefix on every call — a long system prompt, few-shot examples, a pasted reference document — you can cache that prefix so the provider skips reprocessing it. Cached input is about 90% cheaper and faster to first token. How you enable it depends on the provider.

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -575,7 +575,7 @@ Company size: {{ size }} employees
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `provider` | `string` | `anthropic`, `openai`, `azure`, `vertex`, `bedrock`, `perplexity`, or a provider registered with `registerProvider` |
+| `provider` | `string` | `anthropic`, `openai`, `azure`, `amazon-bedrock`, `google-vertex`, `perplexity`, or a provider registered with `registerProvider`. Legacy aliases `bedrock` and `vertex` are deprecated but still accepted. |
 | `model` | `string` | Model identifier |
 | `temperature` | `number` | Sampling temperature (0.0-2.0) |
 | `maxTokens` | `number` | Maximum output tokens |
@@ -591,9 +591,11 @@ Company size: {{ size }} employees
 | `anthropic` | `@ai-sdk/anthropic` | `>=3 <4` |
 | `openai` | `@ai-sdk/openai` | `>=3 <4` |
 | `azure` | `@ai-sdk/azure` | `>=3 <4` |
-| `vertex` | `@ai-sdk/google-vertex` | `>=4 <5` |
-| `bedrock` | `@ai-sdk/amazon-bedrock` | `>=4 <5` |
+| `amazon-bedrock` | `@ai-sdk/amazon-bedrock` | `>=4 <5` |
+| `google-vertex` | `@ai-sdk/google-vertex` | `>=4 <5` |
 | `perplexity` | `@ai-sdk/perplexity` | `>=3 <4` |
+
+Legacy aliases `bedrock` → `amazon-bedrock` and `vertex` → `google-vertex` are deprecated but still work; using them logs a deprecation warning.
 
 Built-in provider instances are initialized lazily. Output creates the provider instance only when a prompt or API call first requests that provider, then reuses it for later calls.
 
@@ -630,33 +632,33 @@ model: gpt-4o
 
 Requires `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, and `AZURE_OPENAI_API_VERSION`.
 
-### Vertex AI
+### Google Vertex AI
 
 ```yaml
 ---
-provider: vertex
+provider: google-vertex
 model: gemini-1.5-pro
 ---
 ```
 
-Requires Google Cloud authentication and configuration.
+Requires Google Cloud authentication and configuration. The legacy alias `vertex` is still accepted.
 
 ### Amazon Bedrock
 
 ```yaml
 ---
-provider: bedrock
+provider: amazon-bedrock
 model: anthropic.claude-sonnet-4-20250514-v1:0
 ---
 ```
 
-Requires AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) or IAM role-based authentication. Set `AWS_SESSION_TOKEN` when using temporary credentials (e.g., from `aws sts assume-role`).
+Requires AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) or IAM role-based authentication. Set `AWS_SESSION_TOKEN` when using temporary credentials (e.g., from `aws sts assume-role`). The legacy alias `bedrock` is still accepted.
 
 For cross-region inference, use the regional inference profile format: `us.anthropic.claude-sonnet-4-20250514-v1:0`.
 
 Always set `maxTokens` in your Bedrock prompt files. Unlike the direct Anthropic provider (which auto-detects per-model limits), the Bedrock SDK has no client-side defaults and relies on server-side defaults that may be lower than the model's capacity.
 
-When using `providerOptions`, use the `bedrock` namespace (not `anthropic`):
+When using `providerOptions`, use the AI SDK `bedrock` namespace (not `anthropic`):
 
 ```yaml
 providerOptions:
@@ -765,7 +767,7 @@ Many providers offer built-in tools like web search. Configure them in YAML fron
 
 ```yaml prompts/research@v1.prompt
 ---
-provider: vertex
+provider: google-vertex
 model: gemini-2.0-flash
 tools:
   googleSearch:
@@ -778,7 +780,7 @@ Research {{ topic }} and provide sources
 </user>
 ```
 
-This is equivalent to calling `vertex.tools.googleSearch({ mode: 'MODE_DYNAMIC', dynamicThreshold: 0.8 })` at the code level, but keeps your prompt self-contained.
+This is equivalent to calling the Vertex provider's `tools.googleSearch({ mode: 'MODE_DYNAMIC', dynamicThreshold: 0.8 })` at the code level, but keeps your prompt self-contained.
 
 YAML tools are merged with code-level tools, so you can combine provider tools (from YAML) with custom tools (from code). Code-level tools take precedence if names conflict.
 

--- a/docs/guides/prompts/index.mdx
+++ b/docs/guides/prompts/index.mdx
@@ -84,7 +84,7 @@ The YAML frontmatter configures the LLM call.
 
 | Field | Description | Example |
 |-------|-------------|---------|
-| `provider` | LLM provider | `anthropic`, `openai`, `azure`, `vertex`, `bedrock` |
+| `provider` | LLM provider | `anthropic`, `openai`, `azure`, `amazon-bedrock`, `google-vertex`, `perplexity` (legacy aliases: `bedrock`, `vertex`) |
 | `model` | Model identifier | `claude-sonnet-4-20250514`, `gpt-4o` |
 
 ### Optional Fields
@@ -164,13 +164,13 @@ providerOptions:
 ---
 ```
 
-**Vertex with Gemini (important namespace note):**
+**Google Vertex with Gemini (important namespace note):**
 ```yaml
 ---
-provider: vertex
+provider: google-vertex
 model: gemini-2.0-flash
 providerOptions:
-  google:               # Use 'google' for Gemini, not 'vertex'!
+  google:               # Use 'google' for Gemini, not 'google-vertex'!
     useSearchGrounding: true
 ---
 ```
@@ -201,9 +201,9 @@ providerOptions:
 | AI SDK | `thinking` | Top-level | Extended thinking (not under provider) |
 | AI Gateway | `order` | Top-level | Provider routing order |
 
-**Vertex Provider Namespace Guide:**
+**Google Vertex Provider Namespace Guide:**
 
-When using `provider: vertex`, the `providerOptions` namespace depends on the model:
+When using `provider: google-vertex` (or the legacy alias `vertex`), the `providerOptions` namespace depends on the model:
 
 - **Gemini models** → Use `google:` namespace
 - **Claude models** → Use `anthropic:` namespace

--- a/sdk/llm/src/agent.js
+++ b/sdk/llm/src/agent.js
@@ -19,6 +19,7 @@ export const createMemoryConversationStore = () => {
 export class Agent extends AIToolLoopAgent {
   #prompt;
   #modelId;
+  #providerId;
   #initialMessages;
   #store;
 
@@ -57,6 +58,7 @@ export class Agent extends AIToolLoopAgent {
 
     this.#prompt = prompt;
     this.#modelId = loadedPrompt.config.model;
+    this.#providerId = loadedPrompt.config.provider;
     // `messages` is system-free but may still hold authored <assistant>/<tool>
     // blocks; seed only <user> turns into each generate()/stream() call.
     this.#initialMessages = messages.filter( isRole( ROLE.USER ) );
@@ -79,7 +81,7 @@ export class Agent extends AIToolLoopAgent {
     try {
       const messages = await this.#fetchMessages( userMessages );
       const response = await super.generate( { messages, allowSystemInMessages: true, ...callOptions } );
-      const wrapped = await wrapTextResponse( { traceId, response, modelId: this.#modelId } );
+      const wrapped = await wrapTextResponse( { traceId, response, providerId: this.#providerId, modelId: this.#modelId } );
       await this.#storeMessages( userMessages, wrapped );
       return wrapped;
     } catch ( error ) {
@@ -96,7 +98,7 @@ export class Agent extends AIToolLoopAgent {
         messages,
         allowSystemInMessages: true,
         ...callOptions,
-        ...wrapStreamOnFinishResponse( { traceId, modelId: this.#modelId, onFinish } ),
+        ...wrapStreamOnFinishResponse( { traceId, modelId: this.#modelId, providerId: this.#providerId, onFinish } ),
         onError( event ) {
           endTraceWithError( { traceId, error: event.error } );
           onError?.( event );

--- a/sdk/llm/src/agent.spec.js
+++ b/sdk/llm/src/agent.spec.js
@@ -100,7 +100,7 @@ const importSut = async () => import( './agent.js' );
 
 const loadedPrompt = {
   name: 'test@v1',
-  config: { model: 'test-model' },
+  config: { provider: 'openai', model: 'test-model' },
   messages: [
     { role: 'system', content: 'You are concise.' },
     { role: 'user', content: 'Initial user message' }
@@ -373,6 +373,7 @@ describe( 'Agent', () => {
     } );
     expect( wrapMocks.wrapTextResponse ).toHaveBeenCalledWith( {
       traceId: 'trace-id',
+      providerId: 'openai',
       modelId: 'test-model',
       response: aiResponse
     } );
@@ -422,6 +423,7 @@ describe( 'Agent', () => {
     } );
     expect( wrapMocks.wrapStreamOnFinishResponse ).toHaveBeenCalledWith( {
       traceId: 'trace-id',
+      providerId: 'openai',
       modelId: 'test-model',
       onFinish
     } );

--- a/sdk/llm/src/ai_provider.js
+++ b/sdk/llm/src/ai_provider.js
@@ -20,12 +20,12 @@ const customFetch = ( input, init ) => fetch( input, { dispatcher: customDispatc
 
 /** Available provider to initialize. */
 const providerInitializers = {
+  'amazon-bedrock': createAmazonBedrock,
   anthropic: createAnthropic,
   azure: createAzure,
-  bedrock: createAmazonBedrock,
+  'google-vertex': createVertex,
   openai: createOpenAI,
-  perplexity: createPerplexity,
-  vertex: createVertex
+  perplexity: createPerplexity
 };
 
 /** Providers already initialized due usage */

--- a/sdk/llm/src/ai_provider.js
+++ b/sdk/llm/src/ai_provider.js
@@ -58,8 +58,8 @@ export function registerProvider( name, providerFn ) {
   if ( !result.success ) {
     throw new ValidationError( `Invalid provider registration: ${z.prettifyError( result.error )}` );
   }
-  const canonical = deprecatedProviderAliases[name];
-  if ( canonical ) {
+  if ( Object.hasOwn( deprecatedProviderAliases, name ) ) {
+    const canonical = deprecatedProviderAliases[name];
     throw new ValidationError(
       `Cannot register provider "${name}": that name is a deprecated alias for "${canonical}". Register "${canonical}" instead.`
     );

--- a/sdk/llm/src/ai_provider.js
+++ b/sdk/llm/src/ai_provider.js
@@ -7,6 +7,7 @@ import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createPerplexity } from '@ai-sdk/perplexity';
 import { createVertex } from '@ai-sdk/google-vertex';
+import { deprecatedProviderAliases } from './deprecated_provider_aliases.js';
 
 /** This custom dispatcher has longer timeouts. */
 const customDispatcher = new EnvHttpProxyAgent( {
@@ -56,6 +57,12 @@ export function registerProvider( name, providerFn ) {
   const result = registerProviderSchema.safeParse( { name, providerFn } );
   if ( !result.success ) {
     throw new ValidationError( `Invalid provider registration: ${z.prettifyError( result.error )}` );
+  }
+  const canonical = deprecatedProviderAliases[name];
+  if ( canonical ) {
+    throw new ValidationError(
+      `Cannot register provider "${name}": that name is a deprecated alias for "${canonical}". Register "${canonical}" instead.`
+    );
   }
   registeredProviders[name] = providerFn;
 }

--- a/sdk/llm/src/ai_provider.spec.js
+++ b/sdk/llm/src/ai_provider.spec.js
@@ -1,12 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const SHIPPED_PROVIDERS = [
+  { name: 'amazon-bedrock', pkg: '@ai-sdk/amazon-bedrock', exportName: 'createAmazonBedrock' },
   { name: 'anthropic', pkg: '@ai-sdk/anthropic', exportName: 'createAnthropic' },
   { name: 'azure', pkg: '@ai-sdk/azure', exportName: 'createAzure' },
-  { name: 'bedrock', pkg: '@ai-sdk/amazon-bedrock', exportName: 'createAmazonBedrock' },
+  { name: 'google-vertex', pkg: '@ai-sdk/google-vertex', exportName: 'createVertex' },
   { name: 'openai', pkg: '@ai-sdk/openai', exportName: 'createOpenAI' },
-  { name: 'perplexity', pkg: '@ai-sdk/perplexity', exportName: 'createPerplexity' },
-  { name: 'vertex', pkg: '@ai-sdk/google-vertex', exportName: 'createVertex' }
+  { name: 'perplexity', pkg: '@ai-sdk/perplexity', exportName: 'createPerplexity' }
 ];
 
 const makeProviderModules = () => Object.fromEntries(
@@ -194,12 +194,12 @@ describe( 'getProviderNames', () => {
     registerProvider( 'openai', vi.fn() );
 
     expect( getProviderNames() ).toEqual( [
+      'amazon-bedrock',
       'anthropic',
       'azure',
-      'bedrock',
+      'google-vertex',
       'openai',
       'perplexity',
-      'vertex',
       'custom'
     ] );
   } );

--- a/sdk/llm/src/ai_provider.spec.js
+++ b/sdk/llm/src/ai_provider.spec.js
@@ -184,6 +184,17 @@ describe( 'registerProvider', () => {
     expect( () => registerProvider( '', vi.fn() ) ).toThrow( 'Provider name must be a non-empty string' );
     expect( () => registerProvider( 'custom', 'not-a-function' ) ).toThrow( 'expected function, received string' );
   } );
+
+  it.each( [
+    [ 'vertex', 'google-vertex' ],
+    [ 'bedrock', 'amazon-bedrock' ]
+  ] )( 'rejects registering deprecated provider alias %s', async ( alias, canonical ) => {
+    const { registerProvider } = await importWithMockedProviders();
+
+    expect( () => registerProvider( alias, vi.fn() ) ).toThrow(
+      `Cannot register provider "${alias}": that name is a deprecated alias for "${canonical}". Register "${canonical}" instead.`
+    );
+  } );
 } );
 
 describe( 'getProviderNames', () => {

--- a/sdk/llm/src/ai_sdk.js
+++ b/sdk/llm/src/ai_sdk.js
@@ -17,7 +17,7 @@ export async function generateText( { prompt, variables, promptDir, skills = [],
   const { loadedPrompt, tools } = prepareTextPrompt( { prompt, variables, promptDir, skills: parsedSkills, tools: aiSdkArgs.tools } );
 
   const traceId = startTrace( { name: 'generateText', prompt, variables, loadedPrompt } );
-  const { model: modelId } = loadedPrompt.config;
+  const { model: modelId, provider: providerId } = loadedPrompt.config;
 
   try {
     const response = await AI.generateText( {
@@ -28,7 +28,7 @@ export async function generateText( { prompt, variables, promptDir, skills = [],
       ...( tools && { tools } ),
       ...( tools && !aiSdkArgs.stopWhen ? { stopWhen: stepCountIs( maxSteps ) } : {} )
     } );
-    return wrapTextResponse( { traceId, modelId, response } );
+    return wrapTextResponse( { traceId, providerId, modelId, response } );
   } catch ( originalError ) {
     const error = mapAiError( originalError );
     endTraceWithError( { traceId, error } );
@@ -46,7 +46,7 @@ export function streamText( { prompt, variables, promptDir, skills = [], maxStep
   const { loadedPrompt, tools } = prepareTextPrompt( { prompt, variables, promptDir, skills: parsedSkills, tools: aiSdkArgs.tools } );
 
   const traceId = startTrace( { name: 'streamText', prompt, variables, loadedPrompt } );
-  const { model: modelId } = loadedPrompt.config;
+  const { model: modelId, provider: providerId } = loadedPrompt.config;
 
   try {
     return AI.streamText( {
@@ -56,7 +56,7 @@ export function streamText( { prompt, variables, promptDir, skills = [], maxStep
       ...aiSdkArgs,
       ...( tools && { tools } ),
       ...( tools && !aiSdkArgs.stopWhen ? { stopWhen: stepCountIs( maxSteps ) } : {} ),
-      ...wrapStreamOnFinishResponse( { traceId, modelId, onFinish } ),
+      ...wrapStreamOnFinishResponse( { traceId, modelId, providerId, onFinish } ),
       onError( event ) {
         const error = mapAiError( event.error );
         endTraceWithError( { traceId, error } );
@@ -75,7 +75,7 @@ export async function generateImage( { prompt, variables, promptDir, images, mas
 
   const loadedPrompt = loadPrompt( prompt, variables, promptDir );
   const traceId = startTrace( { name: 'generateImage', prompt, variables, loadedPrompt } );
-  const { model: modelId } = loadedPrompt.config;
+  const { model: modelId, provider: providerId } = loadedPrompt.config;
 
   try {
     const response = await AI.generateImage( {
@@ -83,7 +83,7 @@ export async function generateImage( { prompt, variables, promptDir, images, mas
       maxRetries: 0,
       ...aiSdkArgs
     } );
-    return wrapImageResponse( { traceId, modelId, response } );
+    return wrapImageResponse( { traceId, providerId, modelId, response } );
   } catch ( originalError ) {
     const error = mapAiError( originalError );
     endTraceWithError( { traceId, error } );

--- a/sdk/llm/src/ai_sdk.spec.js
+++ b/sdk/llm/src/ai_sdk.spec.js
@@ -74,7 +74,7 @@ const importSut = async () => import( './ai_sdk.js' );
 
 const loadedPrompt = {
   name: 'test@v1',
-  config: { model: 'test-model' },
+  config: { provider: 'openai', model: 'test-model' },
   messages: [ { role: 'user', content: 'Hello' } ]
 };
 
@@ -198,6 +198,7 @@ describe( 'ai_sdk', () => {
       } );
       expect( wrapMocks.wrapTextResponse ).toHaveBeenCalledWith( {
         traceId: 'trace-id',
+        providerId: 'openai',
         modelId: 'test-model',
         response: textResponse
       } );
@@ -322,6 +323,7 @@ describe( 'ai_sdk', () => {
       expect( optionMocks.loadAiSdkTextOptions ).toHaveBeenCalledWith( loadedPrompt );
       expect( wrapMocks.wrapStreamOnFinishResponse ).toHaveBeenCalledWith( {
         traceId: 'trace-id',
+        providerId: 'openai',
         modelId: 'test-model',
         onFinish
       } );
@@ -505,6 +507,7 @@ describe( 'ai_sdk', () => {
       } );
       expect( wrapMocks.wrapImageResponse ).toHaveBeenCalledWith( {
         traceId: 'trace-id',
+        providerId: 'openai',
         modelId: 'test-model',
         response: imageResponse
       } );

--- a/sdk/llm/src/cost/fetch_models_pricing.js
+++ b/sdk/llm/src/cost/fetch_models_pricing.js
@@ -18,7 +18,6 @@ const buildModelMap = data => {
   for ( const provider of Object.values( data ) ) {
     for ( const [ modelName, { cost } ] of Object.entries( provider.models ?? {} ) ) {
       if ( cost ) { // some models don't have cost
-        map.set( modelName, cost );
         map.set( `${provider.id}/${modelName}`, cost );
       }
     }

--- a/sdk/llm/src/cost/fetch_models_pricing.spec.js
+++ b/sdk/llm/src/cost/fetch_models_pricing.spec.js
@@ -47,7 +47,7 @@ describe( 'fetchModelsPricing', () => {
     const firstModel = Object.values( fixture )[0];
     const firstModelId = Object.keys( firstModel.models )[0];
     const cost = firstModel.models[firstModelId].cost;
-    expect( result.get( firstModelId ) ).toEqual( cost );
+    expect( result.get( firstModelId ) ).toBeUndefined();
     expect( result.get( `${firstModel.id}/${firstModelId}` ) ).toEqual( cost );
   } );
 
@@ -58,11 +58,11 @@ describe( 'fetchModelsPricing', () => {
 
     const openaiProvider = fixture.openai;
     const openaiModelId = Object.keys( openaiProvider.models )[0];
-    expect( result.get( openaiModelId ) ).toBeDefined();
+    expect( result.get( openaiModelId ) ).toBeUndefined();
     expect( result.get( `openai/${openaiModelId}` ) ).toEqual( openaiProvider.models[openaiModelId].cost );
 
     const anthropicModelId = Object.keys( fixture.anthropic.models )[0];
-    expect( result.get( anthropicModelId ) ).toBeDefined();
+    expect( result.get( `anthropic/${anthropicModelId}` ) ).toEqual( fixture.anthropic.models[anthropicModelId].cost );
   } );
 
   it( 'returns null when response is not ok and no cache', async () => {
@@ -149,7 +149,8 @@ describe( 'fetchModelsPricing', () => {
 
     const result = await fetchModelsPricing();
 
-    expect( result.get( 'withCost' ) ).toEqual( { input: 1, output: 2 } );
-    expect( result.get( 'noCost' ) ).toBeUndefined();
+    expect( result.get( 'p1/withCost' ) ).toEqual( { input: 1, output: 2 } );
+    expect( result.get( 'withCost' ) ).toBeUndefined();
+    expect( result.get( 'p1/noCost' ) ).toBeUndefined();
   } );
 } );

--- a/sdk/llm/src/cost/fetch_models_pricing.spec.js
+++ b/sdk/llm/src/cost/fetch_models_pricing.spec.js
@@ -65,6 +65,18 @@ describe( 'fetchModelsPricing', () => {
     expect( result.get( `anthropic/${anthropicModelId}` ) ).toEqual( fixture.anthropic.models[anthropicModelId].cost );
   } );
 
+  it( 'keeps separate costs when the same model id exists under two providers', async () => {
+    stubFetch( okResponse( fixture ) );
+
+    const result = await fetchModelsPricing();
+    const sharedModelId = 'gpt-4o-2024-11-20';
+
+    expect( result.get( sharedModelId ) ).toBeUndefined();
+    expect( result.get( `openai/${sharedModelId}` ) ).toEqual( fixture.openai.models[sharedModelId].cost );
+    expect( result.get( `azure/${sharedModelId}` ) ).toEqual( fixture.azure.models[sharedModelId].cost );
+    expect( result.get( `openai/${sharedModelId}` ) ).not.toEqual( result.get( `azure/${sharedModelId}` ) );
+  } );
+
   it( 'returns null when response is not ok and no cache', async () => {
     const status = 500;
     stubFetch( { ok: false, status } );

--- a/sdk/llm/src/cost/fixtures/models_api_light.json
+++ b/sdk/llm/src/cost/fixtures/models_api_light.json
@@ -135,6 +135,20 @@
       }
     }
   },
+  "azure": {
+    "id": "azure",
+    "models": {
+      "gpt-4o-2024-11-20": {
+        "id": "gpt-4o-2024-11-20",
+        "name": "GPT-4o (2024-11-20)",
+        "cost": {
+          "input": 3,
+          "output": 12,
+          "cache_read": 1.5
+        }
+      }
+    }
+  },
   "anthropic": {
     "id": "anthropic",
     "models": {

--- a/sdk/llm/src/cost/index.js
+++ b/sdk/llm/src/cost/index.js
@@ -5,11 +5,12 @@ import { Logger } from '@outputai/core';
 /**
  * Calculates the cost of an llm call based on the model and usage.
  * @param {object} args
- * @param {string} args.modelId - Name of the model, provider prefix is optional
+ * @param {string} args.providerId - Id of the provider
+ * @param {string} args.modelId - Id of the model
  * @param {object} args.usage - Usage, as returned from AI SDK
  * @returns {object} The cost with total value and components
  */
-export const calculateLLMCallCost = async ( { modelId, usage } ) => {
+export const calculateLLMCallCost = async ( { providerId, modelId, usage } ) => {
   try {
     const models = await fetchModelsPricing();
 
@@ -18,9 +19,9 @@ export const calculateLLMCallCost = async ( { modelId, usage } ) => {
       return null;
     }
 
-    const pricing = models.get( modelId );
+    const pricing = models.get( `${providerId}/${modelId}` );
     if ( !pricing ) {
-      Logger.warn( 'Missing cost reference for model', { namespace: 'LLM' } );
+      Logger.warn( 'Missing cost reference for model', { namespace: 'LLM', modelId, providerId } );
       return null;
     }
 

--- a/sdk/llm/src/cost/index.spec.js
+++ b/sdk/llm/src/cost/index.spec.js
@@ -47,6 +47,11 @@ vi.mock( '@outputai/core/sdk/runtime', () => {
 import { Tracing } from '@outputai/core/sdk/runtime';
 import { calculateLLMCallCost } from './index.js';
 
+const pricingMap = entries => new Map( entries.map( ( [ providerId, modelId, cost ] ) => [
+  `${providerId}/${modelId}`,
+  cost
+] ) );
+
 const expectLLMUsage = ( result, { modelId, usage, total, tokensUsed } ) => {
   expect( result ).toBeInstanceOf( Tracing.Attribute.LLMUsage );
   expect( result ).toEqual( expect.objectContaining( {
@@ -71,6 +76,7 @@ describe( 'calculateLLMCallCost', () => {
     mockFetchModelsPricing.mockResolvedValue( null );
 
     const result = await calculateLLMCallCost( {
+      providerId: 'openai',
       modelId: 'gpt-4o',
       usage: { inputTokens: 100, outputTokens: 50 }
     } );
@@ -82,6 +88,7 @@ describe( 'calculateLLMCallCost', () => {
     mockFetchModelsPricing.mockResolvedValue( new Map() );
 
     const result = await calculateLLMCallCost( {
+      providerId: 'openai',
       modelId: 'unknown-model',
       usage: { inputTokens: 100, outputTokens: 50 }
     } );
@@ -90,9 +97,12 @@ describe( 'calculateLLMCallCost', () => {
   } );
 
   it( 'calculates input and output usage from model pricing', async () => {
-    mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'gpt-4o', { input: 2, output: 10, cache_read: 1 } ] ] ) );
+    mockFetchModelsPricing.mockResolvedValue( pricingMap( [
+      [ 'openai', 'gpt-4o', { input: 2, output: 10, cache_read: 1 } ]
+    ] ) );
 
     const result = await calculateLLMCallCost( {
+      providerId: 'openai',
       modelId: 'gpt-4o',
       usage: { inputTokens: 1_000_000, outputTokens: 500_000 }
     } );
@@ -109,9 +119,12 @@ describe( 'calculateLLMCallCost', () => {
   } );
 
   it( 'splits input into non-cached and cached usage at respective rates', async () => {
-    mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'cached-model', { input: 4, cache_read: 1, output: 10 } ] ] ) );
+    mockFetchModelsPricing.mockResolvedValue( pricingMap( [
+      [ 'openai', 'cached-model', { input: 4, cache_read: 1, output: 10 } ]
+    ] ) );
 
     const result = await calculateLLMCallCost( {
+      providerId: 'openai',
       modelId: 'cached-model',
       usage: { inputTokens: 1_000_000, cachedInputTokens: 500_000, outputTokens: 100_000 }
     } );
@@ -129,9 +142,12 @@ describe( 'calculateLLMCallCost', () => {
   } );
 
   it( 'still counts cached tokens when the model has no cache_read rate', async () => {
-    mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'no-cache', { input: 2, output: 10 } ] ] ) );
+    mockFetchModelsPricing.mockResolvedValue( pricingMap( [
+      [ 'openai', 'no-cache', { input: 2, output: 10 } ]
+    ] ) );
 
     const result = await calculateLLMCallCost( {
+      providerId: 'openai',
       modelId: 'no-cache',
       usage: { inputTokens: 1_000_000, cachedInputTokens: 200_000, outputTokens: 0 }
     } );
@@ -151,9 +167,12 @@ describe( 'calculateLLMCallCost', () => {
   } );
 
   it( 'omits input usage when pricing has no input rate', async () => {
-    mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'out-only', { output: 10 } ] ] ) );
+    mockFetchModelsPricing.mockResolvedValue( pricingMap( [
+      [ 'openai', 'out-only', { output: 10 } ]
+    ] ) );
 
     const result = await calculateLLMCallCost( {
+      providerId: 'openai',
       modelId: 'out-only',
       usage: { inputTokens: 100, outputTokens: 50 }
     } );
@@ -169,9 +188,12 @@ describe( 'calculateLLMCallCost', () => {
   } );
 
   it( 'omits output usage when pricing has no output rate', async () => {
-    mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'in-only', { input: 1 } ] ] ) );
+    mockFetchModelsPricing.mockResolvedValue( pricingMap( [
+      [ 'openai', 'in-only', { input: 1 } ]
+    ] ) );
 
     const result = await calculateLLMCallCost( {
+      providerId: 'openai',
       modelId: 'in-only',
       usage: { inputTokens: 100, outputTokens: 50 }
     } );
@@ -187,12 +209,12 @@ describe( 'calculateLLMCallCost', () => {
   } );
 
   it( 'includes reasoning usage when present', async () => {
-    mockFetchModelsPricing.mockResolvedValue( new Map( [ [
-      'with-reasoning',
-      { input: 1, output: 10, reasoning: 60 }
-    ] ] ) );
+    mockFetchModelsPricing.mockResolvedValue( pricingMap( [
+      [ 'openai', 'with-reasoning', { input: 1, output: 10, reasoning: 60 } ]
+    ] ) );
 
     const result = await calculateLLMCallCost( {
+      providerId: 'openai',
       modelId: 'with-reasoning',
       usage: { inputTokens: 100, outputTokens: 20, reasoningTokens: 50 }
     } );
@@ -210,9 +232,12 @@ describe( 'calculateLLMCallCost', () => {
   } );
 
   it( 'omits reasoning usage when reasoning cost is missing', async () => {
-    mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'no-reasoning', { input: 1, output: 10 } ] ] ) );
+    mockFetchModelsPricing.mockResolvedValue( pricingMap( [
+      [ 'openai', 'no-reasoning', { input: 1, output: 10 } ]
+    ] ) );
 
     const result = await calculateLLMCallCost( {
+      providerId: 'openai',
       modelId: 'no-reasoning',
       usage: { inputTokens: 100, outputTokens: 20, reasoningTokens: 50 }
     } );
@@ -229,12 +254,12 @@ describe( 'calculateLLMCallCost', () => {
   } );
 
   it( 'includes reasoning usage with zero amount when reasoningTokens is zero', async () => {
-    mockFetchModelsPricing.mockResolvedValue( new Map( [ [
-      'full',
-      { input: 2, output: 8, reasoning: 60 }
-    ] ] ) );
+    mockFetchModelsPricing.mockResolvedValue( pricingMap( [
+      [ 'openai', 'full', { input: 2, output: 8, reasoning: 60 } ]
+    ] ) );
 
     const result = await calculateLLMCallCost( {
+      providerId: 'openai',
       modelId: 'full',
       usage: { inputTokens: 100, outputTokens: 50, reasoningTokens: 0 }
     } );
@@ -252,9 +277,12 @@ describe( 'calculateLLMCallCost', () => {
   } );
 
   it( 'omits usage entries for non-finite token counts', async () => {
-    mockFetchModelsPricing.mockResolvedValue( new Map( [ [ 'm', { input: 1, output: 2 } ] ] ) );
+    mockFetchModelsPricing.mockResolvedValue( pricingMap( [
+      [ 'openai', 'm', { input: 1, output: 2 } ]
+    ] ) );
 
     const result = await calculateLLMCallCost( {
+      providerId: 'openai',
       modelId: 'm',
       usage: { inputTokens: null, outputTokens: undefined }
     } );
@@ -274,6 +302,7 @@ describe( 'calculateLLMCallCost', () => {
     mockFetchModelsPricing.mockRejectedValue( error );
 
     const result = await calculateLLMCallCost( {
+      providerId: 'openai',
       modelId: 'gpt-4o',
       usage: { inputTokens: 100, outputTokens: 50 }
     } );

--- a/sdk/llm/src/cost/index.spec.js
+++ b/sdk/llm/src/cost/index.spec.js
@@ -118,6 +118,44 @@ describe( 'calculateLLMCallCost', () => {
     } );
   } );
 
+  it( 'uses each provider pricing when the same model id exists under two providers', async () => {
+    mockFetchModelsPricing.mockResolvedValue( pricingMap( [
+      [ 'openai', 'gpt-4o', { input: 2, output: 10 } ],
+      [ 'azure', 'gpt-4o', { input: 3, output: 12 } ]
+    ] ) );
+    const usage = { inputTokens: 1_000_000, outputTokens: 0 };
+
+    const openai = await calculateLLMCallCost( {
+      providerId: 'openai',
+      modelId: 'gpt-4o',
+      usage
+    } );
+    const azure = await calculateLLMCallCost( {
+      providerId: 'azure',
+      modelId: 'gpt-4o',
+      usage
+    } );
+
+    expectLLMUsage( openai, {
+      modelId: 'gpt-4o',
+      usage: [
+        { type: 'input', ppm: 2, amount: 1_000_000, total: 2 },
+        { type: 'output', ppm: 10, amount: 0, total: 0 }
+      ],
+      total: 2,
+      tokensUsed: 1_000_000
+    } );
+    expectLLMUsage( azure, {
+      modelId: 'gpt-4o',
+      usage: [
+        { type: 'input', ppm: 3, amount: 1_000_000, total: 3 },
+        { type: 'output', ppm: 12, amount: 0, total: 0 }
+      ],
+      total: 3,
+      tokensUsed: 1_000_000
+    } );
+  } );
+
   it( 'splits input into non-cached and cached usage at respective rates', async () => {
     mockFetchModelsPricing.mockResolvedValue( pricingMap( [
       [ 'openai', 'cached-model', { input: 4, cache_read: 1, output: 10 } ]

--- a/sdk/llm/src/deprecated_provider_aliases.js
+++ b/sdk/llm/src/deprecated_provider_aliases.js
@@ -1,0 +1,8 @@
+/**
+ * Deprecated prompt `provider` spellings → canonical shipped names.
+ * Remove this module when the aliases are dropped.
+ */
+export const deprecatedProviderAliases = {
+  vertex: 'google-vertex',
+  bedrock: 'amazon-bedrock'
+};

--- a/sdk/llm/src/index.d.ts
+++ b/sdk/llm/src/index.d.ts
@@ -91,7 +91,13 @@ export type Prompt = {
 
   /** General configuration for the LLM */
   config: {
-    /** LLM provider (built-in: 'anthropic', 'openai', 'azure', 'vertex', 'bedrock', 'perplexity'; or any registered custom provider) */
+    /**
+     * LLM provider.
+     *
+     * Built-in: `'anthropic'`, `'openai'`, `'azure'`, `'amazon-bedrock'`, `'google-vertex'`,
+     * `'perplexity'`. Legacy aliases `'bedrock'` and `'vertex'` are deprecated but still accepted.
+     * Custom providers registered via {@link registerProvider} are also accepted.
+     */
     provider: string;
 
     /** Model name/identifier */

--- a/sdk/llm/src/prompt/loader.js
+++ b/sdk/llm/src/prompt/loader.js
@@ -4,6 +4,7 @@ import { loadContent } from './load_content.js';
 import { validatePrompt } from './validations.js';
 import { FatalError, Logger } from '@outputai/core';
 import { escape, decode, setupLiquidEncodeFilter } from './escape.js';
+import { deprecatedProviderAliases } from '../deprecated_provider_aliases.js';
 
 const liquid = new Liquid( {
   strictFilters: true,
@@ -19,11 +20,6 @@ const renderPrompt = ( { name, escapedContent, values } ) => {
   } catch ( error ) {
     throw new FatalError( `Prompt "${name}" could not be rendered: ${error.message}`, { cause: error } );
   }
-};
-
-const deprecatedProviderAliases = {
-  vertex: 'google-vertex',
-  bedrock: 'amazon-bedrock'
 };
 
 /**

--- a/sdk/llm/src/prompt/loader.js
+++ b/sdk/llm/src/prompt/loader.js
@@ -2,7 +2,7 @@ import { parsePrompt } from './parser.js';
 import { Liquid } from 'liquidjs';
 import { loadContent } from './load_content.js';
 import { validatePrompt } from './validations.js';
-import { FatalError } from '@outputai/core';
+import { FatalError, Logger } from '@outputai/core';
 import { escape, decode, setupLiquidEncodeFilter } from './escape.js';
 
 const liquid = new Liquid( {
@@ -19,6 +19,11 @@ const renderPrompt = ( { name, escapedContent, values } ) => {
   } catch ( error ) {
     throw new FatalError( `Prompt "${name}" could not be rendered: ${error.message}`, { cause: error } );
   }
+};
+
+const deprecatedProviderAliases = {
+  vertex: 'google-vertex',
+  bedrock: 'amazon-bedrock'
 };
 
 /**
@@ -46,6 +51,12 @@ export const loadPrompt = ( name, values = {}, dir ) => {
     messages: messages.map( m => ( { ...m, content: decode( m.content ) } ) ),
     instructions: instructions === null ? null : decode( instructions )
   };
+
+  const provider = prompt.config.provider;
+  if ( deprecatedProviderAliases[provider] ) {
+    Logger.warn( `Using deprecated provider alias "${provider}". Use "${deprecatedProviderAliases[provider]}" instead.`, { namespace: 'LLM' } );
+    prompt.config.provider = deprecatedProviderAliases[provider];
+  }
 
   validatePrompt( prompt );
 

--- a/sdk/llm/src/prompt/loader.js
+++ b/sdk/llm/src/prompt/loader.js
@@ -49,9 +49,10 @@ export const loadPrompt = ( name, values = {}, dir ) => {
   };
 
   const provider = prompt.config.provider;
-  if ( deprecatedProviderAliases[provider] ) {
-    Logger.warn( `Using deprecated provider alias "${provider}". Use "${deprecatedProviderAliases[provider]}" instead.`, { namespace: 'LLM' } );
-    prompt.config.provider = deprecatedProviderAliases[provider];
+  if ( Object.hasOwn( deprecatedProviderAliases, provider ) ) {
+    const canonical = deprecatedProviderAliases[provider];
+    Logger.warn( `Using deprecated provider alias "${provider}". Use "${canonical}" instead.`, { namespace: 'LLM' } );
+    prompt.config.provider = canonical;
   }
 
   validatePrompt( prompt );

--- a/sdk/llm/src/prompt/loader.spec.js
+++ b/sdk/llm/src/prompt/loader.spec.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Logger } from '@outputai/core';
 import { loadPrompt } from './loader.js';
 
 vi.mock( './parser.js', () => ( {
@@ -261,6 +262,91 @@ model: gpt-4
         }
       }
     } );
+  } );
+
+  it.each( [
+    [ 'vertex', 'google-vertex' ],
+    [ 'bedrock', 'amazon-bedrock' ]
+  ] )( 'rewrites deprecated provider alias %s to %s and warns', ( alias, canonical ) => {
+    const warn = vi.spyOn( Logger, 'warn' ).mockImplementation( () => {} );
+    loadContent.mockReturnValue( {
+      content: '<user>Hello</user>',
+      dir: '/mock/dir'
+    } );
+    parsePrompt.mockReturnValue( {
+      config: {
+        provider: alias,
+        model: 'test-model'
+      },
+      messages: [ { role: 'user', content: 'Hello' } ],
+      instructions: null
+    } );
+
+    const result = loadPrompt( 'test' );
+
+    expect( result.config.provider ).toBe( canonical );
+    expect( validatePrompt ).toHaveBeenCalledWith( expect.objectContaining( {
+      config: expect.objectContaining( { provider: canonical } )
+    } ) );
+    expect( warn ).toHaveBeenCalledWith(
+      `Using deprecated provider alias "${alias}". Use "${canonical}" instead.`,
+      { namespace: 'LLM' }
+    );
+  } );
+
+  it( 'rewrites provider aliases after config decode', () => {
+    const warn = vi.spyOn( Logger, 'warn' ).mockImplementation( () => {} );
+    const encodedConfig = {
+      provider: 'vertex',
+      model: 'gemini-2.5-flash-lite'
+    };
+    loadContent.mockReturnValue( {
+      content: '<user>Hello</user>',
+      dir: '/mock/dir'
+    } );
+    parsePrompt.mockReturnValue( {
+      config: encodedConfig,
+      messages: [ { role: 'user', content: 'Hello' } ],
+      instructions: null
+    } );
+    decode.mockImplementation( value => {
+      if ( value === encodedConfig ) {
+        return {
+          provider: 'bedrock',
+          model: 'gemini-2.5-flash-lite'
+        };
+      }
+      return value;
+    } );
+
+    const result = loadPrompt( 'test' );
+
+    expect( result.config.provider ).toBe( 'amazon-bedrock' );
+    expect( warn ).toHaveBeenCalledWith(
+      'Using deprecated provider alias "bedrock". Use "amazon-bedrock" instead.',
+      { namespace: 'LLM' }
+    );
+  } );
+
+  it( 'leaves canonical provider names unchanged', () => {
+    const warn = vi.spyOn( Logger, 'warn' ).mockImplementation( () => {} );
+    loadContent.mockReturnValue( {
+      content: '<user>Hello</user>',
+      dir: '/mock/dir'
+    } );
+    parsePrompt.mockReturnValue( {
+      config: {
+        provider: 'google-vertex',
+        model: 'gemini-2.5-flash-lite'
+      },
+      messages: [ { role: 'user', content: 'Hello' } ],
+      instructions: null
+    } );
+
+    const result = loadPrompt( 'test' );
+
+    expect( result.config.provider ).toBe( 'google-vertex' );
+    expect( warn ).not.toHaveBeenCalled();
   } );
 
   it( 'throws error when prompt file not found', () => {

--- a/sdk/llm/src/prompt/loader.spec.js
+++ b/sdk/llm/src/prompt/loader.spec.js
@@ -294,34 +294,35 @@ model: gpt-4
     );
   } );
 
-  it( 'rewrites provider aliases after config decode', () => {
+  it( 'rewrites provider aliases on the decoded config', () => {
     const warn = vi.spyOn( Logger, 'warn' ).mockImplementation( () => {} );
-    const encodedConfig = {
-      provider: 'vertex',
-      model: 'gemini-2.5-flash-lite'
+    const parsedConfig = {
+      provider: 'bedrock',
+      model: 'test-model'
+    };
+    const decodedConfig = {
+      provider: 'bedrock',
+      model: 'test-model'
     };
     loadContent.mockReturnValue( {
       content: '<user>Hello</user>',
       dir: '/mock/dir'
     } );
     parsePrompt.mockReturnValue( {
-      config: encodedConfig,
+      config: parsedConfig,
       messages: [ { role: 'user', content: 'Hello' } ],
       instructions: null
     } );
-    decode.mockImplementation( value => {
-      if ( value === encodedConfig ) {
-        return {
-          provider: 'bedrock',
-          model: 'gemini-2.5-flash-lite'
-        };
-      }
-      return value;
-    } );
+    decode.mockImplementation( value => ( value === parsedConfig ? decodedConfig : value ) );
 
     const result = loadPrompt( 'test' );
 
+    expect( decode ).toHaveBeenCalledWith( parsedConfig );
+    expect( result.config ).toBe( decodedConfig );
     expect( result.config.provider ).toBe( 'amazon-bedrock' );
+    expect( validatePrompt ).toHaveBeenCalledWith( expect.objectContaining( {
+      config: decodedConfig
+    } ) );
     expect( warn ).toHaveBeenCalledWith(
       'Using deprecated provider alias "bedrock". Use "amazon-bedrock" instead.',
       { namespace: 'LLM' }

--- a/sdk/llm/src/utils/response_wrappers.js
+++ b/sdk/llm/src/utils/response_wrappers.js
@@ -12,14 +12,15 @@ import { calculateBase64FileSize } from './image.js';
  *
  * @param {object} args
  * @param {string} args.traceId - id created by the startTrace
+ * @param {string} args.providerId - id of the provider used
  * @param {string} args.modelId - id of the model used
  * @param {object} args.response - AI SDK's text response
  * @returns {object} Proxied response
  */
-export const wrapTextResponse = async ( { traceId, modelId, response } ) => {
+export const wrapTextResponse = async ( { traceId, providerId, modelId, response } ) => {
   const { totalUsage: usage, providerMetadata, text: result, steps, sources } = response;
 
-  const cost = await calculateLLMCallCost( { usage, modelId } );
+  const cost = await calculateLLMCallCost( { usage, modelId, providerId } );
   const sourcesFromTools = extractSourcesFromSteps( steps );
 
   endTraceWithSuccess( { traceId, usage, cost, result, providerMetadata, sourcesFromTools } );
@@ -48,13 +49,14 @@ export const wrapTextResponse = async ( { traceId, modelId, response } ) => {
  *
  * @param {object} args
  * @param {string} args.traceId - id created by the startTrace
+ * @param {string} args.providerId - id of the provider used
  * @param {string} args.modelId - id of the model used
  * @param {Function} args.onFinish - Original callback to call with the proxied response
  * @returns {object} Proxied response
  */
-export const wrapStreamOnFinishResponse = ( { traceId, modelId, onFinish: _onFinish } ) => ( {
+export const wrapStreamOnFinishResponse = ( { traceId, providerId, modelId, onFinish: _onFinish } ) => ( {
   async onFinish( response ) {
-    const proxiedResponse = await wrapTextResponse( { traceId, modelId, response } );
+    const proxiedResponse = await wrapTextResponse( { traceId, providerId, modelId, response } );
     _onFinish?.( proxiedResponse );
   }
 } );
@@ -68,13 +70,14 @@ export const wrapStreamOnFinishResponse = ( { traceId, modelId, onFinish: _onFin
  *
  * @param {object} args
  * @param {string} args.traceId - id created by the startTrace
+ * @param {string} args.providerId - id of the provider used
  * @param {string} args.modelId - id of the model used
  * @param {object} args.response - AI SDK's image response
  * @returns {object} Proxied response
  */
-export const wrapImageResponse = async ( { traceId, modelId, response } ) => {
+export const wrapImageResponse = async ( { traceId, providerId, modelId, response } ) => {
   const { usage, providerMetadata } = response;
-  const cost = await calculateLLMCallCost( { usage, modelId } );
+  const cost = await calculateLLMCallCost( { usage, providerId, modelId } );
 
   const result = response.images.map( ( { mediaType, base64 } ) => ( {
     size: calculateBase64FileSize( base64 ),

--- a/sdk/llm/src/utils/response_wrappers.spec.js
+++ b/sdk/llm/src/utils/response_wrappers.spec.js
@@ -52,6 +52,7 @@ const makeAiSdkImageResponse = () => generateImage( {
 
 describe( 'wrapTextResponse', () => {
   const traceId = 'trace-1';
+  const providerId = 'openai';
   const modelId = 'test-model';
   const mockCost = { total: 0.001, components: [ { name: 'input_tokens', value: 0.001 } ] };
 
@@ -65,13 +66,14 @@ describe( 'wrapTextResponse', () => {
   it( 'uses a text response fixture to calculate cost, end trace, and attach cost', async () => {
     const response = clone( textResponseFixture );
 
-    const wrapped = await wrapTextResponse( { traceId, modelId, response } );
+    const wrapped = await wrapTextResponse( { traceId, providerId, modelId, response } );
 
     expect( wrapped.result ).toBe( response.text );
     expect( wrapped.cost ).toEqual( mockCost );
     expect( mocks.calculateLLMCallCost ).toHaveBeenCalledWith( {
       usage: response.totalUsage,
-      modelId
+      modelId,
+      providerId
     } );
     expect( mocks.extractSourcesFromSteps ).toHaveBeenCalledWith( response.steps );
     expect( mocks.endTraceWithSuccess ).toHaveBeenCalledWith( {
@@ -92,7 +94,7 @@ describe( 'wrapTextResponse', () => {
     response.sources = nativeSources;
     mocks.extractSourcesFromSteps.mockReturnValue( [] );
 
-    const wrapped = await wrapTextResponse( { traceId, modelId, response } );
+    const wrapped = await wrapTextResponse( { traceId, providerId, modelId, response } );
 
     expect( wrapped.sources ).toBe( nativeSources );
     expect( mocks.combineSources ).not.toHaveBeenCalled();
@@ -119,7 +121,7 @@ describe( 'wrapTextResponse', () => {
     mocks.extractSourcesFromSteps.mockReturnValue( [ toolSource ] );
     mocks.combineSources.mockReturnValue( mergedSources );
 
-    const wrapped = await wrapTextResponse( { traceId, modelId, response } );
+    const wrapped = await wrapTextResponse( { traceId, providerId, modelId, response } );
 
     expect( wrapped.sources ).toBe( mergedSources );
     expect( mocks.combineSources ).toHaveBeenCalledWith( {
@@ -131,6 +133,7 @@ describe( 'wrapTextResponse', () => {
 
 describe( 'wrapStreamOnFinishResponse', () => {
   const traceId = 'stream-trace';
+  const providerId = 'openai';
   const modelId = 'stream-model';
   const mockCost = { total: 0.002, components: [] };
 
@@ -146,6 +149,7 @@ describe( 'wrapStreamOnFinishResponse', () => {
 
     const callbacks = wrapStreamOnFinishResponse( {
       traceId,
+      providerId,
       modelId,
       onFinish: userOnFinish
     } );
@@ -173,6 +177,7 @@ describe( 'wrapStreamOnFinishResponse', () => {
 
     const callbacks = wrapStreamOnFinishResponse( {
       traceId,
+      providerId,
       modelId
     } );
 
@@ -188,13 +193,15 @@ describe( 'wrapStreamOnFinishResponse', () => {
     } );
     expect( mocks.calculateLLMCallCost ).toHaveBeenCalledWith( {
       usage: response.totalUsage,
-      modelId
+      modelId,
+      providerId
     } );
   } );
 } );
 
 describe( 'wrapImageResponse', () => {
   const traceId = 'image-trace';
+  const providerId = 'openai';
   const modelId = 'image-model';
   const mockCost = { total: 0.003, components: [] };
 
@@ -207,13 +214,14 @@ describe( 'wrapImageResponse', () => {
   it( 'uses an image response fixture to trace image metadata and attach cost', async () => {
     const response = await makeAiSdkImageResponse();
 
-    const wrapped = await wrapImageResponse( { traceId, modelId, response } );
+    const wrapped = await wrapImageResponse( { traceId, providerId, modelId, response } );
 
     expect( wrapped.result ).toBe( response.images[0] );
     expect( wrapped.cost ).toEqual( mockCost );
     expect( mocks.calculateLLMCallCost ).toHaveBeenCalledWith( {
       usage: response.usage,
-      modelId
+      modelId,
+      providerId
     } );
     expect( mocks.calculateBase64FileSize ).toHaveBeenCalledWith( response.images[0].base64 );
     expect( mocks.endTraceWithSuccess ).toHaveBeenCalledWith( {


### PR DESCRIPTION
## Summary

- Fixed scenario that caused model price calculation to the same model from a different provider, resulting in divergent values.
- Added support to `google-vertex` in place of `vertex` and `amazon-bedrock` in place of `bedrock` as provider names for prompt files. Old names are kept, but they are deprecated.

