### PR TITLE
feat(llm): Small LLM features

### DIFF
--- a/.changeset/fuzzy-trains-smile.md
+++ b/.changeset/fuzzy-trains-smile.md
@@ -49,6 +49,7 @@
   - Fixed unsupported callbacks on completion APIs being silently overwritten by internal callbacks.
   - Fixed Agent using AI SDK's two automatic retries while other Output generation APIs disabled them. Agent now uses `maxRetries: 0`.
   - Added the public `GenerateImageInput` type for `generateImage()` `images` and `mask` values.
+  - Fixed `GenerateImageParameters` allowing `mask` without `images`; the public type now matches runtime validation.
 - Fixed invalid Agent constructor and method arguments being forwarded for late failure by validating messages, callbacks, tool choices, and `MessageStore` implementations at the public boundary.
 
 ## Tools and tool loops
@@ -88,10 +89,11 @@
 ## Streaming and Agent message store
 
 - Fixed stream observer failures escaping or disappearing silently. `streamText()` and `Agent.stream()` `onError` and `onEnd` callbacks are fire-and-forget observers. Output maps and forwards provider errors, and logs and ignores observer exceptions and rejected promises.
+- Added logging for internal stream finalization failures before AI SDK suppresses the callback rejection.
 - Updated Agent message store:
   - Renamed `conversationStore` to `messageStore` and `ConversationStore` to `MessageStore`.
   - Removed `createMemoryConversationStore()`. The caller supplies a `MessageStore` (`getMessages` / `addMessages`).
-  - Fixed `Agent.stream()` to persist to `messageStore` when `finishReason` is not `'error'`.
+  - Fixed `Agent.generate()`, `Agent.generateWithStreaming()`, and `Agent.stream()` to persist to `messageStore` only when `finishReason` is not `'error'`.
   - Fixed stream message-store failures suppressing the user `onEnd`. Failures are logged and stream finalization continues.
   - Fixed Agent store failures producing success-then-error trace sequences. Store persistence completes before a successful trace end.
 
@@ -104,6 +106,8 @@
   - Fixed blank or untrimmed search URLs producing invalid citations or unstable source IDs. URLs are trimmed and blank values are dropped.
   - Fixed wrapped text responses not consistently exposing `sources` as an array.
   - Updated `ExtractedSource` to the AI SDK `generateText` sources item type (url and document).
+- Fixed concurrent same-name LLM calls started in the same millisecond sharing trace IDs.
+- Fixed aborted `streamText()` and `Agent.stream()` calls leaving their LLM trace open. Aborts now conclude the trace with an error.
 - Fixed public cost, source, and stream callback types to match wrapped runtime values. `response.cost` and stream `onEnd` `cost` use `LLMGenerationCost`, or `null` when pricing data is unavailable. Stream `onEnd` types also include wrapped `result` and merged `sources`.
 
 ## AI SDK exports and public parameter types
@@ -112,3 +116,4 @@
 - Removed named AI SDK re-exports (`tool`, `Output`, `smoothStream`, `stepCountIs`, `hasToolCall`, `jsonSchema`) and AI SDK type re-exports (`ToolSet`, `FinishReason`, `ModelMessage`, and others). Use the `aiSdk` namespace (or import from `ai`) for those.
 - Removed the Output-owned `GenerateTextAiSdkOptions`, `StreamTextAiSdkOptions`, and `GenerateImageAiSdkOptions` aliases. Use `GenerateTextParameters`, `StreamTextParameters`, and `GenerateImageParameters`.
 - Updated `OutputAgentGenerateWithStreamingParameters` to no longer accept an output type argument.
+- Removed test specs and fixtures from the published package tarball.

--- a/docs/guides/migrations/v0.11.0-to-v0.12.0.mdx
+++ b/docs/guides/migrations/v0.11.0-to-v0.12.0.mdx
@@ -613,7 +613,7 @@ Dropped native AI SDK call arguments from `generateText()`, `generateTextWithStr
 | `onEnd` | - | - | - | optional |
 | `onError` | - | - | - | optional |
 
-`generateImage` `mask` still requires `images`. `Agent.stream()` now appends to `messageStore` in its wrapped `onEnd` when `finishReason` is not `'error'`.
+`generateImage` `mask` still requires `images`. `Agent.generate()`, `Agent.generateWithStreaming()`, and `Agent.stream()` append to `messageStore` only when `finishReason` is not `'error'`. Errored turns are not persisted.
 
 `streamText()` and `Agent.stream()` now treat `onError` as a fire-and-forget observer. Output maps and forwards the provider error, but exceptions and rejected promises from the callback are ignored. To fail a workflow step with the original error, capture it in `onError` and throw it after consuming the stream.
 
@@ -780,7 +780,7 @@ providerOptions:
 - Keep existing `cost:llm:request` handlers for structural compatibility, while allowing corrected reasoning values. Prefer `llm:generation:metering` with `LLMGenerationMeteringEvent` for new normalized usage/cost integrations.
 - Import AI SDK helpers and types from `aiSdk` (`aiSdk.Output`, `aiSdk.tool`, `aiSdk.isStepCount`, `aiSdk.ToolSet`, ...). Replace `import { ai }` with `import { aiSdk }`. Do not import cherry-picked AI SDK types from `@outputai/llm`.
 - Replace `GenerateTextAiSdkOptions`, `StreamTextAiSdkOptions`, and `GenerateImageAiSdkOptions` with their `*Parameters` equivalents. Remove the generic from `OutputAgentGenerateWithStreamingParameters`.
-- Expect `Agent.stream()` to persist message-store history on success.
+- Expect `Agent.generate()`, `Agent.generateWithStreaming()`, and `Agent.stream()` to persist message-store history only when `finishReason` is not `'error'`.
 - Replace `conversationStore` with `messageStore`. Replace `ConversationStore` with `MessageStore`. Remove `createMemoryConversationStore()` and pass your own store.
 - Update Agent tests and error matchers that expected `Agent requires a prompt`.
 - Ensure prompt `provider` and `model` values are non-empty. If set, `maxOutputTokens` and deprecated `maxTokens` must each be positive integers.

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -494,7 +494,7 @@ interface MessageStore {
 `ModelMessage` is an AI SDK type (`aiSdk` / `ai`). There is no built-in store. Implement the interface in memory for a single process, or with your database for durable history.
 
 <Note>
-`generate()`, `generateWithStreaming()`, and `stream()` append messages to the message store. `stream()` stores in its wrapped `onEnd` when `finishReason` is not `'error'`.
+`generate()`, `generateWithStreaming()`, and `stream()` append messages to the message store only when `finishReason` is not `'error'`. Errored turns are not persisted.
 </Note>
 
 ### When to Use Agent vs generateText

--- a/sdk/llm/package.json
+++ b/sdk/llm/package.json
@@ -9,7 +9,11 @@
     "node": ">=24.15.0"
   },
   "files": [
-    "./src"
+    "./src/!(*.spec).js",
+    "./src/index.d.ts",
+    "./src/prompt/!(*.spec).js",
+    "./src/prompt/markup/!(*.spec).js",
+    "./src/utils/!(*.spec).js"
   ],
   "scripts": {
     "build": "pnpm exec tsc -p ./tsconfig.typecheck.json"

--- a/sdk/llm/src/agent.js
+++ b/sdk/llm/src/agent.js
@@ -109,6 +109,7 @@ export class Agent {
     return wrapStream( {
       name: 'Agent.stream',
       prompt: this.#prompt,
+      abortSignal,
       fn: ( { onEndHook, onErrorHook } ) => this.#agent.stream( {
         messages: combinedMessages,
         allowSystemInMessages: true,

--- a/sdk/llm/src/agent.js
+++ b/sdk/llm/src/agent.js
@@ -58,7 +58,9 @@ export class Agent {
           ...( abortSignal && { abortSignal } ),
           ...( toolChoice && { toolChoice } )
         } );
-        await this.#storeMessages( messages.concat( response.responseMessages ?? [] ) );
+        if ( response.finishReason !== 'error' ) {
+          await this.#storeMessages( messages.concat( response.responseMessages ?? [] ) );
+        }
         return response;
       }
     } );
@@ -95,7 +97,9 @@ export class Agent {
         }
 
         state.response.output = await stream.output;
-        await this.#storeMessages( messages.concat( state.response.responseMessages ?? [] ) );
+        if ( state.response.finishReason !== 'error' ) {
+          await this.#storeMessages( messages.concat( state.response.responseMessages ?? [] ) );
+        }
 
         return state.response;
       }

--- a/sdk/llm/src/agent.spec.js
+++ b/sdk/llm/src/agent.spec.js
@@ -379,6 +379,22 @@ describe( 'Agent', () => {
     expect( result ).toBe( aiResponse );
   } );
 
+  it( 'does not store generate messages when finishReason is error', async () => {
+    const store = {
+      getMessages: vi.fn( () => [] ),
+      addMessages: vi.fn()
+    };
+    aiMocks.superGenerate.mockResolvedValueOnce( { ...aiResponse, finishReason: 'error' } );
+    const { Agent } = await importSut();
+    const agent = new Agent( { prompt: 'test@v1', messageStore: store } );
+
+    await agent.generate( {
+      messages: [ { role: 'user', content: 'New question' } ]
+    } );
+
+    expect( store.addMessages ).not.toHaveBeenCalled();
+  } );
+
   it( 'generates with streaming, stores messages, and returns the completed response', async () => {
     const store = {
       getMessages: vi.fn( () => [] ),
@@ -436,6 +452,26 @@ describe( 'Agent', () => {
     ] );
     expect( onChunk ).toHaveBeenCalledWith( { chunk } );
     expect( result ).toEqual( { ...aiResponse, output } );
+  } );
+
+  it( 'does not store generateWithStreaming messages when finishReason is error', async () => {
+    const store = {
+      getMessages: vi.fn( () => [] ),
+      addMessages: vi.fn()
+    };
+    const stream = { output: Promise.resolve( undefined ) };
+    aiMocks.superStream.mockImplementationOnce( options => {
+      options.onEnd( { ...aiResponse, finishReason: 'error' } );
+      return stream;
+    } );
+    const { Agent } = await importSut();
+    const agent = new Agent( { prompt: 'test@v1', messageStore: store } );
+
+    await agent.generateWithStreaming( {
+      messages: [ { role: 'user', content: 'New question' } ]
+    } );
+
+    expect( store.addMessages ).not.toHaveBeenCalled();
   } );
 
   it( 'omits onChunk when generateWithStreaming does not receive it', async () => {

--- a/sdk/llm/src/agent.spec.js
+++ b/sdk/llm/src/agent.spec.js
@@ -481,6 +481,7 @@ describe( 'Agent', () => {
     const onError = vi.fn();
     const onChunk = vi.fn();
     const callerMessage = { role: 'user', content: 'New question' };
+    const abortSignal = new AbortController().signal;
     const { Agent } = await importSut();
     const agent = new Agent( { prompt: 'test@v1', messageStore: store } );
 
@@ -488,18 +489,21 @@ describe( 'Agent', () => {
       messages: [ callerMessage ],
       onEnd,
       onError,
-      onChunk
+      onChunk,
+      abortSignal
     } );
 
     expect( validations.parseAgentStreamArgs ).toHaveBeenCalledWith( {
       messages: [ callerMessage ],
       onEnd,
       onError,
-      onChunk
+      onChunk,
+      abortSignal
     } );
     expect( wrapMocks.wrapStream ).toHaveBeenCalledWith( {
       name: 'Agent.stream',
       prompt: loadedPrompt,
+      abortSignal,
       fn: expect.any( Function )
     } );
     expect( aiMocks.superStream ).toHaveBeenCalledWith( {
@@ -510,6 +514,7 @@ describe( 'Agent', () => {
       ],
       allowSystemInMessages: true,
       onChunk,
+      abortSignal,
       onEnd: expect.any( Function ),
       onError: expect.any( Function )
     } );

--- a/sdk/llm/src/generate.js
+++ b/sdk/llm/src/generate.js
@@ -26,6 +26,7 @@ export const streamText = args => {
   return wrapStream( {
     name: 'streamText',
     prompt,
+    abortSignal: aiOptions.abortSignal,
     fn: ( { onEndHook, onErrorHook } ) => AI.streamText( {
       ...loadAiSdkTextOptions( { prompt, skills, ...aiOptions } ),
       ...( onChunk && { onChunk } ),

--- a/sdk/llm/src/generate.spec.js
+++ b/sdk/llm/src/generate.spec.js
@@ -328,6 +328,7 @@ describe( 'generate', () => {
       const onEnd = vi.fn();
       const onChunk = vi.fn();
       const tools = { userTool: true };
+      const abortSignal = new AbortController().signal;
 
       const result = streamText( {
         prompt: 'test@v1',
@@ -335,7 +336,8 @@ describe( 'generate', () => {
         promptDir: '/prompts',
         onEnd,
         onChunk,
-        tools
+        tools,
+        abortSignal
       } );
 
       expect( validations.parseStreamTextArgs ).toHaveBeenCalledWith( {
@@ -344,19 +346,22 @@ describe( 'generate', () => {
         promptDir: '/prompts',
         onEnd,
         onChunk,
-        tools
+        tools,
+        abortSignal
       } );
       expect( promptMocks.loadPrompt ).toHaveBeenCalledWith( 'test@v1', variables, '/prompts' );
       expect( skillMocks.loadSkills ).toHaveBeenCalledWith( loadedPrompt );
       expect( wrapMocks.wrapStream ).toHaveBeenCalledWith( {
         name: 'streamText',
         prompt: loadedPrompt,
+        abortSignal,
         fn: expect.any( Function )
       } );
       expect( optionMocks.loadAiSdkTextOptions ).toHaveBeenCalledWith( {
         prompt: loadedPrompt,
         skills: loadedSkills,
-        tools
+        tools,
+        abortSignal
       } );
       expect( aiFns.streamText ).toHaveBeenCalledWith( {
         ...textOptions,

--- a/sdk/llm/src/index.d.ts
+++ b/sdk/llm/src/index.d.ts
@@ -281,12 +281,20 @@ export type GenerateImageInput =
     mediaType?: string;
   };
 
+type GenerateImageInputs =
+  | {
+    /** Runtime image inputs for image-to-image generation */
+    images: GenerateImageInput[];
+    /** Optional mask for image editing */
+    mask?: GenerateImageInput;
+  } |
+  {
+    images?: undefined;
+    mask?: never;
+  };
+
 /** Parameters accepted by {@link generateImage}. */
-export type GenerateImageParameters = PromptCallOptions & {
-  /** Runtime image inputs for image-to-image generation */
-  images?: GenerateImageInput[];
-  /** Optional mask for image editing; requires `images` */
-  mask?: GenerateImageInput;
+export type GenerateImageParameters = PromptCallOptions & GenerateImageInputs & {
   /** Abort signal for the request */
   abortSignal?: AbortSignal;
 };
@@ -493,7 +501,7 @@ export function getProviderNames(): string[];
  * Use an LLM model to generate text.
  *
  * This function is a wrapper over the AI SDK's `generateText`.
- * The prompt sets `model`, `messages`, `temperature`, `maxTokens`, `maxSteps`, `skills`, and
+ * The prompt sets `model`, `messages`, generation settings, `maxSteps`, `skills`, and
  * `providerOptions`. Pass either a prompt filename with optional `promptDir` / `variables`, or a
  * loaded or custom {@link Prompt} object. Other call arguments are `tools`, `output`, `toolChoice`,
  * `stopWhen`, and `abortSignal`.

--- a/sdk/llm/src/utils/wrap.js
+++ b/sdk/llm/src/utils/wrap.js
@@ -106,10 +106,13 @@ export const wrapGeneration = async ( { name, prompt, fn } ) => {
  *
  * A throw or rejected Promise from `fn` (stream creation / Agent setup) is mapped and recorded
  * on the LLM trace. A non-Promise return (the `streamText` stream) is returned immediately.
+ * When `abortSignal` aborts, its reason is recorded as an LLM trace error. The listener is removed
+ * when the stream ends, reports an error, or fails during setup.
  *
  * @param {object} args
  * @param {string} args.name - Trace event name
  * @param {object} args.prompt - Loaded prompt (`config.provider` / `config.model` used for cost)
+ * @param {AbortSignal} [args.abortSignal] - Optional signal used to trace stream cancellation
  * @param {(hooks: { onEndHook: Function, onErrorHook: Function }) => object | Promise<object>} args.fn -
  *   Return the SDK stream, or a Promise of that stream (`Agent.stream`); wire the hooks into SDK
  *   `onEnd` / `onError`

--- a/sdk/llm/src/utils/wrap.js
+++ b/sdk/llm/src/utils/wrap.js
@@ -7,6 +7,7 @@ import { mapAiError } from './error_handler.js';
 import { isPromise } from 'node:util/types';
 import { Logger } from '@outputai/core';
 import { convertCostToLegacy } from './legacy_cost_attribute.js';
+import { randomBytes } from 'node:crypto';
 
 /** Creates a proxy of the AI SDK response and attach virtual getters to it based on an object map */
 const createResponseProxy = ( { response, properties } ) => new Proxy( response, {
@@ -17,7 +18,7 @@ const createResponseProxy = ( { response, properties } ) => new Proxy( response,
 
 /** Generate a trace id, starts the tracing and return the id */
 const startTrace = ( { name, prompt } ) => {
-  const traceId = `${name}-${Date.now()}`;
+  const traceId = `${name}-${Date.now()}-${randomBytes( 4 ).toString( 'hex' )}`;
   Tracing.addEventStart( { kind: 'llm', id: traceId, name, details: { prompt } } );
   return traceId;
 };
@@ -114,11 +115,36 @@ export const wrapGeneration = async ( { name, prompt, fn } ) => {
  *   `onEnd` / `onError`
  * @returns {object | Promise<object>} Value returned by `fn`; a rejected Promise is remapped
  */
-export const wrapStream = ( { name, prompt, fn } ) => {
+export const wrapStream = ( { name, prompt, abortSignal, fn } ) => {
   const traceId = startTrace( { name, prompt } );
+
+  const onAbortHook = reason =>
+    handleError( {
+      traceId,
+      error: reason instanceof Error ? reason : new Error( 'Streaming aborted.', { cause: reason } )
+    } );
+
+  const handleAbort = () => {
+    if ( !abortSignal ) {
+      return () => {};
+    }
+
+    if ( abortSignal.aborted ) {
+      onAbortHook( abortSignal.reason );
+      return () => {};
+    }
+
+    const listener = () => onAbortHook( abortSignal.reason );
+    abortSignal.addEventListener( 'abort', listener, { once: true } );
+
+    return () => abortSignal.removeEventListener( 'abort', listener );
+  };
+
+  const removeAbortListener = handleAbort();
 
   const onEndHook = async ( response, callback ) => {
     const state = { proxyResponse: null };
+    removeAbortListener();
     try {
       const { text: result, finalStep, usage } = response;
       const { providerMetadata } = finalStep;
@@ -143,6 +169,7 @@ export const wrapStream = ( { name, prompt, fn } ) => {
 
   const onErrorHook = async ( event, callback ) => {
     const error = handleError( { traceId, error: event.error } );
+    removeAbortListener();
     try {
       await callback?.( error );
     } catch ( callbackError ) {
@@ -157,9 +184,11 @@ export const wrapStream = ( { name, prompt, fn } ) => {
   try {
     const stream = fn( { onEndHook, onErrorHook } );
     return isPromise( stream ) ? stream.catch( error => {
+      removeAbortListener();
       throw handleError( { traceId, error } );
     } ) : stream;
   } catch ( error ) {
+    removeAbortListener();
     throw handleError( { traceId, error } );
   }
 };

--- a/sdk/llm/src/utils/wrap.js
+++ b/sdk/llm/src/utils/wrap.js
@@ -153,6 +153,7 @@ export const wrapStream = ( { name, prompt, abortSignal, fn } ) => {
       Tracing.addEventEnd( { id: traceId, details: { result, usage, providerMetadata, sources } } );
       state.proxyResponse = createResponseProxy( { response, properties: { cost, sources, result } } );
     } catch ( error ) {
+      Logger.error( 'Stream onEnd() handler failed', { namespace: 'LLM', error: error?.message ?? String( error ) } );
       throw handleError( { traceId, error } );
     }
 

--- a/sdk/llm/src/utils/wrap.spec.js
+++ b/sdk/llm/src/utils/wrap.spec.js
@@ -9,7 +9,8 @@ const mocks = vi.hoisted( () => ( {
   calculateCosts: vi.fn(),
   convertCostToLegacy: vi.fn(),
   calculateBase64FileSize: vi.fn(),
-  mapAiError: vi.fn()
+  mapAiError: vi.fn(),
+  randomBytes: vi.fn()
 } ) );
 
 vi.mock( './sources.js', () => ( {
@@ -34,6 +35,10 @@ vi.mock( './image.js', () => ( {
 
 vi.mock( './error_handler.js', () => ( {
   mapAiError: mocks.mapAiError
+} ) );
+
+vi.mock( 'node:crypto', () => ( {
+  randomBytes: mocks.randomBytes
 } ) );
 
 vi.mock( '@outputai/core/sdk/runtime', () => ( {
@@ -88,6 +93,7 @@ describe( 'wrapGeneration / wrapStream', () => {
     mocks.convertCostToLegacy.mockReturnValue( mockLegacyCost );
     mocks.calculateBase64FileSize.mockReturnValue( 1234 );
     mocks.mapAiError.mockReturnValue( mappedError );
+    mocks.randomBytes.mockReturnValue( Buffer.from( 'a1b2c3d4', 'hex' ) );
   } );
 
   afterEach( () => {
@@ -109,25 +115,26 @@ describe( 'wrapGeneration / wrapStream', () => {
 
       expect( tracing.addEventStart ).toHaveBeenCalledWith( {
         kind: 'llm',
-        id: 'generateText-9000000000',
+        id: 'generateText-9000000000-a1b2c3d4',
         name: 'generateText',
         details: { prompt }
       } );
+      expect( mocks.randomBytes ).toHaveBeenCalledWith( 4 );
       expect( mocks.parseLLMUsage ).toHaveBeenCalledWith( {
         usage: response.usage,
         prompt
       } );
       expect( mocks.calculateCosts ).toHaveBeenCalledWith( mockUsage );
       expect( tracing.addEventAttribute ).toHaveBeenNthCalledWith( 1, {
-        eventId: 'generateText-9000000000',
+        eventId: 'generateText-9000000000-a1b2c3d4',
         attribute: mockCost
       } );
       expect( tracing.addEventAttribute ).toHaveBeenNthCalledWith( 2, {
-        eventId: 'generateText-9000000000',
+        eventId: 'generateText-9000000000-a1b2c3d4',
         attribute: mockLegacyCost
       } );
       expect( tracing.addEventAttribute ).toHaveBeenNthCalledWith( 3, {
-        eventId: 'generateText-9000000000',
+        eventId: 'generateText-9000000000-a1b2c3d4',
         attribute: mockUsage
       } );
       expect( mocks.convertCostToLegacy ).toHaveBeenCalledWith( mockCost );
@@ -145,7 +152,7 @@ describe( 'wrapGeneration / wrapStream', () => {
       expect( meteringEventPayload.usage ).not.toBe( mockUsage );
       expect( mocks.extractSources ).toHaveBeenCalledWith( response );
       expect( tracing.addEventEnd ).toHaveBeenCalledWith( {
-        id: 'generateText-9000000000',
+        id: 'generateText-9000000000-a1b2c3d4',
         details: {
           result: response.text,
           usage: response.usage,
@@ -193,7 +200,7 @@ describe( 'wrapGeneration / wrapStream', () => {
       expect( mocks.calculateCosts ).toHaveBeenCalledWith( mockUsage );
       expect( mocks.calculateBase64FileSize ).toHaveBeenCalledWith( response.images[0].base64Data );
       expect( tracing.addEventEnd ).toHaveBeenCalledWith( {
-        id: 'generateImage-9000000000',
+        id: 'generateImage-9000000000-a1b2c3d4',
         details: {
           result: [ { size: 1234, mediaType: 'image/png' } ],
           usage: response.usage,
@@ -216,7 +223,7 @@ describe( 'wrapGeneration / wrapStream', () => {
       } );
 
       expect( tracing.addEventAttribute ).toHaveBeenCalledWith( {
-        eventId: 'generateText-9000000000',
+        eventId: 'generateText-9000000000-a1b2c3d4',
         attribute: mockUsage
       } );
       expect( event.emit ).toHaveBeenCalledOnce();
@@ -225,7 +232,7 @@ describe( 'wrapGeneration / wrapStream', () => {
         usage: mockUsage
       } );
       expect( tracing.addEventEnd ).toHaveBeenCalledWith( {
-        id: 'generateText-9000000000',
+        id: 'generateText-9000000000-a1b2c3d4',
         details: {
           result: response.text,
           usage: response.usage,
@@ -247,11 +254,11 @@ describe( 'wrapGeneration / wrapStream', () => {
       } );
 
       expect( tracing.addEventAttribute ).toHaveBeenNthCalledWith( 1, {
-        eventId: 'generateText-9000000000',
+        eventId: 'generateText-9000000000-a1b2c3d4',
         attribute: mockCost
       } );
       expect( tracing.addEventAttribute ).toHaveBeenNthCalledWith( 2, {
-        eventId: 'generateText-9000000000',
+        eventId: 'generateText-9000000000-a1b2c3d4',
         attribute: mockUsage
       } );
       expect( tracing.addEventAttribute ).toHaveBeenCalledTimes( 2 );
@@ -276,7 +283,7 @@ describe( 'wrapGeneration / wrapStream', () => {
       expect( tracing.addEventAttribute ).not.toHaveBeenCalled();
       expect( event.emit ).not.toHaveBeenCalled();
       expect( tracing.addEventEnd ).toHaveBeenCalledWith( {
-        id: 'generateText-9000000000',
+        id: 'generateText-9000000000-a1b2c3d4',
         details: {
           result: response.text,
           usage: response.usage,
@@ -300,7 +307,7 @@ describe( 'wrapGeneration / wrapStream', () => {
 
       expect( mocks.mapAiError ).toHaveBeenCalledWith( original );
       expect( tracing.addEventError ).toHaveBeenCalledWith( {
-        id: 'Agent.generate-9000000000',
+        id: 'Agent.generate-9000000000-a1b2c3d4',
         details: mappedError
       } );
       expect( tracing.addEventEnd ).not.toHaveBeenCalled();
@@ -308,9 +315,9 @@ describe( 'wrapGeneration / wrapStream', () => {
   } );
 
   describe( 'wrapStream', () => {
-    const hooksFrom = name => {
+    const hooksFrom = ( name, options = {} ) => {
       const fn = vi.fn( () => ( {} ) );
-      wrapStream( { name, prompt, fn } );
+      wrapStream( { name, prompt, fn, ...options } );
       return fn.mock.calls[0][0];
     };
 
@@ -323,7 +330,7 @@ describe( 'wrapGeneration / wrapStream', () => {
       expect( result ).toBe( stream );
       expect( tracing.addEventStart ).toHaveBeenCalledWith( {
         kind: 'llm',
-        id: 'streamText-9000000000',
+        id: 'streamText-9000000000-a1b2c3d4',
         name: 'streamText',
         details: { prompt }
       } );
@@ -332,6 +339,44 @@ describe( 'wrapGeneration / wrapStream', () => {
         onErrorHook: expect.any( Function )
       } );
       expect( tracing.addEventEnd ).not.toHaveBeenCalled();
+    } );
+
+    it( 'records an abort signal reason on the llm trace', () => {
+      const abortController = new AbortController();
+      const abortReason = new DOMException( 'Cancelled by caller', 'AbortError' );
+
+      wrapStream( {
+        name: 'streamText',
+        prompt,
+        abortSignal: abortController.signal,
+        fn: () => ( {} )
+      } );
+      abortController.abort( abortReason );
+
+      expect( mocks.mapAiError ).toHaveBeenCalledWith( abortReason );
+      expect( tracing.addEventError ).toHaveBeenCalledWith( {
+        id: 'streamText-9000000000-a1b2c3d4',
+        details: mappedError
+      } );
+    } );
+
+    it( 'records an already-aborted signal before creating the stream', () => {
+      const abortController = new AbortController();
+      const abortReason = new DOMException( 'Already cancelled', 'AbortError' );
+      abortController.abort( abortReason );
+
+      wrapStream( {
+        name: 'streamText',
+        prompt,
+        abortSignal: abortController.signal,
+        fn: () => ( {} )
+      } );
+
+      expect( mocks.mapAiError ).toHaveBeenCalledWith( abortReason );
+      expect( tracing.addEventError ).toHaveBeenCalledWith( {
+        id: 'streamText-9000000000-a1b2c3d4',
+        details: mappedError
+      } );
     } );
 
     it( 'wraps onEnd, ends the trace, then awaits the callback', async () => {
@@ -355,7 +400,7 @@ describe( 'wrapGeneration / wrapStream', () => {
       expect( proxied.cost ).toEqual( mockCost );
       expect( proxied.sources ).toBe( mergedSources );
       expect( tracing.addEventEnd ).toHaveBeenCalledWith( {
-        id: 'Agent.stream-9000000000',
+        id: 'Agent.stream-9000000000-a1b2c3d4',
         details: {
           result: response.text,
           usage: response.usage,
@@ -364,6 +409,17 @@ describe( 'wrapGeneration / wrapStream', () => {
         }
       } );
       expect( tracing.addEventEnd.mock.invocationCallOrder[0] ).toBeLessThan( callback.mock.invocationCallOrder[0] );
+    } );
+
+    it( 'removes the abort listener when the stream ends', async () => {
+      const abortController = new AbortController();
+      const { onEndHook } = hooksFrom( 'streamText', { abortSignal: abortController.signal } );
+
+      await onEndHook( streamResponse() );
+      abortController.abort( new DOMException( 'Too late', 'AbortError' ) );
+
+      expect( tracing.addEventEnd ).toHaveBeenCalledOnce();
+      expect( tracing.addEventError ).not.toHaveBeenCalled();
     } );
 
     it( 'ends the trace and swallows throws from the onEnd callback', async () => {
@@ -388,10 +444,21 @@ describe( 'wrapGeneration / wrapStream', () => {
 
       expect( mocks.mapAiError ).toHaveBeenCalledWith( original );
       expect( tracing.addEventError ).toHaveBeenCalledWith( {
-        id: 'streamText-9000000000',
+        id: 'streamText-9000000000-a1b2c3d4',
         details: mappedError
       } );
       expect( callback ).toHaveBeenCalledWith( mappedError );
+    } );
+
+    it( 'removes the abort listener when the stream reports an error', async () => {
+      const abortController = new AbortController();
+      const { onErrorHook } = hooksFrom( 'streamText', { abortSignal: abortController.signal } );
+
+      await onErrorHook( { error: new Error( 'stream failed' ) } );
+      abortController.abort( new DOMException( 'Too late', 'AbortError' ) );
+
+      expect( tracing.addEventError ).toHaveBeenCalledOnce();
+      expect( mocks.mapAiError ).toHaveBeenCalledOnce();
     } );
 
     it( 'swallows throws from the onError callback', async () => {
@@ -418,10 +485,13 @@ describe( 'wrapGeneration / wrapStream', () => {
 
     it( 'maps a throw from fn onto the llm trace and rethrows', () => {
       const original = new Error( 'create stream' );
+      const abortController = new AbortController();
+      const removeEventListener = vi.spyOn( abortController.signal, 'removeEventListener' );
 
       expect( () => wrapStream( {
         name: 'streamText',
         prompt,
+        abortSignal: abortController.signal,
         fn: () => {
           throw original;
         }
@@ -429,26 +499,31 @@ describe( 'wrapGeneration / wrapStream', () => {
 
       expect( mocks.mapAiError ).toHaveBeenCalledWith( original );
       expect( tracing.addEventError ).toHaveBeenCalledWith( {
-        id: 'streamText-9000000000',
+        id: 'streamText-9000000000-a1b2c3d4',
         details: mappedError
       } );
+      expect( removeEventListener ).toHaveBeenCalledOnce();
     } );
 
     it( 'maps a rejected promise from fn onto the llm trace and rethrows', async () => {
       const original = new Error( 'prepareCall failed' );
+      const abortController = new AbortController();
+      const removeEventListener = vi.spyOn( abortController.signal, 'removeEventListener' );
 
       await expect( wrapStream( {
         name: 'Agent.stream',
         prompt,
+        abortSignal: abortController.signal,
         fn: () => Promise.reject( original )
       } ) ).rejects.toBe( mappedError );
 
       expect( mocks.mapAiError ).toHaveBeenCalledWith( original );
       expect( tracing.addEventError ).toHaveBeenCalledWith( {
-        id: 'Agent.stream-9000000000',
+        id: 'Agent.stream-9000000000-a1b2c3d4',
         details: mappedError
       } );
       expect( tracing.addEventEnd ).not.toHaveBeenCalled();
+      expect( removeEventListener ).toHaveBeenCalledOnce();
     } );
 
     it( 'returns a fulfilled promise from fn without mapping', async () => {

--- a/test_workflows/src/workflows/llm/stream_text_abort/abort_stream@v1.prompt
+++ b/test_workflows/src/workflows/llm/stream_text_abort/abort_stream@v1.prompt
@@ -1,0 +1,9 @@
+---
+provider: anthropic
+model: claude-sonnet-4-6
+maxOutputTokens: 2048
+---
+
+<user>
+Write the integers from 1 to 1000 in order, separated by commas. Do not omit any numbers.
+</user>

--- a/test_workflows/src/workflows/llm/stream_text_abort/steps.ts
+++ b/test_workflows/src/workflows/llm/stream_text_abort/steps.ts
@@ -1,0 +1,55 @@
+import { step } from '@outputai/core';
+import { streamText } from '@outputai/llm';
+import { workflowOutputSchema } from './types.js';
+
+const abortReason = 'Intentional stream abort';
+
+export const abortStream = step( {
+  name: 'abortStream',
+  description: 'Aborts an active LLM stream after its first text chunk',
+  outputSchema: workflowOutputSchema,
+  fn: async () => {
+    const abortController = new AbortController();
+    const state = {
+      chunksBeforeAbort: 0,
+      onEndCalled: false,
+      onErrorCalled: false
+    };
+
+    const result = streamText( {
+      prompt: 'abort_stream@v1',
+      abortSignal: abortController.signal,
+      onChunk( { chunk } ) {
+        if ( chunk.type !== 'text-delta' || abortController.signal.aborted ) {
+          return;
+        }
+
+        state.chunksBeforeAbort++;
+        abortController.abort( new DOMException( abortReason, 'AbortError' ) );
+      },
+      onEnd() {
+        state.onEndCalled = true;
+      },
+      onError() {
+        state.onErrorCalled = true;
+      }
+    } );
+
+    const observedAbort = { reason: '', sawPart: false };
+    for await ( const part of result.stream ) {
+      if ( part.type === 'abort' ) {
+        observedAbort.sawPart = true;
+        observedAbort.reason = part.reason ?? '';
+      }
+    }
+
+    return {
+      aborted: abortController.signal.aborted,
+      sawAbortPart: observedAbort.sawPart,
+      onEndCalled: state.onEndCalled,
+      onErrorCalled: state.onErrorCalled,
+      chunksBeforeAbort: state.chunksBeforeAbort,
+      abortReason: observedAbort.reason
+    };
+  }
+} );

--- a/test_workflows/src/workflows/llm/stream_text_abort/types.ts
+++ b/test_workflows/src/workflows/llm/stream_text_abort/types.ts
@@ -1,0 +1,12 @@
+import { z } from '@outputai/core';
+
+export const workflowOutputSchema = z.object( {
+  aborted: z.boolean(),
+  sawAbortPart: z.boolean(),
+  onEndCalled: z.boolean(),
+  onErrorCalled: z.boolean(),
+  chunksBeforeAbort: z.number(),
+  abortReason: z.string()
+} );
+
+export type WorkflowOutput = z.infer<typeof workflowOutputSchema>;

--- a/test_workflows/src/workflows/llm/stream_text_abort/workflow.ts
+++ b/test_workflows/src/workflows/llm/stream_text_abort/workflow.ts
@@ -1,0 +1,10 @@
+import { workflow } from '@outputai/core';
+import { abortStream } from './steps.js';
+import { workflowOutputSchema } from './types.js';
+
+export default workflow( {
+  name: 'stream_text_abort',
+  description: 'Aborts an active streamText generation',
+  outputSchema: workflowOutputSchema,
+  fn: async () => abortStream()
+} );


### PR DESCRIPTION
## Summary

- Added random bytes to LLM trace IDs to reduce collision risk.
- Added abortion handling to stream to properly emit trace events.
- Removed Agent turn errors messages from message store.
- Added log when onEnd internal handling fails before calling user callback.
- Fixed image argument types with runtime mask validation.
- Removed specs and fixtures from the published package.
- Fixed stale `maxTokens` wording in generation JSDoc.

