### PR TITLE
fix(docs): v0.11 Release docs

### DIFF
--- a/.changeset/quick-bat-fly.md
+++ b/.changeset/quick-bat-fly.md
@@ -2,4 +2,4 @@
 "output-api": patch
 ---
 
-Upgraded Temporal (`temporalio/*`) libs from v1.17.0 to v.1.20.3
+Upgraded Temporal (`temporalio/*`) libs from v1.17.0 to v1.20.3

--- a/.changeset/shy-foxes-try.md
+++ b/.changeset/shy-foxes-try.md
@@ -3,4 +3,4 @@
 ---
 
 - Upgraded Temporal (`temporalio/*`) libs from v1.17.0 to v1.20.3
-- Upgraded `undici` from v.8.5.0 to v8.9.0
+- Upgraded `undici` from v8.5.0 to v8.9.0

--- a/docs/guides/changelog/index.mdx
+++ b/docs/guides/changelog/index.mdx
@@ -9,11 +9,11 @@ Releases with breaking changes link to a matching section on the [Migrations](/m
 
 {/* AUTO-GENERATED:START — do not edit by hand. Run ./ops/regenerate_docs.sh */}
 
-<Update label="v0.10.0" description="2026-07-09 · minor release">
+<Update label="v0.10.0" description="2026-07-09 - minor release">
 
-See the [v0.9.0 → v0.10.0 migration guide](/migrations/v0.9.0-to-v0.10.0).
+See the [v0.9.0 - v0.10.0 migration guide](/migrations/v0.9.0-to-v0.10.0).
 
-**`output-api`** —
+**`output-api`**
 
 Workflow result endpoints no longer include unavailable trace destinations instead of returning them as `null`.
 This affects:
@@ -43,11 +43,11 @@ _After:_
 }
 ```
 
-**`@outputai/cli`, `output-api`** —
+**`@outputai/cli`, `output-api`**
 
 Add API endpoint and CLI command to get input from a workflow run
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 The JSON output for workflow result commands no longer includes unavailable trace destinations as `null`.
 This affects:
@@ -75,15 +75,16 @@ _After:_
 }
 ```
 
-**`@outputai/llm`** —
+**`@outputai/llm`**
 
 Refactored Anthropic's error `"Grammar compilation timed out."` handling not to throw `FatalError` as this is transient and `FatalError`s terminate the workflow execution without retries.
 
 It seems that the Anthropic API throws this error (HTTP status code 400) when grammar compilation times out for a structured output schema, but after some investigation it was assessed that this error is indeed transient.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 **Trace Changes**
+
 - Internal Activity `getTraceDestinations` is no longer invoked when workflow has `disableTrace: true` configuration.
 - Workflow trace destinations now omit unavailable destinations instead of returning them as `null`:
   _Before:_
@@ -110,6 +111,7 @@ It seems that the Anthropic API throws this error (HTTP status code 400) when gr
 - Internal activities like `getTraceDestinations` and `sendHttpRequest` are no longer omitted in the trace files.
 
 **HTTP helper header changes**
+
 - Both `sendHttpRequest` and `sendPostRequestAndAwaitWebhook` can now interpolate environment variable values in header values:
   ```js
   sendHttpRequest( {
@@ -121,8 +123,8 @@ It seems that the Anthropic API throws this error (HTTP status code 400) when gr
   ```
   When executing this request, `$TOKEN` will be replaced by the value of `process.env.TOKEN`.
 
-
 **sendHttpRequest output changes**
+
 - The response of `sendHttpRequest` no longer includes body or headers by default. Use the `responseOptions` argument to configure this:
   ```js
   sendHttpRequest( {
@@ -135,62 +137,62 @@ It seems that the Anthropic API throws this error (HTTP status code 400) when gr
   ```
 - Response headers included via `responseOptions.includeHeaders` are redacted by header name. This covers common sensitive header names such as authorization, token, secret, password, cookie, and key, but it is a best-effort heuristic.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Removing support for non-wrapped activity results and legacy child workflow executions (pre v0.8.0). Workflow executions from those versions can no longer be replayed.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Add support to Temporal worker tuner options. This can be set using a new environment variable `TEMPORAL_WORKER_TUNER` that accepts a JSON value.
 
 </Update>
 
-<Update label="v0.9.2" description="2026-07-03 · patch release">
+<Update label="v0.9.2" description="2026-07-03 - patch release">
 
-**`@outputai/credentials`, `@outputai/output`, `@outputai/evals`, `@outputai/core`, `@outputai/http`, `@outputai/cli`, `@outputai/llm`, `output-api`** —
+**`@outputai/credentials`, `@outputai/output`, `@outputai/evals`, `@outputai/core`, `@outputai/http`, `@outputai/cli`, `@outputai/llm`, `output-api`**
 
 Pinning v24.15.0 as the minimal supported Node version
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Improving catalog startup performance by storing and reading hash from memo. Storing workflow names in memo.
 
-**`output-api`** —
+**`output-api`**
 
 Improving start/run workflows performance by not querying an workflow to validate `workflowName` argument.
 
 </Update>
 
-<Update label="v0.9.1" description="2026-07-01 · patch release">
+<Update label="v0.9.1" description="2026-07-01 - patch release">
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Add `output workflow history <workflowId>` — renders a run's step timeline as a terminal waterfall (each step's start offset and duration), mirroring the Agents HQ Timeline view. It pages the `GET /workflow/{id}/history` endpoint and correlates the Temporal events into per-step spans (numbering parallel fan-outs `#1..#N`). `--format json` emits the structured spans, `--raw` prints the endpoint's verbatim response, and `--run-id`, `--include-payloads`, `--width`, and `--no-color` are supported. Failed steps list their error reason beneath the chart (when payloads are included), and `FORCE_COLOR` forces ANSI output through a pipe.
 
 The same waterfall is available in the `output dev` TUI: from the Recent Runs tab, press `g` on any run to open its step graph as a full-width overlay. The overlay shows the run's status, start time, and duration, and live-updates while the run is in progress (the time axis tracks elapsed wall-clock and running bars grow). Select a step with `↑/↓` to inspect its input, output, and timing (start/end/duration) in the detail pane; `←/→` switches tabs and `e` expands a field full-screen.
 
-**`@outputai/http`** —
+**`@outputai/http`**
 
 - Added a custom dispatcher that disables HTTP/2 (`allowH2: false`) on fetch, it uses `EnvHttpProxyAgent`;
 - Added support for dispatcher in the init argument of fetch; it has precedence over the custom dispatcher.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 - Disabled HTTP/2 (`allowH2: false`) in the global fetch dispatcher configured by `setGlobalDispatcher` when proxy env vars are detected;
 - Disabled HTTP/2 (`allowH2: false`) in the webhook functions `sendHttpRequest` and `sendPostRequestAndAwaitWebhook` by using a dispatcher (`EnvHttpProxyAgent`).
 
-**`@outputai/llm`** —
+**`@outputai/llm`**
 
 - Disabled HTTP/2 (`allowH2: false`) in the dispatcher of the fetch client used when consuming the AI SDK and fetching model pricing;
 - Replaced the `Agent` dispatcher in favor of `EnvHttpProxyAgent` to respect the proxy env vars. [OUT-506].
 
 </Update>
 
-<Update label="v0.9.0" description="2026-06-26 · minor release">
+<Update label="v0.9.0" description="2026-06-26 - minor release">
 
-See the [v0.8.0 → v0.9.0 migration guide](/migrations/v0.8.0-to-v0.9.0).
+See the [v0.8.0 - v0.9.0 migration guide](/migrations/v0.8.0-to-v0.9.0).
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Added activity lifecycle hooks: `onActivityStart`, `onActivityEnd`, `onActivityError`.
 
@@ -206,11 +208,11 @@ Payload:
 }
 ```
 
-**`@outputai/cli`, `@outputai/llm`, `output-api`, `@outputai/core`, `@outputai/http`** —
+**`@outputai/cli`, `@outputai/llm`, `output-api`, `@outputai/core`, `@outputai/http`**
 
 Updating libraries to fix vulnerabilities
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Replace the custom `--format json` option with oclif's built-in `--json` flag across all workflow commands (OUT-419).
 
@@ -223,19 +225,19 @@ Replace the custom `--format json` option with oclif's built-in `--json` flag ac
 
 The "update available" banner no longer prints to stdout: it now goes to stderr (keeping stdout clean for piping in every mode) and is suppressed entirely under `--json`.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 CLI `start`/`run`/`test`/`dataset generate` now resolve scenarios and route execution against `--catalog`/`OUTPUT_CATALOG_ID` instead of the API server's default catalog. This removes the ~30s scenario-resolution stall in worktrees where the default catalog has no worker polling it. `workflow test` and `workflow dataset generate` also gain a `--catalog` flag (env: `OUTPUT_CATALOG_ID`), matching `list`/`start`/`run`.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Add an "Enter input" option to the `output dev` run pane. Edit a payload and press ctrl+r to run it as-is without saving, or ctrl+s to save it as a scenario first. Previously every ad-hoc run forced you to name and save a scenario file.
 
-**`@outputai/cli`, `output-api`** —
+**`@outputai/cli`, `output-api`**
 
 Add new endpoint for workflow history with server side events
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Added a new `Logger` export for structured logging from both workflows and steps. Logs use the same `message` plus `metadata` shape as the internal worker logger and are routed through the worker's Winston logger.
 
@@ -260,53 +262,53 @@ Supported levels are:
 
 The default displayed level is debug in development and info in production. Override it with `OUTPUT_LOG_LEVEL` env var. This setting also affects internal worker logs.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Including /dist when calculating catalog hash to define if catalog workflow needs restart. Excluding /temp.
 
 </Update>
 
-<Update label="v0.8.1" description="2026-06-22 · patch release">
+<Update label="v0.8.1" description="2026-06-22 - patch release">
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 - Updating connection monitor strategy to ping workflowService instead of healthService.
 - Adding new env vars to configure Temporal worker shutdownForceTime and shutdownGraceTime:
   - TEMPORAL_SHUTDOWN_FORCE_TIME
   - TEMPORAL_SHUTDOWN_GRACE_TIME
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Resolve datasets and evals for nested workflow folders by the workflow's registered name (via the worker catalog), keeping the flat-path lookup as an offline fast path. `output workflow test`, `dataset generate`, and `dataset list` now work for workflows in nested directories (e.g. `src/workflows/a/b/c` registered as `a_b_c`) without a symlink. `output workflow test` also fails fast with an actionable message when a `<wf>_eval` workflow's source exists but didn't compile to `dist`.
 
-**`output-api`** —
+**`output-api`**
 
 Updating connection monitor strategy to ping workflowService instead of healthService.
 
 </Update>
 
-<Update label="v0.8.0" description="2026-06-22 · minor release">
+<Update label="v0.8.0" description="2026-06-22 - minor release">
 
-See the [v0.7.0 → v0.8.0 migration guide](/migrations/v0.7.0-to-v0.8.0).
+See the [v0.7.0 - v0.8.0 migration guide](/migrations/v0.7.0-to-v0.8.0).
 
-**`output-api`** —
+**`output-api`**
 
 `getWorkflowResult` now fetches only the first history event (`WorkflowExecutionStarted`) to extract the workflow input, instead of paging through the full event history. Makes input extraction on the result endpoints (`/workflow/:id/result` and `/workflow/:id/runs/:rid/result`) O(1) regardless of history size.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 improve worker startup time by only calculating workflow sources
 
-**`output-api`, `@outputai/cli`** —
+**`output-api`, `@outputai/cli`**
 
 - Updated workflow result API responses to return workflow output and trace metadata without workflow-level `aggregations`.
 - Regenerated CLI API types to match the workflow result response shape.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Faster CLI startup: ship `oclif.manifest.json` in the published package so only the invoked command module is loaded (instead of importing every command on every invocation), move the update check off the critical path (the init hook now only reads the local cache and refreshes it via a detached background process with a 5s registry timeout, instead of awaiting an unbounded `npm view` subprocess), and load `undici` only when a proxy env var is configured.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 `workflow cost` now calculates costs from the trace events themselves (the as-charged "Original" cost) and applies `costs.yml` as an override layer (the "Adjusted" cost), displaying both per model and per host. This fixes models with no `costs.yml` entry (e.g. `gpt-5.5`) and HTTP hosts (e.g. `api.exa.ai`, `api.firecrawl.dev`) previously reporting $0, and surfaces where the configured `costs.yml` rate diverges from what was actually charged. The bottom line shows the adjusted total with the as-charged total alongside.
 
@@ -314,46 +316,46 @@ Costs come exclusively from trace cost attributes: LLM nodes with an `llm:usage`
 
 **`--format json` field changes** (the report shape changed; update any scripts parsing it): `llmTotalCost` → `llmOriginalCost`/`llmAdjustedCost`; `services[]`/`serviceTotalCost` → `httpCosts[]` (grouped by `host`) with `httpOriginalCost`/`httpAdjustedCost`; `unknownModels` removed; per-call `cost`/`warning` → `originalCost`/`adjustedCost`; new `originalTotalCost`; `totalCost` is now the adjusted total.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Added Temporal connection monitoring. When connection is lost, graceful shuts down the worker.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Fixed missing eventDate fields on hook types.
 
-**`output-api`** —
+**`output-api`**
 
 Added new `/ready` endpoint to report if API is ready to answer to requests.
 
 Added Temporal connection monitoring. When unhealthy, `/ready` return 503; if lost the API shuts down.
 
-**`output-api`** —
+**`output-api`**
 
 Expose structured workflow failure details (`failure` object with `message`, `type`, `retryable`, and a sanitized `cause` chain) in `/workflow/run` and `/workflow/:id/result` responses, alongside the existing `error` string. Also log Temporal/gRPC client errors with full nested context (cause chain, gRPC `code`/`details`, redacted metadata keys, `workflowId`/`runId`/`taskQueue`/query) while keeping client-facing HTTP responses sanitized.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Surface workflow aliases and honor `OUTPUT_CATALOG_ID` in `output workflow list`.
 
 - The default list output now appends `(aliases: ...)` to workflows that have registered aliases, which previously only appeared in `--format table`/`--format json` (OUT-444).
 - Add a `--catalog` flag (env `OUTPUT_CATALOG_ID`) that resolves workflows from a specific catalog, falling back to the server-default catalog — matching the existing behavior of `run` and `start` (OUT-489).
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Add an opt-in `output-worker --check` workflow bundle check that reproduces the worker's webpack bundling without a Temporal server, catching bad workflow imports — e.g. a transitive `node:` built-in — before they crash-loop the worker at startup. `tsc` cannot detect these; only the Temporal bundle can.
 
 - `output-worker --check` bundles workflows via the same `bundleWorkflowCode` path `Worker.create` uses, exits non-zero with the offending module named, and needs no Temporal connection or worker env.
 - Scaffolded projects gain an opt-in `output:worker:check` script plus README/CI guidance (not wired into any build).
 
-**`@outputai/llm`** —
+**`@outputai/llm`**
 
 Route `<system>` blocks to the AI SDK `system` option instead of leaving them in the `messages` array.
 
 - `loadAiSdkTextOptions` now splits resolved messages: system blocks go to the top-level `system` option (as `SystemModelMessage[]`, so per-message `cacheControl`/`providerOptions` are preserved); only user/assistant/tool messages stay in `messages`. `Agent` consumes the split `system` directly as its `instructions`.
 - Silences the AI SDK warning that system messages in `messages` are a prompt-injection risk; `generateText`/`streamText`/`Agent` also set `allowSystemInMessages: true` as defense-in-depth for caller-supplied message histories.
 
-**`@outputai/llm`** —
+**`@outputai/llm`**
 
 Add per-message provider options to `.prompt` files via `messageOptions`.
 
@@ -361,7 +363,7 @@ Add per-message provider options to `.prompt` files via `messageOptions`.
 - Enables Anthropic prompt caching (`{ anthropic: { cacheControl: { type: ephemeral } } }`) and any other per-message provider option, on any provider.
 - Cost tracking now reports cached input tokens (`input_cached`) even for models whose pricing record lacks a `cache_read` rate, so cache savings are visible in usage aggregations instead of silently disappearing.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 - Removed workflow-level usage aggregation from `@outputai/core`; workflows no longer collect activity attributes into final `aggregations` totals or expose those totals in workflow run results.
 - Reworked workflow-to-workflow invocation so direct workflow calls made from workflow code now consistently execute as Temporal child workflows, including calls made through helper functions outside the parent workflow handler.
@@ -371,7 +373,7 @@ Add per-message provider options to `.prompt` files via `messageOptions`.
 - Refactored workflow validation internals around centralized schemas and explicit validator classes for workflows, steps, and evaluators.
 - Hardened Zod schema detection for multi-package or multi-realm Zod v4 environments.
 
-**`output-api`** —
+**`output-api`**
 
 The `continued` workflow status was renamed to `continued_as_new` in API responses.
 
@@ -401,13 +403,14 @@ In the CLI, the old value is still supported.
 
 </Update>
 
-<Update label="v0.7.0" description="2026-06-10 · minor release">
+<Update label="v0.7.0" description="2026-06-10 - minor release">
 
-See the [v0.6.0 → v0.7.0 migration guide](/migrations/v0.6.0-to-v0.7.0).
+See the [v0.6.0 - v0.7.0 migration guide](/migrations/v0.6.0-to-v0.7.0).
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 **Workflow hooks**
+
 Updated `onWorkflowStart()`, `onWorkflowEnd()`, `onWorkflowError()` hooks payload:
 
 ```js
@@ -440,15 +443,18 @@ Where `workflowDetails` is an abstraction over [Temporal's `workflowInfo()`](htt
 ```
 
 **Error hook**
+
 Updated `onError()` hooks payload. The fields change according to the `source`:
 
 **Source is "workflow"**
+
 ```js
 { eventId, eventDate, source, workflowDetails, error }
 ```
 Where `workflowDetails` is the same as in workflow hooks.
 
 **Source is "activity"**
+
 ```js
 { eventId, eventDate, source, workflowDetails, activityInfo, outputActivityKind, error }
 ```
@@ -458,14 +464,17 @@ Where `activityInfo` is Temporal's `activityInfo()` [function return](https://ty
 And `outputActivityKind` is the framework flavor of the Temporal Activity: `step`, `evaluator` or `internal_step`.
 
 **Source is "runtime"**
+
 ```js
 { eventId, eventDate, source, error }
 ```
 
 **"on()" hook**
+
 Updated `on()` hooks with better typing and a new envelope.
 
 **Envelope**
+
 All events have these fields:
 - `eventId`
 - `eventDate`
@@ -474,21 +483,24 @@ All events have these fields:
 - `outputActivityKind`
 
 **Typing**
+
 Besides the envelope fields, each event also has its own fields, their types are specified by the event emitter:
 - `on<HttpRequestEvent>( 'http:request', handler )` from `@outputai/http`;
 - `on<HttpRequestCostEvent>( 'cost:http:request', handler )` from `@outputai/http`;
 - `on<LLMUsageEvent>( 'cost:llm:request', handler )` from `@outputai/llm`
 
 **Execution Context**
+
 Updated `getExecutionContext()` from `core/sdk_activity_integration` to return:
 ```js
 { activityInfo, workflowFilename }
 ```
 
 **Trace File**
+
 Updated trace workflow node ids to use Temporal `runId`, instead of `workflowId`. This helps to create trees when child workflows "continued as new".
 
-**`@outputai/llm`** —
+**`@outputai/llm`**
 
 - Added the `generateImage()` function for image generation, including image model loading, image prompt options, and wrapped image responses;
 - Improved public TS types by deriving AI SDK options and results from the upstream `ai` package;
@@ -496,17 +508,19 @@ Updated trace workflow node ids to use Temporal `runId`, instead of `workflowId`
 - Added validation for prompt skills, text generation arguments, and image prompt options;
 - Updated `streamText()` to support prompt skills and tools consistently with `generateText()`.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Added worker telemetry logs: print Temporal worker status and node memory every X ms, configured by `OUTPUT_WORKER_TELEMETRY_INTERVAL_MS` env var. Default `0` - off.
 
 Message examples:
 **Dev**
+
 ```
 [info] Telemetry: Worker { status: { runState: "RUNNING", numHeartbeatingActivities: 0, workflowPollerState: "POLLING", activityPollerState: "POLLING", hasOutstandingWorkflowPoll: true, hasOutstandingActivityPoll: true, numCachedWorkflows: 1, numInFlightWorkflowActivations: 0, numInFlightActivities: 0, numInFlightNonLocalActivities: 0, numInFlightLocalActivities: 0 }, memory: { availableMemory: 7500000000, constrainedMemory: 20000000000000000000, memoryUsage: { rss: 582348800, heapTotal: 400000000, heapUsed: 200000000, external: 800000000, arrayBuffers: 300000000 } } }
 ```
 
 **Prod**
+
 ```json
 {
   "environment": "production",
@@ -542,7 +556,7 @@ Message examples:
 }
 ```
 
-**`@outputai/llm`** —
+**`@outputai/llm`**
 
 - Added runtime image inputs to `generateImage()`, including image-to-image generation and optional masks for image editing;
 - Added validation and TypeScript types for `generateImage()` `images` and `mask` arguments;
@@ -558,11 +572,11 @@ Message examples:
   - NoSuchProviderError
   - UnsupportedFunctionalityError
 
-**`output-api`, `@outputai/llm`** —
+**`output-api`, `@outputai/llm`**
 
 Fixing vulnerabilities by updating `qs` and `liquidjs` dependencies.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Improve trace error serialization to preserve nested error causes. Error entries in trace files now include the error `name`, `message`, `stack`, and recursively serialized `cause` values up to 10 levels deep, including JSON-safe non-Error causes where present.
 
@@ -582,7 +596,7 @@ Improve trace error serialization to preserve nested error causes. Error entries
 }
 ```
 
-**`@outputai/http`, `@outputai/llm`** —
+**`@outputai/http`, `@outputai/llm`**
 
 Exported event payload types for hook consumers.
 
@@ -591,7 +605,7 @@ Exported event payload types for hook consumers.
 
 Use these with `@outputai/core/hooks` as `on<HttpRequestEvent>( 'http:request', handler )`, so applications can type event-specific fields without redefining the payload shapes locally.
 
-**`@outputai/llm`** —
+**`@outputai/llm`**
 
 Recreate AI SDK `NoObjectGeneratedError` schema validation failures as new `NoObjectGeneratedError` instances with a clearer message:
 
@@ -599,11 +613,11 @@ Recreate AI SDK `NoObjectGeneratedError` schema validation failures as new `NoOb
 No object generated: response did not match schema. First issue is "Invalid input: expected string, received number" at path [name].
 ```
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 `credentials set` and `credentials edit` now check whether the current key can decrypt the existing credentials file before re-encrypting. On a key mismatch they abort with a clear warning that the wrong key may be in use and the file would be re-encrypted under a different key. Pass `--force` / `-f` to proceed anyway (re-encrypts from empty, discarding the undecryptable values).
 
-**`@outputai/llm`** —
+**`@outputai/llm`**
 
 - Updated `@ai-sdk/*` providers and `ai` itself to peer dependencies, with these supported ranges:
   - `ai`: `>=6 <7`
@@ -619,23 +633,23 @@ No object generated: response did not match schema. First issue is "Invalid inpu
 
 </Update>
 
-<Update label="v0.6.0" description="2026-05-29 · minor release">
+<Update label="v0.6.0" description="2026-05-29 - minor release">
 
-See the [v0.5.2 → v0.6.0 migration guide](/migrations/v0.5.2-to-v0.6.0).
+See the [v0.5.2 - v0.6.0 migration guide](/migrations/v0.5.2-to-v0.6.0).
 
-**`output-api`** —
+**`output-api`**
 
 Removed `.attributes` field from workflow results (both `/run` and `/results` endpoints)
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Rewriting the catalog workflow startup logic to better handle multiple instances of the worker and avoiding restarting the workflow unnecessarily.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Removed "Attributes" tab from Recent Runs > [Workflow view].
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 - Removed property `.attributes` from workflow result wrapper object: Workflows will no longer accumulate or expose attributes;
 - Added `__output_workflow_wrapper_version=1` field on workflow wrapper object to better version it;
@@ -667,25 +681,25 @@ Removed "Attributes" tab from Recent Runs > [Workflow view].
 
 </Update>
 
-<Update label="v0.5.2" description="2026-05-27 · patch release">
+<Update label="v0.5.2" description="2026-05-27 - patch release">
 
-**`@outputai/http`** —
+**`@outputai/http`**
 
 Propagate the per-request id across `Response.clone()` so cost emission works from inside ky `afterResponse` hooks. ky clones the response before invoking the hook, which stripped the symbol property `addRequestCost` reads to correlate the request — every hook calling `addRequestCost(response, value)` silently dropped its cost. Patches `clone()` on the original response so each clone re-runs `addRequestIdToResponse`, propagating the tag through any depth of clones. Header-based fallback isn't viable — undici responses are immutable on the received side.
 
 Also tightens the `addRequestIdToResponse` signature to `: void` (was `: Response`). The function mutates in place; the return-the-input pattern was misleading. The one external call site already discarded the return, so no consumer code needs to change.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Every payload emitted through the framework's `messageBus` now carries a UUID v4 `eventId` and millisecond epoch `eventDate` — stamped at the bus layer, so events emitted via `emitEvent` *and* lifecycle hook payloads (`onWorkflowStart`, `onWorkflowEnd`, `onWorkflowError`, `onError`) both receive them. Consumers can rely on `eventId` as a stable per-emit idempotency key — e.g., for webhook retry handling, ClickHouse `ReplacingMergeTree` dedup, audit logs. The previously emitted `requestId` is not safe for this purpose because `cost:http:request` and `http:request` for the same fetch share a `requestId`.
 
 Callers may pre-set `eventId` or `eventDate` on the payload to override the generated values (intended for deterministic retry scenarios). Additive — existing consumers ignoring these fields continue to work.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Bump default local Temporal namespace retention from 24h to 720h (30 days) so workflow runs aren't garbage-collected within a day during local development.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Support multiple `npx output dev` stacks side-by-side:
 
@@ -693,35 +707,35 @@ Support multiple `npx output dev` stacks side-by-side:
 - Document the multi-stack recipe (`DOCKER_SERVICE_NAME`, `OUTPUT_CATALOG_ID`, and the three `OUTPUT_*_HOST_PORT` knobs) in `cli.mdx`.
 - Surface an actionable hint when docker compose fails to bind a host port, naming the conflicting port and the env var that overrides it.
 
-**`@outputai/core`, `@outputai/cli`** —
+**`@outputai/core`, `@outputai/cli`**
 
 Attribute signal emission is now opt-in via `OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION=true`. Each LLM call and HTTP request previously fired a Temporal signal back to the workflow, bloating workflow history on runs with many calls. With emission off (the new default), workflow results still expose `attributes` and `aggregations` keys but they are empty/zeroed, and the `cost:llm:request` / `cost:http:request` hooks do not fire. Set the env var on the worker process to opt back in.
 
 The CLI's dev docker-compose forwards the flag from the host shell, so `OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION=true output dev` opts in without editing compose.
 
-**`output-api`** —
+**`output-api`**
 
 Raise gRPC's default 4 MiB message-size cap on the API server's Temporal connection so workflow result envelopes larger than 4 MiB no longer fail with `RESOURCE_EXHAUSTED`. Configurable via the new `TEMPORAL_GRPC_MAX_MESSAGE_SIZE_BYTES` env var (default 32 MiB).
 
 </Update>
 
-<Update label="v0.5.1" description="2026-05-22 · patch release">
+<Update label="v0.5.1" description="2026-05-22 - patch release">
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Fix worker activity Temporal client to use the configured namespace when signaling workflows. This resolves unauthorized signal errors in Temporal Cloud production namespaces.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Improve reliability of workflow usage and cost metadata collection. Transient Temporal signal failures while recording activity attributes are now handled gracefully, reducing the chance of worker interruptions during workflow runs.
 
 </Update>
 
-<Update label="v0.5.0" description="2026-05-20 · minor release">
+<Update label="v0.5.0" description="2026-05-20 - minor release">
 
-See the [v0.4.0 → v0.5.0 migration guide](/migrations/v0.4.0-to-v0.5.0).
+See the [v0.4.0 - v0.5.0 migration guide](/migrations/v0.4.0-to-v0.5.0).
 
-**`@outputai/core`, `@outputai/http`, `@outputai/llm`, `output-api`** —
+**`@outputai/core`, `@outputai/http`, `@outputai/llm`, `output-api`**
 
 Workflow runs now return durable usage and cost metadata alongside the workflow output. Each completed or failed run can include raw `attributes` plus convenient `aggregations` for total cost, token usage, and HTTP request counts.
 
@@ -745,7 +759,7 @@ Cost events now emit the same attribute-shaped payloads used in workflow results
 
 Learn more in the [workflow result docs](/api), [CLI result format](/packages/cli#workflow-result-json-format), and [cost events guide](/costs/cost-events).
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Improved the dev TUI experience with clearer workflow run views, expanded full-screen modals, and more consistent layout and interaction patterns across screens.
 
@@ -753,7 +767,7 @@ Workflow run details now show result attributes and aggregations alongside input
 
 For scaffolded projects running `output dev`, the local Docker Compose API service now uses the documented `OUTPUT_AWS_*` variables for remote S3 trace access. If you use remote trace storage locally, set `OUTPUT_AWS_REGION`, `OUTPUT_AWS_ACCESS_KEY_ID`, and `OUTPUT_AWS_SECRET_ACCESS_KEY` in your project environment; the accidental `AWS_*` passthrough is no longer used.
 
-**`@outputai/http`** —
+**`@outputai/http`**
 
 Emit a new `http:request` event on every HTTP call made via `@outputai/http`'s `fetch`. The event fires on success, non-2xx responses, and network failures, with payload:
 
@@ -770,58 +784,58 @@ Emit a new `http:request` event on every HTTP call made via `@outputai/http`'s `
 
 Subscribers (`on('http:request', handler)`) also receive `workflowId`, `runId`, and `activityId` auto-attached by `emitEvent`. The existing `cost:http:request` event is unchanged — it continues to fire only when a consumer attaches a cost via `addRequestCost()`. Additive — no existing consumer breaks.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Stream trace JSON when writing local files and uploading to S3, avoiding Node.js string length limits for large trace outputs.
 
-**`@outputai/llm`** —
+**`@outputai/llm`**
 
 Increase built-in LLM provider fetch timeouts for long-running responses.
 
 Default AI SDK `maxRetries` to 0 so workflow retries are handled by Temporal.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Added `runId` to the workflow context and the workflow-lifecycle hook payloads. `context.info.runId` exposes the Temporal run id for the current execution attempt; `onWorkflowStart`, `onWorkflowEnd`, and `onWorkflowError` payloads now include `runId` alongside `id` (workflow id). `executionContext` also carries `runId`, so any consumer subscribed via `on(...)` to an `emitEvent`-emitted event (e.g., `cost:llm:request`) receives `runId` automatically. Additive — existing consumers ignoring the field continue to work.
 
 </Update>
 
-<Update label="v0.4.0" description="2026-05-12 · minor release">
+<Update label="v0.4.0" description="2026-05-12 - minor release">
 
-See the [v0.3.0 → v0.4.0 migration guide](/migrations/v0.3.0-to-v0.4.0).
+See the [v0.3.0 - v0.4.0 migration guide](/migrations/v0.3.0-to-v0.4.0).
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Fixed `output credentials edit` modifying the encrypted credentials file on disk even when the user made no changes in their editor. Because AES-GCM uses a fresh nonce per encryption, the unconditional re-write produced new ciphertext bytes and left the file dirty in git on every invocation. The command now skips the write when the post-editor plaintext is identical to the original.
 
-**`@outputai/llm`** —
+**`@outputai/llm`**
 
 Bump `entities` dependency from v6 to v8. The API surface used (`encodeXML` / `decodeXML`) is unchanged, and v8's ESM-only / Node ≥ 20.19 requirements are already satisfied by this package.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Fixed `output dev` hanging until the health timeout when `docker compose up` exited before creating containers. The CLI now drains and captures recent Compose output, reports early Compose exits immediately, polls status with the same project directory used to start the stack, and only treats running containers as healthy.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 - Fix TypeScript declaration emit for exported workflows that use Zod schemas.
 - Allow TypeScript to generate `.d.ts` files for these workflows without non-portable Zod references.
 - Treat Zod as a peer dependency and avoid leaking schema-specific workflow context types through the invocation config.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 - Bumped scaffold prompt template default from `claude-haiku-4-5` to `claude-sonnet-4-6` and added a dated `current as of` comment pointing at the new `output-dev-model-selection` skill (workflow scaffold, blog_evaluator example, workflow README example).
 - No CLI behavior change beyond the new default model in generated `.prompt` files.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Fixed workflows having the status 'failed' when cancelled via the API/UI. Now they are correctly marked as 'cancelled'.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Fix scenario loading in `output dev` for workflows whose name differs from their local folder path. For example, a workflow named `writing_editor` stored in `src/workflows/writing/editor` now shows and runs its scenarios correctly.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Add support for discovering and running workflows from installed npm packages.
 
@@ -829,27 +843,27 @@ Rename the Output.ai settings property in `package.json` from `output` to `outpu
 
 </Update>
 
-<Update label="v0.3.2" description="2026-05-05 · patch release">
+<Update label="v0.3.2" description="2026-05-05 - patch release">
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Rebuild `output dev` as a full-featured INK TUI. Tabbed UI for Workflows, Recent Runs, Services, and Help with arrow-key navigation, an in-TUI scenario picker and JSON editor for running workflows, an expanded JSON modal for input/output, and a live `docker compose logs` tail with restart hotkeys.
 
 </Update>
 
-<Update label="v0.3.1" description="2026-05-05 · patch release">
+<Update label="v0.3.1" description="2026-05-05 - patch release">
 
-**`@outputai/llm`** —
+**`@outputai/llm`**
 
 Prevent template variables from injecting message blocks into rendered prompts. Variable content containing tag-shaped substrings (e.g. `</user>` or `<system>...</system>`, common when evaluating webpages or chat transcripts) was being tokenized by `parsePrompt` as real message blocks, producing duplicate `system` messages that providers like Anthropic reject. `loadPrompt` now arms every `{{ ... }}` interpolation with an internal escape filter so variable output stays inert at parse time.
 
 </Update>
 
-<Update label="v0.3.0" description="2026-05-05 · minor release">
+<Update label="v0.3.0" description="2026-05-05 - minor release">
 
-See the [v0.2.0 → v0.3.0 migration guide](/migrations/v0.2.0-to-v0.3.0).
+See the [v0.2.0 - v0.3.0 migration guide](/migrations/v0.2.0-to-v0.3.0).
 
-**`@outputai/cli`, `output-api`** —
+**`@outputai/cli`, `output-api`**
 
 Use `catalog` as the public name for the routing/filtering target across the CLI and HTTP API:
 
@@ -859,20 +873,22 @@ Use `catalog` as the public name for the routing/filtering target across the CLI
 
 Internally the value is still a Temporal task queue — only the user-facing name changes.
 
-**`@outputai/core`** —
+**`@outputai/core`**
 
 Optimizing local trace to use less memory and avoid "RangeError: Invalid string length"
 
-**`@outputai/cli`, `@outputai/llm`, `output-api`, `@outputai/core`, `@outputai/credentials`, `@outputai/evals`, `@outputai/output`, `@outputai/http`** —
+**`@outputai/cli`, `@outputai/llm`, `output-api`, `@outputai/core`, `@outputai/credentials`, `@outputai/evals`, `@outputai/output`, `@outputai/http`**
 
 **Dependencies updates**
 
 **Vulnerabilities fixed:**
+
 - uuid: Missing buffer bounds check in v3/v5/v6 when buf: (bump to `>=14.0.0`)
 - postcss: PostCSS has XSS via Unescaped &lt;/style> in its CSS Stringify Output (bump to `>=8.5.10`)
 - @anthropic-ai/sdk: Claude SDK for TypeScript has Insecure Default File Permissions in Local Filesystem Memory Tool (bump to `>=0.91.1`)
 
 **Root package.json updates**
+
 - @changesets/cli: `2.30.0` -> `2.31.0`
 - eslint: `10.2.0` -> `10.2.1`
 - mintlify: `4.2.520` -> `4.2.536`
@@ -880,9 +896,11 @@ Optimizing local trace to use less memory and avoid "RangeError: Invalid string 
 - vitest: `4.1.4` -> `4.1.5`
 
 **pnpm-workspace.yaml (catalog) updates**
+
 - @aws-sdk/client-s3: `3.1031.0` -> `3.1038.0`
 
 **sdk/cli/package.json updates**
+
 - @inquirer/prompts: `8.4.1` -> `8.4.2`
 - @oclif/core: `4.10.5` -> `4.10.6`
 - @oclif/plugin-help: `6.2.44` -> `6.2.45`
@@ -890,30 +908,31 @@ Optimizing local trace to use less memory and avoid "RangeError: Invalid string 
 - orval: `8.8.0` -> `8.9.0`
 
 **sdk/llm/package.json updates**
+
 - @ai-sdk/amazon-bedrock: `4.0.95` -> `4.0.96`
 - liquidjs: `10.25.5` -> `10.25.7`
 
-**`@outputai/http`, `@outputai/llm`** —
+**`@outputai/http`, `@outputai/llm`**
 
 - HTTP: Added a new event `cost:http:request` that is dispatched after calling `addRequestCost()`: the event's payload is `requestId`, `cost` and `url`;
 - LLM: Renamed `llm:call_cost` event to `cost:llm:request`;
 - LLM: Updated the format of the `.cost` property on `.generateText()` response and on the cost hook payload: `components` is now an array;
 - LLM: Updated `.streamText()` `onFinish()` callback to have the `.cost` property: contains the calculated cost for the stream.
 
-**`@outputai/llm`** —
+**`@outputai/llm`**
 
 Update perplexity-ai/ai-sdk to v0.1.3
 
-**`@outputai/credentials`, `@outputai/cli`** —
+**`@outputai/credentials`, `@outputai/cli`**
 
 Improve encrypted credentials loading: add clearer errors when keys are missing or invalid and ensure the CLI exits gracefully instead of printing stack traces.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 - Offer to initialize a git repository when running `output init`. Adds a `--skip-git` flag to opt out in non-interactive / scripted use.
 - Fix `--yes` / `--non-interactive` being rejected as "Nonexistent flag" by oclif's per-command parser when passed to any command.
 
-**`@outputai/credentials`, `@outputai/core`** —
+**`@outputai/credentials`, `@outputai/core`**
 
 - Added new hook functions `onWorkflowStart`, `onWorkflowEnd`, `onWorkflowError`:
   - `onWorkflowStart()`: Triggers when a workflow starts, receives the run id and workflow name;
@@ -925,7 +944,7 @@ Improve encrypted credentials loading: add clearer errors when keys are missing 
 - Added `activityId` and `workflowId` to `onError()` hook handler payload when source is `'activity'`;
 - Added `workflowId` to `onError()` hook handler payload when source is `'workflow'`.
 
-**`output-api`, `@outputai/core`** —
+**`output-api`, `@outputai/core`**
 
 Updating Temporal libraries from `v1.15.0` to `v1.17.0`:
 - @temporalio/activity;
@@ -935,84 +954,86 @@ Updating Temporal libraries from `v1.15.0` to `v1.17.0`:
 - @temporalio/worker;
 - @temporalio/workflow
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Add non-interactive mode with `--yes`/`--non-interactive` flags and TTY auto-detection for sandbox environments
 
-**`@outputai/cli`, `output-api`** —
+**`@outputai/cli`, `output-api`**
 
 Fix the workflow runs pane in the CLI so the detail view reflects the highlighted run instead of always showing the latest run. `GET /workflow/runs` now includes `runId` per row, and the CLI fetches results via the pinned `GET /workflow/{id}/runs/{rid}/result` endpoint.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Enable multiple instance of Output to run locally simultaneously in Docker by enabling dynamic port mapping
 
-**`@outputai/core`, `@outputai/cli`** —
+**`@outputai/core`, `@outputai/cli`**
 
 Add HTTP and gRPC proxy support for sandbox environments via HTTPS_PROXY and TEMPORAL_GRPC_PROXY env vars
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Shadow the worker container's `/app/node_modules` (root pnpm store) with a named Docker volume and run an explicit `output:worker:install` before `output:worker:watch`, so Linux-native packages installed in the container no longer leak into the host's `node_modules/`.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Fix issue where values in .env files were silently ignored
 
-**`@outputai/core`, `@outputai/http`, `@outputai/llm`** —
+**`@outputai/core`, `@outputai/http`, `@outputai/llm`**
 
 Adding trace event attributes and adding method `addRequestCost` to attach cost related info to an HTTP call made with the http module
 
-**`@outputai/llm`** —
+**`@outputai/llm`**
 
 re-export ai.jsonSchema for downstream use
 
-**`@outputai/http`** —
+**`@outputai/http`**
 
 **Custom fetch**
+
 Added a `fetch` function export to the "http" module:
 - Fully compliant with the fetch [spec](https://fetch.spec.whatwg.org/);
 - Integrates with Traces, tracking requests, responses, errors and failures;
 
 **Updated http client**
+
 Refactored `httpClient` exported by "http" to use the custom _fetch_ internally instead of _ky_ hooks.
 
-**`@outputai/cli`, `output-api`** —
+**`@outputai/cli`, `output-api`**
 
 Add new workflow history endpoint
 
 </Update>
 
-<Update label="v0.2.0" description="2026-04-22 · minor release">
+<Update label="v0.2.0" description="2026-04-22 - minor release">
 
-See the [v0.1.12 → v0.2.0 migration guide](/migrations/v0.1.12-to-v0.2.0).
+See the [v0.1.12 - v0.2.0 migration guide](/migrations/v0.1.12-to-v0.2.0).
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Fix `workflow generate` success message to show actual workflow ID and scenario name
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Add `credentials set` command for programmatic credential updates by dot-notation path. Prompts for confirmation when the write would change a value's shape (primitive → object or object → primitive); pass `--yes` to skip in non-interactive environments.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Add interactive workflow run panel to `output dev` with live status polling, keyboard navigation, and Temporal UI integration
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Update plugin command invocations to match renamed `output-plan-workflow`, `output-build-workflow`, and `output-debug-workflow` skills.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Add Docker Compose version check to prevent silent hangs on versions older than v2.24.0
 
-**`output-api`** —
+**`output-api`**
 
 - Fixed `/run` endpoint response to have the same format as `/result`;
 - Fixed `/status` endpoints `status` field format;
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Add `output migrate` command for upgrading projects between versions of the Output framework.
 
@@ -1020,13 +1041,13 @@ The command reads the project's current `@outputai/*` version, fetches the match
 
 Under the hood the CLI invokes `/output-migrate` — a Claude Code skill shipped via the `outputai` plugin marketplace. The skill carries the migration logic but no version-specific content; it fetches every guide at runtime so the docs remain the source of truth.
 
-**`@outputai/evals`** —
+**`@outputai/evals`**
 
 Switch dataset files to multi-case format where each top-level YAML key is the case name. Allows grouping multiple test cases into a single file instead of one file per case.
 
 The old single-case format (with a top-level `name:` field) is no longer supported — existing files must be migrated to the new format. Treated as minor rather than major because adoption is still early and the migration is mechanical.
 
-**`output-api`** —
+**`output-api`**
 
 Add pinned-run routes and deprecate mutation shortcuts.
 
@@ -1046,15 +1067,15 @@ Deprecated routes emit `Deprecation`, `Sunset`, and `Link` response headers on e
 - `POST /workflow/:id/terminate` response now includes `runId`
 - All status, result, and trace-log responses now include `runId`
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Upgrading Docker Node image version from 24.13.0-slim to 24.15.0-slim
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Update the Claude plugin for Output to improve workflow code generation"
 
-**`@outputai/credentials`, `@outputai/core`, `@outputai/cli`, `@outputai/llm`, `output-api`, `@outputai/evals`, `@outputai/output`, `@outputai/http`** —
+**`@outputai/credentials`, `@outputai/core`, `@outputai/cli`, `@outputai/llm`, `output-api`, `@outputai/evals`, `@outputai/output`, `@outputai/http`**
 
 Updating dependencies:
 - @oclif/plugin-help
@@ -1083,123 +1104,123 @@ Adding version overrides to fix vulnerabilities:
 - axios@>=1.0.0 &lt;1.15.0: `>=1.15.0`
 - protobufjs@&lt;7.5.5: `>=7.5.5`
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Auto-forward OUTPUT_CATALOG_ID as default task queue for workflow run/start commands
 
-**`@outputai/core`, `@outputai/cli`, `@outputai/llm`** —
+**`@outputai/core`, `@outputai/cli`, `@outputai/llm`**
 
 Bumping dependency versions
 
 </Update>
 
-<Update label="v0.1.12" description="2026-04-07 · patch release">
+<Update label="v0.1.12" description="2026-04-07 - patch release">
 
-**`@outputai/llm`, `@outputai/core`** —
+**`@outputai/llm`, `@outputai/core`**
 
 Add `agent()` and `skill()` abstractions to `@outputai/llm` for composing reusable LLM agents with structured output and a lazy-loaded skills system. Add `findContentDir()` to `@outputai/core` and fix skill path resolution to be relative to the prompt file rather than the calling module. Add `output-copy-assets` bin to `@outputai/core` to centralise worker asset copying.
 
-**`@outputai/core`, `output-api`** —
+**`@outputai/core`, `output-api`**
 
 Add support for workflow alias names.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Add `output fix` command that realigns npm scripts in a host project's `package.json` with the canonical scripts from the CLI. Added `output:worker` and `output:worker:watch` commands to the scaffold. Pinned the dependency versions installed via the CLI-generated `package.json`.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Pin `output` to a specific version in the scaffold `package.json` instead of a version range.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Update CLI cost configuration for calculating cost of Claude Sonnet 4.6. Improve coding-assistant guidance for schema generation.
 
 </Update>
 
-<Update label="v0.1.11" description="2026-04-02 · patch release">
+<Update label="v0.1.11" description="2026-04-02 - patch release">
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Fix worker health checks and add yarn/pnpm support in the dev container. Dev container worker now supports yarn and pnpm projects via corepack. Health check no longer reports success when containers exit or are unhealthy. Worker health-check detection time dropped from ~36s to ~9s. `start_period` extended from 30s to 60s to reduce false positives on cold start.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Fix the `plan` and `generate` CLI commands. Suppressed Claude file writes and next-step suggestions during plan generation (the CLI owns those responsibilities). Validates plan-file existence before creating a workflow skeleton in `generate`. Rolls back created skeleton files if the workflow build step fails.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Replace log-update / ANSI output in `output dev` with an Ink-based terminal UI, fixing a layout bug where text overlapped after a Docker service recovered from unhealthy.
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Ensure credential references are resolved when running CLI commands.
 
 </Update>
 
-<Update label="v0.1.10" description="2026-03-27 · patch release">
+<Update label="v0.1.10" description="2026-03-27 - patch release">
 
-**All packages** —
+**All packages**
 
 Update dependencies to latest and override versions to fix known vulnerabilities.
 
 </Update>
 
-<Update label="v0.1.9" description="2026-03-27 · patch release">
+<Update label="v0.1.9" description="2026-03-27 - patch release">
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Fix best practices in the `output init` example. Move `blogContentSchema` from `steps.ts` to `types.ts`. Update the README template to use `npx output credentials` flow instead of `.env`.
 
 </Update>
 
-<Update label="v0.1.8" description="2026-03-24 · patch release">
+<Update label="v0.1.8" description="2026-03-24 - patch release">
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Use encrypted credentials in the `output init` scaffold by default. API keys are now stored in `config/credentials.yml.enc` instead of `.env`, and `<SECRET>` markers are renamed to `<FILL_ME_OUT>`.
 
-**`@outputai/llm`** —
+**`@outputai/llm`**
 
 Update `@exalabs/ai-sdk` from 1.0.5 to 2.0.1.
 
 </Update>
 
-<Update label="v0.1.7" description="2026-03-24 · patch release">
+<Update label="v0.1.7" description="2026-03-24 - patch release">
 
-**All packages** —
+**All packages**
 
 Dependency bumps (minor and patch).
 
 </Update>
 
-<Update label="v0.1.6" description="2026-03-23 · patch release">
+<Update label="v0.1.6" description="2026-03-23 - patch release">
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Fix null crash in `workflow cost` when the pricing config is empty or missing.
 
 </Update>
 
-<Update label="v0.1.5" description="2026-03-22 · patch release">
+<Update label="v0.1.5" description="2026-03-22 - patch release">
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Fix prod publish to include the build step before publishing to npm. Previously, packages were published without compiling TypeScript, resulting in a missing `dist/` directory. Add `@next` dist-tag that auto-publishes from every merge to `main`, enabling `npx @outputai/cli@next` for tracking the latest changes.
 
 </Update>
 
-<Update label="v0.1.4" description="2026-03-20 · patch release">
+<Update label="v0.1.4" description="2026-03-20 - patch release">
 
-**All packages** —
+**All packages**
 
 Patch vulnerable dependencies.
 
 </Update>
 
-<Update label="v0.1.3" description="2026-03-19 · patch release">
+<Update label="v0.1.3" description="2026-03-19 - patch release">
 
-**`@outputai/core`, `@outputai/credentials`, `@outputai/cli`** —
+**`@outputai/core`, `@outputai/credentials`, `@outputai/cli`**
 
 Add `credential:` env var convention for automatic secret resolution at worker startup.
 
@@ -1209,17 +1230,17 @@ Add `credential:` env var convention for automatic secret resolution at worker s
 
 </Update>
 
-<Update label="v0.1.2" description="2026-03-19 · patch release">
+<Update label="v0.1.2" description="2026-03-19 - patch release">
 
-**`@outputai/cli`** —
+**`@outputai/cli`**
 
 Update `@anthropic-ai/claude-agent-sdk` from 0.1.71 to 0.2.77.
 
 </Update>
 
-<Update label="v0.1.1" description="2026-03-19 · patch release">
+<Update label="v0.1.1" description="2026-03-19 - patch release">
 
-**All packages** —
+**All packages**
 
 Dependency updates (minor and patch).
 

--- a/docs/guides/changelog/index.mdx
+++ b/docs/guides/changelog/index.mdx
@@ -13,7 +13,9 @@ Releases with breaking changes link to a matching section on the [Migrations](/m
 
 See the [v0.9.0 → v0.10.0 migration guide](/migrations/v0.9.0-to-v0.10.0).
 
-**`output-api`** — Workflow result endpoints no longer include unavailable trace destinations instead of returning them as `null`.
+**`output-api`** —
+
+Workflow result endpoints no longer include unavailable trace destinations instead of returning them as `null`.
 This affects:
 - `POST /workflow/run`
 - `GET /workflow/{id}/result`
@@ -41,9 +43,13 @@ _After:_
 }
 ```
 
-**`@outputai/cli`, `output-api`** — Add API endpoint and CLI command to get input from a workflow run
+**`@outputai/cli`, `output-api`** —
 
-**`@outputai/cli`** — The JSON output for workflow result commands no longer includes unavailable trace destinations as `null`.
+Add API endpoint and CLI command to get input from a workflow run
+
+**`@outputai/cli`** —
+
+The JSON output for workflow result commands no longer includes unavailable trace destinations as `null`.
 This affects:
 - `output workflow run ... --json`
 - `output workflow result <workflow-id> --json`
@@ -69,11 +75,15 @@ _After:_
 }
 ```
 
-**`@outputai/llm`** — Refactored Anthropic's error `"Grammar compilation timed out."` handling not to throw `FatalError` as this is transient and `FatalError`s terminate the workflow execution without retries.
+**`@outputai/llm`** —
+
+Refactored Anthropic's error `"Grammar compilation timed out."` handling not to throw `FatalError` as this is transient and `FatalError`s terminate the workflow execution without retries.
 
 It seems that the Anthropic API throws this error (HTTP status code 400) when grammar compilation times out for a structured output schema, but after some investigation it was assessed that this error is indeed transient.
 
-**`@outputai/core`** — ## Trace Changes
+**`@outputai/core`** —
+
+**Trace Changes**
 - Internal Activity `getTraceDestinations` is no longer invoked when workflow has `disableTrace: true` configuration.
 - Workflow trace destinations now omit unavailable destinations instead of returning them as `null`:
   _Before:_
@@ -99,7 +109,7 @@ It seems that the Anthropic API throws this error (HTTP status code 400) when gr
   ```
 - Internal activities like `getTraceDestinations` and `sendHttpRequest` are no longer omitted in the trace files.
 
-## HTTP helper header changes
+**HTTP helper header changes**
 - Both `sendHttpRequest` and `sendPostRequestAndAwaitWebhook` can now interpolate environment variable values in header values:
   ```js
   sendHttpRequest( {
@@ -112,7 +122,7 @@ It seems that the Anthropic API throws this error (HTTP status code 400) when gr
   When executing this request, `$TOKEN` will be replaced by the value of `process.env.TOKEN`.
 
 
-## sendHttpRequest output changes
+**sendHttpRequest output changes**
 - The response of `sendHttpRequest` no longer includes body or headers by default. Use the `responseOptions` argument to configure this:
   ```js
   sendHttpRequest( {
@@ -125,35 +135,53 @@ It seems that the Anthropic API throws this error (HTTP status code 400) when gr
   ```
 - Response headers included via `responseOptions.includeHeaders` are redacted by header name. This covers common sensitive header names such as authorization, token, secret, password, cookie, and key, but it is a best-effort heuristic.
 
-**`@outputai/core`** — Removing support for non-wrapped activity results and legacy child workflow executions (pre v0.8.0). Workflow executions from those versions can no longer be replayed.
+**`@outputai/core`** —
 
-**`@outputai/core`** — Add support to Temporal worker tuner options. This can be set using a new environment variable `TEMPORAL_WORKER_TUNER` that accepts a JSON value.
+Removing support for non-wrapped activity results and legacy child workflow executions (pre v0.8.0). Workflow executions from those versions can no longer be replayed.
+
+**`@outputai/core`** —
+
+Add support to Temporal worker tuner options. This can be set using a new environment variable `TEMPORAL_WORKER_TUNER` that accepts a JSON value.
 
 </Update>
 
 <Update label="v0.9.2" description="2026-07-03 · patch release">
 
-**`@outputai/credentials`, `@outputai/output`, `@outputai/evals`, `@outputai/core`, `@outputai/http`, `@outputai/cli`, `@outputai/llm`, `output-api`** — Pinning v24.15.0 as the minimal supported Node version
+**`@outputai/credentials`, `@outputai/output`, `@outputai/evals`, `@outputai/core`, `@outputai/http`, `@outputai/cli`, `@outputai/llm`, `output-api`** —
 
-**`@outputai/core`** — Improving catalog startup performance by storing and reading hash from memo. Storing workflow names in memo.
+Pinning v24.15.0 as the minimal supported Node version
 
-**`output-api`** — Improving start/run workflows performance by not querying an workflow to validate `workflowName` argument.
+**`@outputai/core`** —
+
+Improving catalog startup performance by storing and reading hash from memo. Storing workflow names in memo.
+
+**`output-api`** —
+
+Improving start/run workflows performance by not querying an workflow to validate `workflowName` argument.
 
 </Update>
 
 <Update label="v0.9.1" description="2026-07-01 · patch release">
 
-**`@outputai/cli`** — Add `output workflow history <workflowId>` — renders a run's step timeline as a terminal waterfall (each step's start offset and duration), mirroring the Agents HQ Timeline view. It pages the `GET /workflow/{id}/history` endpoint and correlates the Temporal events into per-step spans (numbering parallel fan-outs `#1..#N`). `--format json` emits the structured spans, `--raw` prints the endpoint's verbatim response, and `--run-id`, `--include-payloads`, `--width`, and `--no-color` are supported. Failed steps list their error reason beneath the chart (when payloads are included), and `FORCE_COLOR` forces ANSI output through a pipe.
+**`@outputai/cli`** —
+
+Add `output workflow history <workflowId>` — renders a run's step timeline as a terminal waterfall (each step's start offset and duration), mirroring the Agents HQ Timeline view. It pages the `GET /workflow/{id}/history` endpoint and correlates the Temporal events into per-step spans (numbering parallel fan-outs `#1..#N`). `--format json` emits the structured spans, `--raw` prints the endpoint's verbatim response, and `--run-id`, `--include-payloads`, `--width`, and `--no-color` are supported. Failed steps list their error reason beneath the chart (when payloads are included), and `FORCE_COLOR` forces ANSI output through a pipe.
 
 The same waterfall is available in the `output dev` TUI: from the Recent Runs tab, press `g` on any run to open its step graph as a full-width overlay. The overlay shows the run's status, start time, and duration, and live-updates while the run is in progress (the time axis tracks elapsed wall-clock and running bars grow). Select a step with `↑/↓` to inspect its input, output, and timing (start/end/duration) in the detail pane; `←/→` switches tabs and `e` expands a field full-screen.
 
-**`@outputai/http`** — - Added a custom dispatcher that disables HTTP/2 (`allowH2: false`) on fetch, it uses `EnvHttpProxyAgent`;
+**`@outputai/http`** —
+
+- Added a custom dispatcher that disables HTTP/2 (`allowH2: false`) on fetch, it uses `EnvHttpProxyAgent`;
 - Added support for dispatcher in the init argument of fetch; it has precedence over the custom dispatcher.
 
-**`@outputai/core`** — - Disabled HTTP/2 (`allowH2: false`) in the global fetch dispatcher configured by `setGlobalDispatcher` when proxy env vars are detected;
+**`@outputai/core`** —
+
+- Disabled HTTP/2 (`allowH2: false`) in the global fetch dispatcher configured by `setGlobalDispatcher` when proxy env vars are detected;
 - Disabled HTTP/2 (`allowH2: false`) in the webhook functions `sendHttpRequest` and `sendPostRequestAndAwaitWebhook` by using a dispatcher (`EnvHttpProxyAgent`).
 
-**`@outputai/llm`** — - Disabled HTTP/2 (`allowH2: false`) in the dispatcher of the fetch client used when consuming the AI SDK and fetching model pricing;
+**`@outputai/llm`** —
+
+- Disabled HTTP/2 (`allowH2: false`) in the dispatcher of the fetch client used when consuming the AI SDK and fetching model pricing;
 - Replaced the `Agent` dispatcher in favor of `EnvHttpProxyAgent` to respect the proxy env vars. [OUT-506].
 
 </Update>
@@ -162,7 +190,9 @@ The same waterfall is available in the `output dev` TUI: from the Recent Runs ta
 
 See the [v0.8.0 → v0.9.0 migration guide](/migrations/v0.8.0-to-v0.9.0).
 
-**`@outputai/core`** — Added activity lifecycle hooks: `onActivityStart`, `onActivityEnd`, `onActivityError`.
+**`@outputai/core`** —
+
+Added activity lifecycle hooks: `onActivityStart`, `onActivityEnd`, `onActivityError`.
 
 Payload:
 ```ts
@@ -176,9 +206,13 @@ Payload:
 }
 ```
 
-**`@outputai/cli`, `@outputai/llm`, `output-api`, `@outputai/core`, `@outputai/http`** — Updating libraries to fix vulnerabilities
+**`@outputai/cli`, `@outputai/llm`, `output-api`, `@outputai/core`, `@outputai/http`** —
 
-**`@outputai/cli`** — Replace the custom `--format json` option with oclif's built-in `--json` flag across all workflow commands (OUT-419).
+Updating libraries to fix vulnerabilities
+
+**`@outputai/cli`** —
+
+Replace the custom `--format json` option with oclif's built-in `--json` flag across all workflow commands (OUT-419).
 
 `--json` suppresses informational logs (e.g. `Fetching result for workflow...`) and emits clean, machine-readable JSON to stdout, fixing output that previously mixed status text into JSON.
 
@@ -189,13 +223,21 @@ Payload:
 
 The "update available" banner no longer prints to stdout: it now goes to stderr (keeping stdout clean for piping in every mode) and is suppressed entirely under `--json`.
 
-**`@outputai/cli`** — CLI `start`/`run`/`test`/`dataset generate` now resolve scenarios and route execution against `--catalog`/`OUTPUT_CATALOG_ID` instead of the API server's default catalog. This removes the ~30s scenario-resolution stall in worktrees where the default catalog has no worker polling it. `workflow test` and `workflow dataset generate` also gain a `--catalog` flag (env: `OUTPUT_CATALOG_ID`), matching `list`/`start`/`run`.
+**`@outputai/cli`** —
 
-**`@outputai/cli`** — Add an "Enter input" option to the `output dev` run pane. Edit a payload and press ctrl+r to run it as-is without saving, or ctrl+s to save it as a scenario first. Previously every ad-hoc run forced you to name and save a scenario file.
+CLI `start`/`run`/`test`/`dataset generate` now resolve scenarios and route execution against `--catalog`/`OUTPUT_CATALOG_ID` instead of the API server's default catalog. This removes the ~30s scenario-resolution stall in worktrees where the default catalog has no worker polling it. `workflow test` and `workflow dataset generate` also gain a `--catalog` flag (env: `OUTPUT_CATALOG_ID`), matching `list`/`start`/`run`.
 
-**`@outputai/cli`, `output-api`** — Add new endpoint for workflow history with server side events
+**`@outputai/cli`** —
 
-**`@outputai/core`** — Added a new `Logger` export for structured logging from both workflows and steps. Logs use the same `message` plus `metadata` shape as the internal worker logger and are routed through the worker's Winston logger.
+Add an "Enter input" option to the `output dev` run pane. Edit a payload and press ctrl+r to run it as-is without saving, or ctrl+s to save it as a scenario first. Previously every ad-hoc run forced you to name and save a scenario file.
+
+**`@outputai/cli`, `output-api`** —
+
+Add new endpoint for workflow history with server side events
+
+**`@outputai/core`** —
+
+Added a new `Logger` export for structured logging from both workflows and steps. Logs use the same `message` plus `metadata` shape as the internal worker logger and are routed through the worker's Winston logger.
 
 All log messages are enriched with execution metadata:
 - Workflow logs include `workflowType`, `workflowId`, and `runId`.
@@ -218,20 +260,28 @@ Supported levels are:
 
 The default displayed level is debug in development and info in production. Override it with `OUTPUT_LOG_LEVEL` env var. This setting also affects internal worker logs.
 
-**`@outputai/core`** — Including /dist when calculating catalog hash to define if catalog workflow needs restart. Excluding /temp.
+**`@outputai/core`** —
+
+Including /dist when calculating catalog hash to define if catalog workflow needs restart. Excluding /temp.
 
 </Update>
 
 <Update label="v0.8.1" description="2026-06-22 · patch release">
 
-**`@outputai/core`** — - Updating connection monitor strategy to ping workflowService instead of healthService.
+**`@outputai/core`** —
+
+- Updating connection monitor strategy to ping workflowService instead of healthService.
 - Adding new env vars to configure Temporal worker shutdownForceTime and shutdownGraceTime:
   - TEMPORAL_SHUTDOWN_FORCE_TIME
   - TEMPORAL_SHUTDOWN_GRACE_TIME
 
-**`@outputai/cli`** — Resolve datasets and evals for nested workflow folders by the workflow's registered name (via the worker catalog), keeping the flat-path lookup as an offline fast path. `output workflow test`, `dataset generate`, and `dataset list` now work for workflows in nested directories (e.g. `src/workflows/a/b/c` registered as `a_b_c`) without a symlink. `output workflow test` also fails fast with an actionable message when a `<wf>_eval` workflow's source exists but didn't compile to `dist`.
+**`@outputai/cli`** —
 
-**`output-api`** — Updating connection monitor strategy to ping workflowService instead of healthService.
+Resolve datasets and evals for nested workflow folders by the workflow's registered name (via the worker catalog), keeping the flat-path lookup as an offline fast path. `output workflow test`, `dataset generate`, and `dataset list` now work for workflows in nested directories (e.g. `src/workflows/a/b/c` registered as `a_b_c`) without a symlink. `output workflow test` also fails fast with an actionable message when a `<wf>_eval` workflow's source exists but didn't compile to `dist`.
+
+**`output-api`** —
+
+Updating connection monitor strategy to ping workflowService instead of healthService.
 
 </Update>
 
@@ -239,53 +289,81 @@ The default displayed level is debug in development and info in production. Over
 
 See the [v0.7.0 → v0.8.0 migration guide](/migrations/v0.7.0-to-v0.8.0).
 
-**`output-api`** — `getWorkflowResult` now fetches only the first history event (`WorkflowExecutionStarted`) to extract the workflow input, instead of paging through the full event history. Makes input extraction on the result endpoints (`/workflow/:id/result` and `/workflow/:id/runs/:rid/result`) O(1) regardless of history size.
+**`output-api`** —
 
-**`@outputai/core`** — improve worker startup time by only calculating workflow sources
+`getWorkflowResult` now fetches only the first history event (`WorkflowExecutionStarted`) to extract the workflow input, instead of paging through the full event history. Makes input extraction on the result endpoints (`/workflow/:id/result` and `/workflow/:id/runs/:rid/result`) O(1) regardless of history size.
 
-**`output-api`, `@outputai/cli`** — - Updated workflow result API responses to return workflow output and trace metadata without workflow-level `aggregations`.
+**`@outputai/core`** —
+
+improve worker startup time by only calculating workflow sources
+
+**`output-api`, `@outputai/cli`** —
+
+- Updated workflow result API responses to return workflow output and trace metadata without workflow-level `aggregations`.
 - Regenerated CLI API types to match the workflow result response shape.
 
-**`@outputai/cli`** — Faster CLI startup: ship `oclif.manifest.json` in the published package so only the invoked command module is loaded (instead of importing every command on every invocation), move the update check off the critical path (the init hook now only reads the local cache and refreshes it via a detached background process with a 5s registry timeout, instead of awaiting an unbounded `npm view` subprocess), and load `undici` only when a proxy env var is configured.
+**`@outputai/cli`** —
 
-**`@outputai/cli`** — `workflow cost` now calculates costs from the trace events themselves (the as-charged "Original" cost) and applies `costs.yml` as an override layer (the "Adjusted" cost), displaying both per model and per host. This fixes models with no `costs.yml` entry (e.g. `gpt-5.5`) and HTTP hosts (e.g. `api.exa.ai`, `api.firecrawl.dev`) previously reporting $0, and surfaces where the configured `costs.yml` rate diverges from what was actually charged. The bottom line shows the adjusted total with the as-charged total alongside.
+Faster CLI startup: ship `oclif.manifest.json` in the published package so only the invoked command module is loaded (instead of importing every command on every invocation), move the update check off the critical path (the init hook now only reads the local cache and refreshes it via a detached background process with a 5s registry timeout, instead of awaiting an unbounded `npm view` subprocess), and load `undici` only when a proxy env var is configured.
+
+**`@outputai/cli`** —
+
+`workflow cost` now calculates costs from the trace events themselves (the as-charged "Original" cost) and applies `costs.yml` as an override layer (the "Adjusted" cost), displaying both per model and per host. This fixes models with no `costs.yml` entry (e.g. `gpt-5.5`) and HTTP hosts (e.g. `api.exa.ai`, `api.firecrawl.dev`) previously reporting $0, and surfaces where the configured `costs.yml` rate diverges from what was actually charged. The bottom line shows the adjusted total with the as-charged total alongside.
 
 Costs come exclusively from trace cost attributes: LLM nodes with an `llm:usage` event and HTTP calls with an `http:request:cost` event are counted as-charged (even on error responses — the event proves a charge); calls without events are not priced. Traces from SDK versions that predate cost attributes (&lt; 0.5) report no costs. Only exact (`computed`) recomputes override an event cost — estimates and failed recomputes never do, and a configured `$0` price is now honored. Body-dependent `costs.yml` service rules require traces recorded with `OUTPUT_TRACE_HTTP_VERBOSE=true` (the dev default).
 
 **`--format json` field changes** (the report shape changed; update any scripts parsing it): `llmTotalCost` → `llmOriginalCost`/`llmAdjustedCost`; `services[]`/`serviceTotalCost` → `httpCosts[]` (grouped by `host`) with `httpOriginalCost`/`httpAdjustedCost`; `unknownModels` removed; per-call `cost`/`warning` → `originalCost`/`adjustedCost`; new `originalTotalCost`; `totalCost` is now the adjusted total.
 
-**`@outputai/core`** — Added Temporal connection monitoring. When connection is lost, graceful shuts down the worker.
+**`@outputai/core`** —
 
-**`@outputai/core`** — Fixed missing eventDate fields on hook types.
+Added Temporal connection monitoring. When connection is lost, graceful shuts down the worker.
 
-**`output-api`** — Added new `/ready` endpoint to report if API is ready to answer to requests.
+**`@outputai/core`** —
+
+Fixed missing eventDate fields on hook types.
+
+**`output-api`** —
+
+Added new `/ready` endpoint to report if API is ready to answer to requests.
 
 Added Temporal connection monitoring. When unhealthy, `/ready` return 503; if lost the API shuts down.
 
-**`output-api`** — Expose structured workflow failure details (`failure` object with `message`, `type`, `retryable`, and a sanitized `cause` chain) in `/workflow/run` and `/workflow/:id/result` responses, alongside the existing `error` string. Also log Temporal/gRPC client errors with full nested context (cause chain, gRPC `code`/`details`, redacted metadata keys, `workflowId`/`runId`/`taskQueue`/query) while keeping client-facing HTTP responses sanitized.
+**`output-api`** —
 
-**`@outputai/cli`** — Surface workflow aliases and honor `OUTPUT_CATALOG_ID` in `output workflow list`.
+Expose structured workflow failure details (`failure` object with `message`, `type`, `retryable`, and a sanitized `cause` chain) in `/workflow/run` and `/workflow/:id/result` responses, alongside the existing `error` string. Also log Temporal/gRPC client errors with full nested context (cause chain, gRPC `code`/`details`, redacted metadata keys, `workflowId`/`runId`/`taskQueue`/query) while keeping client-facing HTTP responses sanitized.
+
+**`@outputai/cli`** —
+
+Surface workflow aliases and honor `OUTPUT_CATALOG_ID` in `output workflow list`.
 
 - The default list output now appends `(aliases: ...)` to workflows that have registered aliases, which previously only appeared in `--format table`/`--format json` (OUT-444).
 - Add a `--catalog` flag (env `OUTPUT_CATALOG_ID`) that resolves workflows from a specific catalog, falling back to the server-default catalog — matching the existing behavior of `run` and `start` (OUT-489).
 
-**`@outputai/core`** — Add an opt-in `output-worker --check` workflow bundle check that reproduces the worker's webpack bundling without a Temporal server, catching bad workflow imports — e.g. a transitive `node:` built-in — before they crash-loop the worker at startup. `tsc` cannot detect these; only the Temporal bundle can.
+**`@outputai/core`** —
+
+Add an opt-in `output-worker --check` workflow bundle check that reproduces the worker's webpack bundling without a Temporal server, catching bad workflow imports — e.g. a transitive `node:` built-in — before they crash-loop the worker at startup. `tsc` cannot detect these; only the Temporal bundle can.
 
 - `output-worker --check` bundles workflows via the same `bundleWorkflowCode` path `Worker.create` uses, exits non-zero with the offending module named, and needs no Temporal connection or worker env.
 - Scaffolded projects gain an opt-in `output:worker:check` script plus README/CI guidance (not wired into any build).
 
-**`@outputai/llm`** — Route `<system>` blocks to the AI SDK `system` option instead of leaving them in the `messages` array.
+**`@outputai/llm`** —
+
+Route `<system>` blocks to the AI SDK `system` option instead of leaving them in the `messages` array.
 
 - `loadAiSdkTextOptions` now splits resolved messages: system blocks go to the top-level `system` option (as `SystemModelMessage[]`, so per-message `cacheControl`/`providerOptions` are preserved); only user/assistant/tool messages stay in `messages`. `Agent` consumes the split `system` directly as its `instructions`.
 - Silences the AI SDK warning that system messages in `messages` are a prompt-injection risk; `generateText`/`streamText`/`Agent` also set `allowSystemInMessages: true` as defense-in-depth for caller-supplied message histories.
 
-**`@outputai/llm`** — Add per-message provider options to `.prompt` files via `messageOptions`.
+**`@outputai/llm`** —
+
+Add per-message provider options to `.prompt` files via `messageOptions`.
 
 - Define named `messageOptions` sets in front matter and attach them to message blocks with `options="<name>"` (e.g. `<system options="cached">`); each set is a provider-namespaced `providerOptions` object merged onto that message.
 - Enables Anthropic prompt caching (`{ anthropic: { cacheControl: { type: ephemeral } } }`) and any other per-message provider option, on any provider.
 - Cost tracking now reports cached input tokens (`input_cached`) even for models whose pricing record lacks a `cache_read` rate, so cache savings are visible in usage aggregations instead of silently disappearing.
 
-**`@outputai/core`** — - Removed workflow-level usage aggregation from `@outputai/core`; workflows no longer collect activity attributes into final `aggregations` totals or expose those totals in workflow run results.
+**`@outputai/core`** —
+
+- Removed workflow-level usage aggregation from `@outputai/core`; workflows no longer collect activity attributes into final `aggregations` totals or expose those totals in workflow run results.
 - Reworked workflow-to-workflow invocation so direct workflow calls made from workflow code now consistently execute as Temporal child workflows, including calls made through helper functions outside the parent workflow handler.
 - Removed workflow call rewriting from the workflow webpack loader while preserving activity, step, and evaluator call rewriting.
 - Renamed workflow invocation configuration types from `WorkflowInvocationConfiguration` to `WorkflowInvocationOptions`.
@@ -293,10 +371,11 @@ Added Temporal connection monitoring. When unhealthy, `/ready` return 503; if lo
 - Refactored workflow validation internals around centralized schemas and explicit validator classes for workflows, steps, and evaluators.
 - Hardened Zod schema detection for multi-package or multi-realm Zod v4 environments.
 
-**`output-api`** — The `continued` workflow status was renamed to `continued_as_new` in API responses.
+**`output-api`** —
 
-## Explicit Status Fields
+The `continued` workflow status was renamed to `continued_as_new` in API responses.
 
+**Explicit Status Fields**
 | Endpoint | HTTP response JSON path | Generated client path |
 | --- | --- | --- |
 | `POST /workflow/run` | `status` | `response.data.status` |
@@ -306,8 +385,7 @@ Added Temporal connection monitoring. When unhealthy, `/ready` return 503; if lo
 | `GET /workflow/{id}/runs/{rid}/status` | `status` | `response.data.status` |
 | `GET /workflow/runs` | `runs[].status` | `response.data.runs[].status` |
 
-## History Metadata Status Fields
-
+**History Metadata Status Fields**
 These endpoints also return workflow status in the history metadata object. The OpenAPI schema currently leaves this nested object unexpanded.
 
 | Endpoint | HTTP response JSON path | Generated client path |
@@ -315,8 +393,7 @@ These endpoints also return workflow status in the history metadata object. The 
 | `GET /workflow/{id}/history` | `workflow.status` | `response.data.workflow.status` |
 | `GET /workflow/{id}/runs/{rid}/history` | `workflow.status` | `response.data.workflow.status` |
 
-## Backwards support
-
+**Backwards support**
 In the CLI, the old value is still supported.
 
 </Update>
@@ -325,7 +402,9 @@ In the CLI, the old value is still supported.
 
 See the [v0.6.0 → v0.7.0 migration guide](/migrations/v0.6.0-to-v0.7.0).
 
-**`@outputai/core`** — ## Workflow hooks
+**`@outputai/core`** —
+
+**Workflow hooks**
 Updated `onWorkflowStart()`, `onWorkflowEnd()`, `onWorkflowError()` hooks payload:
 
 ```js
@@ -357,17 +436,15 @@ Where `workflowDetails` is an abstraction over [Temporal's `workflowInfo()`](htt
 }
 ```
 
-## Error hook
+**Error hook**
 Updated `onError()` hooks payload. The fields change according to the `source`:
 
-### Source is "workflow"
-```js
+**Source is "workflow"**```js
 { eventId, eventDate, source, workflowDetails, error }
 ```
 Where `workflowDetails` is the same as in workflow hooks.
 
-### Source is "activity"
-```js
+**Source is "activity"**```js
 { eventId, eventDate, source, workflowDetails, activityInfo, outputActivityKind, error }
 ```
 
@@ -375,15 +452,14 @@ Where `activityInfo` is Temporal's `activityInfo()` [function return](https://ty
 
 And `outputActivityKind` is the framework flavor of the Temporal Activity: `step`, `evaluator` or `internal_step`.
 
-### Source is "runtime"
-```js
+**Source is "runtime"**```js
 { eventId, eventDate, source, error }
 ```
 
-## "on()" hook
+**"on()" hook**
 Updated `on()` hooks with better typing and a new envelope.
 
-### Envelope
+**Envelope**
 All events have these fields:
 - `eventId`
 - `eventDate`
@@ -391,37 +467,39 @@ All events have these fields:
 - `activityInfo`: From Temporal
 - `outputActivityKind`
 
-### Typing
+**Typing**
 Besides the envelope fields, each event also has its own fields, their types are specified by the event emitter:
 - `on<HttpRequestEvent>( 'http:request', handler )` from `@outputai/http`;
 - `on<HttpRequestCostEvent>( 'cost:http:request', handler )` from `@outputai/http`;
 - `on<LLMUsageEvent>( 'cost:llm:request', handler )` from `@outputai/llm`
 
-## Execution Context
+**Execution Context**
 Updated `getExecutionContext()` from `core/sdk_activity_integration` to return:
 ```js
 { activityInfo, workflowFilename }
 ```
 
-## Trace File
+**Trace File**
 Updated trace workflow node ids to use Temporal `runId`, instead of `workflowId`. This helps to create trees when child workflows "continued as new".
 
-**`@outputai/llm`** — - Added the `generateImage()` function for image generation, including image model loading, image prompt options, and wrapped image responses;
+**`@outputai/llm`** —
+
+- Added the `generateImage()` function for image generation, including image model loading, image prompt options, and wrapped image responses;
 - Improved public TS types by deriving AI SDK options and results from the upstream `ai` package;
 - Removed unused TS types;
 - Added validation for prompt skills, text generation arguments, and image prompt options;
 - Updated `streamText()` to support prompt skills and tools consistently with `generateText()`.
 
-**`@outputai/core`** — Added worker telemetry logs: print Temporal worker status and node memory every X ms, configured by `OUTPUT_WORKER_TELEMETRY_INTERVAL_MS` env var. Default `0` - off.
+**`@outputai/core`** —
+
+Added worker telemetry logs: print Temporal worker status and node memory every X ms, configured by `OUTPUT_WORKER_TELEMETRY_INTERVAL_MS` env var. Default `0` - off.
 
 Message examples:
-### Dev
-```
+**Dev**```
 [info] Telemetry: Worker { status: { runState: "RUNNING", numHeartbeatingActivities: 0, workflowPollerState: "POLLING", activityPollerState: "POLLING", hasOutstandingWorkflowPoll: true, hasOutstandingActivityPoll: true, numCachedWorkflows: 1, numInFlightWorkflowActivations: 0, numInFlightActivities: 0, numInFlightNonLocalActivities: 0, numInFlightLocalActivities: 0 }, memory: { availableMemory: 7500000000, constrainedMemory: 20000000000000000000, memoryUsage: { rss: 582348800, heapTotal: 400000000, heapUsed: 200000000, external: 800000000, arrayBuffers: 300000000 } } }
 ```
 
-### Prod
-```json
+**Prod**```json
 {
   "environment": "production",
   "level": "info",
@@ -456,7 +534,9 @@ Message examples:
 }
 ```
 
-**`@outputai/llm`** — - Added runtime image inputs to `generateImage()`, including image-to-image generation and optional masks for image editing;
+**`@outputai/llm`** —
+
+- Added runtime image inputs to `generateImage()`, including image-to-image generation and optional masks for image editing;
 - Added validation and TypeScript types for `generateImage()` `images` and `mask` arguments;
 - Added conversion of AI SDK non-retryable API errors to `FatalError` across `generateText()`, `streamText()`, and `generateImage()` so permanent provider failures do not trigger workflow/activity retries:
   - APICallError (when `.isRetriable() === false` )
@@ -470,9 +550,13 @@ Message examples:
   - NoSuchProviderError
   - UnsupportedFunctionalityError
 
-**`output-api`, `@outputai/llm`** — Fixing vulnerabilities by updating `qs` and `liquidjs` dependencies.
+**`output-api`, `@outputai/llm`** —
 
-**`@outputai/core`** — Improve trace error serialization to preserve nested error causes. Error entries in trace files now include the error `name`, `message`, `stack`, and recursively serialized `cause` values up to 10 levels deep, including JSON-safe non-Error causes where present.
+Fixing vulnerabilities by updating `qs` and `liquidjs` dependencies.
+
+**`@outputai/core`** —
+
+Improve trace error serialization to preserve nested error causes. Error entries in trace files now include the error `name`, `message`, `stack`, and recursively serialized `cause` values up to 10 levels deep, including JSON-safe non-Error causes where present.
 
 ```js
 {
@@ -490,22 +574,30 @@ Message examples:
 }
 ```
 
-**`@outputai/http`, `@outputai/llm`** — Exported event payload types for hook consumers.
+**`@outputai/http`, `@outputai/llm`** —
+
+Exported event payload types for hook consumers.
 
 - `@outputai/http` now exports `HttpRequestEvent` for `http:request` and `HttpRequestCostEvent` for `cost:http:request`.
 - `@outputai/llm` now exports `LLMUsageEvent` for `cost:llm:request`.
 
 Use these with `@outputai/core/hooks` as `on<HttpRequestEvent>( 'http:request', handler )`, so applications can type event-specific fields without redefining the payload shapes locally.
 
-**`@outputai/llm`** — Recreate AI SDK `NoObjectGeneratedError` schema validation failures as new `NoObjectGeneratedError` instances with a clearer message:
+**`@outputai/llm`** —
+
+Recreate AI SDK `NoObjectGeneratedError` schema validation failures as new `NoObjectGeneratedError` instances with a clearer message:
 
 ```txt
 No object generated: response did not match schema. First issue is "Invalid input: expected string, received number" at path [name].
 ```
 
-**`@outputai/cli`** — `credentials set` and `credentials edit` now check whether the current key can decrypt the existing credentials file before re-encrypting. On a key mismatch they abort with a clear warning that the wrong key may be in use and the file would be re-encrypted under a different key. Pass `--force` / `-f` to proceed anyway (re-encrypts from empty, discarding the undecryptable values).
+**`@outputai/cli`** —
 
-**`@outputai/llm`** — - Updated `@ai-sdk/*` providers and `ai` itself to peer dependencies, with these supported ranges:
+`credentials set` and `credentials edit` now check whether the current key can decrypt the existing credentials file before re-encrypting. On a key mismatch they abort with a clear warning that the wrong key may be in use and the file would be re-encrypted under a different key. Pass `--force` / `-f` to proceed anyway (re-encrypts from empty, discarding the undecryptable values).
+
+**`@outputai/llm`** —
+
+- Updated `@ai-sdk/*` providers and `ai` itself to peer dependencies, with these supported ranges:
   - `ai`: `>=6 <7`
   - `@ai-sdk/amazon-bedrock`: `>=4 <5`
   - `@ai-sdk/anthropic`: `>=3 <4`
@@ -523,13 +615,21 @@ No object generated: response did not match schema. First issue is "Invalid inpu
 
 See the [v0.5.2 → v0.6.0 migration guide](/migrations/v0.5.2-to-v0.6.0).
 
-**`output-api`** — Removed `.attributes` field from workflow results (both `/run` and `/results` endpoints)
+**`output-api`** —
 
-**`@outputai/core`** — Rewriting the catalog workflow startup logic to better handle multiple instances of the worker and avoiding restarting the workflow unnecessarily.
+Removed `.attributes` field from workflow results (both `/run` and `/results` endpoints)
 
-**`@outputai/cli`** — Removed "Attributes" tab from Recent Runs > [Workflow view].
+**`@outputai/core`** —
 
-**`@outputai/core`** — - Removed property `.attributes` from workflow result wrapper object: Workflows will no longer accumulate or expose attributes;
+Rewriting the catalog workflow startup logic to better handle multiple instances of the worker and avoiding restarting the workflow unnecessarily.
+
+**`@outputai/cli`** —
+
+Removed "Attributes" tab from Recent Runs > [Workflow view].
+
+**`@outputai/core`** —
+
+- Removed property `.attributes` from workflow result wrapper object: Workflows will no longer accumulate or expose attributes;
 - Added `__output_workflow_wrapper_version=1` field on workflow wrapper object to better version it;
 - Removed Signals-based communication between Activities and Workflows to share individual attributes:
   - Each activity now aggregates all attributes of the events that happened within it. This is returned in a new wrapper around the activity:
@@ -561,35 +661,51 @@ See the [v0.5.2 → v0.6.0 migration guide](/migrations/v0.5.2-to-v0.6.0).
 
 <Update label="v0.5.2" description="2026-05-27 · patch release">
 
-**`@outputai/http`** — Propagate the per-request id across `Response.clone()` so cost emission works from inside ky `afterResponse` hooks. ky clones the response before invoking the hook, which stripped the symbol property `addRequestCost` reads to correlate the request — every hook calling `addRequestCost(response, value)` silently dropped its cost. Patches `clone()` on the original response so each clone re-runs `addRequestIdToResponse`, propagating the tag through any depth of clones. Header-based fallback isn't viable — undici responses are immutable on the received side.
+**`@outputai/http`** —
+
+Propagate the per-request id across `Response.clone()` so cost emission works from inside ky `afterResponse` hooks. ky clones the response before invoking the hook, which stripped the symbol property `addRequestCost` reads to correlate the request — every hook calling `addRequestCost(response, value)` silently dropped its cost. Patches `clone()` on the original response so each clone re-runs `addRequestIdToResponse`, propagating the tag through any depth of clones. Header-based fallback isn't viable — undici responses are immutable on the received side.
 
 Also tightens the `addRequestIdToResponse` signature to `: void` (was `: Response`). The function mutates in place; the return-the-input pattern was misleading. The one external call site already discarded the return, so no consumer code needs to change.
 
-**`@outputai/core`** — Every payload emitted through the framework's `messageBus` now carries a UUID v4 `eventId` and millisecond epoch `eventDate` — stamped at the bus layer, so events emitted via `emitEvent` *and* lifecycle hook payloads (`onWorkflowStart`, `onWorkflowEnd`, `onWorkflowError`, `onError`) both receive them. Consumers can rely on `eventId` as a stable per-emit idempotency key — e.g., for webhook retry handling, ClickHouse `ReplacingMergeTree` dedup, audit logs. The previously emitted `requestId` is not safe for this purpose because `cost:http:request` and `http:request` for the same fetch share a `requestId`.
+**`@outputai/core`** —
+
+Every payload emitted through the framework's `messageBus` now carries a UUID v4 `eventId` and millisecond epoch `eventDate` — stamped at the bus layer, so events emitted via `emitEvent` *and* lifecycle hook payloads (`onWorkflowStart`, `onWorkflowEnd`, `onWorkflowError`, `onError`) both receive them. Consumers can rely on `eventId` as a stable per-emit idempotency key — e.g., for webhook retry handling, ClickHouse `ReplacingMergeTree` dedup, audit logs. The previously emitted `requestId` is not safe for this purpose because `cost:http:request` and `http:request` for the same fetch share a `requestId`.
 
 Callers may pre-set `eventId` or `eventDate` on the payload to override the generated values (intended for deterministic retry scenarios). Additive — existing consumers ignoring these fields continue to work.
 
-**`@outputai/cli`** — Bump default local Temporal namespace retention from 24h to 720h (30 days) so workflow runs aren't garbage-collected within a day during local development.
+**`@outputai/cli`** —
 
-**`@outputai/cli`** — Support multiple `npx output dev` stacks side-by-side:
+Bump default local Temporal namespace retention from 24h to 720h (30 days) so workflow runs aren't garbage-collected within a day during local development.
+
+**`@outputai/cli`** —
+
+Support multiple `npx output dev` stacks side-by-side:
 
 - Expose `OUTPUT_TEMPORAL_HOST_PORT` (default 7233) so dev Temporal can be relocated off 7233.
 - Document the multi-stack recipe (`DOCKER_SERVICE_NAME`, `OUTPUT_CATALOG_ID`, and the three `OUTPUT_*_HOST_PORT` knobs) in `cli.mdx`.
 - Surface an actionable hint when docker compose fails to bind a host port, naming the conflicting port and the env var that overrides it.
 
-**`@outputai/core`, `@outputai/cli`** — Attribute signal emission is now opt-in via `OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION=true`. Each LLM call and HTTP request previously fired a Temporal signal back to the workflow, bloating workflow history on runs with many calls. With emission off (the new default), workflow results still expose `attributes` and `aggregations` keys but they are empty/zeroed, and the `cost:llm:request` / `cost:http:request` hooks do not fire. Set the env var on the worker process to opt back in.
+**`@outputai/core`, `@outputai/cli`** —
+
+Attribute signal emission is now opt-in via `OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION=true`. Each LLM call and HTTP request previously fired a Temporal signal back to the workflow, bloating workflow history on runs with many calls. With emission off (the new default), workflow results still expose `attributes` and `aggregations` keys but they are empty/zeroed, and the `cost:llm:request` / `cost:http:request` hooks do not fire. Set the env var on the worker process to opt back in.
 
 The CLI's dev docker-compose forwards the flag from the host shell, so `OUTPUT_ENABLE_ATTRIBUTE_SIGNAL_EMISSION=true output dev` opts in without editing compose.
 
-**`output-api`** — Raise gRPC's default 4 MiB message-size cap on the API server's Temporal connection so workflow result envelopes larger than 4 MiB no longer fail with `RESOURCE_EXHAUSTED`. Configurable via the new `TEMPORAL_GRPC_MAX_MESSAGE_SIZE_BYTES` env var (default 32 MiB).
+**`output-api`** —
+
+Raise gRPC's default 4 MiB message-size cap on the API server's Temporal connection so workflow result envelopes larger than 4 MiB no longer fail with `RESOURCE_EXHAUSTED`. Configurable via the new `TEMPORAL_GRPC_MAX_MESSAGE_SIZE_BYTES` env var (default 32 MiB).
 
 </Update>
 
 <Update label="v0.5.1" description="2026-05-22 · patch release">
 
-**`@outputai/core`** — Fix worker activity Temporal client to use the configured namespace when signaling workflows. This resolves unauthorized signal errors in Temporal Cloud production namespaces.
+**`@outputai/core`** —
 
-**`@outputai/core`** — Improve reliability of workflow usage and cost metadata collection. Transient Temporal signal failures while recording activity attributes are now handled gracefully, reducing the chance of worker interruptions during workflow runs.
+Fix worker activity Temporal client to use the configured namespace when signaling workflows. This resolves unauthorized signal errors in Temporal Cloud production namespaces.
+
+**`@outputai/core`** —
+
+Improve reliability of workflow usage and cost metadata collection. Transient Temporal signal failures while recording activity attributes are now handled gracefully, reducing the chance of worker interruptions during workflow runs.
 
 </Update>
 
@@ -597,7 +713,9 @@ The CLI's dev docker-compose forwards the flag from the host shell, so `OUTPUT_E
 
 See the [v0.4.0 → v0.5.0 migration guide](/migrations/v0.4.0-to-v0.5.0).
 
-**`@outputai/core`, `@outputai/http`, `@outputai/llm`, `output-api`** — Workflow runs now return durable usage and cost metadata alongside the workflow output. Each completed or failed run can include raw `attributes` plus convenient `aggregations` for total cost, token usage, and HTTP request counts.
+**`@outputai/core`, `@outputai/http`, `@outputai/llm`, `output-api`** —
+
+Workflow runs now return durable usage and cost metadata alongside the workflow output. Each completed or failed run can include raw `attributes` plus convenient `aggregations` for total cost, token usage, and HTTP request counts.
 
 For example, API and CLI JSON results can now include:
 
@@ -619,13 +737,17 @@ Cost events now emit the same attribute-shaped payloads used in workflow results
 
 Learn more in the [workflow result docs](/api), [CLI result format](/packages/cli#workflow-result-json-format), and [cost events guide](/costs/cost-events).
 
-**`@outputai/cli`** — Improved the dev TUI experience with clearer workflow run views, expanded full-screen modals, and more consistent layout and interaction patterns across screens.
+**`@outputai/cli`** —
+
+Improved the dev TUI experience with clearer workflow run views, expanded full-screen modals, and more consistent layout and interaction patterns across screens.
 
 Workflow run details now show result attributes and aggregations alongside input/output data.
 
 For scaffolded projects running `output dev`, the local Docker Compose API service now uses the documented `OUTPUT_AWS_*` variables for remote S3 trace access. If you use remote trace storage locally, set `OUTPUT_AWS_REGION`, `OUTPUT_AWS_ACCESS_KEY_ID`, and `OUTPUT_AWS_SECRET_ACCESS_KEY` in your project environment; the accidental `AWS_*` passthrough is no longer used.
 
-**`@outputai/http`** — Emit a new `http:request` event on every HTTP call made via `@outputai/http`'s `fetch`. The event fires on success, non-2xx responses, and network failures, with payload:
+**`@outputai/http`** —
+
+Emit a new `http:request` event on every HTTP call made via `@outputai/http`'s `fetch`. The event fires on success, non-2xx responses, and network failures, with payload:
 
 ```
 {
@@ -640,13 +762,19 @@ For scaffolded projects running `output dev`, the local Docker Compose API servi
 
 Subscribers (`on('http:request', handler)`) also receive `workflowId`, `runId`, and `activityId` auto-attached by `emitEvent`. The existing `cost:http:request` event is unchanged — it continues to fire only when a consumer attaches a cost via `addRequestCost()`. Additive — no existing consumer breaks.
 
-**`@outputai/core`** — Stream trace JSON when writing local files and uploading to S3, avoiding Node.js string length limits for large trace outputs.
+**`@outputai/core`** —
 
-**`@outputai/llm`** — Increase built-in LLM provider fetch timeouts for long-running responses.
+Stream trace JSON when writing local files and uploading to S3, avoiding Node.js string length limits for large trace outputs.
+
+**`@outputai/llm`** —
+
+Increase built-in LLM provider fetch timeouts for long-running responses.
 
 Default AI SDK `maxRetries` to 0 so workflow retries are handled by Temporal.
 
-**`@outputai/core`** — Added `runId` to the workflow context and the workflow-lifecycle hook payloads. `context.info.runId` exposes the Temporal run id for the current execution attempt; `onWorkflowStart`, `onWorkflowEnd`, and `onWorkflowError` payloads now include `runId` alongside `id` (workflow id). `executionContext` also carries `runId`, so any consumer subscribed via `on(...)` to an `emitEvent`-emitted event (e.g., `cost:llm:request`) receives `runId` automatically. Additive — existing consumers ignoring the field continue to work.
+**`@outputai/core`** —
+
+Added `runId` to the workflow context and the workflow-lifecycle hook payloads. `context.info.runId` exposes the Temporal run id for the current execution attempt; `onWorkflowStart`, `onWorkflowEnd`, and `onWorkflowError` payloads now include `runId` alongside `id` (workflow id). `executionContext` also carries `runId`, so any consumer subscribed via `on(...)` to an `emitEvent`-emitted event (e.g., `cost:llm:request`) receives `runId` automatically. Additive — existing consumers ignoring the field continue to work.
 
 </Update>
 
@@ -654,24 +782,40 @@ Default AI SDK `maxRetries` to 0 so workflow retries are handled by Temporal.
 
 See the [v0.3.0 → v0.4.0 migration guide](/migrations/v0.3.0-to-v0.4.0).
 
-**`@outputai/cli`** — Fixed `output credentials edit` modifying the encrypted credentials file on disk even when the user made no changes in their editor. Because AES-GCM uses a fresh nonce per encryption, the unconditional re-write produced new ciphertext bytes and left the file dirty in git on every invocation. The command now skips the write when the post-editor plaintext is identical to the original.
+**`@outputai/cli`** —
 
-**`@outputai/llm`** — Bump `entities` dependency from v6 to v8. The API surface used (`encodeXML` / `decodeXML`) is unchanged, and v8's ESM-only / Node ≥ 20.19 requirements are already satisfied by this package.
+Fixed `output credentials edit` modifying the encrypted credentials file on disk even when the user made no changes in their editor. Because AES-GCM uses a fresh nonce per encryption, the unconditional re-write produced new ciphertext bytes and left the file dirty in git on every invocation. The command now skips the write when the post-editor plaintext is identical to the original.
 
-**`@outputai/cli`** — Fixed `output dev` hanging until the health timeout when `docker compose up` exited before creating containers. The CLI now drains and captures recent Compose output, reports early Compose exits immediately, polls status with the same project directory used to start the stack, and only treats running containers as healthy.
+**`@outputai/llm`** —
 
-**`@outputai/core`** — - Fix TypeScript declaration emit for exported workflows that use Zod schemas.
+Bump `entities` dependency from v6 to v8. The API surface used (`encodeXML` / `decodeXML`) is unchanged, and v8's ESM-only / Node ≥ 20.19 requirements are already satisfied by this package.
+
+**`@outputai/cli`** —
+
+Fixed `output dev` hanging until the health timeout when `docker compose up` exited before creating containers. The CLI now drains and captures recent Compose output, reports early Compose exits immediately, polls status with the same project directory used to start the stack, and only treats running containers as healthy.
+
+**`@outputai/core`** —
+
+- Fix TypeScript declaration emit for exported workflows that use Zod schemas.
 - Allow TypeScript to generate `.d.ts` files for these workflows without non-portable Zod references.
 - Treat Zod as a peer dependency and avoid leaking schema-specific workflow context types through the invocation config.
 
-**`@outputai/cli`** — - Bumped scaffold prompt template default from `claude-haiku-4-5` to `claude-sonnet-4-6` and added a dated `current as of` comment pointing at the new `output-dev-model-selection` skill (workflow scaffold, blog_evaluator example, workflow README example).
+**`@outputai/cli`** —
+
+- Bumped scaffold prompt template default from `claude-haiku-4-5` to `claude-sonnet-4-6` and added a dated `current as of` comment pointing at the new `output-dev-model-selection` skill (workflow scaffold, blog_evaluator example, workflow README example).
 - No CLI behavior change beyond the new default model in generated `.prompt` files.
 
-**`@outputai/core`** — Fixed workflows having the status 'failed' when cancelled via the API/UI. Now they are correctly marked as 'cancelled'.
+**`@outputai/core`** —
 
-**`@outputai/cli`** — Fix scenario loading in `output dev` for workflows whose name differs from their local folder path. For example, a workflow named `writing_editor` stored in `src/workflows/writing/editor` now shows and runs its scenarios correctly.
+Fixed workflows having the status 'failed' when cancelled via the API/UI. Now they are correctly marked as 'cancelled'.
 
-**`@outputai/core`** — Add support for discovering and running workflows from installed npm packages.
+**`@outputai/cli`** —
+
+Fix scenario loading in `output dev` for workflows whose name differs from their local folder path. For example, a workflow named `writing_editor` stored in `src/workflows/writing/editor` now shows and runs its scenarios correctly.
+
+**`@outputai/core`** —
+
+Add support for discovering and running workflows from installed npm packages.
 
 Rename the Output.ai settings property in `package.json` from `output` to `outputai`.
 
@@ -679,13 +823,17 @@ Rename the Output.ai settings property in `package.json` from `output` to `outpu
 
 <Update label="v0.3.2" description="2026-05-05 · patch release">
 
-**`@outputai/cli`** — Rebuild `output dev` as a full-featured INK TUI. Tabbed UI for Workflows, Recent Runs, Services, and Help with arrow-key navigation, an in-TUI scenario picker and JSON editor for running workflows, an expanded JSON modal for input/output, and a live `docker compose logs` tail with restart hotkeys.
+**`@outputai/cli`** —
+
+Rebuild `output dev` as a full-featured INK TUI. Tabbed UI for Workflows, Recent Runs, Services, and Help with arrow-key navigation, an in-TUI scenario picker and JSON editor for running workflows, an expanded JSON modal for input/output, and a live `docker compose logs` tail with restart hotkeys.
 
 </Update>
 
 <Update label="v0.3.1" description="2026-05-05 · patch release">
 
-**`@outputai/llm`** — Prevent template variables from injecting message blocks into rendered prompts. Variable content containing tag-shaped substrings (e.g. `</user>` or `<system>...</system>`, common when evaluating webpages or chat transcripts) was being tokenized by `parsePrompt` as real message blocks, producing duplicate `system` messages that providers like Anthropic reject. `loadPrompt` now arms every `{{ ... }}` interpolation with an internal escape filter so variable output stays inert at parse time.
+**`@outputai/llm`** —
+
+Prevent template variables from injecting message blocks into rendered prompts. Variable content containing tag-shaped substrings (e.g. `</user>` or `<system>...</system>`, common when evaluating webpages or chat transcripts) was being tokenized by `parsePrompt` as real message blocks, producing duplicate `system` messages that providers like Anthropic reject. `loadPrompt` now arms every `{{ ... }}` interpolation with an internal escape filter so variable output stays inert at parse time.
 
 </Update>
 
@@ -693,7 +841,9 @@ Rename the Output.ai settings property in `package.json` from `output` to `outpu
 
 See the [v0.2.0 → v0.3.0 migration guide](/migrations/v0.2.0-to-v0.3.0).
 
-**`@outputai/cli`, `output-api`** — Use `catalog` as the public name for the routing/filtering target across the CLI and HTTP API:
+**`@outputai/cli`, `output-api`** —
+
+Use `catalog` as the public name for the routing/filtering target across the CLI and HTTP API:
 
 - `output workflow runs list` gains `--catalog`/`-c` (with `OUTPUT_CATALOG_ID` env fallback) and `GET /workflow/runs` accepts `?catalog=...`, scoping listed runs to a single worker's catalog/session.
 - `output workflow run` and `output workflow start` rename the routing flag to `--catalog`/`-c`. The previous `--task-queue` and `-q` are kept as deprecated aliases (oclif emits a warning when used).
@@ -701,49 +851,62 @@ See the [v0.2.0 → v0.3.0 migration guide](/migrations/v0.2.0-to-v0.3.0).
 
 Internally the value is still a Temporal task queue — only the user-facing name changes.
 
-**`@outputai/core`** — Optimizing local trace to use less memory and avoid "RangeError: Invalid string length"
+**`@outputai/core`** —
 
-**`@outputai/cli`, `@outputai/llm`, `output-api`, `@outputai/core`, `@outputai/credentials`, `@outputai/evals`, `@outputai/output`, `@outputai/http`** — ## Dependencies updates
+Optimizing local trace to use less memory and avoid "RangeError: Invalid string length"
 
-### Vulnerabilities fixed:
+**`@outputai/cli`, `@outputai/llm`, `output-api`, `@outputai/core`, `@outputai/credentials`, `@outputai/evals`, `@outputai/output`, `@outputai/http`** —
+
+**Dependencies updates**
+**Vulnerabilities fixed:**
 - uuid: Missing buffer bounds check in v3/v5/v6 when buf: (bump to `>=14.0.0`)
 - postcss: PostCSS has XSS via Unescaped &lt;/style> in its CSS Stringify Output (bump to `>=8.5.10`)
 - @anthropic-ai/sdk: Claude SDK for TypeScript has Insecure Default File Permissions in Local Filesystem Memory Tool (bump to `>=0.91.1`)
 
-### Root package.json updates
+**Root package.json updates**
 - @changesets/cli: `2.30.0` -> `2.31.0`
 - eslint: `10.2.0` -> `10.2.1`
 - mintlify: `4.2.520` -> `4.2.536`
 - typescript-eslint: `8.58.2` -> `8.59.1`
 - vitest: `4.1.4` -> `4.1.5`
 
-### pnpm-workspace.yaml (catalog) updates
+**pnpm-workspace.yaml (catalog) updates**
 - @aws-sdk/client-s3: `3.1031.0` -> `3.1038.0`
 
-### sdk/cli/package.json updates
+**sdk/cli/package.json updates**
 - @inquirer/prompts: `8.4.1` -> `8.4.2`
 - @oclif/core: `4.10.5` -> `4.10.6`
 - @oclif/plugin-help: `6.2.44` -> `6.2.45`
 - undici: `8.0.2` -> `catalog:`
 - orval: `8.8.0` -> `8.9.0`
 
-### sdk/llm/package.json updates
+**sdk/llm/package.json updates**
 - @ai-sdk/amazon-bedrock: `4.0.95` -> `4.0.96`
 - liquidjs: `10.25.5` -> `10.25.7`
 
-**`@outputai/http`, `@outputai/llm`** — - HTTP: Added a new event `cost:http:request` that is dispatched after calling `addRequestCost()`: the event's payload is `requestId`, `cost` and `url`;
+**`@outputai/http`, `@outputai/llm`** —
+
+- HTTP: Added a new event `cost:http:request` that is dispatched after calling `addRequestCost()`: the event's payload is `requestId`, `cost` and `url`;
 - LLM: Renamed `llm:call_cost` event to `cost:llm:request`;
 - LLM: Updated the format of the `.cost` property on `.generateText()` response and on the cost hook payload: `components` is now an array;
 - LLM: Updated `.streamText()` `onFinish()` callback to have the `.cost` property: contains the calculated cost for the stream.
 
-**`@outputai/llm`** — Update perplexity-ai/ai-sdk to v0.1.3
+**`@outputai/llm`** —
 
-**`@outputai/credentials`, `@outputai/cli`** — Improve encrypted credentials loading: add clearer errors when keys are missing or invalid and ensure the CLI exits gracefully instead of printing stack traces.
+Update perplexity-ai/ai-sdk to v0.1.3
 
-**`@outputai/cli`** — - Offer to initialize a git repository when running `output init`. Adds a `--skip-git` flag to opt out in non-interactive / scripted use.
+**`@outputai/credentials`, `@outputai/cli`** —
+
+Improve encrypted credentials loading: add clearer errors when keys are missing or invalid and ensure the CLI exits gracefully instead of printing stack traces.
+
+**`@outputai/cli`** —
+
+- Offer to initialize a git repository when running `output init`. Adds a `--skip-git` flag to opt out in non-interactive / scripted use.
 - Fix `--yes` / `--non-interactive` being rejected as "Nonexistent flag" by oclif's per-command parser when passed to any command.
 
-**`@outputai/credentials`, `@outputai/core`** — - Added new hook functions `onWorkflowStart`, `onWorkflowEnd`, `onWorkflowError`:
+**`@outputai/credentials`, `@outputai/core`** —
+
+- Added new hook functions `onWorkflowStart`, `onWorkflowEnd`, `onWorkflowError`:
   - `onWorkflowStart()`: Triggers when a workflow starts, receives the run id and workflow name;
   - `onWorkflowEnd()`: Triggers when a workflow ends (no error), receives the run id, workflow name and duration (elapsed time);
   - `onWorkflowError()`: Triggers when a workflow throws an error, receives the run id, workflow name, duration and error thrown;
@@ -753,7 +916,9 @@ Internally the value is still a Temporal task queue — only the user-facing nam
 - Added `activityId` and `workflowId` to `onError()` hook handler payload when source is `'activity'`;
 - Added `workflowId` to `onError()` hook handler payload when source is `'workflow'`.
 
-**`output-api`, `@outputai/core`** — Updating Temporal libraries from `v1.15.0` to `v1.17.0`:
+**`output-api`, `@outputai/core`** —
+
+Updating Temporal libraries from `v1.15.0` to `v1.17.0`:
 - @temporalio/activity;
 - @temporalio/client;
 - @temporalio/common;
@@ -761,31 +926,51 @@ Internally the value is still a Temporal task queue — only the user-facing nam
 - @temporalio/worker;
 - @temporalio/workflow
 
-**`@outputai/cli`** — Add non-interactive mode with `--yes`/`--non-interactive` flags and TTY auto-detection for sandbox environments
+**`@outputai/cli`** —
 
-**`@outputai/cli`, `output-api`** — Fix the workflow runs pane in the CLI so the detail view reflects the highlighted run instead of always showing the latest run. `GET /workflow/runs` now includes `runId` per row, and the CLI fetches results via the pinned `GET /workflow/{id}/runs/{rid}/result` endpoint.
+Add non-interactive mode with `--yes`/`--non-interactive` flags and TTY auto-detection for sandbox environments
 
-**`@outputai/cli`** — Enable multiple instance of Output to run locally simultaneously in Docker by enabling dynamic port mapping
+**`@outputai/cli`, `output-api`** —
 
-**`@outputai/core`, `@outputai/cli`** — Add HTTP and gRPC proxy support for sandbox environments via HTTPS_PROXY and TEMPORAL_GRPC_PROXY env vars
+Fix the workflow runs pane in the CLI so the detail view reflects the highlighted run instead of always showing the latest run. `GET /workflow/runs` now includes `runId` per row, and the CLI fetches results via the pinned `GET /workflow/{id}/runs/{rid}/result` endpoint.
 
-**`@outputai/cli`** — Shadow the worker container's `/app/node_modules` (root pnpm store) with a named Docker volume and run an explicit `output:worker:install` before `output:worker:watch`, so Linux-native packages installed in the container no longer leak into the host's `node_modules/`.
+**`@outputai/cli`** —
 
-**`@outputai/cli`** — Fix issue where values in .env files were silently ignored
+Enable multiple instance of Output to run locally simultaneously in Docker by enabling dynamic port mapping
 
-**`@outputai/core`, `@outputai/http`, `@outputai/llm`** — Adding trace event attributes and adding method `addRequestCost` to attach cost related info to an HTTP call made with the http module
+**`@outputai/core`, `@outputai/cli`** —
 
-**`@outputai/llm`** — re-export ai.jsonSchema for downstream use
+Add HTTP and gRPC proxy support for sandbox environments via HTTPS_PROXY and TEMPORAL_GRPC_PROXY env vars
 
-**`@outputai/http`** — ## Custom fetch
+**`@outputai/cli`** —
+
+Shadow the worker container's `/app/node_modules` (root pnpm store) with a named Docker volume and run an explicit `output:worker:install` before `output:worker:watch`, so Linux-native packages installed in the container no longer leak into the host's `node_modules/`.
+
+**`@outputai/cli`** —
+
+Fix issue where values in .env files were silently ignored
+
+**`@outputai/core`, `@outputai/http`, `@outputai/llm`** —
+
+Adding trace event attributes and adding method `addRequestCost` to attach cost related info to an HTTP call made with the http module
+
+**`@outputai/llm`** —
+
+re-export ai.jsonSchema for downstream use
+
+**`@outputai/http`** —
+
+**Custom fetch**
 Added a `fetch` function export to the "http" module:
 - Fully compliant with the fetch [spec](https://fetch.spec.whatwg.org/);
 - Integrates with Traces, tracking requests, responses, errors and failures;
 
-## Updated http client
+**Updated http client**
 Refactored `httpClient` exported by "http" to use the custom _fetch_ internally instead of _ky_ hooks.
 
-**`@outputai/cli`, `output-api`** — Add new workflow history endpoint
+**`@outputai/cli`, `output-api`** —
+
+Add new workflow history endpoint
 
 </Update>
 
@@ -793,30 +978,48 @@ Refactored `httpClient` exported by "http" to use the custom _fetch_ internally 
 
 See the [v0.1.12 → v0.2.0 migration guide](/migrations/v0.1.12-to-v0.2.0).
 
-**`@outputai/cli`** — Fix `workflow generate` success message to show actual workflow ID and scenario name
+**`@outputai/cli`** —
 
-**`@outputai/cli`** — Add `credentials set` command for programmatic credential updates by dot-notation path. Prompts for confirmation when the write would change a value's shape (primitive → object or object → primitive); pass `--yes` to skip in non-interactive environments.
+Fix `workflow generate` success message to show actual workflow ID and scenario name
 
-**`@outputai/cli`** — Add interactive workflow run panel to `output dev` with live status polling, keyboard navigation, and Temporal UI integration
+**`@outputai/cli`** —
 
-**`@outputai/cli`** — Update plugin command invocations to match renamed `output-plan-workflow`, `output-build-workflow`, and `output-debug-workflow` skills.
+Add `credentials set` command for programmatic credential updates by dot-notation path. Prompts for confirmation when the write would change a value's shape (primitive → object or object → primitive); pass `--yes` to skip in non-interactive environments.
 
-**`@outputai/cli`** — Add Docker Compose version check to prevent silent hangs on versions older than v2.24.0
+**`@outputai/cli`** —
 
-**`output-api`** — - Fixed `/run` endpoint response to have the same format as `/result`;
+Add interactive workflow run panel to `output dev` with live status polling, keyboard navigation, and Temporal UI integration
+
+**`@outputai/cli`** —
+
+Update plugin command invocations to match renamed `output-plan-workflow`, `output-build-workflow`, and `output-debug-workflow` skills.
+
+**`@outputai/cli`** —
+
+Add Docker Compose version check to prevent silent hangs on versions older than v2.24.0
+
+**`output-api`** —
+
+- Fixed `/run` endpoint response to have the same format as `/result`;
 - Fixed `/status` endpoints `status` field format;
 
-**`@outputai/cli`** — Add `output migrate` command for upgrading projects between versions of the Output framework.
+**`@outputai/cli`** —
+
+Add `output migrate` command for upgrading projects between versions of the Output framework.
 
 The command reads the project's current `@outputai/*` version, fetches the matching migration guide from `docs.output.ai/migrations`, applies the steps, bumps dependencies, and runs the project's type checker. If the user is jumping multiple boundaries, it chains the guides covering the full range.
 
 Under the hood the CLI invokes `/output-migrate` — a Claude Code skill shipped via the `outputai` plugin marketplace. The skill carries the migration logic but no version-specific content; it fetches every guide at runtime so the docs remain the source of truth.
 
-**`@outputai/evals`** — Switch dataset files to multi-case format where each top-level YAML key is the case name. Allows grouping multiple test cases into a single file instead of one file per case.
+**`@outputai/evals`** —
+
+Switch dataset files to multi-case format where each top-level YAML key is the case name. Allows grouping multiple test cases into a single file instead of one file per case.
 
 The old single-case format (with a top-level `name:` field) is no longer supported — existing files must be migrated to the new format. Treated as minor rather than major because adoption is still early and the migration is mechanical.
 
-**`output-api`** — Add pinned-run routes and deprecate mutation shortcuts.
+**`output-api`** —
+
+Add pinned-run routes and deprecate mutation shortcuts.
 
 New routes: `GET /workflow/:id/runs/:rid/{status,result,trace-log}` and `PATCH/POST /workflow/:id/runs/:rid/{stop,terminate,reset}` allow targeting a specific Temporal run by ID.
 
@@ -834,11 +1037,17 @@ Deprecated routes emit `Deprecation`, `Sunset`, and `Link` response headers on e
 - `POST /workflow/:id/terminate` response now includes `runId`
 - All status, result, and trace-log responses now include `runId`
 
-**`@outputai/cli`** — Upgrading Docker Node image version from 24.13.0-slim to 24.15.0-slim
+**`@outputai/cli`** —
 
-**`@outputai/cli`** — Update the Claude plugin for Output to improve workflow code generation"
+Upgrading Docker Node image version from 24.13.0-slim to 24.15.0-slim
 
-**`@outputai/credentials`, `@outputai/core`, `@outputai/cli`, `@outputai/llm`, `output-api`, `@outputai/evals`, `@outputai/output`, `@outputai/http`** — Updating dependencies:
+**`@outputai/cli`** —
+
+Update the Claude plugin for Output to improve workflow code generation"
+
+**`@outputai/credentials`, `@outputai/core`, `@outputai/cli`, `@outputai/llm`, `output-api`, `@outputai/evals`, `@outputai/output`, `@outputai/http`** —
+
+Updating dependencies:
 - @oclif/plugin-help
 - dotenv
 - json-schema-library
@@ -865,85 +1074,125 @@ Adding version overrides to fix vulnerabilities:
 - axios@>=1.0.0 &lt;1.15.0: `>=1.15.0`
 - protobufjs@&lt;7.5.5: `>=7.5.5`
 
-**`@outputai/cli`** — Auto-forward OUTPUT_CATALOG_ID as default task queue for workflow run/start commands
+**`@outputai/cli`** —
 
-**`@outputai/core`, `@outputai/cli`, `@outputai/llm`** — Bumping dependency versions
+Auto-forward OUTPUT_CATALOG_ID as default task queue for workflow run/start commands
+
+**`@outputai/core`, `@outputai/cli`, `@outputai/llm`** —
+
+Bumping dependency versions
 
 </Update>
 
 <Update label="v0.1.12" description="2026-04-07 · patch release">
 
-**`@outputai/llm`, `@outputai/core`** — Add `agent()` and `skill()` abstractions to `@outputai/llm` for composing reusable LLM agents with structured output and a lazy-loaded skills system. Add `findContentDir()` to `@outputai/core` and fix skill path resolution to be relative to the prompt file rather than the calling module. Add `output-copy-assets` bin to `@outputai/core` to centralise worker asset copying.
+**`@outputai/llm`, `@outputai/core`** —
 
-**`@outputai/core`, `output-api`** — Add support for workflow alias names.
+Add `agent()` and `skill()` abstractions to `@outputai/llm` for composing reusable LLM agents with structured output and a lazy-loaded skills system. Add `findContentDir()` to `@outputai/core` and fix skill path resolution to be relative to the prompt file rather than the calling module. Add `output-copy-assets` bin to `@outputai/core` to centralise worker asset copying.
 
-**`@outputai/cli`** — Add `output fix` command that realigns npm scripts in a host project's `package.json` with the canonical scripts from the CLI. Added `output:worker` and `output:worker:watch` commands to the scaffold. Pinned the dependency versions installed via the CLI-generated `package.json`.
+**`@outputai/core`, `output-api`** —
 
-**`@outputai/cli`** — Pin `output` to a specific version in the scaffold `package.json` instead of a version range.
+Add support for workflow alias names.
 
-**`@outputai/cli`** — Update CLI cost configuration for calculating cost of Claude Sonnet 4.6. Improve coding-assistant guidance for schema generation.
+**`@outputai/cli`** —
+
+Add `output fix` command that realigns npm scripts in a host project's `package.json` with the canonical scripts from the CLI. Added `output:worker` and `output:worker:watch` commands to the scaffold. Pinned the dependency versions installed via the CLI-generated `package.json`.
+
+**`@outputai/cli`** —
+
+Pin `output` to a specific version in the scaffold `package.json` instead of a version range.
+
+**`@outputai/cli`** —
+
+Update CLI cost configuration for calculating cost of Claude Sonnet 4.6. Improve coding-assistant guidance for schema generation.
 
 </Update>
 
 <Update label="v0.1.11" description="2026-04-02 · patch release">
 
-**`@outputai/cli`** — Fix worker health checks and add yarn/pnpm support in the dev container. Dev container worker now supports yarn and pnpm projects via corepack. Health check no longer reports success when containers exit or are unhealthy. Worker health-check detection time dropped from ~36s to ~9s. `start_period` extended from 30s to 60s to reduce false positives on cold start.
+**`@outputai/cli`** —
 
-**`@outputai/cli`** — Fix the `plan` and `generate` CLI commands. Suppressed Claude file writes and next-step suggestions during plan generation (the CLI owns those responsibilities). Validates plan-file existence before creating a workflow skeleton in `generate`. Rolls back created skeleton files if the workflow build step fails.
+Fix worker health checks and add yarn/pnpm support in the dev container. Dev container worker now supports yarn and pnpm projects via corepack. Health check no longer reports success when containers exit or are unhealthy. Worker health-check detection time dropped from ~36s to ~9s. `start_period` extended from 30s to 60s to reduce false positives on cold start.
 
-**`@outputai/cli`** — Replace log-update / ANSI output in `output dev` with an Ink-based terminal UI, fixing a layout bug where text overlapped after a Docker service recovered from unhealthy.
+**`@outputai/cli`** —
 
-**`@outputai/cli`** — Ensure credential references are resolved when running CLI commands.
+Fix the `plan` and `generate` CLI commands. Suppressed Claude file writes and next-step suggestions during plan generation (the CLI owns those responsibilities). Validates plan-file existence before creating a workflow skeleton in `generate`. Rolls back created skeleton files if the workflow build step fails.
+
+**`@outputai/cli`** —
+
+Replace log-update / ANSI output in `output dev` with an Ink-based terminal UI, fixing a layout bug where text overlapped after a Docker service recovered from unhealthy.
+
+**`@outputai/cli`** —
+
+Ensure credential references are resolved when running CLI commands.
 
 </Update>
 
 <Update label="v0.1.10" description="2026-03-27 · patch release">
 
-**All packages** — Update dependencies to latest and override versions to fix known vulnerabilities.
+**All packages** —
+
+Update dependencies to latest and override versions to fix known vulnerabilities.
 
 </Update>
 
 <Update label="v0.1.9" description="2026-03-27 · patch release">
 
-**`@outputai/cli`** — Fix best practices in the `output init` example. Move `blogContentSchema` from `steps.ts` to `types.ts`. Update the README template to use `npx output credentials` flow instead of `.env`.
+**`@outputai/cli`** —
+
+Fix best practices in the `output init` example. Move `blogContentSchema` from `steps.ts` to `types.ts`. Update the README template to use `npx output credentials` flow instead of `.env`.
 
 </Update>
 
 <Update label="v0.1.8" description="2026-03-24 · patch release">
 
-**`@outputai/cli`** — Use encrypted credentials in the `output init` scaffold by default. API keys are now stored in `config/credentials.yml.enc` instead of `.env`, and `<SECRET>` markers are renamed to `<FILL_ME_OUT>`.
+**`@outputai/cli`** —
 
-**`@outputai/llm`** — Update `@exalabs/ai-sdk` from 1.0.5 to 2.0.1.
+Use encrypted credentials in the `output init` scaffold by default. API keys are now stored in `config/credentials.yml.enc` instead of `.env`, and `<SECRET>` markers are renamed to `<FILL_ME_OUT>`.
+
+**`@outputai/llm`** —
+
+Update `@exalabs/ai-sdk` from 1.0.5 to 2.0.1.
 
 </Update>
 
 <Update label="v0.1.7" description="2026-03-24 · patch release">
 
-**All packages** — Dependency bumps (minor and patch).
+**All packages** —
+
+Dependency bumps (minor and patch).
 
 </Update>
 
 <Update label="v0.1.6" description="2026-03-23 · patch release">
 
-**`@outputai/cli`** — Fix null crash in `workflow cost` when the pricing config is empty or missing.
+**`@outputai/cli`** —
+
+Fix null crash in `workflow cost` when the pricing config is empty or missing.
 
 </Update>
 
 <Update label="v0.1.5" description="2026-03-22 · patch release">
 
-**`@outputai/cli`** — Fix prod publish to include the build step before publishing to npm. Previously, packages were published without compiling TypeScript, resulting in a missing `dist/` directory. Add `@next` dist-tag that auto-publishes from every merge to `main`, enabling `npx @outputai/cli@next` for tracking the latest changes.
+**`@outputai/cli`** —
+
+Fix prod publish to include the build step before publishing to npm. Previously, packages were published without compiling TypeScript, resulting in a missing `dist/` directory. Add `@next` dist-tag that auto-publishes from every merge to `main`, enabling `npx @outputai/cli@next` for tracking the latest changes.
 
 </Update>
 
 <Update label="v0.1.4" description="2026-03-20 · patch release">
 
-**All packages** — Patch vulnerable dependencies.
+**All packages** —
+
+Patch vulnerable dependencies.
 
 </Update>
 
 <Update label="v0.1.3" description="2026-03-19 · patch release">
 
-**`@outputai/core`, `@outputai/credentials`, `@outputai/cli`** — Add `credential:` env var convention for automatic secret resolution at worker startup.
+**`@outputai/core`, `@outputai/credentials`, `@outputai/cli`** —
+
+Add `credential:` env var convention for automatic secret resolution at worker startup.
 
 - `@outputai/core`: add `WORKER_BEFORE_START` lifecycle event and `onBeforeStart` hook.
 - `@outputai/credentials`: add `resolveCredentialRefs()` that resolves `credential:<dot.path>` env vars from encrypted credentials, auto-registered via `onBeforeStart` on import.
@@ -953,13 +1202,17 @@ Adding version overrides to fix vulnerabilities:
 
 <Update label="v0.1.2" description="2026-03-19 · patch release">
 
-**`@outputai/cli`** — Update `@anthropic-ai/claude-agent-sdk` from 0.1.71 to 0.2.77.
+**`@outputai/cli`** —
+
+Update `@anthropic-ai/claude-agent-sdk` from 0.1.71 to 0.2.77.
 
 </Update>
 
 <Update label="v0.1.1" description="2026-03-19 · patch release">
 
-**All packages** — Dependency updates (minor and patch).
+**All packages** —
+
+Dependency updates (minor and patch).
 
 </Update>
 

--- a/docs/guides/changelog/index.mdx
+++ b/docs/guides/changelog/index.mdx
@@ -376,6 +376,7 @@ Add per-message provider options to `.prompt` files via `messageOptions`.
 The `continued` workflow status was renamed to `continued_as_new` in API responses.
 
 **Explicit Status Fields**
+
 | Endpoint | HTTP response JSON path | Generated client path |
 | --- | --- | --- |
 | `POST /workflow/run` | `status` | `response.data.status` |
@@ -386,6 +387,7 @@ The `continued` workflow status was renamed to `continued_as_new` in API respons
 | `GET /workflow/runs` | `runs[].status` | `response.data.runs[].status` |
 
 **History Metadata Status Fields**
+
 These endpoints also return workflow status in the history metadata object. The OpenAPI schema currently leaves this nested object unexpanded.
 
 | Endpoint | HTTP response JSON path | Generated client path |
@@ -394,6 +396,7 @@ These endpoints also return workflow status in the history metadata object. The 
 | `GET /workflow/{id}/runs/{rid}/history` | `workflow.status` | `response.data.workflow.status` |
 
 **Backwards support**
+
 In the CLI, the old value is still supported.
 
 </Update>
@@ -439,12 +442,14 @@ Where `workflowDetails` is an abstraction over [Temporal's `workflowInfo()`](htt
 **Error hook**
 Updated `onError()` hooks payload. The fields change according to the `source`:
 
-**Source is "workflow"**```js
+**Source is "workflow"**
+```js
 { eventId, eventDate, source, workflowDetails, error }
 ```
 Where `workflowDetails` is the same as in workflow hooks.
 
-**Source is "activity"**```js
+**Source is "activity"**
+```js
 { eventId, eventDate, source, workflowDetails, activityInfo, outputActivityKind, error }
 ```
 
@@ -452,7 +457,8 @@ Where `activityInfo` is Temporal's `activityInfo()` [function return](https://ty
 
 And `outputActivityKind` is the framework flavor of the Temporal Activity: `step`, `evaluator` or `internal_step`.
 
-**Source is "runtime"**```js
+**Source is "runtime"**
+```js
 { eventId, eventDate, source, error }
 ```
 
@@ -495,11 +501,13 @@ Updated trace workflow node ids to use Temporal `runId`, instead of `workflowId`
 Added worker telemetry logs: print Temporal worker status and node memory every X ms, configured by `OUTPUT_WORKER_TELEMETRY_INTERVAL_MS` env var. Default `0` - off.
 
 Message examples:
-**Dev**```
+**Dev**
+```
 [info] Telemetry: Worker { status: { runState: "RUNNING", numHeartbeatingActivities: 0, workflowPollerState: "POLLING", activityPollerState: "POLLING", hasOutstandingWorkflowPoll: true, hasOutstandingActivityPoll: true, numCachedWorkflows: 1, numInFlightWorkflowActivations: 0, numInFlightActivities: 0, numInFlightNonLocalActivities: 0, numInFlightLocalActivities: 0 }, memory: { availableMemory: 7500000000, constrainedMemory: 20000000000000000000, memoryUsage: { rss: 582348800, heapTotal: 400000000, heapUsed: 200000000, external: 800000000, arrayBuffers: 300000000 } } }
 ```
 
-**Prod**```json
+**Prod**
+```json
 {
   "environment": "production",
   "level": "info",
@@ -858,6 +866,7 @@ Optimizing local trace to use less memory and avoid "RangeError: Invalid string 
 **`@outputai/cli`, `@outputai/llm`, `output-api`, `@outputai/core`, `@outputai/credentials`, `@outputai/evals`, `@outputai/output`, `@outputai/http`** —
 
 **Dependencies updates**
+
 **Vulnerabilities fixed:**
 - uuid: Missing buffer bounds check in v3/v5/v6 when buf: (bump to `>=14.0.0`)
 - postcss: PostCSS has XSS via Unescaped &lt;/style> in its CSS Stringify Output (bump to `>=8.5.10`)

--- a/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
+++ b/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
@@ -681,6 +681,19 @@ This section covers the workflow execution changes in `@outputai/core` v0.11.0.
 - Shared activities are registered as `<workflow-name>#<activity-name>` instead of `$shared#<activity-name>`.
 - Child workflow invocation options are passed as workflow arguments instead of being propagated through Temporal memo.
 - A child workflow's definition-level `activityOptions` now override inherited parent options. Invocation-level and step-level options remain more specific.
+- Worker startup fails if a workflow-scoped activity uses the same name as a shared activity.
+- Steps/evaluators files that use unsupported export or import shapes (or top-level activity calls) fail worker startup instead of bundling with broken rewrites.
+
+### Steps and evaluators file shape
+
+These forms were already unsupported by workflow rewriting. The worker now rejects them during bundling:
+
+| Invalid | Valid |
+| --- | --- |
+| `export default step(…)` / `export * from './other.js'` | `export const foo = step(…)` (named exports only) |
+| `import foo from './steps.js'` / `import * as steps from './steps.js'` | `import { foo } from './steps.js'` |
+| `const steps = require( './steps.js' )` | `const { foo } = require( './steps.js' )` |
+| `foo()` at module top level | Call `foo()` inside a function |
 
 ### Before upgrading running workers
 
@@ -808,6 +821,8 @@ Step-level `options.activityOptions` still have final precedence. Review step de
 - Drain the old task queue, keep a v0.10.x worker until that queue is empty, route new work to a v0.11.0 queue, or restart open executions before the cutover.
 - Do not run v0.10.x and v0.11.0 workers on the same Temporal task queue.
 - Update dashboards and history tooling that match `$shared#<activity-name>`.
+- Rename any workflow activity that shares a name with a shared activity.
+- Replace default/`export *` exports and default/namespace/non-destructured imports in steps and evaluators with named bindings; move top-level activity calls into functions.
 - Audit parent and child workflows that configure the same retry or timeout fields.
 - Pass `activityOptions` on child invocations where the parent must override the child's definition.
 - Update tests that assert inherited parent options override child definition options.
@@ -834,6 +849,49 @@ npx output workflow test <workflowName>
 
 - Replace any scripts, CI steps, or aliases that call `output workflow test_eval` with `output workflow test`.
 - No change if you already use `output workflow test`.
+
+## CLI: worker hot-reload and install scripts
+
+### What changed
+
+In v0.10.x, worker hot-reload watched `package.json` and `output:worker` ran `npm install` on every restart. Editing dependencies (or even touching `package.json`) triggered a full install cycle through nodemon.
+
+In v0.11.0, hot-reload only watches source under `src`. Dependency installs are explicit:
+
+- `output:worker` builds and starts; it no longer runs install.
+- `output:worker:watch` no longer passes `--watch package.json` to nodemon.
+- `output:worker:install` remains the script that runs `npm install`.
+- `output dev` still runs `output:worker:install` once when the worker container starts, then uses watch for source changes only.
+
+### Update project scripts
+
+Existing projects keep their old `package.json` scripts until you sync them. From the project root:
+
+```bash
+npx output fix
+```
+
+That rewrites `scripts` to the current scaffold template, including the new `output:worker` and `output:worker:watch` definitions. It does not install packages and does not change your dependencies list.
+
+### After you change dependencies
+
+Hot-reload will not pick up new or updated packages. After editing `package.json` / the lockfile:
+
+1. Run `npm install` on the host.
+2. Recreate the worker so it reinstalls into its `node_modules` volume:
+   - Foreground `output dev` that owns the stack: quit it, then start `output dev` again.
+   - Attached session or `output dev -d`: run `output dev down`, then `output dev` again.
+
+If you start the worker yourself (without `output dev`), run `npm run output:worker:install` before `npm run output:worker` whenever dependencies change.
+
+### Worker scripts checklist
+
+- Run `npx output fix` once after upgrading so `output:worker` / `output:worker:watch` match the v0.11.0 scaffold.
+- Treat dependency changes as an install + worker recreate, not a hot-reload.
+
+## CLI: `.env` loading
+
+The CLI loads `.env` with Node's `process.loadEnvFile` instead of `dotenv`. Values are taken literally — `${OTHER}` is not expanded. Put the final value in the file (or export the variable in the shell). `OUTPUT_CLI_ENV` still selects which file to load.
 
 ## LLM permanent errors and schema-mismatch messages
 

--- a/docs/guides/operations/deployment/railway.mdx
+++ b/docs/guides/operations/deployment/railway.mdx
@@ -44,7 +44,7 @@ This is the default structure — it doesn't include any deployment configuratio
 The Output API is published as a Docker image. Deploy it first so you can verify the connection to Temporal before adding the worker.
 
 1. Click **+ New** → **Docker Image**
-2. Enter: `docker.io/outputai/api:0.1`
+2. Enter: `docker.io/outputai/api:0.10.0`
 3. Configure variables:
 
 ```bash

--- a/docs/guides/operations/deployment/render.mdx
+++ b/docs/guides/operations/deployment/render.mdx
@@ -96,7 +96,7 @@ services:
     name: your-project-output-api
     runtime: image
     image:
-      url: docker.io/outputai/api:0.1
+      url: docker.io/outputai/api:0.10.0
     plan: pro
     region: oregon
     envVars:

--- a/docs/guides/packages/cli.mdx
+++ b/docs/guides/packages/cli.mdx
@@ -710,6 +710,6 @@ OUTPUT_CLI_ENV=.env.staging output workflow run lead_enrichment acme
 | `OUTPUT_API_HOST_PORT` | `3001` | Host port for the Output API server |
 | `OUTPUT_TEMPORAL_UI_HOST_PORT` | `8080` | Host port for the Temporal UI |
 | `OUTPUT_TEMPORAL_HOST_PORT` | `7233` | Host port for the Temporal gRPC endpoint. Override to run multiple dev stacks side-by-side |
-| `OUTPUT_API_VERSION` | `1.9` | API Docker image tag. Set to `dev` for local builds |
+| `OUTPUT_API_VERSION` | `0.10.0` | API Docker image tag. Set to `dev` for local builds |
 | `OUTPUT_WORKFLOWS_DIR` | `.` | Workflows subdirectory relative to project root. Set to `test_workflows` for monorepo dev |
 | `ANTHROPIC_API_KEY` | — | Anthropic API key for AI-assisted workflow generation (`workflow plan`, `workflow generate`) |

--- a/docs/guides/scripts/lib/renderer.mjs
+++ b/docs/guides/scripts/lib/renderer.mjs
@@ -31,12 +31,22 @@ function escapeMdxText( text ) {
 // Changeset summaries often use `##` section titles. If left as ATX headings
 // they become page-level <h2>s inside <Update> and leak into Mintlify's TOC.
 function demoteMarkdownHeadings( text ) {
+  // Headings often sit immediately before a fenced block. mapProse puts the
+  // fence in the next segment, so the prose segment ends with `\n`. With the
+  // `m` flag, `\s*$` consumes that final newline (`\s*` + `$` at EOS), and the
+  // join becomes `**Title**```js` — Mintlify then parses the fence body as JS.
+  // Only strip spaces/tabs at EOL.
   return mapProse( text, segment =>
-    segment.replace( /^(#{1,6})[ \t]+(.+?)\s*$/gm, ( _match, _hashes, title ) => `**${title}**` )
+    segment.replace( /^(#{1,6})[ \t]+(.+?)[ \t]*$/gm, ( _match, _hashes, title ) => `**${title}**` )
   );
 }
 
-function renderChangeBlock( change ) {
+/**
+ * Render one changelog change as MDX (package line + summary).
+ * @param {{ packages: Array<{ name: string }>, summary: string }} change
+ * @returns {string}
+ */
+export function renderChangeBlock( change ) {
   const inner = change.packages.length === 0
     ? 'All packages'
     : change.packages.map( p => `\`${p.name}\`` ).join( ', ' );

--- a/docs/guides/scripts/lib/renderer.mjs
+++ b/docs/guides/scripts/lib/renderer.mjs
@@ -8,25 +8,42 @@
  * relative link is prepended to that release's block.
  */
 
+// Apply a transform only outside inline/fenced code so changeset examples stay
+// verbatim while surrounding MDX prose can be escaped or rewritten.
+function mapProse( text, transform ) {
+  const codeSpans = /(```[\s\S]*?```|`[^`]*`)/g;
+  return text
+    .split( codeSpans )
+    .map( ( segment, i ) => ( i % 2 === 1 ? segment : transform( segment ) ) )
+    .join( '' );
+}
+
 // MDX reads a bare `<` as the start of a JSX tag and `{` as an expression, so
 // arbitrary changeset prose (e.g. `hono@<4.12.12`, `</style>`) breaks parsing
 // and drops the whole page. Escape those two characters in the prose parts of
 // the summary, leaving inline-code spans and fenced code blocks verbatim.
 function escapeMdxText( text ) {
-  const codeSpans = /(```[\s\S]*?```|`[^`]*`)/g;
-  return text
-    .split( codeSpans )
-    .map( ( segment, i ) => i % 2 === 1
-      ? segment
-      : segment.replace( /</g, '&lt;' ).replace( /\{/g, '&#123;' ) )
-    .join( '' );
+  return mapProse( text, segment =>
+    segment.replace( /</g, '&lt;' ).replace( /\{/g, '&#123;' )
+  );
+}
+
+// Changeset summaries often use `##` section titles. If left as ATX headings
+// they become page-level <h2>s inside <Update> and leak into Mintlify's TOC.
+function demoteMarkdownHeadings( text ) {
+  return mapProse( text, segment =>
+    segment.replace( /^(#{1,6})[ \t]+(.+?)\s*$/gm, ( _match, _hashes, title ) => `**${title}**` )
+  );
 }
 
 function renderChangeBlock( change ) {
   const inner = change.packages.length === 0
     ? 'All packages'
     : change.packages.map( p => `\`${p.name}\`` ).join( ', ' );
-  return `**${inner}** — ${escapeMdxText( change.summary )}`;
+  // Keep the summary on its own line so a leading `##` / `-` is not glued onto
+  // the `**pkg** —` paragraph (which rendered as literal `##` / a stray `-`).
+  const summary = escapeMdxText( demoteMarkdownHeadings( change.summary ) );
+  return `**${inner}** —\n\n${summary}`;
 }
 
 function renderMigrationLink( guide ) {

--- a/docs/guides/scripts/lib/renderer.mjs
+++ b/docs/guides/scripts/lib/renderer.mjs
@@ -1,5 +1,5 @@
 /**
- * Pure rendering functions — turn releases.json data into MDX strings.
+ * Pure rendering functions - turn releases.json data into MDX strings.
  *
  * renderChangelogBody() returns the <Update> blocks that get spliced into the
  * hand-written changelog page (docs/guides/changelog/index.mdx) between its
@@ -8,21 +8,13 @@
  * relative link is prepended to that release's block.
  */
 
-// Apply a transform only outside fenced code blocks (``` … ```).
-function mapOutsideFences( text, transform ) {
-  const fences = /(```[\s\S]*?```)/g;
-  return text
-    .split( fences )
-    .map( ( segment, i ) => ( i % 2 === 1 ? segment : transform( segment ) ) )
-    .join( '' );
-}
+const FENCE_RE = /(```[\s\S]*?```)/g;
+const CODE_OR_FENCE_RE = /(```[\s\S]*?```|`[^`]*`)/g;
 
-// Apply a transform only outside inline/fenced code so changeset examples stay
-// verbatim while surrounding MDX prose can be escaped or rewritten.
-function mapProse( text, transform ) {
-  const codeSpans = /(```[\s\S]*?```|`[^`]*`)/g;
+// Apply a transform only outside segments matched by `splitRe` (odd split parts).
+function mapOutside( splitRe, text, transform ) {
   return text
-    .split( codeSpans )
+    .split( splitRe )
     .map( ( segment, i ) => ( i % 2 === 1 ? segment : transform( segment ) ) )
     .join( '' );
 }
@@ -32,7 +24,7 @@ function mapProse( text, transform ) {
 // and drops the whole page. Escape those two characters in the prose parts of
 // the summary, leaving inline-code spans and fenced code blocks verbatim.
 function escapeMdxText( text ) {
-  return mapProse( text, segment =>
+  return mapOutside( CODE_OR_FENCE_RE, text, segment =>
     segment.replace( /</g, '&lt;' ).replace( /\{/g, '&#123;' )
   );
 }
@@ -40,7 +32,7 @@ function escapeMdxText( text ) {
 // Changeset summaries often use `##` section titles. If left as ATX headings
 // they become page-level <h2>s inside <Update> and leak into Mintlify's TOC.
 function demoteMarkdownHeadings( text ) {
-  // Split on fences only — not inline code. mapProse would carve
+  // Split on fences only - not inline code. Splitting on inline code would carve
   // `## `workflow start --monitor`` into "## " + "`…`" and the heading regex
   // (which needs [ \t]+(.+?)) would miss, leaving a real <h2>. Mid-title
   // inline code would also mangle `## Update `x` here` into `**Update**`x` here`.
@@ -49,20 +41,20 @@ function demoteMarkdownHeadings( text ) {
   // separated from the paragraph (tables cannot interrupt a paragraph; lists
   // and fences can).
   //
-  // Only strip spaces/tabs at EOL — not `\s`. With fence splitting the prose
+  // Only strip spaces/tabs at EOL - not `\s`. With fence splitting the prose
   // segment often ends in `\n`; `\s*$` would eat it and glue `**Title**```js`.
-  return mapOutsideFences( text, segment =>
+  return mapOutside( FENCE_RE, text, segment =>
     segment.replace(
-      /^(#{1,6})[ \t]+(.+?)[ \t]*$/gm,
-      ( _match, _hashes, title ) => `**${title}**\n`
+      /^(?:#{1,6})[ \t]+(.+?)[ \t]*$/gm,
+      ( _match, title ) => `**${title}**\n`
     )
   );
 }
 
 // The extra newline after demotion stacks with blank lines already in the
-// changeset (`## A\n\n## B` → three newlines). Keep a single blank line.
+// changeset (`## A\n\n## B` becomes three newlines). Keep a single blank line.
 function collapseExtraBlankLines( text ) {
-  return mapOutsideFences( text, segment => segment.replace( /\n{3,}/g, '\n\n' ) );
+  return mapOutside( FENCE_RE, text, segment => segment.replace( /\n{3,}/g, '\n\n' ) );
 }
 
 /**

--- a/docs/guides/scripts/lib/renderer.mjs
+++ b/docs/guides/scripts/lib/renderer.mjs
@@ -8,6 +8,15 @@
  * relative link is prepended to that release's block.
  */
 
+// Apply a transform only outside fenced code blocks (``` … ```).
+function mapOutsideFences( text, transform ) {
+  const fences = /(```[\s\S]*?```)/g;
+  return text
+    .split( fences )
+    .map( ( segment, i ) => ( i % 2 === 1 ? segment : transform( segment ) ) )
+    .join( '' );
+}
+
 // Apply a transform only outside inline/fenced code so changeset examples stay
 // verbatim while surrounding MDX prose can be escaped or rewritten.
 function mapProse( text, transform ) {
@@ -31,14 +40,29 @@ function escapeMdxText( text ) {
 // Changeset summaries often use `##` section titles. If left as ATX headings
 // they become page-level <h2>s inside <Update> and leak into Mintlify's TOC.
 function demoteMarkdownHeadings( text ) {
-  // Headings often sit immediately before a fenced block. mapProse puts the
-  // fence in the next segment, so the prose segment ends with `\n`. With the
-  // `m` flag, `\s*$` consumes that final newline (`\s*` + `$` at EOS), and the
-  // join becomes `**Title**```js` — Mintlify then parses the fence body as JS.
-  // Only strip spaces/tabs at EOL.
-  return mapProse( text, segment =>
-    segment.replace( /^(#{1,6})[ \t]+(.+?)[ \t]*$/gm, ( _match, _hashes, title ) => `**${title}**` )
+  // Split on fences only — not inline code. mapProse would carve
+  // `## `workflow start --monitor`` into "## " + "`…`" and the heading regex
+  // (which needs [ \t]+(.+?)) would miss, leaving a real <h2>. Mid-title
+  // inline code would also mangle `## Update `x` here` into `**Update**`x` here`.
+  //
+  // Emit an extra newline after the bold title so a following GFM table is
+  // separated from the paragraph (tables cannot interrupt a paragraph; lists
+  // and fences can).
+  //
+  // Only strip spaces/tabs at EOL — not `\s`. With fence splitting the prose
+  // segment often ends in `\n`; `\s*$` would eat it and glue `**Title**```js`.
+  return mapOutsideFences( text, segment =>
+    segment.replace(
+      /^(#{1,6})[ \t]+(.+?)[ \t]*$/gm,
+      ( _match, _hashes, title ) => `**${title}**\n`
+    )
   );
+}
+
+// The extra newline after demotion stacks with blank lines already in the
+// changeset (`## A\n\n## B` → three newlines). Keep a single blank line.
+function collapseExtraBlankLines( text ) {
+  return mapOutsideFences( text, segment => segment.replace( /\n{3,}/g, '\n\n' ) );
 }
 
 /**
@@ -50,19 +74,19 @@ export function renderChangeBlock( change ) {
   const inner = change.packages.length === 0
     ? 'All packages'
     : change.packages.map( p => `\`${p.name}\`` ).join( ', ' );
-  // Keep the summary on its own line so a leading `##` / `-` is not glued onto
-  // the `**pkg** —` paragraph (which rendered as literal `##` / a stray `-`).
-  const summary = escapeMdxText( demoteMarkdownHeadings( change.summary ) );
-  return `**${inner}** —\n\n${summary}`;
+  // Package label on its own line, then the summary, so a leading `##` or `-`
+  // in the summary stays a block construct instead of trailing the label.
+  const summary = escapeMdxText( collapseExtraBlankLines( demoteMarkdownHeadings( change.summary ) ) );
+  return `**${inner}**\n\n${summary}`;
 }
 
 function renderMigrationLink( guide ) {
-  return `See the [v${guide.from} → v${guide.to} migration guide](/migrations/${guide.slug}).`;
+  return `See the [v${guide.from} - v${guide.to} migration guide](/migrations/${guide.slug}).`;
 }
 
 function renderUpdateBlock( release, migrationByToVersion ) {
   const lines = [
-    `<Update label="v${release.version}" description="${release.date} · ${release.level} release">`,
+    `<Update label="v${release.version}" description="${release.date} - ${release.level} release">`,
     ''
   ];
 

--- a/docs/guides/scripts/lib/renderer.spec.js
+++ b/docs/guides/scripts/lib/renderer.spec.js
@@ -4,11 +4,10 @@ import { renderChangeBlock, renderChangelogBody } from './renderer.mjs';
 const pkg = name => ( { name } );
 
 describe( 'renderChangeBlock', () => {
-  it( 'keeps a newline between a demoted heading and a following fenced block', () => {
-    // mapProse splits the fence into its own segment, so the heading segment
-    // ends with `\n`. Demotion must not eat that newline or Mintlify parses
-    // `{ … }` inside the fence as an MDX expression ("Could not parse
-    // expression with acorn").
+  it( 'keeps a blank line between a demoted heading and a following fenced block', () => {
+    // Fence splitting leaves the heading segment ending with `\n`. Demotion must
+    // not eat that newline (or Mintlify parses `{ … }` in the fence as MDX), and
+    // adds one more so the bold title is its own paragraph.
     const out = renderChangeBlock( {
       packages: [ pkg( '@outputai/core' ) ],
       summary: [
@@ -20,7 +19,7 @@ describe( 'renderChangeBlock', () => {
       ].join( '\n' )
     } );
 
-    expect( out ).toContain( '**Source is "workflow"**\n```js\n' );
+    expect( out ).toContain( '**Source is "workflow"**\n\n```js\n' );
     expect( out ).not.toMatch( /\*\*Source is "workflow"\*\*```/ );
     expect( out ).toContain( '{ eventId, eventDate, source, workflowDetails, error }' );
   } );
@@ -44,10 +43,64 @@ describe( 'renderChangeBlock', () => {
       ].join( '\n' )
     } );
 
-    expect( out ).toContain( '**Error hook**\n' );
-    expect( out ).toContain( '**Source is "activity"**\n```js\n' );
-    expect( out ).toContain( '**Source is "runtime"**\n```js\n' );
+    expect( out ).toContain( '**Error hook**\n\n' );
+    expect( out ).toContain( '**Source is "activity"**\n\n```js\n' );
+    expect( out ).toContain( '**Source is "runtime"**\n\n```js\n' );
     expect( out ).not.toMatch( /\*\*[^*\n]+\*\*```/ );
+  } );
+
+  it( 'demotes a heading whose title starts with inline code (olive-moons shape)', () => {
+    // Regression: splitting on inline code left a prose segment of "## " that
+    // the heading regex could not match, so the ATX heading survived into MDX.
+    const out = renderChangeBlock( {
+      packages: [ pkg( '@outputai/cli' ) ],
+      summary: [
+        '## `workflow start --monitor`',
+        '',
+        'Added a `--monitor` flag.'
+      ].join( '\n' )
+    } );
+
+    expect( out ).not.toMatch( /^#{1,6} /m );
+    expect( out ).toContain( '**`workflow start --monitor`**\n\n' );
+    expect( out ).toContain( 'Added a `--monitor` flag.' );
+  } );
+
+  it( 'demotes a heading with inline code in the middle of the title', () => {
+    // Regression: mapProse used to turn this into `**Update**`x` here`.
+    const out = renderChangeBlock( {
+      packages: [ pkg( '@outputai/cli' ) ],
+      summary: '## Update `x` here\nbody'
+    } );
+
+    expect( out ).not.toMatch( /^#{1,6} /m );
+    expect( out ).toContain( '**Update `x` here**\n\nbody' );
+    expect( out ).not.toContain( '**Update**`x`' );
+  } );
+
+  it( 'inserts a blank line so a GFM table after a demoted heading still parses', () => {
+    const out = renderChangeBlock( {
+      packages: [ pkg( '@outputai/core' ) ],
+      summary: [
+        '## Options',
+        '| Flag | Meaning |',
+        '| --- | --- |',
+        '| `-m` | monitor |'
+      ].join( '\n' )
+    } );
+
+    expect( out ).toContain( '**Options**\n\n| Flag | Meaning |' );
+    expect( out ).not.toMatch( /\*\*Options\*\*\n\|/ );
+  } );
+
+  it( 'collapses blank lines stacked by demotion when the changeset already had one', () => {
+    const out = renderChangeBlock( {
+      packages: [ pkg( '@outputai/core' ) ],
+      summary: '## Dependencies updates\n\n### Vulnerabilities fixed:\n- uuid: …'
+    } );
+
+    expect( out ).toContain( '**Dependencies updates**\n\n**Vulnerabilities fixed:**\n\n- uuid: …' );
+    expect( out ).not.toContain( '**Dependencies updates**\n\n\n**Vulnerabilities fixed:**' );
   } );
 
   it( 'leaves no ATX headings that would leak into the page TOC', () => {
@@ -67,8 +120,18 @@ describe( 'renderChangeBlock', () => {
       summary: '- Added a custom dispatcher\n- Added support for dispatcher in init'
     } );
 
-    expect( out.startsWith( '**`@outputai/http`** —\n\n- Added a custom dispatcher\n' ) ).toBe( true );
-    expect( out ).not.toContain( '— - ' );
+    expect( out.startsWith( '**`@outputai/http`**\n\n- Added a custom dispatcher\n' ) ).toBe( true );
+  } );
+
+  it( 'does not put an em dash on the package label line', () => {
+    const out = renderChangeBlock( {
+      packages: [ pkg( 'output-api' ) ],
+      summary: 'Workflow result endpoints changed.'
+    } );
+
+    expect( out.startsWith( '**`output-api`**\n\nWorkflow result endpoints changed.' ) ).toBe( true );
+    expect( out.split( '\n' )[0] ).toBe( '**`output-api`**' );
+    expect( out ).not.toContain( '—' );
   } );
 
   it( 'escapes bare < and { in prose but leaves fenced code verbatim', () => {
@@ -119,8 +182,8 @@ describe( 'renderChangelogBody', () => {
     }, new Map( [ [ '0.7.0', { from: '0.6.0', to: '0.7.0', slug: 'v0.6.0-to-v0.7.0' } ] ] ) );
 
     expect( body ).toContain( '<Update label="v0.7.0"' );
-    expect( body ).toContain( 'See the [v0.6.0 → v0.7.0 migration guide]' );
-    expect( body ).toContain( '**Source is "workflow"**\n```js\n{ eventId }\n```' );
+    expect( body ).toContain( 'See the [v0.6.0 - v0.7.0 migration guide]' );
+    expect( body ).toContain( '**Source is "workflow"**\n\n```js\n{ eventId }\n```' );
     expect( body ).not.toMatch( /\*\*Source is "workflow"\*\*```/ );
   } );
 } );

--- a/docs/guides/scripts/lib/renderer.spec.js
+++ b/docs/guides/scripts/lib/renderer.spec.js
@@ -165,6 +165,23 @@ describe( 'renderChangeBlock', () => {
 
     expect( out ).toContain( '```md\n## Still a heading in the example\n```' );
   } );
+
+  it( 'does not collapse consecutive blank lines inside fenced code', () => {
+    const out = renderChangeBlock( {
+      packages: [ pkg( '@outputai/cli' ) ],
+      summary: [
+        'Example:',
+        '```txt',
+        'before',
+        '',
+        '',
+        'after',
+        '```'
+      ].join( '\n' )
+    } );
+
+    expect( out ).toContain( '```txt\nbefore\n\n\nafter\n```' );
+  } );
 } );
 
 describe( 'renderChangelogBody', () => {

--- a/docs/guides/scripts/lib/renderer.spec.js
+++ b/docs/guides/scripts/lib/renderer.spec.js
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { renderChangeBlock, renderChangelogBody } from './renderer.mjs';
+
+const pkg = name => ( { name } );
+
+describe( 'renderChangeBlock', () => {
+  it( 'keeps a newline between a demoted heading and a following fenced block', () => {
+    // mapProse splits the fence into its own segment, so the heading segment
+    // ends with `\n`. Demotion must not eat that newline or Mintlify parses
+    // `{ … }` inside the fence as an MDX expression ("Could not parse
+    // expression with acorn").
+    const out = renderChangeBlock( {
+      packages: [ pkg( '@outputai/core' ) ],
+      summary: [
+        '### Source is "workflow"',
+        '```js',
+        '{ eventId, eventDate, source, workflowDetails, error }',
+        '```',
+        'Where `workflowDetails` is unchanged.'
+      ].join( '\n' )
+    } );
+
+    expect( out ).toContain( '**Source is "workflow"**\n```js\n' );
+    expect( out ).not.toMatch( /\*\*Source is "workflow"\*\*```/ );
+    expect( out ).toContain( '{ eventId, eventDate, source, workflowDetails, error }' );
+  } );
+
+  it( 'demotes multiple heading levels before fences without gluing', () => {
+    const out = renderChangeBlock( {
+      packages: [ pkg( '@outputai/core' ) ],
+      summary: [
+        '## Error hook',
+        'Updated payloads.',
+        '',
+        '### Source is "activity"',
+        '```js',
+        '{ eventId, error }',
+        '```',
+        '',
+        '### Source is "runtime"',
+        '```js',
+        '{ eventId }',
+        '```'
+      ].join( '\n' )
+    } );
+
+    expect( out ).toContain( '**Error hook**\n' );
+    expect( out ).toContain( '**Source is "activity"**\n```js\n' );
+    expect( out ).toContain( '**Source is "runtime"**\n```js\n' );
+    expect( out ).not.toMatch( /\*\*[^*\n]+\*\*```/ );
+  } );
+
+  it( 'leaves no ATX headings that would leak into the page TOC', () => {
+    const out = renderChangeBlock( {
+      packages: [ pkg( '@outputai/core' ) ],
+      summary: '## Trace Changes\n- item\n\n### Nested\nbody'
+    } );
+
+    expect( out ).not.toMatch( /^#{1,6} /m );
+    expect( out ).toContain( '**Trace Changes**' );
+    expect( out ).toContain( '**Nested**' );
+  } );
+
+  it( 'puts the summary on its own line so a leading list marker is not glued to the package prefix', () => {
+    const out = renderChangeBlock( {
+      packages: [ pkg( '@outputai/http' ) ],
+      summary: '- Added a custom dispatcher\n- Added support for dispatcher in init'
+    } );
+
+    expect( out.startsWith( '**`@outputai/http`** —\n\n- Added a custom dispatcher\n' ) ).toBe( true );
+    expect( out ).not.toContain( '— - ' );
+  } );
+
+  it( 'escapes bare < and { in prose but leaves fenced code verbatim', () => {
+    const out = renderChangeBlock( {
+      packages: [ pkg( '@outputai/core' ) ],
+      summary: [
+        'Uses hono@<4.12.12 and {brace} in prose.',
+        '```js',
+        'const x = { a: 1 };',
+        'if ( n < 4 ) {}',
+        '```'
+      ].join( '\n' )
+    } );
+
+    expect( out ).toContain( 'hono@&lt;4.12.12' );
+    expect( out ).toContain( '&#123;brace}' );
+    expect( out ).toContain( 'const x = { a: 1 };' );
+    expect( out ).toContain( 'if ( n < 4 ) {}' );
+  } );
+
+  it( 'does not demote heading-like lines inside fenced code', () => {
+    const out = renderChangeBlock( {
+      packages: [ pkg( '@outputai/cli' ) ],
+      summary: [
+        'Example:',
+        '```md',
+        '## Still a heading in the example',
+        '```'
+      ].join( '\n' )
+    } );
+
+    expect( out ).toContain( '```md\n## Still a heading in the example\n```' );
+  } );
+} );
+
+describe( 'renderChangelogBody', () => {
+  it( 'renders update blocks with demoted headings and intact fences', () => {
+    const body = renderChangelogBody( {
+      releases: [ {
+        version: '0.7.0',
+        date: '2026-06-10',
+        level: 'minor',
+        changes: [ {
+          packages: [ pkg( '@outputai/core' ) ],
+          summary: '### Source is "workflow"\n```js\n{ eventId }\n```'
+        } ]
+      } ]
+    }, new Map( [ [ '0.7.0', { from: '0.6.0', to: '0.7.0', slug: 'v0.6.0-to-v0.7.0' } ] ] ) );
+
+    expect( body ).toContain( '<Update label="v0.7.0"' );
+    expect( body ).toContain( 'See the [v0.6.0 → v0.7.0 migration guide]' );
+    expect( body ).toContain( '**Source is "workflow"**\n```js\n{ eventId }\n```' );
+    expect( body ).not.toMatch( /\*\*Source is "workflow"\*\*```/ );
+  } );
+} );


### PR DESCRIPTION
## Summary

- Fix changelog compiler to put changeset summaries on their own line and demote ATX headings so Mintlify no longer treats them as page-level h2s;
- Improved migration guides to add woirker fail-fast validations, dotenv change on the CLI and hot-reload/output fix commands;
- Fixing version names on changesets;
- Updating API version on docs