### PR TITLE
refactor(core): Re-adding Error object to workflow error hooks

### DIFF
--- a/.changeset/direct-results-flow.md
+++ b/.changeset/direct-results-flow.md
@@ -25,9 +25,6 @@
     - `CompleteAsyncError`, throw;
     - `TemporalFailure`, throw;
     - Other errors, create an `ApplicationFailure`, serialize the original error in `.details[0].error`, and determine whether it is non-retryable from the error class name and `activityInfo.retryPolicy.nonRetryableErrorTypes`;
-- Refactored hook error payloads:
-  - Workflow errors are now serialized plain objects that preserve `name`, `message`, `cause`, and additional diagnostic properties;
-  - Activity and runtime errors remain `Error` instances;
 - `ValidationError` now extends from `FatalError`.
 - `FatalError` is now always handled as non retryable, user configurable `activityOptions.retry.nonRetryableErrorTypes` will not overwrite it anymore.
 - Forwarded Temporal SDK and native Core logs through Output's logger for consistent production/development formatting, omitted redundant failure logs (workflow/activity failures), and added `OUTPUT_TEMPORAL_LOG_LEVEL` to configure verbosity;

--- a/.changeset/pink-lady-crush.md
+++ b/.changeset/pink-lady-crush.md
@@ -1,0 +1,5 @@
+---
+"@outputai/core": patch
+---
+
+- Workflow errors passed to `onWorkflowError` and workflow-sourced `onError` are rehydrated to `Error` instances after crossing the Temporal sandbox (preserving `name`, `message`, `cause`, and other enumerable properties).

--- a/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
+++ b/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
@@ -239,22 +239,28 @@ on( 'cost:llm:request', event => {
 } );
 ```
 
-### Workflow error hooks receive serialized objects
+### Workflow error hooks receive rehydrated `Error` instances
 
-Workflow errors are serialized before crossing Temporal's workflow sandbox boundary. The `error` field passed to `onWorkflowError` and workflow-sourced `onError` handlers is now a plain error-like object rather than an `Error` instance.
+Workflow errors are still serialized to cross Temporal's workflow sandbox boundary
+(so `name`, `message`, `cause`, and other diagnostics survive). Before hooks run,
+the worker rehydrates that payload into an `Error`. `onWorkflowError` and
+workflow-sourced `onError` handlers therefore receive an `Error` instance again —
+the same shape as activity and runtime error hooks.
 
 ```ts
 import { onError } from '@outputai/core/hooks';
 
 onError( event => {
   if ( event.source === 'workflow' ) {
+    console.log( event.error instanceof Error ); // true
     console.log( event.error.name, event.error.message );
-    // event.error instanceof Error === false
   }
 } );
 ```
 
-Activity and runtime error hooks continue to receive `Error` instances.
+The rehydrated value is a reconstructed `Error`, not the original subclass
+(`instanceof FatalError` may be false even when `error.name === 'FatalError'`).
+Prefer `error.name` when you need to distinguish failure kinds after the boundary.
 
 ### Update imported hook payload types
 
@@ -327,7 +333,8 @@ No migration is needed unless an `onError` handler explicitly relied on `$catalo
 - Guard `event.payload` before accessing its fields.
 - Keep framework fields such as `eventId`, `workflowDetails`, and `activityInfo` at the top level.
 - Remove reads of `aggregations` from activity lifecycle and error hooks.
-- Treat workflow hook errors as serialized error-like objects rather than `Error` instances.
+- Treat workflow hook errors as reconstructed `Error` instances (not plain
+  serialized objects). Use `error.name` when original subclass identity matters.
 - Filter `outputActivityKind === 'internal_step'` in activity lifecycle hooks when internal activities should remain hidden.
 - Remove assumptions that `onError` reports `$catalog` workflow failures.
 

--- a/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
+++ b/docs/guides/migrations/v0.10.0-to-v0.11.0.mdx
@@ -241,11 +241,7 @@ on( 'cost:llm:request', event => {
 
 ### Workflow error hooks receive rehydrated `Error` instances
 
-Workflow errors are still serialized to cross Temporal's workflow sandbox boundary
-(so `name`, `message`, `cause`, and other diagnostics survive). Before hooks run,
-the worker rehydrates that payload into an `Error`. `onWorkflowError` and
-workflow-sourced `onError` handlers therefore receive an `Error` instance again —
-the same shape as activity and runtime error hooks.
+Workflow errors are still serialized to cross Temporal's workflow sandbox boundary (so `name`, `message`, `cause`, and other diagnostics survive). Before hooks run, the worker rehydrates that payload into an `Error`. `onWorkflowError` and workflow-sourced `onError` handlers therefore receive an `Error` instance again — the same shape as activity and runtime error hooks.
 
 ```ts
 import { onError } from '@outputai/core/hooks';
@@ -258,9 +254,7 @@ onError( event => {
 } );
 ```
 
-The rehydrated value is a reconstructed `Error`, not the original subclass
-(`instanceof FatalError` may be false even when `error.name === 'FatalError'`).
-Prefer `error.name` when you need to distinguish failure kinds after the boundary.
+The rehydrated value is always a bare `Error`, not the original subclass. `instanceof FatalError` is false even when `error.name === 'FatalError'`. Use `error.name`, or `hasErrorType(error, FatalError)` from `@outputai/core` (matches `.name` and walks `.cause`), to distinguish failure kinds after the boundary. Extra enumerable fields may still be present at runtime; narrow or cast in TypeScript when you need them.
 
 ### Update imported hook payload types
 
@@ -333,8 +327,7 @@ No migration is needed unless an `onError` handler explicitly relied on `$catalo
 - Guard `event.payload` before accessing its fields.
 - Keep framework fields such as `eventId`, `workflowDetails`, and `activityInfo` at the top level.
 - Remove reads of `aggregations` from activity lifecycle and error hooks.
-- Treat workflow hook errors as reconstructed `Error` instances (not plain
-  serialized objects). Use `error.name` when original subclass identity matters.
+- Treat workflow hook errors as reconstructed `Error` instances (not plain serialized objects). `instanceof FatalError` is always false after rehydration — use `error.name` or `hasErrorType(error, FatalError)` when subclass identity matters.
 - Filter `outputActivityKind === 'internal_step'` in activity lifecycle hooks when internal activities should remain hidden.
 - Remove assumptions that `onError` reports `$catalog` workflow failures.
 

--- a/docs/guides/operations/error-hooks.mdx
+++ b/docs/guides/operations/error-hooks.mdx
@@ -55,7 +55,11 @@ So:
 
 `outputActivityKind` identifies the Output activity type. Possible values are `step`, `evaluator`, and `internal_step`.
 
-For `activity` and `runtime`, `error` is the original `Error` instance. Workflow errors cross Temporal's sandbox boundary as plain serialized objects. They retain `name`, `message`, an optional recursive `cause`, and additional enumerable diagnostic properties, but they are not `instanceof Error`.
+Activity, runtime, and workflow error hooks all receive `Error` instances. Workflow
+errors are still serialized to cross Temporal's sandbox boundary, then rehydrated
+before hooks run — so `name`, `message`, an optional recursive `cause`, and other
+enumerable diagnostic properties survive, but the value is a reconstructed `Error`
+(not the original subclass).
 
 `eventId` is a UUID v4 stamped per emit — use it as a stable idempotency key when forwarding errors to external systems (Sentry, PagerDuty, your own incident pipeline). `eventDate` is the millisecond epoch timestamp for when the event was emitted. Use `source` to branch in one handler, or ignore payload fields that are undefined for that source.
 

--- a/docs/guides/operations/error-hooks.mdx
+++ b/docs/guides/operations/error-hooks.mdx
@@ -55,11 +55,7 @@ So:
 
 `outputActivityKind` identifies the Output activity type. Possible values are `step`, `evaluator`, and `internal_step`.
 
-Activity, runtime, and workflow error hooks all receive `Error` instances. Workflow
-errors are still serialized to cross Temporal's sandbox boundary, then rehydrated
-before hooks run — so `name`, `message`, an optional recursive `cause`, and other
-enumerable diagnostic properties survive, but the value is a reconstructed `Error`
-(not the original subclass).
+Activity, runtime, and workflow error hooks all receive `Error` instances. Workflow errors are still serialized to cross Temporal's sandbox boundary, then rehydrated before hooks run — so `name`, `message`, an optional recursive `cause`, and other enumerable diagnostic properties survive. The value is always a bare `Error`, not the original subclass (`instanceof FatalError` is false even when `error.name === 'FatalError'`). Use `error.name`, or `hasErrorType(error, FatalError)` from `@outputai/core`, to distinguish failure kinds.
 
 `eventId` is a UUID v4 stamped per emit — use it as a stable idempotency key when forwarding errors to external systems (Sentry, PagerDuty, your own incident pipeline). `eventDate` is the millisecond epoch timestamp for when the event was emitted. Use `source` to branch in one handler, or ignore payload fields that are undefined for that source.
 

--- a/docs/guides/packages/core.mdx
+++ b/docs/guides/packages/core.mdx
@@ -186,11 +186,7 @@ type WorkflowDetails = {
 - **`workflow`** — `eventId`, `eventDate`, `source`, `workflowDetails`, `error`
 - **`runtime`** — `eventId`, `eventDate`, `source`, `error`
 
-Activity, runtime, and workflow error hooks all receive `Error` instances. Workflow
-errors are still serialized to cross Temporal's sandbox boundary, then rehydrated
-before hooks run — so `name`, `message`, an optional recursive `cause`, and other
-enumerable diagnostic properties survive, but the value is a reconstructed `Error`
-(not the original subclass).
+Activity, runtime, and workflow error hooks all receive `Error` instances. Workflow errors are still serialized to cross Temporal's sandbox boundary, then rehydrated before hooks run — so `name`, `message`, an optional recursive `cause`, and other enumerable diagnostic properties survive. The value is always a bare `Error`, not the original subclass (`instanceof FatalError` is false even when `error.name === 'FatalError'`). Use `error.name`, or `hasErrorType(error, FatalError)` from `@outputai/core`, to distinguish failure kinds.
 
 The internal `$catalog` workflow is excluded from lifecycle and error hooks. Activity hooks include internal activities, identified by `outputActivityKind: 'internal_step'`.
 

--- a/docs/guides/packages/core.mdx
+++ b/docs/guides/packages/core.mdx
@@ -186,7 +186,11 @@ type WorkflowDetails = {
 - **`workflow`** — `eventId`, `eventDate`, `source`, `workflowDetails`, `error`
 - **`runtime`** — `eventId`, `eventDate`, `source`, `error`
 
-Activity and runtime errors are `Error` instances. Workflow errors cross Temporal's sandbox boundary as plain serialized objects containing `name`, `message`, an optional recursive `cause`, and any additional enumerable diagnostic properties.
+Activity, runtime, and workflow error hooks all receive `Error` instances. Workflow
+errors are still serialized to cross Temporal's sandbox boundary, then rehydrated
+before hooks run — so `name`, `message`, an optional recursive `cause`, and other
+enumerable diagnostic properties survive, but the value is a reconstructed `Error`
+(not the original subclass).
 
 The internal `$catalog` workflow is excluded from lifecycle and error hooks. Activity hooks include internal activities, identified by `outputActivityKind: 'internal_step'`.
 

--- a/sdk/core/src/helpers/errors.js
+++ b/sdk/core/src/helpers/errors.js
@@ -28,7 +28,7 @@ export const inheritsFromAnyNamedType = ( obj, classNames ) => {
 
 /**
  * Builds an error attributing all enumerable properties from a given object.
- * Property `clause` is serialized recursively.
+ * Property `cause` is rehydrated recursively when it is a plain object.
  *
  * If object is already an error, it is returned as it is.
  *
@@ -41,10 +41,14 @@ export const rehydrateError = target => {
   }
   const error = new Error();
   error.stack = undefined;
-  if ( target !== null && target !== undefined ) {
+  if ( target === null || target === undefined ) {
+    return error;
+  }
+  if ( typeof target === 'object' ) {
     for ( const [ p, v ] of Object.entries( target ) ) {
       error[p] = ( p === 'cause' && isPlainObject( v ) ) ? rehydrateError( v ) : v;
     }
+    return error;
   }
-  return error;
+  return new Error( String( target ) );
 };

--- a/sdk/core/src/helpers/errors.js
+++ b/sdk/core/src/helpers/errors.js
@@ -32,6 +32,8 @@ export const inheritsFromAnyNamedType = ( obj, classNames ) => {
  *
  * If object is already an error, it is returned as it is.
  *
+ * If is a primitive, it will only set message to its string value.
+ *
  * @param {unknown} target
  * @returns {Error}
  */
@@ -41,6 +43,7 @@ export const rehydrateError = target => {
   }
   const error = new Error();
   error.stack = undefined;
+
   if ( target === null || target === undefined ) {
     return error;
   }
@@ -50,5 +53,6 @@ export const rehydrateError = target => {
     }
     return error;
   }
-  return new Error( String( target ) );
+  error.message = String( target );
+  return error;
 };

--- a/sdk/core/src/helpers/errors.js
+++ b/sdk/core/src/helpers/errors.js
@@ -1,3 +1,5 @@
+import { isPlainObject } from './object.js';
+
 /**
  * Checks whether a value inherits from a constructor matching any supplied class name.
  * @param {*} obj - Value whose prototype chain to inspect
@@ -22,4 +24,27 @@ export const inheritsFromAnyNamedType = ( obj, classNames ) => {
     return true;
   }
   return inheritsFromAnyNamedType( prototype, classNames );
+};
+
+/**
+ * Builds an error attributing all enumerable properties from a given object.
+ * Property `clause` is serialized recursively.
+ *
+ * If object is already an error, it is returned as it is.
+ *
+ * @param {unknown} target
+ * @returns {Error}
+ */
+export const rehydrateError = target => {
+  if ( target instanceof Error ) {
+    return target;
+  }
+  const error = new Error();
+  error.stack = undefined;
+  if ( target !== null && target !== undefined ) {
+    for ( const [ p, v ] of Object.entries( target ) ) {
+      error[p] = ( p === 'cause' && isPlainObject( v ) ) ? rehydrateError( v ) : v;
+    }
+  }
+  return error;
 };

--- a/sdk/core/src/helpers/errors.spec.js
+++ b/sdk/core/src/helpers/errors.spec.js
@@ -144,7 +144,7 @@ describe( 'rehydrateError', () => {
 
     expect( result ).toBeInstanceOf( Error );
     expect( result.message ).toBe( message );
-    expect( typeof result.stack ).toBe( 'string' );
+    expect( result.stack ).toBeUndefined();
   } );
 
   it( 'copies enumerable array indexes onto an empty Error', () => {

--- a/sdk/core/src/helpers/errors.spec.js
+++ b/sdk/core/src/helpers/errors.spec.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { inheritsFromAnyNamedType } from './errors.js';
+import { inheritsFromAnyNamedType, rehydrateError } from './errors.js';
 
 describe( 'inheritsFromAnyNamedType', () => {
   class BaseFailure extends Error {}
@@ -41,5 +41,93 @@ describe( 'inheritsFromAnyNamedType', () => {
     expect( inheritsFromAnyNamedType( value, [] ) ).toBe( false );
     expect( inheritsFromAnyNamedType( null, [ 'BaseFailure' ] ) ).toBe( false );
     expect( inheritsFromAnyNamedType( 'failure', [ 'String' ] ) ).toBe( false );
+  } );
+} );
+
+describe( 'rehydrateError', () => {
+  it( 'returns the same Error instance when given an Error', () => {
+    const original = new Error( 'already an error' );
+    original.name = 'FatalError';
+
+    expect( rehydrateError( original ) ).toBe( original );
+  } );
+
+  it( 'rebuilds a plain serialized error with name and message', () => {
+    const result = rehydrateError( {
+      name: 'FatalError',
+      message: 'workflow failed'
+    } );
+
+    expect( result ).toBeInstanceOf( Error );
+    expect( result.name ).toBe( 'FatalError' );
+    expect( result.message ).toBe( 'workflow failed' );
+    expect( result.stack ).toBeUndefined();
+  } );
+
+  it( 'restores stack when present on the serialized object', () => {
+    const result = rehydrateError( {
+      name: 'Error',
+      message: 'boom',
+      stack: 'Error: boom\n    at workflow.js:1:1'
+    } );
+
+    expect( result.stack ).toBe( 'Error: boom\n    at workflow.js:1:1' );
+  } );
+
+  it( 'copies additional enumerable properties', () => {
+    const result = rehydrateError( {
+      name: 'HTTPError',
+      message: 'bad request',
+      status: 400,
+      code: 'BAD_REQUEST'
+    } );
+
+    expect( result.status ).toBe( 400 );
+    expect( result.code ).toBe( 'BAD_REQUEST' );
+  } );
+
+  it( 'recursively rehydrates a plain-object cause', () => {
+    const result = rehydrateError( {
+      name: 'ActivityFailure',
+      message: 'Activity task failed',
+      cause: {
+        name: 'ApplicationFailure',
+        message: 'root failure',
+        cause: {
+          name: 'ValidationError',
+          message: 'invalid input'
+        }
+      }
+    } );
+
+    expect( result.cause ).toBeInstanceOf( Error );
+    expect( result.cause.name ).toBe( 'ApplicationFailure' );
+    expect( result.cause.message ).toBe( 'root failure' );
+    expect( result.cause.cause ).toBeInstanceOf( Error );
+    expect( result.cause.cause.name ).toBe( 'ValidationError' );
+    expect( result.cause.cause.message ).toBe( 'invalid input' );
+  } );
+
+  it( 'leaves a non-object cause unchanged', () => {
+    const result = rehydrateError( {
+      name: 'Error',
+      message: 'outer',
+      cause: 'string cause'
+    } );
+
+    expect( result.cause ).toBe( 'string cause' );
+  } );
+
+  it( 'returns an empty Error for null and undefined without throwing', () => {
+    const fromNull = rehydrateError( null );
+    const fromUndefined = rehydrateError( undefined );
+
+    expect( fromNull ).toBeInstanceOf( Error );
+    expect( fromNull.message ).toBe( '' );
+    expect( fromNull.stack ).toBeUndefined();
+
+    expect( fromUndefined ).toBeInstanceOf( Error );
+    expect( fromUndefined.message ).toBe( '' );
+    expect( fromUndefined.stack ).toBeUndefined();
   } );
 } );

--- a/sdk/core/src/helpers/errors.spec.js
+++ b/sdk/core/src/helpers/errors.spec.js
@@ -130,4 +130,60 @@ describe( 'rehydrateError', () => {
     expect( fromUndefined.message ).toBe( '' );
     expect( fromUndefined.stack ).toBeUndefined();
   } );
+
+  it.each( [
+    [ 'string', 'boom', 'boom' ],
+    [ 'number', 42, '42' ],
+    [ 'boolean', true, 'true' ],
+    [ 'bigint', 1n, '1' ],
+    [ 'symbol', Symbol( 'x' ), 'Symbol(x)' ],
+    [ 'named function', function named() {}, 'function named() {}' ],
+    [ 'arrow function', () => {}, '() => {}' ]
+  ] )( 'stringifies a %s into Error.message', ( _label, input, message ) => {
+    const result = rehydrateError( input );
+
+    expect( result ).toBeInstanceOf( Error );
+    expect( result.message ).toBe( message );
+    expect( typeof result.stack ).toBe( 'string' );
+  } );
+
+  it( 'copies enumerable array indexes onto an empty Error', () => {
+    const result = rehydrateError( [ 'a', 'b' ] );
+
+    expect( result ).toBeInstanceOf( Error );
+    expect( result.message ).toBe( '' );
+    expect( result.stack ).toBeUndefined();
+    expect( result[0] ).toBe( 'a' );
+    expect( result[1] ).toBe( 'b' );
+  } );
+
+  it( 'returns an empty Error for RegExp and Date (no enumerable own props)', () => {
+    const fromRegexp = rehydrateError( /foo/gi );
+    const fromDate = rehydrateError( new Date( '2020-01-01T00:00:00.000Z' ) );
+
+    expect( fromRegexp ).toBeInstanceOf( Error );
+    expect( fromRegexp.message ).toBe( '' );
+    expect( fromRegexp.stack ).toBeUndefined();
+
+    expect( fromDate ).toBeInstanceOf( Error );
+    expect( fromDate.message ).toBe( '' );
+    expect( fromDate.stack ).toBeUndefined();
+  } );
+
+  it( 'copies enumerable own props from a custom class instance', () => {
+    class Widget {
+      constructor() {
+        this.x = 1;
+        this.name = 'WidgetError';
+      }
+    }
+
+    const result = rehydrateError( new Widget() );
+
+    expect( result ).toBeInstanceOf( Error );
+    expect( result.message ).toBe( '' );
+    expect( result.stack ).toBeUndefined();
+    expect( result.x ).toBe( 1 );
+    expect( result.name ).toBe( 'WidgetError' );
+  } );
 } );

--- a/sdk/core/src/hooks/index.d.ts
+++ b/sdk/core/src/hooks/index.d.ts
@@ -115,6 +115,8 @@ export interface WorkflowErrorHookPayload extends WorkflowPayloadBase {
    * Workflow error rehydrated after crossing the Temporal sandbox boundary.
    * Preserves `name`, `message`, `cause`, and other enumerable properties from
    * the serialized form; it is a reconstructed `Error`, not the original class.
+   * Extra fields are present at runtime but not on the `Error` type — narrow or
+   * cast in TypeScript when you need them.
    */
   error: Error;
 }
@@ -160,6 +162,8 @@ export type ErrorHookPayload =
      * Workflow error rehydrated after crossing the Temporal sandbox boundary.
      * Preserves `name`, `message`, `cause`, and other enumerable properties from
      * the serialized form; it is a reconstructed `Error`, not the original class.
+     * Extra fields are present at runtime but not on the `Error` type — narrow or
+     * cast in TypeScript when you need them.
      */
     error: Error;
   } ) |

--- a/sdk/core/src/hooks/index.d.ts
+++ b/sdk/core/src/hooks/index.d.ts
@@ -90,22 +90,6 @@ export interface HookPayloadBase {
 }
 
 /**
- * A serialized error-like object emitted from a workflow.
- *
- * Additional enumerable properties from the original error may also be present.
- */
-export interface SerializedError {
-  /** Error name. */
-  name: string;
-  /** Error message. */
-  message: string;
-  /** Serialized underlying cause, when present. */
-  cause?: SerializedError;
-  /** Additional properties captured from the original error. */
-  [property: string]: unknown;
-}
-
-/**
  * Common hook payload fields for events associated with an workflow.
  */
 export interface WorkflowPayloadBase extends HookPayloadBase {
@@ -127,8 +111,12 @@ export type WorkflowEndHookPayload = WorkflowPayloadBase;
  * Payload passed to the onWorkflowError() handler when a workflow run fails.
  */
 export interface WorkflowErrorHookPayload extends WorkflowPayloadBase {
-  /** Serialized workflow error. */
-  error: SerializedError;
+  /**
+   * Workflow error rehydrated after crossing the Temporal sandbox boundary.
+   * Preserves `name`, `message`, `cause`, and other enumerable properties from
+   * the serialized form; it is a reconstructed `Error`, not the original class.
+   */
+  error: Error;
 }
 
 /**
@@ -168,8 +156,12 @@ export type ErrorHookPayload =
   ( WorkflowPayloadBase & {
     /** Workflow error origin. */
     source: 'workflow';
-    /** Serialized workflow error. */
-    error: SerializedError;
+    /**
+     * Workflow error rehydrated after crossing the Temporal sandbox boundary.
+     * Preserves `name`, `message`, `cause`, and other enumerable properties from
+     * the serialized form; it is a reconstructed `Error`, not the original class.
+     */
+    error: Error;
   } ) |
   ( ActivityErrorHookPayload & {
     /** Activity error origin. */

--- a/sdk/core/src/worker/sinks.js
+++ b/sdk/core/src/worker/sinks.js
@@ -2,6 +2,7 @@ import { BusEventType, ComponentType } from '#consts';
 import * as Tracing from '#tracing';
 import { mainEventBus } from '#bus';
 import { createWorkflowDetails } from '#helpers/temporal_context';
+import { rehydrateError } from '#helpers/errors';
 
 // This sink allow for sandbox Temporal environment to send trace logs back to the main thread.
 export const sinks = {
@@ -48,7 +49,8 @@ export const sinks = {
     error: {
       fn: ( workflowInfo, error ) => {
         const { runId, memo: { traceInfo } } = workflowInfo;
-        mainEventBus.emit( BusEventType.WORKFLOW_ERROR, { workflowDetails: createWorkflowDetails( workflowInfo ), error } );
+        // re-hydrate workflow error
+        mainEventBus.emit( BusEventType.WORKFLOW_ERROR, { workflowDetails: createWorkflowDetails( workflowInfo ), error: rehydrateError( error ) } );
         if ( traceInfo ) {
           Tracing.addEventError( { id: runId, details: error, traceInfo } );
         }

--- a/sdk/core/src/worker/sinks.spec.js
+++ b/sdk/core/src/worker/sinks.spec.js
@@ -15,6 +15,8 @@ const createWorkflowDetailsMock = vi.hoisted( () => vi.fn( workflowInfo => ( {
   runId: workflowInfo.runId
 } ) ) );
 
+const rehydrateErrorMock = vi.hoisted( () => vi.fn( error => error ) );
+
 vi.mock( '#bus', () => ( { mainEventBus: mainEventBusMock } ) );
 vi.mock( '#tracing', () => ( {
   addEventStart: addEventStartMock,
@@ -23,6 +25,9 @@ vi.mock( '#tracing', () => ( {
 } ) );
 vi.mock( '#helpers/temporal_context', () => ( {
   createWorkflowDetails: createWorkflowDetailsMock
+} ) );
+vi.mock( '#helpers/errors', () => ( {
+  rehydrateError: rehydrateErrorMock
 } ) );
 
 describe( 'worker/sinks', () => {
@@ -128,11 +133,17 @@ describe( 'worker/sinks', () => {
 
   it( 'workflow.error emits workflow error events and trace error events', async () => {
     const { sinks } = await import( './sinks.js' );
-    const error = new Error( 'workflow failed' );
+    const error = { name: 'Error', message: 'workflow failed' };
+    const rehydrated = new Error( 'workflow failed' );
+    rehydrateErrorMock.mockReturnValueOnce( rehydrated );
 
     sinks.workflow.error.fn( workflowInfo, error );
 
-    expect( mainEventBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_ERROR, { workflowDetails, error } );
+    expect( rehydrateErrorMock ).toHaveBeenCalledWith( error );
+    expect( mainEventBusMock.emit ).toHaveBeenCalledWith(
+      BusEventType.WORKFLOW_ERROR,
+      { workflowDetails, error: rehydrated }
+    );
     expect( addEventErrorMock ).toHaveBeenCalledWith( {
       id: 'run-1',
       details: error,
@@ -142,11 +153,17 @@ describe( 'worker/sinks', () => {
 
   it( 'workflow.error skips tracing when trace info is absent', async () => {
     const { sinks } = await import( './sinks.js' );
-    const error = new Error( 'workflow failed' );
+    const error = { name: 'Error', message: 'workflow failed' };
+    const rehydrated = new Error( 'workflow failed' );
+    rehydrateErrorMock.mockReturnValueOnce( rehydrated );
 
     sinks.workflow.error.fn( { ...workflowInfo, memo: {} }, error );
 
-    expect( mainEventBusMock.emit ).toHaveBeenCalledWith( BusEventType.WORKFLOW_ERROR, { workflowDetails, error } );
+    expect( rehydrateErrorMock ).toHaveBeenCalledWith( error );
+    expect( mainEventBusMock.emit ).toHaveBeenCalledWith(
+      BusEventType.WORKFLOW_ERROR,
+      { workflowDetails, error: rehydrated }
+    );
     expect( addEventErrorMock ).not.toHaveBeenCalled();
   } );
 

--- a/test_workflows/src/workflows/error/workflow/workflow.ts
+++ b/test_workflows/src/workflows/error/workflow/workflow.ts
@@ -1,9 +1,9 @@
-import { workflow } from '@outputai/core';
+import { FatalError, workflow } from '@outputai/core';
 
 export default workflow( {
   name: 'error_workflow',
   description: 'A workflow to test root workflow errors',
   fn: async () => {
-    throw new Error( 'I am error' );
+    throw new FatalError( 'I am error' );
   }
 } );


### PR DESCRIPTION
## Summary

- Replacing the error-like object on workflow error hooks in favor of a rehydrated Error instance.
