### PR TITLE
feat(llm): Allow prompt object generation argument (OUT-564)

### DIFF
--- a/.changeset/bright-prompts-flow.md
+++ b/.changeset/bright-prompts-flow.md
@@ -1,0 +1,5 @@
+---
+"@outputai/llm": minor
+---
+
+Added support for passing a loaded or custom `Prompt` object directly to `generateText()`, `generateTextWithStreaming()`, `streamText()`, `generateImage()`, and the `Agent` constructor. Prompt filename strings remain supported; `variables` and `promptDir` apply only when loading a prompt by filename.

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -907,7 +907,7 @@ Each completed text generation call emits a `cost:llm:request` event after the L
 
 ## loadPrompt
 
-Load and render a prompt file without generating - useful for debugging:
+Load and render a prompt file for inspection, reuse, or direct use as a generation argument:
 
 ```typescript
 import { loadPrompt } from '@outputai/llm';
@@ -923,6 +923,8 @@ console.log(prompt.messages);     // PromptMessage[] with system, user, or assis
 console.log(prompt.instructions); // string | null
 console.log(prompt.variables);    // { companyName: 'Acme Corp', industry: 'SaaS', size: 250 }
 ```
+
+The returned `Prompt` can be passed directly to `generateText`, `generateTextWithStreaming`, `streamText`, `generateImage`, or `new Agent()`. See [Passing Prompt Objects Directly](/prompts#passing-prompt-objects-directly).
 
 For instruction-mode prompts, `messages` is empty and `instructions` contains the rendered body. For message-mode prompts, `messages` contains the parsed role blocks and `instructions` is `null`. See [Prompt Body Modes](/prompts#prompt-body-modes).
 

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -318,11 +318,11 @@ const { output } = await generateText({
 
 ## Agents
 
-The `Agent` class wraps AI SDK's `ToolLoopAgent` with Output [prompt files](/prompts) and the [skills](/prompts/skills) system. Use it when you need multi-step tool execution, conversation history, or a reusable agent instance with a fixed configuration. For single-shot LLM calls without tools, `generateText` is simpler.
+The `Agent` class wraps AI SDK's `ToolLoopAgent` with Output [prompts](/prompts) and the [skills](/prompts/skills) system. Use it when you need multi-step tool execution, conversation history, or a reusable agent instance with a fixed configuration. For single-shot LLM calls without tools, `generateText` is simpler.
 
 ### Construction
 
-The prompt file is loaded and rendered at construction time. Variables and tools are fixed at construction. Skills and `maxSteps` come from the prompt file. The agent is ready to call `generate()`, `generateWithStreaming()`, or `stream()` immediately.
+A prompt filename is loaded and rendered at construction time. A loaded or custom `Prompt` object can be passed directly instead. Variables and `promptDir` apply only to filename prompts; tools are fixed at construction. Skills and `maxSteps` come from the resolved prompt. The agent is ready to call `generate()`, `generateWithStreaming()`, or `stream()` immediately.
 
 Each call seeds authored `<user>` blocks from the prompt. `<system>` blocks become `instructions`. Authored `<assistant>` blocks are dropped; use `generateText` when the prompt is a few-shot or prefilled thread.
 
@@ -355,9 +355,9 @@ export const reviewContent = step({
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `prompt` | `string` | *(required)* | Prompt file name (e.g. `'writing_assistant@v1'`) |
-| `promptDir` | `string` | - | Override the stack-resolved prompt directory |
-| `variables` | `PromptVariables` | - | Template variables rendered at construction |
+| `prompt` | `string \| Prompt` | *(required)* | Prompt filename or a loaded/custom prompt object |
+| `promptDir` | `string` | - | Override the stack-resolved prompt directory for a filename prompt |
+| `variables` | `PromptVariables` | - | Template variables rendered for a filename prompt |
 | `tools` | AI SDK tools | - | Caller tools; merged with prompt YAML tools (`load_skill` last) |
 | `stopWhen` | function or function[] | - | Custom stop condition (overrides prompt `maxSteps` when tools exist) |
 | `output` | `aiSdk.Output` | - | Structured output spec (e.g. `aiSdk.Output.object({ schema })`) |
@@ -842,7 +842,7 @@ const { result, toolCalls } = await generateText({
 
 ## Call arguments
 
-`variables` accepts Liquid values, including nested objects and arrays. Use dot notation and Liquid loops to read structured values in the prompt template.
+`prompt` accepts either a prompt filename string or a loaded/custom `Prompt` object. When passing an object, do not also pass `promptDir` or `variables`: prompt objects are already resolved and rendered. For filename prompts, `variables` accepts Liquid values, including nested objects and arrays. Use dot notation and Liquid loops to read structured values in the prompt template.
 
 ### Text APIs
 
@@ -866,9 +866,9 @@ const { result, toolCalls } = await generateText({
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| `prompt` | yes | Prompt file name |
-| `promptDir` | no | Override the stack-resolved prompt directory |
-| `variables` | no | Template variables |
+| `prompt` | yes | Prompt filename or a loaded/custom `Prompt` object |
+| `promptDir` | no | Override the stack-resolved prompt directory for a filename prompt |
+| `variables` | no | Template variables for a filename prompt |
 | `images` | no | Source images for image-to-image |
 | `mask` | no | Inpainting mask; requires `images` |
 | `abortSignal` | no | Cancel the request |

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -586,7 +586,7 @@ Company size: {{ size }} employees
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `provider` | `string` | `anthropic`, `openai`, `azure`, `amazon-bedrock`, `google-vertex`, `perplexity`, or a provider registered with `registerProvider`. Legacy aliases `bedrock` and `vertex` are deprecated but still accepted. |
+| `provider` | `string` | `anthropic`, `openai`, `azure`, `amazon-bedrock`, `google-vertex`, `perplexity`, or a provider registered with `registerProvider`. Legacy aliases `bedrock` and `vertex` are deprecated but still accepted and normalized with a warning. |
 | `model` | `string` | Model identifier |
 | `temperature` | `number` | Sampling temperature; supported range varies by provider |
 | `maxOutputTokens` | `number` | Maximum output tokens |
@@ -621,7 +621,7 @@ Unknown top-level keys throw `Invalid prompt file`. Snake_case aliases of known 
 | `google-vertex` | `@ai-sdk/google-vertex` | `>=4 <5` |
 | `perplexity` | `@ai-sdk/perplexity` | `>=3 <4` |
 
-Legacy aliases `bedrock` → `amazon-bedrock` and `vertex` → `google-vertex` are deprecated but still work; using them logs a deprecation warning.
+Legacy aliases `bedrock` -> `amazon-bedrock` and `vertex` -> `google-vertex` are deprecated but still work; prompt parsing normalizes them to their canonical names and logs a deprecation warning.
 
 Built-in provider instances are initialized lazily. Output creates the provider instance only when a prompt or API call first requests that provider, then reuses it for later calls.
 

--- a/docs/guides/prompts/index.mdx
+++ b/docs/guides/prompts/index.mdx
@@ -90,7 +90,7 @@ const prompt: Prompt = {
 await generateText({ prompt });
 ```
 
-Prompt objects are already resolved and rendered, so `promptDir` and call-level `variables` cannot be used with them. `fileDir` remains the base directory for relative skill paths. Custom objects must use canonical provider names; deprecated provider aliases are normalized only when loading prompt files.
+Prompt objects are already resolved and rendered, so `promptDir` and call-level `variables` cannot be used with them. `fileDir` remains the base directory for relative skill paths. Use canonical provider names in custom objects. Deprecated aliases are still accepted and normalized with a warning.
 
 <Warning>
   Only accept prompt objects from trusted sources. They can select providers and models and load local skill files relative to `fileDir`.

--- a/docs/guides/prompts/index.mdx
+++ b/docs/guides/prompts/index.mdx
@@ -92,6 +92,10 @@ await generateText({ prompt });
 
 Prompt objects are already resolved and rendered, so `promptDir` and call-level `variables` cannot be used with them. `fileDir` remains the base directory for relative skill paths. Custom objects must use canonical provider names; deprecated provider aliases are normalized only when loading prompt files.
 
+<Warning>
+  Only accept prompt objects from trusted sources. They can select providers and models and load local skill files relative to `fileDir`.
+</Warning>
+
 ## File Organization
 
 Place prompt files in a `prompts/` subfolder within your workflow directory:

--- a/docs/guides/prompts/index.mdx
+++ b/docs/guides/prompts/index.mdx
@@ -50,6 +50,48 @@ await generateText({
 
 Output searches recursively from your workflow's directory to find the prompt file.
 
+## Passing Prompt Objects Directly
+
+`generateText`, `generateTextWithStreaming`, `streamText`, `generateImage`, and `new Agent()` also accept a loaded or custom `Prompt` object. This lets you load a prompt once or supply one from another source:
+
+```typescript
+import { generateText, loadPrompt } from '@outputai/llm';
+
+const prompt = loadPrompt('generate_summary@v1', {
+  company_name: 'Acme Corp',
+  website_content: '...'
+});
+
+await generateText({ prompt });
+```
+
+A custom object must match the normalized `Prompt` shape:
+
+```typescript
+import { generateText } from '@outputai/llm';
+import type { Prompt } from '@outputai/llm';
+
+const prompt: Prompt = {
+  name: 'custom-summary',
+  fileDir: process.cwd(),
+  variables: {},
+  config: {
+    provider: 'openai',
+    model: 'gpt-4o',
+    maxSteps: 10,
+    skills: []
+  },
+  messages: [
+    { role: 'user', content: 'Summarize the latest account activity.' }
+  ],
+  instructions: null
+};
+
+await generateText({ prompt });
+```
+
+Prompt objects are already resolved and rendered, so `promptDir` and call-level `variables` cannot be used with them. `fileDir` remains the base directory for relative skill paths. Custom objects must use canonical provider names; deprecated provider aliases are normalized only when loading prompt files.
+
 ## File Organization
 
 Place prompt files in a `prompts/` subfolder within your workflow directory:

--- a/sdk/llm/src/agent.js
+++ b/sdk/llm/src/agent.js
@@ -14,9 +14,9 @@ export class Agent extends AIToolLoopAgent {
   #store;
 
   constructor( args ) {
-    const { promptFile, promptDir, variables, tools, output, stopWhen, messageStore } = Validator.parseAgentArgs( args );
+    const { promptFile, promptObject, promptDir, variables, tools, output, stopWhen, messageStore } = Validator.parseAgentArgs( args );
 
-    const prompt = loadPrompt( promptFile, variables, promptDir );
+    const prompt = promptObject ?? loadPrompt( promptFile, variables, promptDir );
     const skills = loadSkills( prompt );
 
     const { system, messages, ...aiOptions } = loadAiSdkTextOptions( { prompt, skills, tools, output, stopWhen } );

--- a/sdk/llm/src/agent.spec.js
+++ b/sdk/llm/src/agent.spec.js
@@ -213,6 +213,23 @@ describe( 'Agent', () => {
     } );
   } );
 
+  it( 'uses a prompt object without loading a prompt file', async () => {
+    validations.parseAgentArgs.mockReturnValueOnce( { promptObject: loadedPrompt } );
+    const { Agent } = await importSut();
+
+    new Agent( { prompt: loadedPrompt } );
+
+    expect( promptMocks.loadPrompt ).not.toHaveBeenCalled();
+    expect( skillMocks.loadSkills ).toHaveBeenCalledWith( loadedPrompt );
+    expect( optionMocks.loadAiSdkTextOptions ).toHaveBeenCalledWith( {
+      prompt: loadedPrompt,
+      skills: loadedSkills,
+      tools: undefined,
+      output: undefined,
+      stopWhen: undefined
+    } );
+  } );
+
   it( 'passes option tools through to ToolLoopAgent', async () => {
     const { Agent } = await importSut();
     optionMocks.loadAiSdkTextOptions.mockReturnValueOnce( {

--- a/sdk/llm/src/generate.js
+++ b/sdk/llm/src/generate.js
@@ -7,8 +7,8 @@ import { loadSkills } from './utils/skills.js';
 import * as Validator from './validations.js';
 
 export const generateText = async args => {
-  const { promptFile, variables, promptDir, ...aiOptions } = Validator.parseGenerateTextArgs( args );
-  const prompt = loadPrompt( promptFile, variables, promptDir );
+  const { promptFile, promptObject, variables, promptDir, ...aiOptions } = Validator.parseGenerateTextArgs( args );
+  const prompt = promptObject ?? loadPrompt( promptFile, variables, promptDir );
   const skills = loadSkills( prompt );
 
   return wrapGeneration( {
@@ -19,8 +19,8 @@ export const generateText = async args => {
 };
 
 export const streamText = args => {
-  const { promptFile, variables, promptDir, onFinish, onError, onChunk, ...aiOptions } = Validator.parseStreamTextArgs( args );
-  const prompt = loadPrompt( promptFile, variables, promptDir );
+  const { promptFile, promptObject, variables, promptDir, onFinish, onError, onChunk, ...aiOptions } = Validator.parseStreamTextArgs( args );
+  const prompt = promptObject ?? loadPrompt( promptFile, variables, promptDir );
   const skills = loadSkills( prompt );
 
   return wrapStream( {
@@ -39,8 +39,8 @@ export const streamText = args => {
  * Generates a completed text response over streaming transport, invoking `onChunk` as parts arrive.
  */
 export const generateTextWithStreaming = async args => {
-  const { promptFile, variables, promptDir, onChunk, ...aiOptions } = Validator.parseGenerateTextWithStreamingArgs( args );
-  const prompt = loadPrompt( promptFile, variables, promptDir );
+  const { promptFile, promptObject, variables, promptDir, onChunk, ...aiOptions } = Validator.parseGenerateTextWithStreamingArgs( args );
+  const prompt = promptObject ?? loadPrompt( promptFile, variables, promptDir );
   const skills = loadSkills( prompt );
 
   return wrapGeneration( {
@@ -70,8 +70,8 @@ export const generateTextWithStreaming = async args => {
 };
 
 export const generateImage = async args => {
-  const { promptFile, promptDir, variables, ...aiOptions } = Validator.parseGenerateImageArgs( args );
-  const prompt = loadPrompt( promptFile, variables, promptDir );
+  const { promptFile, promptObject, promptDir, variables, ...aiOptions } = Validator.parseGenerateImageArgs( args );
+  const prompt = promptObject ?? loadPrompt( promptFile, variables, promptDir );
 
   return wrapGeneration( {
     name: 'generateImage',

--- a/sdk/llm/src/generate.spec.js
+++ b/sdk/llm/src/generate.spec.js
@@ -189,6 +189,20 @@ describe( 'generate', () => {
       expect( result ).toBe( textResponse );
     } );
 
+    it( 'uses a prompt object without loading a prompt file', async () => {
+      validations.parseGenerateTextArgs.mockReturnValueOnce( { promptObject: loadedPrompt } );
+      const { generateText } = await importSut();
+
+      await generateText( { prompt: loadedPrompt } );
+
+      expect( promptMocks.loadPrompt ).not.toHaveBeenCalled();
+      expect( skillMocks.loadSkills ).toHaveBeenCalledWith( loadedPrompt );
+      expect( optionMocks.loadAiSdkTextOptions ).toHaveBeenCalledWith( {
+        prompt: loadedPrompt,
+        skills: loadedSkills
+      } );
+    } );
+
     it( 'propagates parse errors before wrapping or calling AI SDK', async () => {
       const validationError = new Error( 'Invalid args' );
       validations.parseGenerateTextArgs.mockImplementationOnce( () => {
@@ -249,6 +263,25 @@ describe( 'generate', () => {
       expect( streamMocks.drainStream ).toHaveBeenCalledWith( stream, undefined );
       expect( onChunk ).toHaveBeenCalledWith( { chunk } );
       expect( result ).toEqual( { ...textResponse, output } );
+    } );
+
+    it( 'uses a prompt object without loading a prompt file', async () => {
+      const stream = { output: Promise.resolve( undefined ) };
+      validations.parseGenerateTextWithStreamingArgs.mockReturnValueOnce( { promptObject: loadedPrompt } );
+      aiFns.streamText.mockImplementationOnce( options => {
+        options.onFinish( { ...textResponse } );
+        return stream;
+      } );
+      const { generateTextWithStreaming } = await importSut();
+
+      await generateTextWithStreaming( { prompt: loadedPrompt } );
+
+      expect( promptMocks.loadPrompt ).not.toHaveBeenCalled();
+      expect( skillMocks.loadSkills ).toHaveBeenCalledWith( loadedPrompt );
+      expect( optionMocks.loadAiSdkTextOptions ).toHaveBeenCalledWith( {
+        prompt: loadedPrompt,
+        skills: loadedSkills
+      } );
     } );
 
     it( 'omits onChunk when the caller does not provide it', async () => {
@@ -336,6 +369,20 @@ describe( 'generate', () => {
       expect( wrapMocks.streamHooks.onFinishHook ).toHaveBeenCalledWith( textResponse, onFinish );
       expect( onFinish ).toHaveBeenCalledWith( textResponse );
       expect( result ).toBe( streamResult );
+    } );
+
+    it( 'uses a prompt object without loading a prompt file', async () => {
+      validations.parseStreamTextArgs.mockReturnValueOnce( { promptObject: loadedPrompt } );
+      const { streamText } = await importSut();
+
+      streamText( { prompt: loadedPrompt } );
+
+      expect( promptMocks.loadPrompt ).not.toHaveBeenCalled();
+      expect( skillMocks.loadSkills ).toHaveBeenCalledWith( loadedPrompt );
+      expect( optionMocks.loadAiSdkTextOptions ).toHaveBeenCalledWith( {
+        prompt: loadedPrompt,
+        skills: loadedSkills
+      } );
     } );
 
     it( 'omits onChunk when the caller does not provide it', async () => {
@@ -434,6 +481,18 @@ describe( 'generate', () => {
       } );
       expect( aiFns.generateImage ).toHaveBeenCalledWith( imageOptions );
       expect( result ).toBe( imageResponse );
+    } );
+
+    it( 'uses a prompt object without loading a prompt file', async () => {
+      validations.parseGenerateImageArgs.mockReturnValueOnce( { promptObject: loadedPrompt } );
+      const { generateImage } = await importSut();
+
+      await generateImage( { prompt: loadedPrompt } );
+
+      expect( promptMocks.loadPrompt ).not.toHaveBeenCalled();
+      expect( optionMocks.loadAiSdkImageOptions ).toHaveBeenCalledWith( {
+        prompt: loadedPrompt
+      } );
     } );
 
     it( 'supports text-to-image calls without images or mask', async () => {

--- a/sdk/llm/src/index.d.ts
+++ b/sdk/llm/src/index.d.ts
@@ -83,8 +83,9 @@ export type Prompt = {
      * LLM provider.
      *
      * Built-in: `'anthropic'`, `'openai'`, `'azure'`, `'amazon-bedrock'`, `'google-vertex'`,
-     * `'perplexity'`. Legacy aliases `'bedrock'` and `'vertex'` are deprecated but still accepted.
-     * Custom providers registered via {@link registerProvider} are also accepted.
+     * `'perplexity'`. Legacy aliases `'bedrock'` and `'vertex'` are deprecated but still accepted
+     * in prompts and normalized to their canonical names with a warning. Custom providers
+     * registered via {@link registerProvider} are also accepted.
      */
     provider: string;
 

--- a/sdk/llm/src/index.d.ts
+++ b/sdk/llm/src/index.d.ts
@@ -68,13 +68,13 @@ export type PromptMessage = {
  * ```
  */
 export type Prompt = {
-  /** Name of the prompt file */
+  /** Prompt name used in tracing and errors. */
   name: string;
 
-  /** Directory containing the resolved prompt file */
+  /** Base directory for resolving relative prompt resources such as skills. */
   fileDir: string;
 
-  /** Interpolation values used when the prompt was loaded. Defaults to `{}`. */
+  /** Interpolation values associated with the prompt. Defaults to `{}` when validated. */
   variables: PromptVariables;
 
   /** General configuration for the LLM */
@@ -223,13 +223,24 @@ type PromptFileCallOptions = {
   promptDir?: string;
 };
 
+type PromptObjectCallOptions = {
+  /** Loaded or custom prompt object. */
+  prompt: Prompt;
+  /** Prompt objects are already rendered and cannot receive interpolation variables. */
+  variables?: never;
+  /** Prompt objects are not resolved from a prompt directory. */
+  promptDir?: never;
+};
+
+type PromptCallOptions = PromptFileCallOptions | PromptObjectCallOptions;
+
 type StopWhen<Tools extends ToolSet = ToolSet> =
   StopCondition<NoInfer<Tools>> | Array<StopCondition<NoInfer<Tools>>>;
 
 type TextCallOptions<
   Tools extends ToolSet = ToolSet,
   OutputSpec extends AnyAiOutput = AnyAiOutput
-> = PromptFileCallOptions & {
+> = PromptCallOptions & {
   /** AI SDK tools, accepted structurally to tolerate different Zod peer versions. */
   tools?: CompatibleToolSet;
   /** Structured output specification */
@@ -282,7 +293,7 @@ export type GenerateImageInput =
   };
 
 /** Parameters accepted by {@link generateImage}. */
-export type GenerateImageParameters = PromptFileCallOptions & {
+export type GenerateImageParameters = PromptCallOptions & {
   /** Runtime image inputs for image-to-image generation */
   images?: GenerateImageInput[];
   /** Optional mask for image editing; requires `images` */
@@ -294,7 +305,7 @@ export type GenerateImageParameters = PromptFileCallOptions & {
 /** Agent constructor options. */
 export type OutputAgentConstructorParameters<
   OutputSpec extends AnyAiOutput = AnyAiOutput
-> = PromptFileCallOptions & {
+> = PromptCallOptions & {
   /** Structured output specification */
   output?: OutputSpec;
   /** AI SDK tools available during the reasoning loop */
@@ -428,9 +439,10 @@ export function getProviderNames(): string[];
  * Use an LLM model to generate text.
  *
  * This function is a wrapper over the AI SDK's `generateText`.
- * The prompt file sets `model`, `messages`, generation settings, `maxSteps`, `skills`, and
- * `providerOptions`. Call arguments are `prompt`, `promptDir`, `variables`, `tools`, `output`,
- * `toolChoice`, `stopWhen`, and `abortSignal`.
+ * The prompt sets `model`, `messages`, `temperature`, `maxTokens`, `maxSteps`, `skills`, and
+ * `providerOptions`. Pass either a prompt filename with optional `promptDir` / `variables`, or a
+ * loaded or custom {@link Prompt} object. Other call arguments are `tools`, `output`, `toolChoice`,
+ * `stopWhen`, and `abortSignal`.
  *
  * @param args - Generation arguments. See {@link GenerateTextParameters}.
  * @returns AI SDK response with text and metadata.
@@ -463,9 +475,10 @@ export function generateTextWithStreaming<
  * Use an LLM model to stream text generation.
  *
  * This function is a wrapper over the AI SDK's `streamText`.
- * The prompt file sets `model`, `messages`, generation settings, `maxSteps`, `skills`, and
- * `providerOptions`. Call arguments match {@link generateText}, plus `onChunk`, `onFinish`, and
- * `onError`. `onFinish` is wrapped to add `result`, `cost`, and merged `sources`.
+ * The prompt sets `model`, `messages`, `temperature`, `maxTokens`, `maxSteps`, `skills`, and
+ * `providerOptions`. Pass either a prompt filename with optional `promptDir` / `variables`, or a
+ * loaded or custom {@link Prompt} object. Other call arguments match {@link generateText}, plus
+ * `onChunk`, `onFinish`, and `onError`. `onFinish` adds `result`, `cost`, and merged `sources`.
  *
  * @param args - Streaming arguments. See {@link StreamTextParameters}.
  * @returns AI SDK stream result with textStream, fullStream, and metadata promises.
@@ -478,10 +491,11 @@ export function streamText<
 ): AIStreamTextResult<Tools, OutputSpec>;
 
 /**
- * Use an image model to generate images from a prompt file.
+ * Use an image model to generate images from a prompt filename or object.
  *
- * The prompt file supplies `model`, instructions, `n`, `size`, `aspectRatio`, `seed`,
- * `maxImagesPerCall`, and `providerOptions`. Call arguments are `prompt`, `promptDir`, `variables`,
+ * The prompt supplies `model`, instructions, `n`, `size`, `aspectRatio`, `seed`,
+ * `maxImagesPerCall`, and `providerOptions`. Pass either a prompt filename with optional
+ * `promptDir` / `variables`, or a loaded or custom {@link Prompt} object. Other call arguments are
  * `images`, `mask`, and `abortSignal`.
  *
  * @param args - Image generation arguments. See {@link GenerateImageParameters}.
@@ -498,7 +512,7 @@ export interface MessageStore {
 }
 
 /**
- * Agent extends AI SDK's ToolLoopAgent with Output.ai prompt file rendering.
+ * Agent extends AI SDK's ToolLoopAgent with Output.ai prompt loading and validation.
  *
  * @example Workflow step - variables per call, stateless
  * ```ts

--- a/sdk/llm/src/prompt/loader.full.spec.js
+++ b/sdk/llm/src/prompt/loader.full.spec.js
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { FatalError, ValidationError } from '@outputai/core';
 import { Role } from '../consts.js';
+import { parseAgentArgs, parseGenerateTextArgs } from '../validations.js';
 import { loadPrompt } from './loader.js';
 
 const dirs = [];
@@ -25,6 +26,21 @@ afterEach( () => {
 } );
 
 describe( 'loadPrompt (full)', () => {
+  it( 'round-trips a loaded prompt through generation argument validation', () => {
+    const dir = tempDir();
+    writePrompt( dir, 'round-trip', `---
+provider: openai
+model: gpt-4o
+---
+<user>Hello</user>
+` );
+
+    const prompt = loadPrompt( 'round-trip', {}, dir );
+
+    expect( parseGenerateTextArgs( { prompt } ) ).toEqual( { promptObject: prompt } );
+    expect( parseAgentArgs( { prompt } ) ).toEqual( { promptObject: prompt } );
+  } );
+
   it( 'loads a chat prompt, interpolates frontmatter and body, and returns a validated prompt', () => {
     const dir = tempDir();
     writePrompt( dir, 'chat', `---

--- a/sdk/llm/src/prompt/validations.js
+++ b/sdk/llm/src/prompt/validations.js
@@ -1,5 +1,6 @@
 import { Logger, ValidationError, z } from '@outputai/core';
 import { deprecatedProviderAliases } from '../deprecated_provider_aliases.js';
+import { Role } from '../consts.js';
 
 const log = Logger.createLogger( 'LLM' );
 
@@ -68,7 +69,7 @@ export const promptSchema = z.object( {
   config: promptConfigSchema,
   messages: z.array(
     z.object( {
-      role: z.string(),
+      role: z.enum( Object.values( Role ) ),
       content: z.string(),
       providerOptions: objectMapSchema.optional()
     } ).strict()

--- a/sdk/llm/src/prompt/validations.spec.js
+++ b/sdk/llm/src/prompt/validations.spec.js
@@ -94,6 +94,20 @@ describe( 'parsePromptSchema', () => {
     expect( result.config.maxOutputTokens ).toBe( 2000 );
   } );
 
+  it( 'should reject an unsupported message role', () => {
+    expect( () => parse( {
+      name: 'invalid-role',
+      config: {
+        provider: 'openai',
+        model: 'gpt-4'
+      },
+      messages: [ {
+        role: 'developer',
+        content: 'You are a helpful assistant.'
+      } ]
+    } ) ).toThrow( /messages\[0\]\.role/ );
+  } );
+
   it( 'should validate a prompt with thinking providerOptions', () => {
     const promptWithThinking = {
       name: 'thinking-prompt',

--- a/sdk/llm/src/validations.js
+++ b/sdk/llm/src/validations.js
@@ -1,5 +1,6 @@
 import { Buffer } from 'node:buffer';
 import { ValidationError, z } from '@outputai/core';
+import { Role } from './consts.js';
 import { promptSchema } from './prompt/validations.js';
 
 const rejectPromptOwnedCallArg = name => z.unknown().optional().refine(
@@ -48,7 +49,7 @@ const messageStoreSchema = z.custom(
 );
 
 const modelMessageSchema = z.object( {
-  role: z.enum( [ 'system', 'user', 'assistant', 'tool' ] ),
+  role: z.enum( [ ...Object.values( Role ), 'tool' ] ),
   content: z.union( [ z.string(), z.array( z.unknown() ) ] )
 } ).loose();
 
@@ -65,15 +66,10 @@ const promptInputSchema = z.unknown().transform( ( value, ctx ) => {
   return result.data;
 } );
 
-const promptFileCallFields = {
-  prompt: promptFileSchema,
+const promptCallFields = {
+  prompt: promptInputSchema,
   promptDir: z.string().min( 1 ).optional(),
   variables: variablesSchema.optional()
-};
-
-const promptCallFields = {
-  ...promptFileCallFields,
-  prompt: promptInputSchema
 };
 
 const textRuntimeCallFields = {

--- a/sdk/llm/src/validations.js
+++ b/sdk/llm/src/validations.js
@@ -1,5 +1,6 @@
 import { Buffer } from 'node:buffer';
 import { ValidationError, z } from '@outputai/core';
+import { promptSchema } from './prompt/validations.js';
 
 const rejectPromptOwnedCallArg = name => z.unknown().optional().refine(
   value => value === undefined,
@@ -52,10 +53,17 @@ const modelMessageSchema = z.object( {
   content: z.union( [ z.string(), z.array( z.unknown() ) ] )
 } ).loose();
 
+const promptFileSchema = z.string().min( 1 );
+
 const promptFileCallFields = {
-  prompt: z.string().min( 1 ),
+  prompt: promptFileSchema,
   promptDir: z.string().min( 1 ).optional(),
   variables: variablesSchema.optional()
+};
+
+const promptCallFields = {
+  ...promptFileCallFields,
+  prompt: z.union( [ promptFileSchema, promptSchema ] )
 };
 
 const textRuntimeCallFields = {
@@ -67,32 +75,51 @@ const textRuntimeCallFields = {
 };
 
 const generateTextCallFields = {
-  ...promptFileCallFields,
+  ...promptCallFields,
   ...promptOwnedCallArgRejection,
   ...textRuntimeCallFields
 };
 
-const toPromptFileArgs = ( { prompt, maxSteps, skills, ...rest } ) => ( {
-  promptFile: prompt,
+const toPromptArgs = ( { prompt, maxSteps, skills, ...rest } ) => ( {
+  ...( typeof prompt === 'string' ? { promptFile: prompt } : { promptObject: prompt } ),
   ...rest
 } );
 
-const generateTextArgsSchema = z.object( generateTextCallFields ).strict().transform( toPromptFileArgs );
+const rejectPromptObjectFileArgs = ( args, ctx ) => {
+  if ( typeof args.prompt === 'string' ) {
+    return;
+  }
+
+  for ( const field of [ 'promptDir', 'variables' ] ) {
+    if ( args[field] !== undefined ) {
+      ctx.addIssue( {
+        code: 'custom',
+        path: [ field ],
+        message: `${field} cannot be used when prompt is an object`
+      } );
+    }
+  }
+};
+
+const generateTextArgsSchema = z.object( generateTextCallFields )
+  .strict()
+  .superRefine( rejectPromptObjectFileArgs )
+  .transform( toPromptArgs );
 
 const generateTextWithStreamingArgsSchema = z.object( {
   ...generateTextCallFields,
   onChunk: functionSchema.optional()
-} ).strict().transform( toPromptFileArgs );
+} ).strict().superRefine( rejectPromptObjectFileArgs ).transform( toPromptArgs );
 
 const streamTextArgsSchema = z.object( {
   ...generateTextCallFields,
   onChunk: functionSchema.optional(),
   onError: functionSchema.optional(),
   onFinish: functionSchema.optional()
-} ).strict().transform( toPromptFileArgs );
+} ).strict().superRefine( rejectPromptObjectFileArgs ).transform( toPromptArgs );
 
 const agentCallFields = {
-  ...promptFileCallFields,
+  ...promptCallFields,
   ...promptOwnedCallArgRejection,
   messageStore: messageStoreSchema.optional(),
   output: outputSchema.optional(),
@@ -107,7 +134,10 @@ const agentMethodCallFields = {
   ...promptOwnedCallArgRejection
 };
 
-const agentArgsSchema = z.object( agentCallFields ).strict().transform( toPromptFileArgs );
+const agentArgsSchema = z.object( agentCallFields )
+  .strict()
+  .superRefine( rejectPromptObjectFileArgs )
+  .transform( toPromptArgs );
 
 const agentGenerateArgsSchema = z.object( agentMethodCallFields ).strict();
 
@@ -149,10 +179,12 @@ const generateImageCallFields = {
   abortSignal: z.instanceof( AbortSignal ).optional(),
   images: z.array( imageInputSchema ).min( 1 ).optional(),
   mask: imageInputSchema.optional(),
-  ...promptFileCallFields
+  ...promptCallFields
 };
 
 const generateImageArgsSchema = z.object( generateImageCallFields ).strict().superRefine( ( args, ctx ) => {
+  rejectPromptObjectFileArgs( args, ctx );
+
   if ( args.mask && !args.images ) {
     ctx.addIssue( {
       code: 'custom',
@@ -160,7 +192,7 @@ const generateImageArgsSchema = z.object( generateImageCallFields ).strict().sup
       message: 'mask requires images.'
     } );
   }
-} ).transform( toPromptFileArgs );
+} ).transform( toPromptArgs );
 
 const parseSchema = ( schema, input, errorPrefix ) => {
   const result = schema.safeParse( input );

--- a/sdk/llm/src/validations.js
+++ b/sdk/llm/src/validations.js
@@ -31,10 +31,9 @@ const stopWhenSchema = z.union( [
   z.array( functionSchema ).min( 1 )
 ] );
 
-const opaqueObjectSchema = z.custom(
-  value => value !== null && typeof value === 'object' && !Array.isArray( value ),
-  'Expected object'
-);
+const isObject = value => value !== null && typeof value === 'object' && !Array.isArray( value );
+
+const opaqueObjectSchema = z.custom( isObject, 'Expected object' );
 
 const outputSchema = opaqueObjectSchema;
 
@@ -56,7 +55,7 @@ const modelMessageSchema = z.object( {
 const promptFileSchema = z.string().min( 1 );
 
 const promptInputSchema = z.unknown().transform( ( value, ctx ) => {
-  const result = ( typeof value === 'string' ? promptFileSchema : promptSchema ).safeParse( value );
+  const result = ( isObject( value ) ? promptSchema : promptFileSchema ).safeParse( value );
   if ( !result.success ) {
     for ( const issue of result.error.issues ) {
       ctx.addIssue( issue );
@@ -97,7 +96,7 @@ const toPromptArgs = ( { prompt, maxSteps, skills, ...rest } ) => ( {
 } );
 
 const rejectPromptObjectFileArgs = ( args, ctx ) => {
-  if ( typeof args.prompt === 'string' ) {
+  if ( !isObject( args.prompt ) ) {
     return;
   }
 

--- a/sdk/llm/src/validations.js
+++ b/sdk/llm/src/validations.js
@@ -55,6 +55,17 @@ const modelMessageSchema = z.object( {
 
 const promptFileSchema = z.string().min( 1 );
 
+const promptInputSchema = z.unknown().transform( ( value, ctx ) => {
+  const result = ( typeof value === 'string' ? promptFileSchema : promptSchema ).safeParse( value );
+  if ( !result.success ) {
+    for ( const issue of result.error.issues ) {
+      ctx.addIssue( issue );
+    }
+    return value;
+  }
+  return result.data;
+} );
+
 const promptFileCallFields = {
   prompt: promptFileSchema,
   promptDir: z.string().min( 1 ).optional(),
@@ -63,7 +74,7 @@ const promptFileCallFields = {
 
 const promptCallFields = {
   ...promptFileCallFields,
-  prompt: z.union( [ promptFileSchema, promptSchema ] )
+  prompt: promptInputSchema
 };
 
 const textRuntimeCallFields = {

--- a/sdk/llm/src/validations.spec.js
+++ b/sdk/llm/src/validations.spec.js
@@ -15,6 +15,19 @@ const makeOutput = () => ( { name: 'object' } );
 
 const searchTool = { description: 'Search' };
 const stopWhen = () => false;
+const promptObject = {
+  name: 'custom',
+  config: {
+    provider: 'openai',
+    model: 'gpt-4o',
+    maxSteps: 10,
+    skills: []
+  },
+  messages: [ { role: 'user', content: 'Hello' } ],
+  instructions: null,
+  fileDir: '/prompts',
+  variables: {}
+};
 
 describe( 'parseGenerateTextArgs', () => {
   it( 'renames prompt to promptFile and keeps allowlisted leftovers', () => {
@@ -50,6 +63,32 @@ describe( 'parseGenerateTextArgs', () => {
     } );
 
     expect( parsed.stopWhen ).toEqual( [ stopWhen ] );
+  } );
+
+  it.each( [
+    [ 'generateText', parseGenerateTextArgs ],
+    [ 'generateTextWithStreaming', parseGenerateTextWithStreamingArgs ],
+    [ 'streamText', parseStreamTextArgs ],
+    [ 'generateImage', parseGenerateImageArgs ],
+    [ 'Agent', parseAgentArgs ]
+  ] )( 'normalizes a prompt object for %s', ( _, parse ) => {
+    expect( parse( { prompt: promptObject } ) ).toEqual( {
+      promptObject
+    } );
+  } );
+
+  it.each( [ 'promptDir', 'variables' ] )( 'rejects %s with a prompt object', field => {
+    expect( () => parseGenerateTextArgs( {
+      prompt: promptObject,
+      [field]: field === 'promptDir' ? '/other' : { topic: 'other' }
+    } ) ).toThrow( `${field} cannot be used when prompt is an object` );
+  } );
+
+  it( 'rejects prompt file arguments with an Agent prompt object', () => {
+    expect( () => parseAgentArgs( {
+      prompt: promptObject,
+      promptDir: '/other'
+    } ) ).toThrow( 'promptDir cannot be used when prompt is an object' );
   } );
 
   it( 'throws ValidationError with generateText prefix for invalid args', () => {

--- a/sdk/llm/src/validations.spec.js
+++ b/sdk/llm/src/validations.spec.js
@@ -29,7 +29,7 @@ const promptObject = {
   variables: {}
 };
 
-describe( 'prompt object arguments', () => {
+describe( 'prompt arguments', () => {
   it.each( [
     [ 'generateText', parseGenerateTextArgs ],
     [ 'generateTextWithStreaming', parseGenerateTextWithStreamingArgs ],
@@ -65,6 +65,21 @@ describe( 'prompt object arguments', () => {
         }
       }
     } ) ).toThrow( /prompt\.config\.model/ );
+  } );
+
+  it.each( [
+    [ 'missing', {} ],
+    [ 'numeric', { prompt: 123, variables: { topic: 'testing' } } ]
+  ] )( 'keeps filename-shaped errors for a %s prompt', ( _, args ) => {
+    const error = { message: '' };
+    try {
+      parseGenerateTextArgs( args );
+    } catch ( e ) {
+      error.message = e.message;
+    }
+
+    expect( error.message ).toContain( 'expected string' );
+    expect( error.message ).not.toContain( 'variables cannot be used when prompt is an object' );
   } );
 } );
 

--- a/sdk/llm/src/validations.spec.js
+++ b/sdk/llm/src/validations.spec.js
@@ -29,6 +29,45 @@ const promptObject = {
   variables: {}
 };
 
+describe( 'prompt object arguments', () => {
+  it.each( [
+    [ 'generateText', parseGenerateTextArgs ],
+    [ 'generateTextWithStreaming', parseGenerateTextWithStreamingArgs ],
+    [ 'streamText', parseStreamTextArgs ],
+    [ 'generateImage', parseGenerateImageArgs ],
+    [ 'Agent', parseAgentArgs ]
+  ] )( 'normalizes a prompt object for %s', ( _, parse ) => {
+    expect( parse( { prompt: promptObject } ) ).toEqual( {
+      promptObject
+    } );
+  } );
+
+  it.each( [ 'promptDir', 'variables' ] )( 'rejects %s with a prompt object', field => {
+    expect( () => parseGenerateTextArgs( {
+      prompt: promptObject,
+      [field]: field === 'promptDir' ? '/other' : { topic: 'other' }
+    } ) ).toThrow( `${field} cannot be used when prompt is an object` );
+  } );
+
+  it( 'rejects prompt file arguments with an Agent prompt object', () => {
+    expect( () => parseAgentArgs( {
+      prompt: promptObject,
+      promptDir: '/other'
+    } ) ).toThrow( 'promptDir cannot be used when prompt is an object' );
+  } );
+
+  it( 'reports specific validation issues for an invalid prompt object', () => {
+    expect( () => parseGenerateTextArgs( {
+      prompt: {
+        ...promptObject,
+        config: {
+          provider: 'openai'
+        }
+      }
+    } ) ).toThrow( /prompt\.config\.model/ );
+  } );
+} );
+
 describe( 'parseGenerateTextArgs', () => {
   it( 'renames prompt to promptFile and keeps allowlisted leftovers', () => {
     const abortSignal = AbortSignal.abort();
@@ -63,32 +102,6 @@ describe( 'parseGenerateTextArgs', () => {
     } );
 
     expect( parsed.stopWhen ).toEqual( [ stopWhen ] );
-  } );
-
-  it.each( [
-    [ 'generateText', parseGenerateTextArgs ],
-    [ 'generateTextWithStreaming', parseGenerateTextWithStreamingArgs ],
-    [ 'streamText', parseStreamTextArgs ],
-    [ 'generateImage', parseGenerateImageArgs ],
-    [ 'Agent', parseAgentArgs ]
-  ] )( 'normalizes a prompt object for %s', ( _, parse ) => {
-    expect( parse( { prompt: promptObject } ) ).toEqual( {
-      promptObject
-    } );
-  } );
-
-  it.each( [ 'promptDir', 'variables' ] )( 'rejects %s with a prompt object', field => {
-    expect( () => parseGenerateTextArgs( {
-      prompt: promptObject,
-      [field]: field === 'promptDir' ? '/other' : { topic: 'other' }
-    } ) ).toThrow( `${field} cannot be used when prompt is an object` );
-  } );
-
-  it( 'rejects prompt file arguments with an Agent prompt object', () => {
-    expect( () => parseAgentArgs( {
-      prompt: promptObject,
-      promptDir: '/other'
-    } ) ).toThrow( 'promptDir cannot be used when prompt is an object' );
   } );
 
   it( 'throws ValidationError with generateText prefix for invalid args', () => {

--- a/test_workflows/src/workflows/llm/generate_text/steps.ts
+++ b/test_workflows/src/workflows/llm/generate_text/steps.ts
@@ -1,5 +1,5 @@
 import { step, z } from '@outputai/core';
-import { generateText, aiSdk } from '@outputai/llm';
+import { generateText, aiSdk, loadPrompt } from '@outputai/llm';
 
 export const explainTopic = step( {
   name: 'explainTopic',
@@ -33,8 +33,7 @@ export const generateCookingInstruction = step( {
   outputSchema: cookOutputSchema,
   fn: async ( { receipt } ) => {
     const { output } = await generateText( {
-      prompt: 'cooking_instructions@v1',
-      variables: { receipt },
+      prompt: loadPrompt( 'cooking_instructions@v1', { receipt } ),
       output: aiSdk.Output.object( { schema: cookOutputSchema } )
     } );
     return output;


### PR DESCRIPTION
## Summary

- Added support for an object `Prompt` as the prompt argument of all generation methods on LLM in addition to its usual string value.
