### PR TITLE
feat(cli): Added support for more AI SDK options (OUT-561, OUT-562)

### DIFF
--- a/.changeset/fuzzy-trains-smile.md
+++ b/.changeset/fuzzy-trains-smile.md
@@ -83,7 +83,7 @@
   - Unknown top-level keys throw.
   - `model` must be a non-empty string.
   - Added support for the native AI SDK generation properties `maxOutputTokens`, `topP`, `topK`, `presencePenalty`, `frequencyPenalty`, `stopSequences`, and text-generation `seed`.
-  - Deprecated `maxTokens` in favor of `maxOutputTokens`; both must be positive integers.
+  - Deprecated `maxTokens` in favor of `maxOutputTokens`. Existing prompts remain compatible: `loadPrompt` retains `maxTokens` and copies its value to `maxOutputTokens` when the canonical key is absent. When both keys are set, `maxOutputTokens` takes precedence. Each key must be a positive integer when provided.
 
 ## Streaming and Agent message store
 

--- a/.changeset/fuzzy-trains-smile.md
+++ b/.changeset/fuzzy-trains-smile.md
@@ -82,7 +82,8 @@
 - Fixed prompt file `config` accepting ignored or invalid values:
   - Unknown top-level keys throw.
   - `model` must be a non-empty string.
-  - `maxTokens` must be a positive integer.
+  - Added support for the native AI SDK generation properties `maxOutputTokens`, `topP`, `topK`, `presencePenalty`, `frequencyPenalty`, `stopSequences`, and text-generation `seed`.
+  - Deprecated `maxTokens` in favor of `maxOutputTokens`; both must be positive integers.
 
 ## Streaming and Agent message store
 

--- a/.claude/skills/prompt-file-provider-options/SKILL.md
+++ b/.claude/skills/prompt-file-provider-options/SKILL.md
@@ -19,6 +19,8 @@ In providerOptions:
 └─ Is it provider-specific? -> Nested under provider namespace
 ```
 
+Use `maxOutputTokens` for new prompts. Deprecated `maxTokens` remains on the loaded config and populates `maxOutputTokens` when the canonical key is absent; when both are set, `maxOutputTokens` takes precedence.
+
 ### Common Mistakes to Avoid
 
 ❌ **Mistake 1: Putting provider options at top-level**

--- a/.claude/skills/prompt-file-provider-options/SKILL.md
+++ b/.claude/skills/prompt-file-provider-options/SKILL.md
@@ -10,9 +10,9 @@ When creating `.prompt` files, understanding the `providerOptions` structure is 
 ### Decision Tree: Where Does This Option Go?
 
 ```
-Is the key on the prompt config allowlist (provider, model, temperature, maxTokens, maxSteps, skills, tools, providerOptions, messageOptions, n, maxImagesPerCall, size, aspectRatio, seed)?
+Is the key on the prompt config allowlist (provider, model, temperature, maxOutputTokens, deprecated maxTokens, topP, topK, presencePenalty, frequencyPenalty, stopSequences, seed, maxSteps, skills, tools, providerOptions, messageOptions, n, maxImagesPerCall, size, aspectRatio)?
 ├─ YES -> Top-level config
-└─ NO -> Nest under providerOptions (unknown top-level keys throw; snake_case aliases like max_tokens fail with a camelCase suggestion)
+└─ NO -> Nest under providerOptions (unknown top-level keys throw; snake_case aliases like max_output_tokens fail with a camelCase suggestion)
 
 In providerOptions:
 ├─ Is it 'thinking' or 'order'? -> Top-level (special AI SDK features)
@@ -95,22 +95,21 @@ providerOptions:
 ❌ **Mistake 5: Unknown or snake_case top-level keys**
 ```yaml
 provider: openai
-max_tokens: 16000       # WRONG: snake_case alias of maxTokens
-topP: 0.9               # WRONG: not a shared top-level field
+max_output_tokens: 16000 # WRONG: snake_case alias of maxOutputTokens
 reasoningEffort: medium # WRONG: OpenAI-specific
 ```
 
 ✅ **Correct:**
 ```yaml
 provider: openai
-maxTokens: 16000
+maxOutputTokens: 16000
+topP: 0.9
 providerOptions:
   openai:
     reasoningEffort: medium
-    topP: 0.9
 ```
 
-Unknown top-level keys throw `Invalid prompt file`. A snake_case alias of a known field fails with a suggestion (`max_tokens` -> use `maxTokens`). Nested `providerOptions` stays open.
+Unknown top-level keys throw `Invalid prompt file`. A snake_case alias of a known field fails with a suggestion (`max_output_tokens` -> use `maxOutputTokens`). Nested `providerOptions` stays open.
 
 ### Quick Reference: Common Provider Options
 
@@ -153,7 +152,7 @@ providerOptions:
 ```yaml
 provider: amazon-bedrock
 model: anthropic.claude-sonnet-4-20250514-v1:0
-maxTokens: 64000              # Recommended: Bedrock has no client-side defaults
+maxOutputTokens: 64000        # Recommended: Bedrock has no client-side defaults
 providerOptions:
   bedrock:                    # Note: AI SDK 'bedrock' namespace, not 'anthropic'
     guardrailConfig:

--- a/coding_assistants/claude/plugins/outputai/agents/workflow_prompt_writer.md
+++ b/coding_assistants/claude/plugins/outputai/agents/workflow_prompt_writer.md
@@ -48,12 +48,14 @@ The body is either message mode or instruction mode. After leading whitespace an
 |--------|------|-------------|
 | `provider` | string | LLM provider: `anthropic`, `openai`, `google-vertex`, `amazon-bedrock`, `azure`, `perplexity` |
 | `model` | string | Model identifier (provider-specific) |
-| `temperature` | number | Creativity (0.0-1.0, lower = more deterministic) |
+| `temperature` | number | Sampling temperature; supported range varies by provider |
 | `maxOutputTokens` | number | Maximum response length |
 
 Frontmatter is a **strict camelCase allowlist**. Unknown top-level keys throw `Invalid prompt file`. A snake_case alias of a known field fails with a suggestion (`max_output_tokens` -> use `maxOutputTokens`). Put provider-specific keys (`effort`, `reasoningEffort`) under `providerOptions`, which stays open.
 
 Allowed top-level keys: `provider`, `model`, `temperature`, `maxOutputTokens`, deprecated `maxTokens`, `topP`, `topK`, `presencePenalty`, `frequencyPenalty`, `stopSequences`, `seed`, `maxSteps`, `skills`, `tools`, `providerOptions`, `messageOptions`, `n`, `maxImagesPerCall`, `size`, `aspectRatio`.
+
+Use `maxOutputTokens` for new prompts. Deprecated `maxTokens` remains on the loaded config and populates `maxOutputTokens` when the canonical key is absent; when both are set, `maxOutputTokens` takes precedence.
 
 ### Provider Consistency
 

--- a/coding_assistants/claude/plugins/outputai/agents/workflow_prompt_writer.md
+++ b/coding_assistants/claude/plugins/outputai/agents/workflow_prompt_writer.md
@@ -34,7 +34,7 @@ provider: anthropic
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: claude-sonnet-4-6
 temperature: 0.7
-maxTokens: 2000
+maxOutputTokens: 2000
 ---
 <system>You are a helpful assistant.</system>
 <user>{{ instructions }}</user>
@@ -49,11 +49,11 @@ The body is either message mode or instruction mode. After leading whitespace an
 | `provider` | string | LLM provider: `anthropic`, `openai`, `google-vertex`, `amazon-bedrock`, `azure`, `perplexity` |
 | `model` | string | Model identifier (provider-specific) |
 | `temperature` | number | Creativity (0.0-1.0, lower = more deterministic) |
-| `maxTokens` | number | Maximum response length |
+| `maxOutputTokens` | number | Maximum response length |
 
-Frontmatter is a **strict camelCase allowlist**. Unknown top-level keys throw `Invalid prompt file`. A snake_case alias of a known field fails with a suggestion (`max_tokens` -> use `maxTokens`). Put provider-specific keys (`effort`, `reasoningEffort`, `topP`) under `providerOptions`, which stays open.
+Frontmatter is a **strict camelCase allowlist**. Unknown top-level keys throw `Invalid prompt file`. A snake_case alias of a known field fails with a suggestion (`max_output_tokens` -> use `maxOutputTokens`). Put provider-specific keys (`effort`, `reasoningEffort`) under `providerOptions`, which stays open.
 
-Allowed top-level keys: `provider`, `model`, `temperature`, `maxTokens`, `maxSteps`, `skills`, `tools`, `providerOptions`, `messageOptions`, `n`, `maxImagesPerCall`, `size`, `aspectRatio`, `seed`.
+Allowed top-level keys: `provider`, `model`, `temperature`, `maxOutputTokens`, deprecated `maxTokens`, `topP`, `topK`, `presencePenalty`, `frequencyPenalty`, `stopSequences`, `seed`, `maxSteps`, `skills`, `tools`, `providerOptions`, `messageOptions`, `n`, `maxImagesPerCall`, `size`, `aspectRatio`.
 
 ### Provider Consistency
 
@@ -573,7 +573,7 @@ provider: anthropic
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: claude-sonnet-4-6
 temperature: 0.7
-maxTokens: 4000
+maxOutputTokens: 4000
 ---
 ```
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-eval-testing/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-eval-testing/SKILL.md
@@ -207,7 +207,7 @@ provider: anthropic
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: claude-haiku-4-5-20251001
 temperature: 0
-maxTokens: 1000
+maxOutputTokens: 1000
 ---
 
 <system>

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-model-selection/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-model-selection/SKILL.md
@@ -137,7 +137,7 @@ Drop the translated string into your `.prompt` frontmatter:
 provider: anthropic
 model: claude-sonnet-4-6
 temperature: 0.7
-maxTokens: 4096
+maxOutputTokens: 4096
 ---
 ```
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
@@ -108,9 +108,9 @@ When no existing prompts dictate a provider, default to `anthropic`. For the mod
 ```yaml
 ---
 provider: anthropic
-# current as of 2026-05-04 — run output-dev-model-selection for the latest
+# current as of 2026-05-04 - run output-dev-model-selection for the latest
 model: claude-sonnet-4-6
-temperature: 0.7       # 0.0 to 1.0, default varies by provider
+temperature: 0.7       # Supported range and default vary by provider
 maxOutputTokens: 4096  # Maximum output tokens
 maxSteps: 5            # Tool-loop ceiling when tools or skills are present (default 10)
 skills:                # Skill file or directory paths, relative to this prompt
@@ -125,6 +125,8 @@ providerOptions:       # Provider-specific options
 Frontmatter is a **strict camelCase allowlist**. Unknown top-level keys throw `Invalid prompt file`. A snake_case alias of a known field fails with a suggestion (`max_output_tokens` -> use `maxOutputTokens`). Put provider-specific keys (`effort`, `reasoningEffort`) under `providerOptions`, which stays open. Nested `thinking` stays open too (`budgetTokens` is the documented key; extra nested keys are not rejected as unknown top-level config).
 
 Allowed top-level keys: `provider`, `model`, `temperature`, `maxOutputTokens`, deprecated `maxTokens`, `topP`, `topK`, `presencePenalty`, `frequencyPenalty`, `stopSequences`, `seed`, `maxSteps`, `skills`, `tools`, `providerOptions`, `messageOptions`, `n`, `maxImagesPerCall`, `size`, `aspectRatio`.
+
+Use `maxOutputTokens` for new prompts. Deprecated `maxTokens` remains on the loaded config and populates `maxOutputTokens` when the canonical key is absent; when both are set, `maxOutputTokens` takes precedence.
 
 Call arguments: `prompt`, `promptDir`, `variables`, `tools`, `output`, `toolChoice`, `stopWhen`, `abortSignal` on `generateText` (plus `onChunk` on `generateTextWithStreaming`; plus `onChunk` / `onFinish` / `onError` on `streamText`). `generateImage`: `prompt`, `promptDir`, `variables`, `images`, `mask`, `abortSignal`.
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-prompt-file/SKILL.md
@@ -57,7 +57,7 @@ provider: anthropic
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: claude-sonnet-4-6
 temperature: 0.7
-maxTokens: 4096
+maxOutputTokens: 4096
 ---
 
 <system>
@@ -111,7 +111,7 @@ provider: anthropic
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: claude-sonnet-4-6
 temperature: 0.7       # 0.0 to 1.0, default varies by provider
-maxTokens: 4096        # Maximum output tokens
+maxOutputTokens: 4096  # Maximum output tokens
 maxSteps: 5            # Tool-loop ceiling when tools or skills are present (default 10)
 skills:                # Skill file or directory paths, relative to this prompt
   - ./skills
@@ -122,9 +122,9 @@ providerOptions:       # Provider-specific options
 ---
 ```
 
-Frontmatter is a **strict camelCase allowlist**. Unknown top-level keys throw `Invalid prompt file`. A snake_case alias of a known field fails with a suggestion (`max_tokens` -> use `maxTokens`). Put provider-specific keys (`effort`, `reasoningEffort`, `topP`) under `providerOptions`, which stays open. Nested `thinking` stays open too (`budgetTokens` is the documented key; extra nested keys are not rejected as unknown top-level config).
+Frontmatter is a **strict camelCase allowlist**. Unknown top-level keys throw `Invalid prompt file`. A snake_case alias of a known field fails with a suggestion (`max_output_tokens` -> use `maxOutputTokens`). Put provider-specific keys (`effort`, `reasoningEffort`) under `providerOptions`, which stays open. Nested `thinking` stays open too (`budgetTokens` is the documented key; extra nested keys are not rejected as unknown top-level config).
 
-Allowed top-level keys: `provider`, `model`, `temperature`, `maxTokens`, `maxSteps`, `skills`, `tools`, `providerOptions`, `messageOptions`, `n`, `maxImagesPerCall`, `size`, `aspectRatio`, `seed`.
+Allowed top-level keys: `provider`, `model`, `temperature`, `maxOutputTokens`, deprecated `maxTokens`, `topP`, `topK`, `presencePenalty`, `frequencyPenalty`, `stopSequences`, `seed`, `maxSteps`, `skills`, `tools`, `providerOptions`, `messageOptions`, `n`, `maxImagesPerCall`, `size`, `aspectRatio`.
 
 Call arguments: `prompt`, `promptDir`, `variables`, `tools`, `output`, `toolChoice`, `stopWhen`, `abortSignal` on `generateText` (plus `onChunk` on `generateTextWithStreaming`; plus `onChunk` / `onFinish` / `onError` on `streamText`). `generateImage`: `prompt`, `promptDir`, `variables`, `images`, `mask`, `abortSignal`.
 
@@ -139,7 +139,7 @@ Call arguments: `prompt`, `promptDir`, `variables`, `tools`, `output`, `toolChoi
 provider: anthropic
 model: claude-sonnet-4-6
 temperature: 0.7
-maxTokens: 8192
+maxOutputTokens: 8192
 ---
 ```
 
@@ -150,7 +150,7 @@ maxTokens: 8192
 provider: anthropic
 model: claude-sonnet-4-6
 temperature: 0.7
-maxTokens: 32000
+maxOutputTokens: 32000
 providerOptions:
   thinking:
     type: enabled
@@ -166,7 +166,7 @@ provider: openai
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: gpt-5-5
 temperature: 0.7
-maxTokens: 4096
+maxOutputTokens: 4096
 ---
 ```
 
@@ -178,7 +178,7 @@ provider: google-vertex
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: gemini-3-pro
 temperature: 0.7
-maxTokens: 8192
+maxOutputTokens: 8192
 ---
 ```
 
@@ -284,7 +284,7 @@ provider: anthropic
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: claude-sonnet-4-6
 temperature: 0.7
-maxTokens: 32000
+maxOutputTokens: 32000
 providerOptions:
   thinking:
     type: enabled
@@ -668,7 +668,7 @@ Requirements:
 - [ ] File located in `prompts/` folder inside workflow directory
 - [ ] File named `{promptName}@v{version}.prompt`
 - [ ] YAML frontmatter includes `provider` and `model`
-- [ ] Frontmatter uses camelCase only; no unknown top-level keys (`topP`, `effort`, `reasoningEffort`, `max_tokens`)
+- [ ] Frontmatter uses camelCase only; no unknown top-level keys (`effort`, `reasoningEffort`) or snake_case aliases (`max_output_tokens`)
 - [ ] The body uses message mode for text generation, or instruction mode for `generateImage` / direct `loadPrompt()` consumption
 - [ ] Message blocks use supported role tags (`<system>`, `<user>`, `<assistant>`); no authored `<tool>` blocks
 - [ ] Message mode has no root text between blocks, no self-closing role blocks, and no unclosed blocks

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-skill-file/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-skill-file/SKILL.md
@@ -88,7 +88,7 @@ List skill paths in the prompt YAML frontmatter. Paths resolve relative to the p
 ---
 provider: anthropic
 model: claude-sonnet-4-6
-maxTokens: 2048
+maxOutputTokens: 2048
 skills:
   - ./skills
   - ../shared_skills/tone_guide.md
@@ -146,7 +146,7 @@ OUTPUT_COMPLETE
 provider: anthropic
 # current as of 2026-05-04 - run output-dev-model-selection for the latest
 model: claude-sonnet-4-6
-maxTokens: 2048
+maxOutputTokens: 2048
 skills:
   - ./skills
 ---

--- a/coding_assistants/claude/plugins/outputai/skills/output-dev-upgrade-prompt-models/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-dev-upgrade-prompt-models/SKILL.md
@@ -85,7 +85,7 @@ For each confirmed file, edit only the YAML frontmatter:
 
 - Replace the `model:` line with the resolved latest ID.
 - If a `# current as of YYYY-MM-DD …` comment is present (the convention used in `output-dev-prompt-file` examples and CLI scaffolds), update its date to today's (`date +%Y-%m-%d`). Match the comment by the literal `current as of ` prefix and only rewrite the date — leave the trailing text intact.
-- Leave `provider:`, `temperature:`, `maxTokens:`, `providerOptions:`, and the message body untouched.
+- Leave `provider:`, `temperature:`, `maxOutputTokens:` (or deprecated `maxTokens:`), `providerOptions:`, and the message body untouched.
 
 Refreshing the dated comment in the same edit keeps the "as of" convention coherent — without it, an upgraded prompt would have a fresh model paired with a stale date.
 

--- a/coding_assistants/claude/plugins/outputai/skills/output-eval-judge-prompt/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-eval-judge-prompt/SKILL.md
@@ -86,7 +86,7 @@ provider: anthropic
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: claude-haiku-4-5-20251001
 temperature: 0
-maxTokens: 1500
+maxOutputTokens: 1500
 ---
 
 <system>
@@ -218,7 +218,7 @@ provider: anthropic
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: claude-haiku-4-5-20251001
 temperature: 0
-maxTokens: 1500
+maxOutputTokens: 1500
 ---
 
 <system>

--- a/coding_assistants/claude/plugins/outputai/skills/output-meta-project-context/SKILL.md
+++ b/coding_assistants/claude/plugins/outputai/skills/output-meta-project-context/SKILL.md
@@ -363,7 +363,7 @@ provider: anthropic
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: claude-sonnet-4-6
 temperature: 0.7
-maxTokens: 4096
+maxOutputTokens: 4096
 ---
 
 <system>

--- a/docs/guides/evaluators/workflow-evaluators.mdx
+++ b/docs/guides/evaluators/workflow-evaluators.mdx
@@ -231,7 +231,7 @@ Here's a judge prompt for topic evaluation:
 provider: anthropic
 model: claude-haiku-4-5-20251001
 temperature: 0
-maxTokens: 1000
+maxOutputTokens: 1000
 ---
 
 <system>

--- a/docs/guides/migrations/v0.11.0-to-v0.12.0.mdx
+++ b/docs/guides/migrations/v0.11.0-to-v0.12.0.mdx
@@ -396,7 +396,7 @@ type Options = OutputAgentGenerateWithStreamingParameters;
 
 ## Call arguments are a fixed list
 
-Dropped native AI SDK call arguments from `generateText()`, `generateTextWithStreaming()`, `streamText()`, `generateImage()`, and `Agent`. Calls no longer accept `temperature`, `maxTokens`, `maxSteps`, `providerOptions`, image `n`/`size`/`seed`, `experimental_transform`, `onStepFinish`, and similar. Unknown keys throw. Set model and image config (including `maxSteps`, default 10) on the prompt file; call-argument `stopWhen` still overrides it.
+Dropped native AI SDK call arguments from `generateText()`, `generateTextWithStreaming()`, `streamText()`, `generateImage()`, and `Agent`. Calls no longer accept `temperature`, `maxOutputTokens`, `maxTokens`, `maxSteps`, `providerOptions`, image `n`/`size`/`seed`, `experimental_transform`, `onStepFinish`, and similar. Unknown keys throw. Set model and generation or image config (including `maxSteps`, default 10) on the prompt file; call-argument `stopWhen` still overrides it.
 
 | Argument | `generateText` | `generateTextWithStreaming` | `streamText` | `generateImage` |
 |----------|----------------|-----------------------------|--------------|-----------------|
@@ -523,14 +523,14 @@ That includes a missing/empty `prompt`, an empty `promptDir`, and call-argument 
 
 ## Prompt config is a strict key list
 
-Unknown top-level keys on a `.prompt` file now throw `Invalid prompt file`. Previously they were kept on `config` and ignored. `provider` and `model` must be non-empty strings, and `maxTokens` must be a positive integer. Nested `providerOptions` (including `thinking`) stays open.
+Unknown top-level keys on a `.prompt` file now throw `Invalid prompt file`. Previously they were kept on `config` and ignored. `provider` and `model` must be non-empty strings, and `maxOutputTokens` or its deprecated `maxTokens` alias must be a positive integer. Nested `providerOptions` (including `thinking`) stays open.
 
-Allowed top-level keys: `provider`, `model`, `temperature`, `maxTokens`, `maxSteps`, `skills`, `tools`, `providerOptions`, `messageOptions`, `n`, `maxImagesPerCall`, `size`, `aspectRatio`, `seed`.
+Allowed top-level keys: `provider`, `model`, `temperature`, `maxOutputTokens`, deprecated `maxTokens`, `topP`, `topK`, `presencePenalty`, `frequencyPenalty`, `stopSequences`, `seed`, `maxSteps`, `skills`, `tools`, `providerOptions`, `messageOptions`, `n`, `maxImagesPerCall`, `size`, `aspectRatio`.
 
 Snake_case aliases of those keys fail with a suggestion:
 
 ```
-Invalid prompt file "writer@v1": Unrecognized key: "max_tokens". "max_tokens" is not valid; use "maxTokens"
+Invalid prompt file "writer@v1": Unrecognized key: "max_output_tokens". "max_output_tokens" is not valid; use "maxOutputTokens"
 ```
 
 Move provider-specific fields under `providerOptions`. `effort` and `reasoningEffort` at the top level are unknown keys; they belong under `providerOptions.anthropic` and `providerOptions.openai`.
@@ -542,7 +542,7 @@ Move provider-specific fields under `providerOptions`. `effort` and `reasoningEf
 provider: openai
 model: gpt-5.4
 reasoningEffort: medium
-max_tokens: 16000
+max_output_tokens: 16000
 ---
 ```
 
@@ -552,7 +552,7 @@ max_tokens: 16000
 ---
 provider: openai
 model: gpt-5.4
-maxTokens: 16000
+maxOutputTokens: 16000
 providerOptions:
   openai:
     reasoningEffort: medium
@@ -565,7 +565,7 @@ providerOptions:
 - Remove `skill()`, `Skill`, and `SkillsArg` imports; move inline skills into files listed under prompt `skills:`.
 - Add `skills: ./skills` (or explicit file paths) to prompts that relied on colocated auto-discovery.
 - Expect YAML tools and call-argument tools to merge; remove YAML tools if you previously relied on replacement.
-- Strip dropped call arguments from `generateText` / `generateTextWithStreaming` / `streamText` / `generateImage` / `Agent` (`temperature`, `maxTokens`, `maxSteps`, `providerOptions`, `maxRetries`, `experimental_transform`, `onStepFinish`, image `n` / `size` / `seed`, and any other AI SDK-only keys). Unknown keys throw. Put model and image config on the prompt file; call-argument `stopWhen` still overrides `maxSteps`.
+- Strip dropped call arguments from `generateText` / `generateTextWithStreaming` / `streamText` / `generateImage` / `Agent` (`temperature`, `maxOutputTokens`, `maxTokens`, `maxSteps`, `providerOptions`, `maxRetries`, `experimental_transform`, `onStepFinish`, image `n` / `size` / `seed`, and any other AI SDK-only keys). Unknown keys throw. Put model and generation or image config on the prompt file; call-argument `stopWhen` still overrides `maxSteps`.
 - Set `maxSteps: 1` on YAML-only grounding prompts that must stay one-shot, or pass `stopWhen: aiSdk.stepCountIs(1)` on the call.
 - Rename `promptFileDir` to `fileDir`. Read interpolation values from `prompt.variables`.
 - Treat `config.skills` as always `string[]` after `loadPrompt`.
@@ -587,5 +587,5 @@ providerOptions:
 - Expect `Agent.stream()` to persist message-store history on success.
 - Replace `conversationStore` with `messageStore`. Replace `ConversationStore` with `MessageStore`. Remove `createMemoryConversationStore()` and pass your own store.
 - Update Agent tests and error matchers that expected `Agent requires a prompt`.
-- Ensure prompt `provider` and `model` values are non-empty, and set `maxTokens` to a positive integer.
-- Move unknown prompt frontmatter keys (`topP`, `effort`, `reasoningEffort`, `max_tokens`) onto the allowlist or under `providerOptions`. Expect `Invalid prompt file` for leftover extras.
+- Ensure prompt `provider` and `model` values are non-empty, and set `maxOutputTokens` or deprecated `maxTokens` to a positive integer.
+- Remove unsupported prompt frontmatter keys. Expect `Invalid prompt file` for leftover extras.

--- a/docs/guides/migrations/v0.11.0-to-v0.12.0.mdx
+++ b/docs/guides/migrations/v0.11.0-to-v0.12.0.mdx
@@ -530,7 +530,7 @@ Allowed top-level keys: `provider`, `model`, `temperature`, `maxOutputTokens`, d
 Snake_case aliases of those keys fail with a suggestion:
 
 ```
-Invalid prompt file "writer@v1": Unrecognized key: "max_output_tokens". "max_output_tokens" is not valid; use "maxOutputTokens"
+Invalid prompt file "writer@v1": Unrecognized key: "max_images_per_call". "max_images_per_call" is not valid; use "maxImagesPerCall"
 ```
 
 Move provider-specific fields under `providerOptions`. `effort` and `reasoningEffort` at the top level are unknown keys; they belong under `providerOptions.anthropic` and `providerOptions.openai`.
@@ -588,4 +588,4 @@ providerOptions:
 - Replace `conversationStore` with `messageStore`. Replace `ConversationStore` with `MessageStore`. Remove `createMemoryConversationStore()` and pass your own store.
 - Update Agent tests and error matchers that expected `Agent requires a prompt`.
 - Ensure prompt `provider` and `model` values are non-empty, and set `maxOutputTokens` or deprecated `maxTokens` to a positive integer.
-- Remove unsupported prompt frontmatter keys. Expect `Invalid prompt file` for leftover extras.
+- Review prompt frontmatter against the supported configuration and remove unsupported fields. Any remaining fields cause an Invalid prompt file error.

--- a/docs/guides/migrations/v0.11.0-to-v0.12.0.mdx
+++ b/docs/guides/migrations/v0.11.0-to-v0.12.0.mdx
@@ -523,9 +523,11 @@ That includes a missing/empty `prompt`, an empty `promptDir`, and call-argument 
 
 ## Prompt config is a strict key list
 
-Unknown top-level keys on a `.prompt` file now throw `Invalid prompt file`. Previously they were kept on `config` and ignored. `provider` and `model` must be non-empty strings, and `maxOutputTokens` or its deprecated `maxTokens` alias must be a positive integer. Nested `providerOptions` (including `thinking`) stays open.
+Unknown top-level keys on a `.prompt` file now throw `Invalid prompt file`. Previously they were kept on `config` and ignored. `provider` and `model` must be non-empty strings. When provided, `maxOutputTokens` and deprecated `maxTokens` must each be a positive integer. Nested `providerOptions` (including `thinking`) stays open.
 
 Allowed top-level keys: `provider`, `model`, `temperature`, `maxOutputTokens`, deprecated `maxTokens`, `topP`, `topK`, `presencePenalty`, `frequencyPenalty`, `stopSequences`, `seed`, `maxSteps`, `skills`, `tools`, `providerOptions`, `messageOptions`, `n`, `maxImagesPerCall`, `size`, `aspectRatio`.
+
+`maxTokens` remains available for backward compatibility and is retained on the loaded prompt config. When `maxOutputTokens` is absent, `loadPrompt` also copies the `maxTokens` value to `maxOutputTokens`. When both keys are set, `maxOutputTokens` takes precedence. Text generation APIs read the normalized `maxOutputTokens` value.
 
 Snake_case aliases of those keys fail with a suggestion:
 
@@ -587,5 +589,5 @@ providerOptions:
 - Expect `Agent.stream()` to persist message-store history on success.
 - Replace `conversationStore` with `messageStore`. Replace `ConversationStore` with `MessageStore`. Remove `createMemoryConversationStore()` and pass your own store.
 - Update Agent tests and error matchers that expected `Agent requires a prompt`.
-- Ensure prompt `provider` and `model` values are non-empty, and set `maxOutputTokens` or deprecated `maxTokens` to a positive integer.
+- Ensure prompt `provider` and `model` values are non-empty. If set, `maxOutputTokens` and deprecated `maxTokens` must each be positive integers.
 - Review prompt frontmatter against the supported configuration and remove unsupported fields. Any remaining fields cause an Invalid prompt file error.

--- a/docs/guides/packages/evals.mdx
+++ b/docs/guides/packages/evals.mdx
@@ -248,7 +248,7 @@ Judge `.prompt` files live in the same `tests/evals/` directory as your evaluato
 provider: anthropic
 model: claude-haiku-4-5-20251001
 temperature: 0
-maxTokens: 1000
+maxOutputTokens: 1000
 ---
 
 <system>

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -588,9 +588,9 @@ Company size: {{ size }} employees
 |--------|------|-------------|
 | `provider` | `string` | `anthropic`, `openai`, `azure`, `amazon-bedrock`, `google-vertex`, `perplexity`, or a provider registered with `registerProvider`. Legacy aliases `bedrock` and `vertex` are deprecated but still accepted. |
 | `model` | `string` | Model identifier |
-| `temperature` | `number` | Sampling temperature (0.0-2.0) |
+| `temperature` | `number` | Sampling temperature; supported range varies by provider |
 | `maxOutputTokens` | `number` | Maximum output tokens |
-| `maxTokens` | `number` | Deprecated alias for `maxOutputTokens` |
+| `maxTokens` | `number` | Deprecated compatibility key; prefer `maxOutputTokens` |
 | `topP` | `number` | Nucleus sampling value; usually set instead of `temperature` |
 | `topK` | `number` | Restricts sampling to the top K token choices |
 | `presencePenalty` | `number` | Penalizes tokens already present in the prompt or generated output |
@@ -603,6 +603,8 @@ Company size: {{ size }} employees
 | `providerOptions` | `object` | Provider-specific options - see [ProviderOptions Guide](/prompts#provider-options) |
 | `messageOptions` | `object` | Named per-message `providerOptions` sets |
 | `n`, `size`, `aspectRatio`, `maxImagesPerCall` | | Image generation fields |
+
+`loadPrompt` retains `maxTokens` on `config` for backward compatibility. When `maxOutputTokens` is absent, it also copies the `maxTokens` value to `maxOutputTokens`. When both keys are set, `maxOutputTokens` takes precedence. Text generation APIs use `maxOutputTokens`.
 
 Unknown top-level keys throw `Invalid prompt file`. Snake_case aliases of known fields (`max_output_tokens`) include a suggestion (`use "maxOutputTokens"`). Put provider-specific keys such as `effort` and `reasoningEffort` under `providerOptions`.
 

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -589,15 +589,22 @@ Company size: {{ size }} employees
 | `provider` | `string` | `anthropic`, `openai`, `azure`, `amazon-bedrock`, `google-vertex`, `perplexity`, or a provider registered with `registerProvider`. Legacy aliases `bedrock` and `vertex` are deprecated but still accepted. |
 | `model` | `string` | Model identifier |
 | `temperature` | `number` | Sampling temperature (0.0-2.0) |
-| `maxTokens` | `number` | Maximum output tokens |
+| `maxOutputTokens` | `number` | Maximum output tokens |
+| `maxTokens` | `number` | Deprecated alias for `maxOutputTokens` |
+| `topP` | `number` | Nucleus sampling value; usually set instead of `temperature` |
+| `topK` | `number` | Restricts sampling to the top K token choices |
+| `presencePenalty` | `number` | Penalizes tokens already present in the prompt or generated output |
+| `frequencyPenalty` | `number` | Penalizes tokens according to how often they appear |
+| `stopSequences` | `string[]` | Sequences that stop text generation |
+| `seed` | `number` | Random seed for deterministic text or image generation when supported |
 | `maxSteps` | `number` (default 10 after `loadPrompt`) | Tool-loop iterations when tools or skills are present |
 | `skills` | `string` or `string[]` in YAML; always `string[]` after `loadPrompt` (`[]` if omitted) | Skill file or directory paths, relative to this prompt |
 | `tools` | `object` | Provider-specific tools (web search, etc.) |
 | `providerOptions` | `object` | Provider-specific options - see [ProviderOptions Guide](/prompts#provider-options) |
 | `messageOptions` | `object` | Named per-message `providerOptions` sets |
-| `n`, `size`, `aspectRatio`, `seed`, `maxImagesPerCall` | | Image generation fields |
+| `n`, `size`, `aspectRatio`, `maxImagesPerCall` | | Image generation fields |
 
-Unknown top-level keys throw `Invalid prompt file`. Snake_case aliases of known fields (`max_tokens`) include a suggestion (`use "maxTokens"`). Put provider-specific keys such as `effort`, `reasoningEffort`, and `topP` under `providerOptions`.
+Unknown top-level keys throw `Invalid prompt file`. Snake_case aliases of known fields (`max_output_tokens`) include a suggestion (`use "maxOutputTokens"`). Put provider-specific keys such as `effort` and `reasoningEffort` under `providerOptions`.
 
 ## Providers
 
@@ -673,7 +680,7 @@ Requires AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REG
 
 For cross-region inference, use the regional inference profile format: `us.anthropic.claude-sonnet-4-20250514-v1:0`.
 
-Always set `maxTokens` in your Bedrock prompt files. Unlike the direct Anthropic provider (which auto-detects per-model limits), the Bedrock SDK has no client-side defaults and relies on server-side defaults that may be lower than the model's capacity.
+Always set `maxOutputTokens` in your Bedrock prompt files. Unlike the direct Anthropic provider (which auto-detects per-model limits), the Bedrock SDK has no client-side defaults and relies on server-side defaults that may be lower than the model's capacity.
 
 When using `providerOptions`, use the AI SDK `bedrock` namespace (not `anthropic`):
 

--- a/docs/guides/prompts/index.mdx
+++ b/docs/guides/prompts/index.mdx
@@ -91,9 +91,9 @@ The YAML frontmatter configures the LLM call.
 
 | Field | Description | Example |
 |-------|-------------|---------|
-| `temperature` | Randomness (0-2) | `0` for judges, `0.3` for summaries, `0.7` for general |
+| `temperature` | Sampling temperature; supported range varies by provider | `0` for judges, `0.3` for summaries, `0.7` for general |
 | `maxOutputTokens` | Maximum output tokens | `2000` |
-| `maxTokens` | Deprecated alias for `maxOutputTokens` | `2000` |
+| `maxTokens` | Deprecated compatibility key; prefer `maxOutputTokens` | `2000` |
 | `topP` | Nucleus sampling value; usually set instead of `temperature` | `0.9` |
 | `topK` | Restrict sampling to the top K token choices | `40` |
 | `presencePenalty` | Penalize tokens already present in the prompt or generated output | `0.2` |
@@ -106,6 +106,8 @@ The YAML frontmatter configures the LLM call.
 | `providerOptions` | Provider-specific config | See below |
 | `messageOptions` | Named per-message `providerOptions` sets | See [Prompt Caching](/packages/llm#prompt-caching) |
 | `n`, `size`, `aspectRatio`, `maxImagesPerCall` | Image generation fields | See [Image Output](/packages/llm#image-output) |
+
+`loadPrompt` retains `maxTokens` on `config` for backward compatibility. When `maxOutputTokens` is absent, it also copies the `maxTokens` value to `maxOutputTokens`. When both keys are set, `maxOutputTokens` takes precedence. Text generation APIs use `maxOutputTokens`.
 
 All fields use **camelCase**. Unknown top-level keys throw. A snake_case alias of a known field fails with a suggestion (`max_output_tokens` -> use `maxOutputTokens`). Provider-specific keys such as `effort` and `reasoningEffort` belong under `providerOptions`, not at the top level.
 

--- a/docs/guides/prompts/index.mdx
+++ b/docs/guides/prompts/index.mdx
@@ -10,7 +10,7 @@ Prompts in Output live in `.prompt` files inside a `prompts/` folder — version
 provider: anthropic
 model: claude-sonnet-4-20250514
 temperature: 0.3
-maxTokens: 2000
+maxOutputTokens: 2000
 ---
 
 <system>
@@ -92,22 +92,29 @@ The YAML frontmatter configures the LLM call.
 | Field | Description | Example |
 |-------|-------------|---------|
 | `temperature` | Randomness (0-2) | `0` for judges, `0.3` for summaries, `0.7` for general |
-| `maxTokens` | Max output tokens | `2000` |
+| `maxOutputTokens` | Maximum output tokens | `2000` |
+| `maxTokens` | Deprecated alias for `maxOutputTokens` | `2000` |
+| `topP` | Nucleus sampling value; usually set instead of `temperature` | `0.9` |
+| `topK` | Restrict sampling to the top K token choices | `40` |
+| `presencePenalty` | Penalize tokens already present in the prompt or generated output | `0.2` |
+| `frequencyPenalty` | Penalize tokens according to how often they appear | `0.2` |
+| `stopSequences` | Stop text generation when one of these sequences is produced | `["END"]` |
+| `seed` | Random seed for deterministic text or image generation when supported | `42` |
 | `maxSteps` | Tool-loop iterations when tools or skills are present (default 10). Always a positive integer after `loadPrompt`. | `5` |
 | `skills` | Skill file or directory paths, relative to this prompt. YAML may be a string or array; after `loadPrompt` always `string[]` (`[]` if omitted). | `./skills`, `../shared/tone.md` |
 | `tools` | Provider-specific tools | Vertex `googleSearch`, OpenAI `webSearch` |
 | `providerOptions` | Provider-specific config | See below |
 | `messageOptions` | Named per-message `providerOptions` sets | See [Prompt Caching](/packages/llm#prompt-caching) |
-| `n`, `size`, `aspectRatio`, `seed`, `maxImagesPerCall` | Image generation fields | See [Image Output](/packages/llm#image-output) |
+| `n`, `size`, `aspectRatio`, `maxImagesPerCall` | Image generation fields | See [Image Output](/packages/llm#image-output) |
 
-All fields use **camelCase**. Unknown top-level keys throw. A snake_case alias of a known field fails with a suggestion (`max_tokens` -> use `maxTokens`). Provider-specific keys such as `effort`, `reasoningEffort`, and `topP` belong under `providerOptions`, not at the top level.
+All fields use **camelCase**. Unknown top-level keys throw. A snake_case alias of a known field fails with a suggestion (`max_output_tokens` -> use `maxOutputTokens`). Provider-specific keys such as `effort` and `reasoningEffort` belong under `providerOptions`, not at the top level.
 
 ```yaml
 ---
 provider: anthropic
 model: claude-sonnet-4-20250514
 temperature: 0.3
-maxTokens: 2000
+maxOutputTokens: 2000
 ---
 ```
 
@@ -120,7 +127,7 @@ Prompt configurations have two layers:
 provider: anthropic
 model: claude-sonnet-4-20250514
 temperature: 0.7        # Standard option
-maxTokens: 4000         # Standard option
+maxOutputTokens: 4000   # Standard option
 maxSteps: 5             # Tool-loop ceiling when tools or skills are present (default 10)
 ```
 
@@ -140,7 +147,7 @@ providerOptions:
 - Multi-provider configurations (Vertex with multiple model types)
 
 **When NOT to use providerOptions:**
-- Shared top-level fields: `temperature`, `maxTokens`, `maxSteps`, `skills`, `tools`, `messageOptions`, and the image fields (`n`, `size`, `aspectRatio`, `seed`, `maxImagesPerCall`)
+- Shared top-level fields: `temperature`, `maxOutputTokens`, `topP`, `topK`, `presencePenalty`, `frequencyPenalty`, `stopSequences`, `seed`, `maxSteps`, `skills`, `tools`, `messageOptions`, and the image fields (`n`, `size`, `aspectRatio`, `maxImagesPerCall`)
 - These go at the top level alongside `provider` and `model`
 
 ### Provider Options

--- a/docs/guides/prompts/skills.mdx
+++ b/docs/guides/prompts/skills.mdx
@@ -28,7 +28,7 @@ prompts/
 ---
 provider: anthropic
 model: claude-sonnet-4-20250514
-maxTokens: 2048
+maxOutputTokens: 2048
 maxSteps: 5
 skills:
   - ./skills

--- a/docs/guides/start-here/getting-started.mdx
+++ b/docs/guides/start-here/getting-started.mdx
@@ -317,7 +317,7 @@ export const evaluateSignalToNoise = evaluator({
 provider: anthropic
 model: claude-haiku-4-5
 temperature: 0.3
-maxTokens: 256
+maxOutputTokens: 256
 ---
 
 <system>

--- a/sdk/cli/src/templates/project/src/workflows/blog_evaluator/prompts/signal_noise@v1.prompt.template
+++ b/sdk/cli/src/templates/project/src/workflows/blog_evaluator/prompts/signal_noise@v1.prompt.template
@@ -3,7 +3,7 @@ provider: anthropic
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: claude-sonnet-4-6
 temperature: 0.3
-maxTokens: 4096
+maxOutputTokens: 4096
 ---
 
 <system>

--- a/sdk/cli/src/templates/workflow/README.md.template
+++ b/sdk/cli/src/templates/workflow/README.md.template
@@ -178,7 +178,7 @@ export const evaluateQuality = evaluator( {
 
 Create prompt files in `prompts/` following the pattern:
 - File naming: `promptName@v1.prompt`
-- Include YAML frontmatter with provider, model, temperature, and maxTokens
+- Include YAML frontmatter with provider, model, temperature, and maxOutputTokens
 - Use LiquidJS syntax for variables: `{{ variableName }}`
 - Start the rendered body with a role tag for message mode, or with plain text for instruction mode
 
@@ -193,7 +193,7 @@ provider: anthropic
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: claude-sonnet-4-6
 temperature: 0.3
-maxTokens: 1024
+maxOutputTokens: 1024
 ---
 
 <system>

--- a/sdk/cli/src/templates/workflow/prompts/example@v1.prompt.template
+++ b/sdk/cli/src/templates/workflow/prompts/example@v1.prompt.template
@@ -3,7 +3,7 @@ provider: anthropic
 # current as of 2026-05-04 — run output-dev-model-selection for the latest
 model: claude-sonnet-4-6
 temperature: 0.3
-maxTokens: 4096
+maxOutputTokens: 4096
 ---
 
 <system>

--- a/sdk/llm/src/ai_sdk_options.js
+++ b/sdk/llm/src/ai_sdk_options.js
@@ -8,6 +8,30 @@ const buildSkillsMessageContent = skills =>
   'Available skills (use load_skill to get full instructions):\n' +
   skills.map( s => `- ${s.name}: ${s.description}` ).join( '\n' );
 
+const textPromptConfigKeys = [
+  'frequencyPenalty',
+  'maxOutputTokens',
+  'presencePenalty',
+  'providerOptions',
+  'seed',
+  'stopSequences',
+  'temperature',
+  'topK',
+  'topP'
+];
+
+const imagePromptConfigKeys = [
+  'aspectRatio',
+  'maxImagesPerCall',
+  'n',
+  'providerOptions',
+  'seed',
+  'size'
+];
+
+const select = ( keys, target ) =>
+  Object.fromEntries( Object.entries( target ).filter( ( [ k, v ] ) => keys.includes( k ) && v !== undefined ) );
+
 /**
  * Build options for AI SDK text generation.
  *
@@ -47,12 +71,12 @@ export const loadAiSdkTextOptions = ( { prompt, tools, skills, stopWhen, output,
     model: loadTextModel( prompt ),
     system: systemMessages,
     messages: allMessages,
-    providerOptions: prompt.config.providerOptions,
     ...( output && { output } ),
     ...( abortSignal && { abortSignal } ),
     ...( stopWhen && { stopWhen } ),
-    ...( Number.isFinite( prompt.config.temperature ) && { temperature: prompt.config.temperature } ),
-    ...( Number.isFinite( prompt.config.maxTokens ) && { maxOutputTokens: prompt.config.maxTokens } )
+    // @TEMP maxTokens is deprecated in favor of native maxOutputTokens
+    ...( Number.isFinite( prompt.config.maxTokens ) && { maxOutputTokens: prompt.config.maxTokens } ),
+    ...select( textPromptConfigKeys, prompt.config )
   };
 
   // Tools parsing
@@ -90,7 +114,7 @@ export const loadAiSdkImageOptions = ( { prompt, images, mask, abortSignal } ) =
   if ( !prompt.instructions ) {
     throw new FatalError( `Prompt "${prompt.name}" has no instructions. Image prompts must use plain instructions.` );
   }
-  const options = {
+  return {
     maxRetries: 0,
     model: loadImageModel( prompt ),
     prompt: ( images || mask ) ? {
@@ -98,13 +122,7 @@ export const loadAiSdkImageOptions = ( { prompt, images, mask, abortSignal } ) =
       ...( images && { images } ),
       ...( mask && { mask } )
     } : prompt.instructions,
-    providerOptions: prompt.config.providerOptions,
-    ...( abortSignal && { abortSignal } )
+    ...( abortSignal && { abortSignal } ),
+    ...select( imagePromptConfigKeys, prompt.config )
   };
-  for ( const key of [ 'n', 'maxImagesPerCall', 'size', 'aspectRatio', 'seed' ] ) {
-    if ( prompt.config[key] !== undefined ) {
-      options[key] = prompt.config[key];
-    }
-  }
-  return options;
 };

--- a/sdk/llm/src/ai_sdk_options.js
+++ b/sdk/llm/src/ai_sdk_options.js
@@ -74,8 +74,6 @@ export const loadAiSdkTextOptions = ( { prompt, tools, skills, stopWhen, output,
     ...( output && { output } ),
     ...( abortSignal && { abortSignal } ),
     ...( stopWhen && { stopWhen } ),
-    // @TEMP maxTokens is deprecated in favor of native maxOutputTokens
-    ...( Number.isFinite( prompt.config.maxTokens ) && { maxOutputTokens: prompt.config.maxTokens } ),
     ...select( textPromptConfigKeys, prompt.config )
   };
 

--- a/sdk/llm/src/ai_sdk_options.spec.js
+++ b/sdk/llm/src/ai_sdk_options.spec.js
@@ -95,6 +95,24 @@ describe( 'ai_sdk_options', () => {
       } );
     } );
 
+    it( 'forwards all supported text generation options', async () => {
+      const generationOptions = {
+        frequencyPenalty: 0.2,
+        maxOutputTokens: 2000,
+        presencePenalty: 0.3,
+        providerOptions: { openai: { reasoningEffort: 'low' } },
+        seed: 42,
+        stopSequences: [ 'END' ],
+        temperature: 0.4,
+        topK: 40,
+        topP: 0.9
+      };
+
+      const result = await loadText( { prompt: makeTextPrompt( generationOptions ) } );
+
+      expect( result ).toMatchObject( generationOptions );
+    } );
+
     it( 'preserves temperature 0', async () => {
       const result = await loadText( { prompt: makeTextPrompt( { temperature: 0 } ) } );
 

--- a/sdk/llm/src/ai_sdk_options.spec.js
+++ b/sdk/llm/src/ai_sdk_options.spec.js
@@ -75,7 +75,7 @@ describe( 'ai_sdk_options', () => {
     it( 'maps a loaded prompt to model, system, messages, and generation config', async () => {
       const prompt = makeTextPrompt( {
         temperature: 0.3,
-        maxTokens: 1000,
+        maxOutputTokens: 1000,
         providerOptions: { anthropic: { effort: 'medium' } }
       } );
 
@@ -328,7 +328,7 @@ describe( 'ai_sdk_options', () => {
         aspectRatio: '1:1',
         seed: 42,
         temperature: 0.7,
-        maxTokens: 1000,
+        maxOutputTokens: 1000,
         providerOptions: { openai: { quality: 'high' } }
       } );
 

--- a/sdk/llm/src/index.d.ts
+++ b/sdk/llm/src/index.d.ts
@@ -58,7 +58,7 @@ export type PromptMessage = {
  *     provider: 'anthropic',
  *     model: 'claude-opus-4-1',
  *     temperature: 0.7,
- *     maxTokens: 2048,
+ *     maxOutputTokens: 2048,
  *     maxSteps: 10,
  *     skills: []
  *   },
@@ -94,8 +94,30 @@ export type Prompt = {
     /** Generation temperature (0-2). Lower = more deterministic */
     temperature?: number;
 
-    /** Maximum number of tokens in the response */
+    /** Maximum number of tokens in the response. */
+    maxOutputTokens?: number;
+
+    /**
+     * Maximum number of tokens in the response.
+     *
+     * @deprecated Use `maxOutputTokens`.
+     */
     maxTokens?: number;
+
+    /** Nucleus sampling value. Usually set instead of `temperature`. */
+    topP?: number;
+
+    /** Limits sampling to the top K token choices. */
+    topK?: number;
+
+    /** Penalizes tokens that already appear in the prompt or generated output. */
+    presencePenalty?: number;
+
+    /** Penalizes tokens according to how often they appear. */
+    frequencyPenalty?: number;
+
+    /** Sequences that stop text generation when produced. */
+    stopSequences?: string[];
 
     /** Tool-loop iterations when `stopWhen` is omitted. Always a positive integer after load (default 10). */
     maxSteps: number;
@@ -112,7 +134,7 @@ export type Prompt = {
     /** Image aspect ratio, for example `16:9` */
     aspectRatio?: `${number}:${number}`;
 
-    /** Random seed for deterministic image generation when supported */
+    /** Random seed for deterministic text or image generation when supported */
     seed?: number;
 
     /** Skill file or directory paths relative to the prompt file. Always a `string[]` after load (`[]` if unset). */
@@ -406,7 +428,7 @@ export function getProviderNames(): string[];
  * Use an LLM model to generate text.
  *
  * This function is a wrapper over the AI SDK's `generateText`.
- * The prompt file sets `model`, `messages`, `temperature`, `maxTokens`, `maxSteps`, `skills`, and
+ * The prompt file sets `model`, `messages`, generation settings, `maxSteps`, `skills`, and
  * `providerOptions`. Call arguments are `prompt`, `promptDir`, `variables`, `tools`, `output`,
  * `toolChoice`, `stopWhen`, and `abortSignal`.
  *
@@ -441,7 +463,7 @@ export function generateTextWithStreaming<
  * Use an LLM model to stream text generation.
  *
  * This function is a wrapper over the AI SDK's `streamText`.
- * The prompt file sets `model`, `messages`, `temperature`, `maxTokens`, `maxSteps`, `skills`, and
+ * The prompt file sets `model`, `messages`, generation settings, `maxSteps`, `skills`, and
  * `providerOptions`. Call arguments match {@link generateText}, plus `onChunk`, `onFinish`, and
  * `onError`. `onFinish` is wrapped to add `result`, `cost`, and merged `sources`.
  *

--- a/sdk/llm/src/index.d.ts
+++ b/sdk/llm/src/index.d.ts
@@ -91,7 +91,7 @@ export type Prompt = {
     /** Model name/identifier */
     model: string;
 
-    /** Generation temperature (0-2). Lower = more deterministic */
+    /** Generation temperature. Supported range and behavior vary by provider. */
     temperature?: number;
 
     /** Maximum number of tokens in the response. */

--- a/sdk/llm/src/prompt/loader.full.spec.js
+++ b/sdk/llm/src/prompt/loader.full.spec.js
@@ -31,7 +31,7 @@ describe( 'loadPrompt (full)', () => {
 provider: {{ provider }}
 model: {{ model }}
 temperature: {{ temperature }}
-maxTokens: {{ maxTokens }}
+maxOutputTokens: {{ maxOutputTokens }}
 providerOptions:
   thinking:
     type: enabled
@@ -45,7 +45,7 @@ providerOptions:
       provider: 'anthropic',
       model: 'claude-sonnet-4-20250514',
       temperature: 0.7,
-      maxTokens: 1000,
+      maxOutputTokens: 1000,
       budget: 1500,
       role: 'tutor',
       name: 'Ada'
@@ -57,7 +57,7 @@ providerOptions:
         provider: 'anthropic',
         model: 'claude-sonnet-4-20250514',
         temperature: 0.7,
-        maxTokens: 1000,
+        maxOutputTokens: 1000,
         providerOptions: {
           thinking: {
             type: 'enabled',
@@ -282,12 +282,12 @@ model: gpt-4
     writePrompt( dir, 'chat', `---
 provider: anthropic
 model: claude-sonnet-4-20250514
-max_tokens: 64000
+max_output_tokens: 64000
 ---
 <user>Hello</user>
 ` );
 
     expect( () => loadPrompt( 'chat', {}, dir ) ).toThrow( ValidationError );
-    expect( () => loadPrompt( 'chat', {}, dir ) ).toThrow( /"max_tokens" is not valid; use "maxTokens"/ );
+    expect( () => loadPrompt( 'chat', {}, dir ) ).toThrow( /"max_output_tokens" is not valid; use "maxOutputTokens"/ );
   } );
 } );

--- a/sdk/llm/src/prompt/loader.js
+++ b/sdk/llm/src/prompt/loader.js
@@ -1,8 +1,7 @@
 import { Context, Liquid } from 'liquidjs';
 import { parsePromptSchema } from './validations.js';
-import { FatalError, Logger } from '@outputai/core';
+import { FatalError } from '@outputai/core';
 import { pipeInterpolations, interpolationFilterToken, encode, decode } from './interpolations.js';
-import { deprecatedProviderAliases } from '../deprecated_provider_aliases.js';
 import { Path } from '@outputai/core/sdk/helpers';
 import { searchAndReadFile } from '../utils/file.js';
 import matter from 'gray-matter';
@@ -64,20 +63,5 @@ export const loadPrompt = ( name, variables = {}, dir = Path.resolveInvocationDi
 
   const { messages, instructions } = tryStep( () => parseContent( content, config.messageOptions ), 'Error parsing content' );
 
-  // @TODO: this handle aliases removal in v0.11, it can be removed down the road
-  const provider = config.provider;
-  if ( Object.hasOwn( deprecatedProviderAliases, provider ) ) {
-    const canonical = deprecatedProviderAliases[provider];
-    Logger.warn( `Using deprecated provider alias "${provider}". Use "${canonical}" instead.`, { namespace: 'LLM' } );
-    config.provider = canonical;
-  }
-
-  return parsePromptSchema( {
-    name,
-    config,
-    messages,
-    instructions,
-    fileDir: file.dir,
-    variables
-  } );
+  return parsePromptSchema( { name, config, messages, instructions, fileDir: file.dir, variables } );
 };

--- a/sdk/llm/src/prompt/loader.spec.js
+++ b/sdk/llm/src/prompt/loader.spec.js
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { Logger } from '@outputai/core';
 
 const liquidMocks = vi.hoisted( () => ( {
   createContext: vi.fn(),
@@ -186,35 +185,6 @@ describe( 'loadPrompt', () => {
 
     expect( result.messages ).toEqual( [] );
     expect( result.instructions ).toBe( 'Generate a poster.' );
-  } );
-
-  it.each( [
-    [ 'vertex', 'google-vertex' ],
-    [ 'bedrock', 'amazon-bedrock' ]
-  ] )( 'rewrites deprecated provider alias %s to %s and warns', ( alias, canonical ) => {
-    const warn = vi.spyOn( Logger, 'warn' ).mockImplementation( () => {} );
-    stubMatter( { provider: alias, model: 'test-model' } );
-
-    const result = loadPrompt( 'test' );
-
-    expect( result.config.provider ).toBe( canonical );
-    expect( parsePromptSchema ).toHaveBeenCalledWith( expect.objectContaining( {
-      config: expect.objectContaining( { provider: canonical } )
-    } ) );
-    expect( warn ).toHaveBeenCalledWith(
-      `Using deprecated provider alias "${alias}". Use "${canonical}" instead.`,
-      { namespace: 'LLM' }
-    );
-  } );
-
-  it( 'leaves canonical provider names unchanged', () => {
-    const warn = vi.spyOn( Logger, 'warn' ).mockImplementation( () => {} );
-    stubMatter( { provider: 'google-vertex', model: 'gemini-2.5-flash-lite' } );
-
-    const result = loadPrompt( 'test' );
-
-    expect( result.config.provider ).toBe( 'google-vertex' );
-    expect( warn ).not.toHaveBeenCalled();
   } );
 
   it( 'throws when the prompt file is not found', () => {

--- a/sdk/llm/src/prompt/validations.js
+++ b/sdk/llm/src/prompt/validations.js
@@ -1,5 +1,4 @@
-import { ValidationError, z } from '@outputai/core';
-import { Logger } from '@outputai/core';
+import { Logger, ValidationError, z } from '@outputai/core';
 import { deprecatedProviderAliases } from '../deprecated_provider_aliases.js';
 
 const log = Logger.createLogger( 'LLM' );
@@ -58,9 +57,9 @@ const promptConfigSchema = z.object( {
   size: z.string().regex( /^\d+x\d+$/ ).optional(),
   skills: z.preprocess( v => Array.isArray( v ) ? v : [].concat( v ?? [] ), z.array( z.string().min( 1 ) ) ),
   stopSequences: z.array( z.string() ).optional(),
-  temperature: z.number().optional(),
-  topK: z.number().optional(),
-  topP: z.number().optional(),
+  temperature: z.number().nonnegative().optional(),
+  topK: z.number().nonnegative().optional(),
+  topP: z.number().nonnegative().optional(),
   tools: objectMapSchema.optional()
 } ).strict();
 

--- a/sdk/llm/src/prompt/validations.js
+++ b/sdk/llm/src/prompt/validations.js
@@ -10,13 +10,16 @@ const objectMapSchema = z.record(
 
 const promptConfigSchema = z.object( {
   aspectRatio: z.string().regex( /^\d+:\d+$/ ).optional(),
+  frequencyPenalty: z.number().optional(),
   maxImagesPerCall: z.number().int().positive().optional(),
+  maxOutputTokens: z.number().int().positive().optional(),
   maxSteps: z.number().int().positive().default( 10 ),
   maxTokens: z.number().int().positive().optional(),
   // A provider-namespaced options object, e.g. { anthropic: { cacheControl: { type: 'ephemeral' } } }
   messageOptions: z.record( z.string(), objectMapSchema ).optional(),
   model: z.string().min( 1 ),
   n: z.number().int().positive().optional(),
+  presencePenalty: z.number().optional(),
   provider: z.string().min( 1 ),
   providerOptions: z.object( {
     thinking: z.object( {
@@ -27,7 +30,10 @@ const promptConfigSchema = z.object( {
   seed: z.number().int().optional(),
   size: z.string().regex( /^\d+x\d+$/ ).optional(),
   skills: z.preprocess( v => Array.isArray( v ) ? v : [].concat( v ?? [] ), z.array( z.string().min( 1 ) ) ),
+  stopSequences: z.array( z.string() ).optional(),
   temperature: z.number().optional(),
+  topK: z.number().optional(),
+  topP: z.number().optional(),
   tools: objectMapSchema.optional()
 } ).strict();
 

--- a/sdk/llm/src/prompt/validations.js
+++ b/sdk/llm/src/prompt/validations.js
@@ -1,4 +1,31 @@
 import { ValidationError, z } from '@outputai/core';
+import { Logger } from '@outputai/core';
+import { deprecatedProviderAliases } from '../deprecated_provider_aliases.js';
+
+const log = Logger.createLogger( 'LLM' );
+
+const handleDeprecatedKeys = prompt => {
+  const { config: { maxTokens, maxOutputTokens, provider } } = prompt;
+
+  // @TODO: maxTokens was replaced by maxOutputTokens in v0.12, it can be removed down the road
+  if ( Number.isFinite( maxTokens ) ) {
+    if ( Number.isFinite( maxOutputTokens ) ) {
+      log.warn( 'Prompt has both "maxOutputTokens" and deprecated "maxTokens" keys set, "maxTokens" value will be ignored.' );
+    } else {
+      log.warn( 'Prompt has deprecated key "maxTokens". Its value was set to "maxOutputTokens".' );
+      prompt.config.maxOutputTokens = maxTokens;
+    }
+  }
+
+  // @TODO: this handle aliases removal in v0.11, it can be removed down the road
+  if ( Object.hasOwn( deprecatedProviderAliases, provider ) ) {
+    const canonical = deprecatedProviderAliases[provider];
+    log.warn( `Prompt uses deprecated provider alias "${provider}". Use "${canonical}" instead.` );
+    prompt.config.provider = canonical;
+  }
+
+  return prompt;
+};
 
 const objectMapSchema = z.record(
   z.string(),
@@ -60,7 +87,7 @@ export const promptSchema = z.object( {
   } else if ( hasMessages && hasInstructions ) {
     addIssue( 'Prompt cannot include both message blocks and plain instructions.' );
   }
-} );
+} ).transform( handleDeprecatedKeys );
 
 const promptConfigKeys = new Set( Object.keys( promptConfigSchema.shape ) );
 

--- a/sdk/llm/src/prompt/validations.spec.js
+++ b/sdk/llm/src/prompt/validations.spec.js
@@ -31,6 +31,18 @@ describe( 'parsePromptSchema', () => {
     expect( () => parse( validPrompt ) ).not.toThrow();
   } );
 
+  it.each( [ 'temperature', 'topK', 'topP' ] )( 'should reject a negative %s', field => {
+    expect( () => parse( {
+      name: `negative-${field}`,
+      config: {
+        provider: 'anthropic',
+        model: 'claude-3-opus-20240229',
+        [field]: -0.1
+      },
+      messages: [ { role: 'user', content: 'Hello' } ]
+    } ) ).toThrow( ValidationError );
+  } );
+
   it( 'should validate a minimal prompt with only required fields', () => {
     const minimalPrompt = {
       name: 'minimal-prompt',

--- a/sdk/llm/src/prompt/validations.spec.js
+++ b/sdk/llm/src/prompt/validations.spec.js
@@ -12,7 +12,13 @@ describe( 'parsePromptSchema', () => {
         provider: 'anthropic',
         model: 'claude-3-opus-20240229',
         temperature: 0.7,
-        maxTokens: 1000
+        maxOutputTokens: 1000,
+        topP: 0.9,
+        topK: 40,
+        presencePenalty: 0.2,
+        frequencyPenalty: 0.3,
+        stopSequences: [ 'END' ],
+        seed: 42
       },
       messages: [
         {
@@ -603,9 +609,7 @@ describe( 'parsePromptSchema', () => {
       config: {
         provider: 'openai',
         model: 'gpt-4',
-        topP: 0.9,
-        seed: 42,
-        stopSequences: [ 'END' ]
+        unsupportedOption: true
       },
       messages: [
         {

--- a/sdk/llm/src/prompt/validations.spec.js
+++ b/sdk/llm/src/prompt/validations.spec.js
@@ -51,6 +51,37 @@ describe( 'parsePromptSchema', () => {
     expect( parse( minimalPrompt ).variables ).toEqual( {} );
   } );
 
+  it( 'should copy deprecated maxTokens to maxOutputTokens', () => {
+    const result = parse( {
+      name: 'deprecated-max-tokens',
+      config: {
+        provider: 'openai',
+        model: 'gpt-4',
+        maxTokens: 1000
+      },
+      messages: [ { role: 'user', content: 'Hello' } ]
+    } );
+
+    expect( result.config.maxTokens ).toBe( 1000 );
+    expect( result.config.maxOutputTokens ).toBe( 1000 );
+  } );
+
+  it( 'should keep maxOutputTokens when both token limit keys are set', () => {
+    const result = parse( {
+      name: 'both-token-limits',
+      config: {
+        provider: 'openai',
+        model: 'gpt-4',
+        maxTokens: 1000,
+        maxOutputTokens: 2000
+      },
+      messages: [ { role: 'user', content: 'Hello' } ]
+    } );
+
+    expect( result.config.maxTokens ).toBe( 1000 );
+    expect( result.config.maxOutputTokens ).toBe( 2000 );
+  } );
+
   it( 'should validate a prompt with thinking providerOptions', () => {
     const promptWithThinking = {
       name: 'thinking-prompt',

--- a/test_workflows/src/workflows/llm/agent_demo/prompts/no_skills_assistant@v1.prompt
+++ b/test_workflows/src/workflows/llm/agent_demo/prompts/no_skills_assistant@v1.prompt
@@ -1,7 +1,7 @@
 ---
 provider: anthropic
 model: claude-haiku-4-5-20251001
-maxTokens: 2048
+maxOutputTokens: 2048
 skills: []
 ---
 

--- a/test_workflows/src/workflows/llm/agent_demo/prompts/writing_assistant@v1.prompt
+++ b/test_workflows/src/workflows/llm/agent_demo/prompts/writing_assistant@v1.prompt
@@ -1,7 +1,7 @@
 ---
 provider: anthropic
 model: claude-haiku-4-5-20251001
-maxTokens: 2048
+maxOutputTokens: 2048
 maxSteps: 5
 skills:
   - ./skills

--- a/test_workflows/src/workflows/llm/blog_generator/generate_blog@v1.prompt
+++ b/test_workflows/src/workflows/llm/blog_generator/generate_blog@v1.prompt
@@ -2,7 +2,7 @@
 provider: anthropic
 model: claude-haiku-4-5-20251001
 temperature: 0.7
-maxTokens: 4000
+maxOutputTokens: 4000
 ---
 
 <system>

--- a/test_workflows/src/workflows/llm/blog_generator/tests/evals/judge_quality@v1.prompt
+++ b/test_workflows/src/workflows/llm/blog_generator/tests/evals/judge_quality@v1.prompt
@@ -2,7 +2,7 @@
 provider: anthropic
 model: claude-haiku-4-5-20251001
 temperature: 0
-maxTokens: 1000
+maxOutputTokens: 1000
 ---
 
 <system>

--- a/test_workflows/src/workflows/llm/blog_generator/tests/evals/judge_tone@v1.prompt
+++ b/test_workflows/src/workflows/llm/blog_generator/tests/evals/judge_tone@v1.prompt
@@ -2,7 +2,7 @@
 provider: anthropic
 model: claude-haiku-4-5-20251001
 temperature: 0
-maxTokens: 1000
+maxOutputTokens: 1000
 ---
 
 <system>

--- a/test_workflows/src/workflows/llm/blog_generator/tests/evals/judge_topic@v1.prompt
+++ b/test_workflows/src/workflows/llm/blog_generator/tests/evals/judge_topic@v1.prompt
@@ -2,7 +2,7 @@
 provider: anthropic
 model: claude-haiku-4-5-20251001
 temperature: 0
-maxTokens: 1000
+maxOutputTokens: 1000
 ---
 
 <system>

--- a/test_workflows/src/workflows/llm/generate_text/choice@v1.prompt
+++ b/test_workflows/src/workflows/llm/generate_text/choice@v1.prompt
@@ -1,6 +1,6 @@
 ---
-provider: anthropic
-model: claude-haiku-4-5
+provider: openai
+model: gpt-4.1-mini
 temperature: 0.7
 ---
 

--- a/test_workflows/src/workflows/llm/generate_text/prompt@v1.prompt
+++ b/test_workflows/src/workflows/llm/generate_text/prompt@v1.prompt
@@ -2,7 +2,7 @@
 provider: anthropic
 model: claude-haiku-4-5
 temperature: 0.7
-maxTokens: 4000
+maxOutputTokens: 4000
 messageOptions:
   cached:
     anthropic:

--- a/test_workflows/src/workflows/llm/generate_text_with_streaming/stream_content@v1.prompt
+++ b/test_workflows/src/workflows/llm/generate_text_with_streaming/stream_content@v1.prompt
@@ -2,7 +2,7 @@
 provider: anthropic
 model: claude-sonnet-4-6
 temperature: 0.7
-maxTokens: 1024
+maxOutputTokens: 1024
 ---
 
 <assistant>

--- a/test_workflows/src/workflows/llm/invalid_schema/invalid_schema@v1.prompt
+++ b/test_workflows/src/workflows/llm/invalid_schema/invalid_schema@v1.prompt
@@ -2,7 +2,7 @@
 provider: anthropic
 model: claude-haiku-4-5
 temperature: 0
-maxTokens: 1000
+maxOutputTokens: 1000
 ---
 
 <assistant>

--- a/test_workflows/src/workflows/llm/stream_text/stream_content@v1.prompt
+++ b/test_workflows/src/workflows/llm/stream_text/stream_content@v1.prompt
@@ -2,7 +2,7 @@
 provider: anthropic
 model: claude-sonnet-4-6
 temperature: 0.7
-maxTokens: 1024
+maxOutputTokens: 1024
 ---
 
 <assistant>

--- a/test_workflows/src/workflows/llm/stream_text_error/missing_model@v1.prompt
+++ b/test_workflows/src/workflows/llm/stream_text_error/missing_model@v1.prompt
@@ -2,7 +2,7 @@
 provider: anthropic
 model: claude-this-model-does-not-exist
 temperature: 0
-maxTokens: 64
+maxOutputTokens: 64
 ---
 
 <user>

--- a/test_workflows/src/workflows/llm/web_search/prompts/web_search@v1.prompt
+++ b/test_workflows/src/workflows/llm/web_search/prompts/web_search@v1.prompt
@@ -1,7 +1,7 @@
 ---
 provider: anthropic
 model: claude-sonnet-4-6
-maxTokens: 1024
+maxOutputTokens: 1024
 ---
 
 <system>


### PR DESCRIPTION
## Summary

- Added support for more text generation top level AI SDK options in the prompt files:
  - topP
  - topK
  - presencePenalty
  - frequencyPenalty
  - stopSequences
  - seed
- Added support for `maxOutputTokens`. It is intended to replace existing `maxTokens`, which is now being deprecated. Added deprecation instructions and migrated all related documents to use the new key. If both values are informed the new key has precedence. The key was updated to align with the AI SDK naming.
- Updating a test workflow to use a GPT mode, allowing more variety on the tests.
