### PR TITLE
chore: Add Gemini grounded search tracking

### DIFF
--- a/.changeset/legal-teeth-rule.md
+++ b/.changeset/legal-teeth-rule.md
@@ -1,0 +1,6 @@
+---
+"@outputai/cli": patch
+"@outputai/llm": patch
+---
+
+add support for gemini grounded search reporting in sdk/llm costs

--- a/.changeset/legal-teeth-rule.md
+++ b/.changeset/legal-teeth-rule.md
@@ -1,6 +1,8 @@
 ---
-"@outputai/cli": patch
-"@outputai/llm": patch
+"@outputai/cli": minor
+"@outputai/llm": minor
 ---
 
-add support for gemini grounded search reporting in sdk/llm costs
+Added support for pricing Gemini grounded search, which providers bill per request rather than per token. `LLMGenerationUsage` and `LLMGenerationCost` items gain a `request` group alongside `input` and `output`, and the legacy `cost:llm:request` payload gains a matching `grounding_query`/`grounding_prompt` line (with `ppm: 0` when the charge can't be priced, so legacy consumers still see that a grounded call happened).
+
+`output workflow cost` prices these request-based charges and marks any call with an unpriced charge (grounding or otherwise) with a `*` and a "cost incomplete" footnote, since the reported total understates the actual bill.

--- a/.changeset/legal-teeth-rule.md
+++ b/.changeset/legal-teeth-rule.md
@@ -3,6 +3,6 @@
 "@outputai/llm": minor
 ---
 
-Added support for pricing Gemini grounded search, which providers bill per request rather than per token. `LLMGenerationUsage` and `LLMGenerationCost` items gain a `request` group alongside `input` and `output`, and the legacy `cost:llm:request` payload gains a matching `grounding_query`/`grounding_prompt` line (with `ppm: 0` when the charge can't be priced, so legacy consumers still see that a grounded call happened).
+Added support for pricing Gemini grounded search, which providers bill per request rather than per token. `LLMGenerationUsage` and `LLMGenerationCost` items gain a `request` group alongside `input` and `output`. The legacy `cost:llm:request` payload is unchanged and does not carry grounding charges — its shape is frozen, so grounding costs are only visible on the new normalized attribute.
 
 `output workflow cost` prices these request-based charges and marks any call with an unpriced charge (grounding or otherwise) with a `*` and a "cost incomplete" footnote, since the reported total understates the actual bill.

--- a/docs/guides/costs/cost-events.mdx
+++ b/docs/guides/costs/cost-events.mdx
@@ -205,7 +205,7 @@ on<LLMUsageEvent>( 'cost:llm:request', event => {
 }
 ```
 
-The legacy payload represents priced usage through the historical `input`, `input_cached`, `output`, and `reasoning` line types, plus a `grounding_query` or `grounding_prompt` line whenever a per-request grounding charge applies. It intentionally retains the old cache-write folding and reasoning fallback behavior. Its `total` includes every line, but `tokensUsed` is calculated from the token line types only — grounding lines are counted in requests, not tokens, so they are excluded. An unpriced grounding charge still produces a legacy line, with `ppm: 0`, so legacy consumers can see that a grounded call happened even though it can't be priced. The `cost:llm:request` payload and `llm:usage` trace attribute are generated from the same object.
+The legacy payload represents priced usage through the historical `input`, `input_cached`, `output`, and `reasoning` line types only. It intentionally retains the old cache-write folding and reasoning fallback behavior, and its shape is frozen: per-request charges such as grounding are never added as new `usage` line types, since existing consumers reduce or map over that array and a new type could break them. Grounding costs are only available on the normalized `llm:generation:cost` attribute and `llm:generation:metering` event described above. The `cost:llm:request` payload and `llm:usage` trace attribute are generated from the same object.
 
 Use `llm:generation:metering` for new integrations. It is more faithful to the provider response because usage is independent from pricing, cache writes and reasoning remain explicit, provider identity is included, and fallback or missing prices are represented rather than hidden.
 

--- a/docs/guides/costs/cost-events.mdx
+++ b/docs/guides/costs/cost-events.mdx
@@ -117,6 +117,7 @@ The handler receives the standard event envelope. `payload.usage` is always pres
       "status": "precise",
       "input": 0.001085,
       "output": 0.000135,
+      "request": null,
       "total": 0.00122,
       "items": [
         { "group": "input", "label": "no_cache", "amount": 217, "ppm": 5, "total": 0.001085, "status": "ok" },
@@ -154,11 +155,13 @@ The handler receives the standard event envelope. `payload.usage` is always pres
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `group` | `"input" \| "output"` | Aggregate category. |
-| `label` | `string \| null` | Input detail (`no_cache`, `cache_read`, `cache_write`), output detail (`text`, `reasoning`), or `null` for aggregate usage. |
-| `amount` | `number` | Token count for this dimension. |
+| `group` | `"input" \| "output" \| "request"` | Aggregate category. `request` covers per-request charges such as grounding with Google Search, billed per request rather than per token. |
+| `label` | `string \| null` | Input detail (`no_cache`, `cache_read`, `cache_write`), output detail (`text`, `reasoning`), request detail (`grounding_query`, `grounding_prompt`, or `grounding` when the rate is unknown), or `null` for aggregate usage. |
+| `amount` | `number` | Count for this dimension: a token count for `input`/`output` items, and a query or grounded-request count for `request` items. |
 
 When the detailed counts do not reconcile with the aggregate count, Output keeps the aggregate input or output item instead of recording a misleading breakdown.
+
+Per-request items are recorded independently from tokens and are excluded from the `input`, `output`, and `total` token aggregates above.
 
 ### Normalized cost
 
@@ -166,8 +169,8 @@ When the detailed counts do not reconcile with the aggregate count, Output keeps
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `input`, `output`, `total` | `number \| null` | Aggregate dollar costs for available priced items. |
-| `status` | `"precise" \| "imprecise" \| "incomplete"` | Whether all rates were exact, a fallback rate was used, or usage/pricing was incomplete. |
+| `input`, `output`, `request`, `total` | `number \| null` | Aggregate dollar costs for available priced items. `request` holds per-request charges (such as grounding), and `total` is the sum of `input`, `output`, and `request`. |
+| `status` | `"precise" \| "imprecise" \| "incomplete"` | Whether all rates were exact, a fallback rate was used, or usage/pricing was incomplete. A per-request charge with no known rate lands `incomplete`. |
 | `items[].ppm` | `number \| null` | Applied price per million tokens. |
 | `items[].total` | `number \| null` | Calculated item cost. |
 | `items[].status` | `"ok" \| "fallback" \| "missing"` | Whether the exact rate, a regular input/output fallback, or no rate was available. |
@@ -202,7 +205,7 @@ on<LLMUsageEvent>( 'cost:llm:request', event => {
 }
 ```
 
-The legacy payload represents priced usage through the historical `input`, `input_cached`, `output`, and `reasoning` line types. It intentionally retains the old cache-write folding and reasoning fallback behavior. Its `total` and `tokensUsed` are calculated from those legacy lines. The `cost:llm:request` payload and `llm:usage` trace attribute are generated from the same object.
+The legacy payload represents priced usage through the historical `input`, `input_cached`, `output`, and `reasoning` line types, plus a `grounding_query` or `grounding_prompt` line when a priced per-request grounding charge applies. It intentionally retains the old cache-write folding and reasoning fallback behavior. Its `total` includes every line, but `tokensUsed` is calculated from the token line types only — grounding lines are counted in requests, not tokens, so they are excluded. An unpriced grounding charge produces no legacy line at all. The `cost:llm:request` payload and `llm:usage` trace attribute are generated from the same object.
 
 Use `llm:generation:metering` for new integrations. It is more faithful to the provider response because usage is independent from pricing, cache writes and reasoning remain explicit, provider identity is included, and fallback or missing prices are represented rather than hidden.
 

--- a/docs/guides/costs/cost-events.mdx
+++ b/docs/guides/costs/cost-events.mdx
@@ -205,7 +205,7 @@ on<LLMUsageEvent>( 'cost:llm:request', event => {
 }
 ```
 
-The legacy payload represents priced usage through the historical `input`, `input_cached`, `output`, and `reasoning` line types, plus a `grounding_query` or `grounding_prompt` line when a priced per-request grounding charge applies. It intentionally retains the old cache-write folding and reasoning fallback behavior. Its `total` includes every line, but `tokensUsed` is calculated from the token line types only — grounding lines are counted in requests, not tokens, so they are excluded. An unpriced grounding charge produces no legacy line at all. The `cost:llm:request` payload and `llm:usage` trace attribute are generated from the same object.
+The legacy payload represents priced usage through the historical `input`, `input_cached`, `output`, and `reasoning` line types, plus a `grounding_query` or `grounding_prompt` line whenever a per-request grounding charge applies. It intentionally retains the old cache-write folding and reasoning fallback behavior. Its `total` includes every line, but `tokensUsed` is calculated from the token line types only — grounding lines are counted in requests, not tokens, so they are excluded. An unpriced grounding charge still produces a legacy line, with `ppm: 0`, so legacy consumers can see that a grounded call happened even though it can't be priced. The `cost:llm:request` payload and `llm:usage` trace attribute are generated from the same object.
 
 Use `llm:generation:metering` for new integrations. It is more faithful to the provider response because usage is independent from pricing, cache writes and reasoning remain explicit, provider identity is included, and fallback or missing prices are represented rather than hidden.
 

--- a/sdk/cli/src/services/cost_calculator.spec.ts
+++ b/sdk/cli/src/services/cost_calculator.spec.ts
@@ -63,6 +63,7 @@ function llmCostNode( id: string, model: string, items: LLMGenerationCost['items
     items.filter( item => item.group === group ).reduce( ( sum, item ) => sum + ( item.total ?? 0 ), 0 );
   const input = totalOf( 'input' );
   const output = totalOf( 'output' );
+  const request = totalOf( 'request' );
 
   return {
     id,
@@ -75,7 +76,8 @@ function llmCostNode( id: string, model: string, items: LLMGenerationCost['items
         modelId: model,
         input,
         output,
-        total: input + output,
+        request,
+        total: input + output + request,
         status: 'precise',
         items
       }

--- a/sdk/cli/src/services/cost_calculator.spec.ts
+++ b/sdk/cli/src/services/cost_calculator.spec.ts
@@ -427,7 +427,9 @@ describe( 'findLLMCalls', () => {
         outputTokens: 110,
         reasoningTokens: 70
       },
-      originalCost: 0
+      originalCost: 0,
+      // Usage-only means cost computation produced no priced result at all.
+      incomplete: true
     } );
     expect( calls[0].lines ).toEqual( [
       { type: 'input', ppm: 0, amount: 100, total: 0 },

--- a/sdk/cli/src/services/cost_calculator.spec.ts
+++ b/sdk/cli/src/services/cost_calculator.spec.ts
@@ -58,7 +58,12 @@ function llmEventNode( id: string, model: string, lines: LLMUsageLine[] ): Trace
   };
 }
 
-function llmCostNode( id: string, model: string, items: LLMGenerationCost['items'] ): TraceNode {
+function llmCostNode(
+  id: string,
+  model: string,
+  items: LLMGenerationCost['items'],
+  status: LLMGenerationCost['status'] = 'precise'
+): TraceNode {
   const totalOf = ( group: LLMGenerationCost['items'][number]['group'] ): number =>
     items.filter( item => item.group === group ).reduce( ( sum, item ) => sum + ( item.total ?? 0 ), 0 );
   const input = totalOf( 'input' );
@@ -78,7 +83,7 @@ function llmCostNode( id: string, model: string, items: LLMGenerationCost['items
         output,
         request,
         total: input + output + request,
-        status: 'precise',
+        status,
         items
       }
     }
@@ -327,6 +332,75 @@ describe( 'findLLMCalls', () => {
       'reasoning'
     ] );
     expect( calls[0].originalCost ).toBeCloseTo( 0.001965, 8 );
+  } );
+
+  it( 'reads a priced grounding request item without counting it as tokens', () => {
+    const items: LLMGenerationCost['items'] = [
+      { group: 'input', label: 'no_cache', amount: 1032, ppm: 0.3, total: 0.0003096, status: 'ok' },
+      { group: 'output', label: 'text', amount: 793, ppm: 2.5, total: 0.0019825, status: 'ok' },
+      { group: 'request', label: 'grounding_prompt', amount: 1, ppm: 35_000, total: 0.035, status: 'ok' }
+    ];
+    const calls = findLLMCalls( {
+      kind: 'workflow',
+      children: [ llmCostNode( 'grounded', 'gemini-2.5-flash', items ) ]
+    } );
+
+    expect( calls[0].incomplete ).toBe( false );
+    expect( calls[0].originalCost ).toBeCloseTo( 0.0372921, 8 );
+    // Grounding bills per request, so it must not inflate token usage.
+    expect( calls[0].usage ).toEqual( {
+      inputTokens: 1032,
+      cachedInputTokens: 0,
+      outputTokens: 793,
+      reasoningTokens: 0
+    } );
+    expect( calls[0].lines.find( l => l.type === 'request_grounding_prompt' ) ).toEqual( {
+      type: 'request_grounding_prompt',
+      ppm: 35_000,
+      amount: 1,
+      total: 0.035
+    } );
+  } );
+
+  it( 'preserves a priced grounding charge as-charged when re-pricing at costs.yml rates', () => {
+    const items: LLMGenerationCost['items'] = [
+      { group: 'input', label: 'no_cache', amount: 1032, ppm: 0.3, total: 0.0003096, status: 'ok' },
+      { group: 'output', label: 'text', amount: 793, ppm: 2.5, total: 0.0019825, status: 'ok' },
+      { group: 'request', label: 'grounding_prompt', amount: 1, ppm: 35_000, total: 0.035, status: 'ok' }
+    ];
+    const config = {
+      models: { 'gemini-2.5-flash': { provider: 'google-vertex', input: 0.3, output: 2.5 } },
+      services: {}
+    };
+    const report = calculateCost(
+      { kind: 'workflow', name: 'w', children: [ llmCostNode( 'grounded', 'gemini-2.5-flash', items ) ] },
+      config
+    );
+
+    // grounding has no costs.yml line rate, so it degrades to its as-charged total, not $0.
+    expect( report.llmAdjustedCost ).toBeCloseTo( 0.0372921, 8 );
+  } );
+
+  it( 'flags an unrated grounding charge as incomplete instead of a silent $0', () => {
+    const items: LLMGenerationCost['items'] = [
+      { group: 'input', label: 'no_cache', amount: 1000, ppm: 1, total: 0.001, status: 'ok' },
+      { group: 'output', label: null, amount: 500, ppm: 5, total: 0.0025, status: 'ok' },
+      { group: 'request', label: 'grounding', amount: 3, ppm: null, total: null, status: 'missing' }
+    ];
+    const calls = findLLMCalls( {
+      kind: 'workflow',
+      children: [ llmCostNode( 'unrated', 'gemini-9-ultra', items, 'incomplete' ) ]
+    } );
+
+    expect( calls[0].incomplete ).toBe( true );
+    // The unrated line still shows up (as $0), but the call carries the signal.
+    expect( calls[0].lines.find( l => l.type === 'request_grounding' ) ).toEqual( {
+      type: 'request_grounding',
+      ppm: 0,
+      amount: 3,
+      total: 0
+    } );
+    expect( calls[0].usage ).toMatchObject( { inputTokens: 1000, outputTokens: 500 } );
   } );
 
   it( 'reads normalized usage without interpreting token totals as cost', () => {

--- a/sdk/cli/src/services/cost_calculator.ts
+++ b/sdk/cli/src/services/cost_calculator.ts
@@ -125,7 +125,8 @@ function parseLegacyLLMUsageEvent(
     model: event.modelId || 'unknown',
     usage: eventTokenUsage( event.usage ?? [] ),
     originalCost: event.total,
-    lines: event.usage ?? []
+    lines: event.usage ?? [],
+    incomplete: false
   };
 }
 
@@ -143,7 +144,8 @@ function parseNormalizedLLMUsage( node: TraceNode, stepName: string | null, even
     model: event.modelId || 'unknown',
     usage: normalizedItemTokenUsage( event.items ),
     originalCost: 0,
-    lines
+    lines,
+    incomplete: false
   };
 }
 
@@ -161,7 +163,10 @@ function parseLLMCostEvent( node: TraceNode, stepName: string | null, event: LLM
     model: event.modelId || 'unknown',
     usage: normalizedItemTokenUsage( event.items ),
     originalCost: event.total ?? 0,
-    lines
+    lines,
+    // An INCOMPLETE event carries a real but unpriced charge (e.g. unrated
+    // grounding). Flag it so the report can mark the understated total.
+    incomplete: event.status === 'incomplete'
   };
 }
 
@@ -623,7 +628,8 @@ function aggregateLLMCosts(
       cached: call.usage.cachedInputTokens ?? 0,
       reasoning: call.usage.reasoningTokens ?? 0,
       originalCost,
-      adjustedCost
+      adjustedCost,
+      incomplete: call.incomplete
     } );
 
     totals.inputTokens += call.usage.inputTokens ?? 0;

--- a/sdk/cli/src/services/cost_calculator.ts
+++ b/sdk/cli/src/services/cost_calculator.ts
@@ -145,7 +145,9 @@ function parseNormalizedLLMUsage( node: TraceNode, stepName: string | null, even
     usage: normalizedItemTokenUsage( event.items ),
     originalCost: 0,
     lines,
-    incomplete: false
+    // This path only runs when cost computation produced no llm:generation:cost
+    // attribute at all, so every line here is unpriced by construction.
+    incomplete: true
   };
 }
 

--- a/sdk/cli/src/services/cost_calculator.ts
+++ b/sdk/cli/src/services/cost_calculator.ts
@@ -145,8 +145,9 @@ function parseNormalizedLLMUsage( node: TraceNode, stepName: string | null, even
     usage: normalizedItemTokenUsage( event.items ),
     originalCost: 0,
     lines,
-    // This path only runs when cost computation produced no llm:generation:cost
-    // attribute at all, so every line here is unpriced by construction.
+    // This path runs whenever cost computation produced no llm:generation:cost
+    // attribute at all (e.g. pricing config missing, not just unrated grounding),
+    // so every line here is unpriced by construction, not only grounding calls.
     incomplete: true
   };
 }

--- a/sdk/cli/src/types/cost.ts
+++ b/sdk/cli/src/types/cost.ts
@@ -64,6 +64,10 @@ export interface LLMCall {
   originalCost: number;
   // Normalized lines used for reporting and optional costs.yml re-pricing.
   lines: LLMUsageLine[];
+  // True when the cost event is INCOMPLETE — a real charge it couldn't price
+  // (e.g. unrated grounding) or usage the provider only partly reported, so
+  // the reported total understates the bill.
+  incomplete: boolean;
 }
 
 export interface HTTPCall {
@@ -145,6 +149,8 @@ export interface LLMCostResult {
   // Cost after applying any costs.yml override (equals originalCost when no
   // override applies).
   adjustedCost: number;
+  // True when the underlying cost event was INCOMPLETE (unpriced charge).
+  incomplete: boolean;
 }
 
 // Result of recomputing a single HTTP cost from costs.yml service rules.
@@ -208,6 +214,8 @@ export interface LLMModelSummary {
   count: number;
   originalCost: number;
   adjustedCost: number;
+  // True when any call for this model had an unpriced (INCOMPLETE) charge.
+  incomplete: boolean;
 }
 
 export interface HostSummary {

--- a/sdk/cli/src/utils/cost_formatter.spec.ts
+++ b/sdk/cli/src/utils/cost_formatter.spec.ts
@@ -40,22 +40,30 @@ function report( llmCalls: LLMCostResult[] ): CostReport {
 }
 
 describe( 'formatCostReport incomplete marker', () => {
-  it( 'marks a model with an unpriced charge and prints the footnote', () => {
-    const out = formatCostReport( report( [ llmResult( { incomplete: true } ) ] ) );
-    expect( out ).toContain( '*' );
+  it( 'marks the model row with an unpriced charge and prints the footnote', () => {
+    const out = formatCostReport( report( [ llmResult( { model: 'gemini-2.5-flash', incomplete: true } ) ] ) );
+    const modelRow = out.split( '\n' ).find( line => line.includes( 'gemini-2.5-flash' ) );
+    expect( modelRow ).toContain( '$0.0037 *' );
     expect( out ).toContain( 'cost incomplete' );
   } );
 
   it( 'omits the marker and footnote when every call is fully priced', () => {
     const out = formatCostReport( report( [ llmResult() ] ) );
+    const modelRow = out.split( '\n' ).find( line => line.includes( 'gemini-2.5-flash' ) );
+    expect( modelRow ).not.toContain( '*' );
     expect( out ).not.toContain( 'cost incomplete' );
   } );
 
-  it( 'marks the flagged call in the verbose table', () => {
+  it( 'marks the flagged call row in the verbose table', () => {
     const out = formatCostReport(
-      report( [ llmResult( { step: 'grounded', incomplete: true } ) ] ),
+      report( [ llmResult( { step: 'grounded', incomplete: true } ), llmResult( { step: 'plain' } ) ] ),
       { verbose: true }
     );
+    const lines = out.split( '\n' );
+    const groundedRow = lines.find( line => line.includes( 'grounded' ) );
+    const plainRow = lines.find( line => line.includes( 'plain' ) );
+    expect( groundedRow ).toContain( '$0.0037 *' );
+    expect( plainRow ).not.toContain( '*' );
     expect( out ).toContain( 'cost incomplete' );
   } );
 } );

--- a/sdk/cli/src/utils/cost_formatter.spec.ts
+++ b/sdk/cli/src/utils/cost_formatter.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import type { CostReport, LLMCostResult } from '#types/cost.js';
+import { formatCostReport } from '#utils/cost_formatter.js';
+
+function llmResult( overrides: Partial<LLMCostResult> = {} ): LLMCostResult {
+  return {
+    step: 'gen',
+    model: 'gemini-2.5-flash',
+    input: 1032,
+    output: 793,
+    cached: 0,
+    reasoning: 0,
+    originalCost: 0.0037,
+    adjustedCost: 0.0037,
+    incomplete: false,
+    ...overrides
+  };
+}
+
+function report( llmCalls: LLMCostResult[] ): CostReport {
+  const originalCost = llmCalls.reduce( ( s, c ) => s + c.originalCost, 0 );
+  const adjustedCost = llmCalls.reduce( ( s, c ) => s + c.adjustedCost, 0 );
+  return {
+    traceFile: 'trace.json',
+    workflowName: 'w',
+    durationMs: 1000,
+    llmCalls,
+    llmOriginalCost: originalCost,
+    llmAdjustedCost: adjustedCost,
+    totalInputTokens: 1032,
+    totalOutputTokens: 793,
+    totalCachedTokens: 0,
+    totalReasoningTokens: 0,
+    httpCosts: [],
+    httpOriginalCost: 0,
+    httpAdjustedCost: 0,
+    originalTotalCost: originalCost,
+    totalCost: adjustedCost
+  };
+}
+
+describe( 'formatCostReport incomplete marker', () => {
+  it( 'marks a model with an unpriced charge and prints the footnote', () => {
+    const out = formatCostReport( report( [ llmResult( { incomplete: true } ) ] ) );
+    expect( out ).toContain( '*' );
+    expect( out ).toContain( 'cost incomplete' );
+  } );
+
+  it( 'omits the marker and footnote when every call is fully priced', () => {
+    const out = formatCostReport( report( [ llmResult() ] ) );
+    expect( out ).not.toContain( 'cost incomplete' );
+  } );
+
+  it( 'marks the flagged call in the verbose table', () => {
+    const out = formatCostReport(
+      report( [ llmResult( { step: 'grounded', incomplete: true } ) ] ),
+      { verbose: true }
+    );
+    expect( out ).toContain( 'cost incomplete' );
+  } );
+} );

--- a/sdk/cli/src/utils/cost_formatter.ts
+++ b/sdk/cli/src/utils/cost_formatter.ts
@@ -36,15 +36,25 @@ function pluralize( count: number, singular: string ): string {
   return count === 1 ? `1 ${singular}` : `${count} ${singular}s`;
 }
 
+// Marks a figure whose call had a real but unpriced charge (e.g. unrated
+// grounding), so a $0.00 line reads as "unpriced" rather than a clean zero.
+const INCOMPLETE_MARKER = '*';
+const INCOMPLETE_FOOTNOTE = '* cost incomplete (unpriced charge such as grounding, or missing usage); the total understates the bill';
+
+function markIncomplete( text: string, incomplete: boolean ): string {
+  return incomplete ? `${text} ${INCOMPLETE_MARKER}` : text;
+}
+
 export function parseCostData( report: CostReport ): ParsedCostData {
-  const byModel: Record<string, { count: number; originalCost: number; adjustedCost: number }> = {};
+  const byModel: Record<string, { count: number; originalCost: number; adjustedCost: number; incomplete: boolean }> = {};
   for ( const r of report.llmCalls ) {
     if ( !byModel[r.model] ) {
-      byModel[r.model] = { count: 0, originalCost: 0, adjustedCost: 0 };
+      byModel[r.model] = { count: 0, originalCost: 0, adjustedCost: 0, incomplete: false };
     }
     byModel[r.model].count++;
     byModel[r.model].originalCost += r.originalCost;
     byModel[r.model].adjustedCost += r.adjustedCost;
+    byModel[r.model].incomplete ||= r.incomplete;
   }
 
   const llmModels: LLMModelSummary[] = Object.entries( byModel )
@@ -105,12 +115,13 @@ function formatSummary( data: ParsedCostData ): string {
       colAligns: [ 'left', 'right', 'right', 'right' ]
     } );
 
+    const anyIncomplete = data.llmModels.some( m => m.incomplete );
     for ( const m of data.llmModels ) {
       table.push( [
         m.model,
         pluralize( m.count, 'call' ),
-        formatCurrency( m.originalCost ),
-        formatCurrency( m.adjustedCost )
+        markIncomplete( formatCurrency( m.originalCost ), m.incomplete ),
+        markIncomplete( formatCurrency( m.adjustedCost ), m.incomplete )
       ] );
     }
 
@@ -123,6 +134,9 @@ function formatSummary( data: ParsedCostData ): string {
 
     lines.push( 'LLM Costs:' );
     lines.push( table.toString() );
+    if ( anyIncomplete ) {
+      lines.push( INCOMPLETE_FOOTNOTE );
+    }
     lines.push( '' );
   }
 
@@ -181,6 +195,7 @@ function formatVerbose( data: ParsedCostData ): string {
       colAligns
     } );
 
+    const anyIncomplete = data.llmCalls.some( r => r.incomplete );
     for ( const r of data.llmCalls ) {
       const row: string[] = [
         r.step,
@@ -194,7 +209,10 @@ function formatVerbose( data: ParsedCostData ): string {
       if ( data.verbose.hasReasoning ) {
         row.push( formatNumber( r.reasoning ) );
       }
-      row.push( formatCurrency( r.originalCost ), formatCurrency( r.adjustedCost ) );
+      row.push(
+        markIncomplete( formatCurrency( r.originalCost ), r.incomplete ),
+        markIncomplete( formatCurrency( r.adjustedCost ), r.incomplete )
+      );
       table.push( row );
     }
 
@@ -215,6 +233,9 @@ function formatVerbose( data: ParsedCostData ): string {
 
     lines.push( 'LLM Calls:' );
     lines.push( table.toString() );
+    if ( anyIncomplete ) {
+      lines.push( INCOMPLETE_FOOTNOTE );
+    }
     lines.push( '' );
   }
 

--- a/sdk/llm/src/fixtures/text_response_v7_google_vertex.js
+++ b/sdk/llm/src/fixtures/text_response_v7_google_vertex.js
@@ -90,7 +90,13 @@ export default {
       providerMetadata: {
         googleVertex: {
           promptFeedback: null,
-          groundingMetadata: null,
+          groundingMetadata: {
+            webSearchQueries: [
+              'how does a carburetor work',
+              'carburetor venturi effect'
+            ],
+            retrievalQueries: null
+          },
           urlContextMetadata: null,
           safetyRatings: null,
           usageMetadata: {
@@ -117,7 +123,13 @@ export default {
         },
         vertex: {
           promptFeedback: null,
-          groundingMetadata: null,
+          groundingMetadata: {
+            webSearchQueries: [
+              'how does a carburetor work',
+              'carburetor venturi effect'
+            ],
+            retrievalQueries: null
+          },
           urlContextMetadata: null,
           safetyRatings: null,
           usageMetadata: {
@@ -249,7 +261,13 @@ export default {
     providerMetadata: {
       googleVertex: {
         promptFeedback: null,
-        groundingMetadata: null,
+        groundingMetadata: {
+          webSearchQueries: [
+            'how does a carburetor work',
+            'carburetor venturi effect'
+          ],
+          retrievalQueries: null
+        },
         urlContextMetadata: null,
         safetyRatings: null,
         usageMetadata: {
@@ -276,7 +294,13 @@ export default {
       },
       vertex: {
         promptFeedback: null,
-        groundingMetadata: null,
+        groundingMetadata: {
+          webSearchQueries: [
+            'how does a carburetor work',
+            'carburetor venturi effect'
+          ],
+          retrievalQueries: null
+        },
         urlContextMetadata: null,
         safetyRatings: null,
         usageMetadata: {
@@ -325,7 +349,13 @@ export default {
   providerMetadata: {
     googleVertex: {
       promptFeedback: null,
-      groundingMetadata: null,
+      groundingMetadata: {
+        webSearchQueries: [
+          'how does a carburetor work',
+          'carburetor venturi effect'
+        ],
+        retrievalQueries: null
+      },
       urlContextMetadata: null,
       safetyRatings: null,
       usageMetadata: {
@@ -352,7 +382,13 @@ export default {
     },
     vertex: {
       promptFeedback: null,
-      groundingMetadata: null,
+      groundingMetadata: {
+        webSearchQueries: [
+          'how does a carburetor work',
+          'carburetor venturi effect'
+        ],
+        retrievalQueries: null
+      },
       urlContextMetadata: null,
       safetyRatings: null,
       usageMetadata: {

--- a/sdk/llm/src/index.d.ts
+++ b/sdk/llm/src/index.d.ts
@@ -341,9 +341,9 @@ export type ExtractedSource =
 
 export type LLMGenerationUsageStatus = 'complete' | 'incomplete';
 
-/** Token usage reported for one normalized LLM usage component. */
+/** Token usage reported for one normalized LLM usage component. `request` counts billable requests, not tokens. */
 export interface LLMGenerationUsageItem {
-  group: 'input' | 'output';
+  group: 'input' | 'output' | 'request';
   label: string | null;
   amount: number;
 }
@@ -386,7 +386,7 @@ export type LLMGenerationCostStatus = 'precise' | 'imprecise' | 'incomplete';
 
 /** Cost calculated for one normalized LLM usage item. */
 export interface LLMGenerationCostItem {
-  group: 'input' | 'output';
+  group: 'input' | 'output' | 'request';
   label: string | null;
   amount: number;
   ppm: number | null;
@@ -401,6 +401,7 @@ export interface LLMGenerationCost extends BaseAttribute {
   modelId: string;
   input: number | null;
   output: number | null;
+  request: number | null;
   total: number | null;
   status: LLMGenerationCostStatus;
   items: LLMGenerationCostItem[];

--- a/sdk/llm/src/utils/cost.full.spec.js
+++ b/sdk/llm/src/utils/cost.full.spec.js
@@ -257,6 +257,7 @@ describe( 'calculateCosts with AI SDK response fixtures', () => {
       modelId,
       input,
       output,
+      request: null,
       total,
       status,
       items: items.map( ( [ group, label, amount, ppm, itemTotal, itemStatus ] ) => ( {

--- a/sdk/llm/src/utils/cost.full.spec.js
+++ b/sdk/llm/src/utils/cost.full.spec.js
@@ -23,6 +23,7 @@ import { LLMGenerationUsageItem, parseLLMUsage } from './usage.js';
 
 const INPUT = LLMGenerationUsageItem.Group.INPUT;
 const OUTPUT = LLMGenerationUsageItem.Group.OUTPUT;
+const REQUEST = LLMGenerationUsageItem.Group.REQUEST;
 const OK = LLMGenerationCostItem.Status.OK;
 const FALLBACK = LLMGenerationCostItem.Status.FALLBACK;
 const MISSING = LLMGenerationCostItem.Status.MISSING;
@@ -153,13 +154,15 @@ const cases = [
     modelId: 'gemini-2.5-flash',
     input: 0.0003096,
     output: 0.0034525,
-    total: 0.0037621,
+    request: 0.035,
+    total: 0.0387621,
     status: LLMGenerationCost.Status.IMPRECISE,
     items: [
       [ INPUT, 'no_cache', 1032, 0.3, 0.0003096, OK ],
       [ INPUT, 'cache_read', 0, 0.03, 0, OK ],
       [ OUTPUT, 'text', 793, 2.5, 0.0019825, OK ],
-      [ OUTPUT, 'reasoning', 588, 2.5, 0.00147, FALLBACK ]
+      [ OUTPUT, 'reasoning', 588, 2.5, 0.00147, FALLBACK ],
+      [ REQUEST, 'grounding_prompt', 1, 35_000, 0.035, OK ]
     ]
   },
   {
@@ -236,6 +239,7 @@ describe( 'calculateCosts with AI SDK response fixtures', () => {
     modelId,
     input,
     output,
+    request = null,
     total,
     status,
     items
@@ -247,7 +251,8 @@ describe( 'calculateCosts with AI SDK response fixtures', () => {
           model: modelId
         }
       },
-      usage: fixture.usage
+      usage: fixture.usage,
+      steps: fixture.steps
     } );
     const result = await calculateCosts( usage );
 
@@ -257,7 +262,7 @@ describe( 'calculateCosts with AI SDK response fixtures', () => {
       modelId,
       input,
       output,
-      request: null,
+      request,
       total,
       status,
       items: items.map( ( [ group, label, amount, ppm, itemTotal, itemStatus ] ) => ( {

--- a/sdk/llm/src/utils/cost.js
+++ b/sdk/llm/src/utils/cost.js
@@ -62,18 +62,13 @@ export class LLMGenerationCost extends Tracing.Attribute.BaseAttribute {
     } else {
       this.status = LLMGenerationCost.Status.PRECISE;
     }
-    const inputItems = items.filter( p => p.group === LLMGenerationUsageItem.Group.INPUT && exists( p.total ) );
-    if ( inputItems.length > 0 ) {
-      this.input = inputItems.reduce( ( s, p ) => s.add( p.total ), Decimal( 0 ) ).toNumber();
-    }
-    const outputItems = items.filter( p => p.group === LLMGenerationUsageItem.Group.OUTPUT && exists( p.total ) );
-    if ( outputItems.length > 0 ) {
-      this.output = outputItems.reduce( ( s, p ) => s.add( p.total ), Decimal( 0 ) ).toNumber();
-    }
-    const requestItems = items.filter( p => p.group === LLMGenerationUsageItem.Group.REQUEST && exists( p.total ) );
-    if ( requestItems.length > 0 ) {
-      this.request = requestItems.reduce( ( s, p ) => s.add( p.total ), Decimal( 0 ) ).toNumber();
-    }
+    const sumGroup = group => {
+      const groupItems = items.filter( p => p.group === group && exists( p.total ) );
+      return groupItems.length > 0 ? groupItems.reduce( ( s, p ) => s.add( p.total ), Decimal( 0 ) ).toNumber() : null;
+    };
+    this.input = sumGroup( LLMGenerationUsageItem.Group.INPUT );
+    this.output = sumGroup( LLMGenerationUsageItem.Group.OUTPUT );
+    this.request = sumGroup( LLMGenerationUsageItem.Group.REQUEST );
     if ( exists( this.input ) || exists( this.output ) || exists( this.request ) ) {
       this.total = Decimal( this.input ?? 0 ).add( this.output ?? 0 ).add( this.request ?? 0 ).toNumber();
     }

--- a/sdk/llm/src/utils/cost.js
+++ b/sdk/llm/src/utils/cost.js
@@ -1,6 +1,7 @@
 import { fetchModelsPricing } from './models_pricing.js';
 import { Tracing } from '@outputai/core/sdk/runtime';
 import { LLMGenerationUsage, LLMGenerationUsageItem } from './usage.js';
+import { GROUNDING_PPM } from './grounding.js';
 import { Logger } from '@outputai/core';
 import Decimal from 'decimal.js';
 
@@ -41,6 +42,7 @@ export class LLMGenerationCost extends Tracing.Attribute.BaseAttribute {
   modelId;
   input = null;
   output = null;
+  request = null;
   total = null;
   status = LLMGenerationCost.Status.INCOMPLETE;
   items = [];
@@ -68,8 +70,12 @@ export class LLMGenerationCost extends Tracing.Attribute.BaseAttribute {
     if ( outputItems.length > 0 ) {
       this.output = outputItems.reduce( ( s, p ) => s.add( p.total ), Decimal( 0 ) ).toNumber();
     }
-    if ( exists( this.input ) || exists( this.output ) ) {
-      this.total = Decimal( this.input ?? 0 ).add( this.output ?? 0 ).toNumber();
+    const requestItems = items.filter( p => p.group === LLMGenerationUsageItem.Group.REQUEST && exists( p.total ) );
+    if ( requestItems.length > 0 ) {
+      this.request = requestItems.reduce( ( s, p ) => s.add( p.total ), Decimal( 0 ) ).toNumber();
+    }
+    if ( exists( this.input ) || exists( this.output ) || exists( this.request ) ) {
+      this.total = Decimal( this.input ?? 0 ).add( this.output ?? 0 ).add( this.request ?? 0 ).toNumber();
     }
   }
 }
@@ -86,6 +92,10 @@ const resolveValue = values => {
 };
 
 const resolvePrice = ( { group, label, pricing } ) => {
+  // Per-request charges are never token-priced: models.dev has no rate for them.
+  if ( group === LLMGenerationUsageItem.Group.REQUEST ) {
+    return resolveValue( [ GROUNDING_PPM[label] ] );
+  }
   if ( !pricing ) {
     return resolveValue( [] );
   }
@@ -132,6 +142,12 @@ export const calculateCosts = async usage => {
     const total = exists( ppm ) ? Decimal( amount ).div( 1_000_000 ).mul( ppm ).toNumber() : null;
     return new LLMGenerationCostItem( group, label, amount, ppm, total, status );
   } );
+
+  const unrated = items.some( v =>
+    v.group === LLMGenerationUsageItem.Group.REQUEST && v.status === LLMGenerationCostItem.Status.MISSING );
+  if ( unrated ) {
+    Logger.warn( 'Grounded call with no grounding rate for model', { namespace: 'LLM', modelId, providerId } );
+  }
 
   return new LLMGenerationCost( modelId, providerId, items, usage.status );
 };

--- a/sdk/llm/src/utils/cost.js
+++ b/sdk/llm/src/utils/cost.js
@@ -1,7 +1,7 @@
 import { fetchModelsPricing } from './models_pricing.js';
 import { Tracing } from '@outputai/core/sdk/runtime';
 import { LLMGenerationUsage, LLMGenerationUsageItem } from './usage.js';
-import { GROUNDING_PPM } from './grounding.js';
+import { GroundingPpmMap } from './grounding.js';
 import { Logger } from '@outputai/core';
 import Decimal from 'decimal.js';
 
@@ -89,7 +89,7 @@ const resolveValue = values => {
 const resolvePrice = ( { group, label, pricing } ) => {
   // Per-request charges are never token-priced: models.dev has no rate for them.
   if ( group === LLMGenerationUsageItem.Group.REQUEST ) {
-    return resolveValue( [ GROUNDING_PPM[label] ] );
+    return resolveValue( [ GroundingPpmMap.get( label ) ] );
   }
   if ( !pricing ) {
     return resolveValue( [] );

--- a/sdk/llm/src/utils/cost.spec.js
+++ b/sdk/llm/src/utils/cost.spec.js
@@ -12,6 +12,7 @@ import { LLMGenerationUsage, LLMGenerationUsageItem } from './usage.js';
 
 const INPUT = LLMGenerationUsageItem.Group.INPUT;
 const OUTPUT = LLMGenerationUsageItem.Group.OUTPUT;
+const REQUEST = LLMGenerationUsageItem.Group.REQUEST;
 const MODEL_ID = 'test-model';
 const PROVIDER_ID = 'test-provider';
 
@@ -60,6 +61,7 @@ describe( 'calculateCosts', () => {
       modelId: MODEL_ID,
       input: 2,
       output: 5,
+      request: null,
       total: 7,
       status: LLMGenerationCost.Status.PRECISE,
       items: [
@@ -220,6 +222,93 @@ describe( 'calculateCosts', () => {
       status: LLMGenerationCost.Status.PRECISE
     } );
     expect( result.items.every( value => value.status === LLMGenerationCostItem.Status.OK ) ).toBe( true );
+  } );
+
+  it( 'prices a Gemini 3 grounding query from the local rate table', async () => {
+    mockFetchModelsPricing.mockResolvedValue( pricing( { input: 2, output: 10 } ) );
+
+    const result = await calculateCosts( usage( [
+      item( INPUT, null, 1_000_000 ),
+      item( OUTPUT, null, 500_000 ),
+      item( REQUEST, 'grounding_query', 3 )
+    ] ) );
+
+    expect( result ).toMatchObject( {
+      input: 2,
+      output: 5,
+      request: 0.042,
+      total: 7.042,
+      status: LLMGenerationCost.Status.PRECISE
+    } );
+    expect( result.items.at( -1 ) ).toEqual(
+      new LLMGenerationCostItem( REQUEST, 'grounding_query', 3, 14_000, 0.042, LLMGenerationCostItem.Status.OK )
+    );
+    expect( Logger.warn ).not.toHaveBeenCalled();
+  } );
+
+  it( 'prices a Gemini 2 grounding prompt from the local rate table', async () => {
+    mockFetchModelsPricing.mockResolvedValue( pricing( { input: 2, output: 10 } ) );
+
+    const result = await calculateCosts( usage( [
+      item( INPUT, null, 1_000_000 ),
+      item( OUTPUT, null, 500_000 ),
+      item( REQUEST, 'grounding_prompt', 1 )
+    ] ) );
+
+    expect( result ).toMatchObject( {
+      request: 0.035,
+      total: 7.035,
+      status: LLMGenerationCost.Status.PRECISE
+    } );
+  } );
+
+  it( 'never prices a request item at the input token rate', async () => {
+    mockFetchModelsPricing.mockResolvedValue( new Map() );
+
+    const result = await calculateCosts( usage( [
+      item( REQUEST, 'grounding_query', 2 )
+    ] ) );
+
+    expect( result.items ).toEqual( [
+      new LLMGenerationCostItem( REQUEST, 'grounding_query', 2, 14_000, 0.028, LLMGenerationCostItem.Status.OK )
+    ] );
+  } );
+
+  it( 'marks an unrated grounded call incomplete and warns', async () => {
+    mockFetchModelsPricing.mockResolvedValue( pricing( { input: 2, output: 10 } ) );
+
+    const result = await calculateCosts( usage( [
+      item( INPUT, null, 1_000_000 ),
+      item( OUTPUT, null, 500_000 ),
+      item( REQUEST, 'grounding', 2 )
+    ] ) );
+
+    expect( result ).toMatchObject( {
+      input: 2,
+      output: 5,
+      request: null,
+      total: 7,
+      status: LLMGenerationCost.Status.INCOMPLETE
+    } );
+    expect( result.items.at( -1 ) ).toEqual(
+      new LLMGenerationCostItem( REQUEST, 'grounding', 2, null, null, LLMGenerationCostItem.Status.MISSING )
+    );
+    expect( Logger.warn ).toHaveBeenCalledWith(
+      'Grounded call with no grounding rate for model',
+      { namespace: 'LLM', modelId: MODEL_ID, providerId: PROVIDER_ID }
+    );
+  } );
+
+  it( 'leaves an ungrounded cost without a request total', async () => {
+    mockFetchModelsPricing.mockResolvedValue( pricing( { input: 2, output: 10 } ) );
+
+    const result = await calculateCosts( usage( [
+      item( INPUT, null, 1_000_000 ),
+      item( OUTPUT, null, 500_000 )
+    ] ) );
+
+    expect( result.request ).toBeNull();
+    expect( result.total ).toBe( 7 );
   } );
 
   it( 'uses decimal arithmetic for fractional prices', async () => {

--- a/sdk/llm/src/utils/grounding.js
+++ b/sdk/llm/src/utils/grounding.js
@@ -6,8 +6,8 @@
  * Verified 2026-09-01: https://cloud.google.com/vertex-ai/generative-ai/pricing
  */
 const UNITS = [
-  { match: /^gemini-3/, label: 'grounding_query', ppm: 14_000 },
-  { match: /^gemini-2/, label: 'grounding_prompt', ppm: 35_000 }
+  { match: /^gemini-3/, label: 'grounding_query', ppm: 14_000, perQuery: true },
+  { match: /^gemini-2/, label: 'grounding_prompt', ppm: 35_000, perQuery: false }
 ];
 
 /**
@@ -29,7 +29,7 @@ export const isGroundingLabel = label => label === GROUNDING_UNKNOWN_LABEL || la
  * here if image or retrieval grounding is enabled.
  *
  * @param {string} modelId - Id of the model that produced the response
- * @param {object} [providerMetadata] - AI SDK provider metadata of the final step
+ * @param {object} [providerMetadata] - AI SDK provider metadata of a single step
  * @returns {{ label: string, amount: number } | null} Grounding label and amount, or null when ungrounded
  */
 export const parseGroundingUsage = ( modelId, providerMetadata ) => {
@@ -46,6 +46,6 @@ export const parseGroundingUsage = ( modelId, providerMetadata ) => {
 
   return {
     label: unit.label,
-    amount: unit.label === 'grounding_query' ? queries.length : 1
+    amount: unit.perQuery ? queries.length : 1
   };
 };

--- a/sdk/llm/src/utils/grounding.js
+++ b/sdk/llm/src/utils/grounding.js
@@ -1,0 +1,51 @@
+/**
+ * Grounding with Google Search is billed per request, not per token, and models.dev carries no
+ * per-request rate, so the table lives here. Gemini 3 bills per Grounding Query; Gemini 2.x bills
+ * per Grounding Prompt, once, regardless of query count. Different units, so the family decides
+ * both the label and the amount. Rates are price-per-million to match `ppm` semantics.
+ * Verified 2026-09-01: https://cloud.google.com/vertex-ai/generative-ai/pricing
+ */
+const UNITS = [
+  { match: /^gemini-3/, label: 'grounding_query', ppm: 14_000 },
+  { match: /^gemini-2/, label: 'grounding_prompt', ppm: 35_000 }
+];
+
+/**
+ * Unknown family: still record the quantity so the call is visibly unpriced rather than silently
+ * token-only. No rate resolves for this label, so the item lands MISSING and the cost attribute
+ * goes INCOMPLETE.
+ */
+export const GROUNDING_UNKNOWN_LABEL = 'grounding';
+
+export const GROUNDING_PPM = Object.fromEntries( UNITS.map( u => [ u.label, u.ppm ] ) );
+
+export const isGroundingLabel = label => label === GROUNDING_UNKNOWN_LABEL || label in GROUNDING_PPM;
+
+/**
+ * Extracts the billable grounding quantity from provider metadata.
+ *
+ * Counts web-search grounding only. `groundingMetadata` also carries `imageSearchQueries` and
+ * `retrievalQueries`, which bill on their own terms; neither appears in current traffic. Extend
+ * here if image or retrieval grounding is enabled.
+ *
+ * @param {string} modelId - Id of the model that produced the response
+ * @param {object} [providerMetadata] - AI SDK provider metadata of the final step
+ * @returns {{ label: string, amount: number } | null} Grounding label and amount, or null when ungrounded
+ */
+export const parseGroundingUsage = ( modelId, providerMetadata ) => {
+  const meta = providerMetadata?.vertex ?? providerMetadata?.google;
+  const queries = meta?.groundingMetadata?.webSearchQueries;
+  if ( !Array.isArray( queries ) || queries.length === 0 ) {
+    return null;
+  }
+
+  const unit = UNITS.find( u => u.match.test( modelId ) );
+  if ( !unit ) {
+    return { label: GROUNDING_UNKNOWN_LABEL, amount: queries.length };
+  }
+
+  return {
+    label: unit.label,
+    amount: unit.label === 'grounding_query' ? queries.length : 1
+  };
+};

--- a/sdk/llm/src/utils/grounding.js
+++ b/sdk/llm/src/utils/grounding.js
@@ -17,7 +17,7 @@ const UNITS = [
  */
 export const GROUNDING_UNKNOWN_LABEL = 'grounding';
 
-export const GROUNDING_PPM = Object.fromEntries( UNITS.map( u => [ u.label, u.ppm ] ) );
+export const GroundingPpmMap = new Map( UNITS.map( u => [ u.label, u.ppm ] ) );
 
 /**
  * Extracts the billable grounding quantity from provider metadata.

--- a/sdk/llm/src/utils/grounding.js
+++ b/sdk/llm/src/utils/grounding.js
@@ -19,8 +19,6 @@ export const GROUNDING_UNKNOWN_LABEL = 'grounding';
 
 export const GROUNDING_PPM = Object.fromEntries( UNITS.map( u => [ u.label, u.ppm ] ) );
 
-export const isGroundingLabel = label => label === GROUNDING_UNKNOWN_LABEL || label in GROUNDING_PPM;
-
 /**
  * Extracts the billable grounding quantity from provider metadata.
  *

--- a/sdk/llm/src/utils/grounding.spec.js
+++ b/sdk/llm/src/utils/grounding.spec.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import googleVertexText from '../fixtures/text_response_v7_google_vertex.js';
-import { GROUNDING_PPM, GROUNDING_UNKNOWN_LABEL, isGroundingLabel, parseGroundingUsage } from './grounding.js';
+import { GROUNDING_PPM, GROUNDING_UNKNOWN_LABEL, parseGroundingUsage } from './grounding.js';
 
 const metadata = ( key, webSearchQueries ) => ( {
   [key]: { groundingMetadata: { webSearchQueries } }
@@ -12,16 +12,6 @@ describe( 'GROUNDING_PPM', () => {
       grounding_query: 14_000,
       grounding_prompt: 35_000
     } );
-  } );
-} );
-
-describe( 'isGroundingLabel', () => {
-  it.each( [ 'grounding_query', 'grounding_prompt', GROUNDING_UNKNOWN_LABEL ] )( 'matches %s', label => {
-    expect( isGroundingLabel( label ) ).toBe( true );
-  } );
-
-  it.each( [ 'input', 'output', 'reasoning', 'input_cached', null, undefined ] )( 'rejects %s', label => {
-    expect( isGroundingLabel( label ) ).toBe( false );
   } );
 } );
 

--- a/sdk/llm/src/utils/grounding.spec.js
+++ b/sdk/llm/src/utils/grounding.spec.js
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import googleVertexText from '../fixtures/text_response_v7_google_vertex.js';
+import { GROUNDING_PPM, GROUNDING_UNKNOWN_LABEL, isGroundingLabel, parseGroundingUsage } from './grounding.js';
+
+const metadata = ( key, webSearchQueries ) => ( {
+  [key]: { groundingMetadata: { webSearchQueries } }
+} );
+
+describe( 'GROUNDING_PPM', () => {
+  it( 'prices both billing units per million', () => {
+    expect( GROUNDING_PPM ).toEqual( {
+      grounding_query: 14_000,
+      grounding_prompt: 35_000
+    } );
+  } );
+} );
+
+describe( 'isGroundingLabel', () => {
+  it.each( [ 'grounding_query', 'grounding_prompt', GROUNDING_UNKNOWN_LABEL ] )( 'matches %s', label => {
+    expect( isGroundingLabel( label ) ).toBe( true );
+  } );
+
+  it.each( [ 'input', 'output', 'reasoning', 'input_cached', null, undefined ] )( 'rejects %s', label => {
+    expect( isGroundingLabel( label ) ).toBe( false );
+  } );
+} );
+
+describe( 'parseGroundingUsage', () => {
+  it( 'counts one query per web search on Gemini 3', () => {
+    expect( parseGroundingUsage( 'gemini-3.1-flash-lite', metadata( 'vertex', [ 'a', 'b', 'c' ] ) ) ).toEqual( {
+      label: 'grounding_query',
+      amount: 3
+    } );
+  } );
+
+  it( 'charges Gemini 2 once per prompt regardless of query count', () => {
+    expect( parseGroundingUsage( 'gemini-2.5-flash', metadata( 'vertex', [ 'a', 'b', 'c' ] ) ) ).toEqual( {
+      label: 'grounding_prompt',
+      amount: 1
+    } );
+  } );
+
+  it( 'reads the google provider metadata key', () => {
+    expect( parseGroundingUsage( 'gemini-3-pro', metadata( 'google', [ 'a' ] ) ) ).toEqual( {
+      label: 'grounding_query',
+      amount: 1
+    } );
+  } );
+
+  it( 'records an unpriced quantity for an unknown model family', () => {
+    expect( parseGroundingUsage( 'claude-haiku-4-5', metadata( 'vertex', [ 'a', 'b' ] ) ) ).toEqual( {
+      label: GROUNDING_UNKNOWN_LABEL,
+      amount: 2
+    } );
+  } );
+
+  it( 'reads grounding from a Vertex response fixture', () => {
+    expect( parseGroundingUsage( 'gemini-2.5-flash', googleVertexText.finalStep.providerMetadata ) ).toEqual( {
+      label: 'grounding_prompt',
+      amount: 1
+    } );
+  } );
+
+  it.each( [
+    { name: 'no provider metadata', modelId: 'gemini-3-pro', metadata: undefined },
+    { name: 'a non-google provider', modelId: 'gemini-3-pro', metadata: { anthropic: {} } },
+    { name: 'null grounding metadata', modelId: 'gemini-3-pro', metadata: { vertex: { groundingMetadata: null } } },
+    { name: 'no web search queries', modelId: 'gemini-3-pro', metadata: { vertex: { groundingMetadata: {} } } },
+    { name: 'an empty query list', modelId: 'gemini-3-pro', metadata: metadata( 'vertex', [] ) }
+  ] )( 'returns null for $name', ( { modelId, metadata: providerMetadata } ) => {
+    expect( parseGroundingUsage( modelId, providerMetadata ) ).toBeNull();
+  } );
+} );

--- a/sdk/llm/src/utils/grounding.spec.js
+++ b/sdk/llm/src/utils/grounding.spec.js
@@ -1,17 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import googleVertexText from '../fixtures/text_response_v7_google_vertex.js';
-import { GROUNDING_PPM, GROUNDING_UNKNOWN_LABEL, parseGroundingUsage } from './grounding.js';
+import { GroundingPpmMap, GROUNDING_UNKNOWN_LABEL, parseGroundingUsage } from './grounding.js';
 
 const metadata = ( key, webSearchQueries ) => ( {
   [key]: { groundingMetadata: { webSearchQueries } }
 } );
 
-describe( 'GROUNDING_PPM', () => {
+describe( 'GroundingPpmMap', () => {
   it( 'prices both billing units per million', () => {
-    expect( GROUNDING_PPM ).toEqual( {
-      grounding_query: 14_000,
-      grounding_prompt: 35_000
-    } );
+    expect( GroundingPpmMap ).toEqual( new Map( [
+      [ 'grounding_query', 14_000 ],
+      [ 'grounding_prompt', 35_000 ]
+    ] ) );
   } );
 } );
 

--- a/sdk/llm/src/utils/legacy_cost_attribute.js
+++ b/sdk/llm/src/utils/legacy_cost_attribute.js
@@ -1,4 +1,5 @@
 import { Tracing } from '@outputai/core/sdk/runtime';
+import { isGroundingLabel } from './grounding.js';
 import Decimal from 'decimal.js';
 
 const exists = v => Number.isFinite( v );
@@ -21,7 +22,10 @@ export class LLMUsageLegacy extends Tracing.Attribute.BaseAttribute {
     for ( const item of usage ) {
       item.total = Decimal( item.amount ).div( 1_000_000 ).mul( item.ppm ).toNumber();
       this.total = this.total.add( item.total );
-      this.tokensUsed = this.tokensUsed.add( item.amount );
+      // Per-request lines are counted in requests, not tokens
+      if ( !isGroundingLabel( item.type ) ) {
+        this.tokensUsed = this.tokensUsed.add( item.amount );
+      }
     }
 
     this.total = this.total.toNumber();
@@ -69,6 +73,11 @@ export const convertCostToLegacy = cost => {
     if ( reasoningItem ) {
       usage.push( { type: 'reasoning', ppm: reasoningItem.ppm, amount: reasoningItem.amount } );
     }
+  }
+
+  const groundingItem = cost.items.find( ( { group, total } ) => group === 'request' && exists( total ) );
+  if ( groundingItem ) {
+    usage.push( { type: groundingItem.label, ppm: groundingItem.ppm, amount: groundingItem.amount } );
   }
 
   return new LLMUsageLegacy( cost.modelId, usage );

--- a/sdk/llm/src/utils/legacy_cost_attribute.js
+++ b/sdk/llm/src/utils/legacy_cost_attribute.js
@@ -75,9 +75,12 @@ export const convertCostToLegacy = cost => {
     }
   }
 
-  const groundingItem = cost.items.find( ( { group, total } ) => group === 'request' && exists( total ) );
+  // Included even when unrated (status 'missing'), same as cacheReadItem above,
+  // so legacy consumers still see that a grounded call happened.
+  const groundingItem = cost.items.find( ( { group } ) => group === 'request' );
   if ( groundingItem ) {
-    usage.push( { type: groundingItem.label, ppm: groundingItem.ppm, amount: groundingItem.amount } );
+    const ppm = groundingItem.status === 'missing' ? 0 : groundingItem.ppm;
+    usage.push( { type: groundingItem.label, ppm, amount: groundingItem.amount } );
   }
 
   return new LLMUsageLegacy( cost.modelId, usage );

--- a/sdk/llm/src/utils/legacy_cost_attribute.js
+++ b/sdk/llm/src/utils/legacy_cost_attribute.js
@@ -1,5 +1,4 @@
 import { Tracing } from '@outputai/core/sdk/runtime';
-import { isGroundingLabel } from './grounding.js';
 import Decimal from 'decimal.js';
 
 const exists = v => Number.isFinite( v );
@@ -22,10 +21,7 @@ export class LLMUsageLegacy extends Tracing.Attribute.BaseAttribute {
     for ( const item of usage ) {
       item.total = Decimal( item.amount ).div( 1_000_000 ).mul( item.ppm ).toNumber();
       this.total = this.total.add( item.total );
-      // Per-request lines are counted in requests, not tokens
-      if ( !isGroundingLabel( item.type ) ) {
-        this.tokensUsed = this.tokensUsed.add( item.amount );
-      }
+      this.tokensUsed = this.tokensUsed.add( item.amount );
     }
 
     this.total = this.total.toNumber();
@@ -73,14 +69,6 @@ export const convertCostToLegacy = cost => {
     if ( reasoningItem ) {
       usage.push( { type: 'reasoning', ppm: reasoningItem.ppm, amount: reasoningItem.amount } );
     }
-  }
-
-  // Included even when unrated (status 'missing'), same as cacheReadItem above,
-  // so legacy consumers still see that a grounded call happened.
-  const groundingItem = cost.items.find( ( { group } ) => group === 'request' );
-  if ( groundingItem ) {
-    const ppm = groundingItem.status === 'missing' ? 0 : groundingItem.ppm;
-    usage.push( { type: groundingItem.label, ppm, amount: groundingItem.amount } );
   }
 
   return new LLMUsageLegacy( cost.modelId, usage );

--- a/sdk/llm/src/utils/legacy_cost_attribute.spec.js
+++ b/sdk/llm/src/utils/legacy_cost_attribute.spec.js
@@ -261,7 +261,7 @@ describe( 'convertCostToLegacy', () => {
     } );
   } );
 
-  it( 'carries a priced grounding line without counting it as tokens', () => {
+  it( 'omits request-group (grounding) lines; they belong to the new cost attribute only', () => {
     expect( convertCostToLegacy( cost( [
       item( INPUT, null, 100, 2, 0.0002 ),
       item( OUTPUT, null, 50, 10, 0.0005 ),
@@ -271,27 +271,10 @@ describe( 'convertCostToLegacy', () => {
       modelId: MODEL_ID,
       usage: [
         { type: 'input', ppm: 2, amount: 100, total: 0.0002 },
-        { type: 'output', ppm: 10, amount: 50, total: 0.0005 },
-        { type: 'grounding_query', ppm: 14_000, amount: 3, total: 0.042 }
+        { type: 'output', ppm: 10, amount: 50, total: 0.0005 }
       ],
-      total: 0.0427,
+      total: 0.0007,
       tokensUsed: 150
-    } );
-  } );
-
-  it( 'carries an unpriced grounding line as $0 rather than omitting it', () => {
-    expect( convertCostToLegacy( cost( [
-      item( INPUT, null, 100, 2, 0.0002 ),
-      item( REQUEST, 'grounding', 2, null, null, MISSING )
-    ] ) ) ).toEqual( {
-      type: 'llm:usage',
-      modelId: MODEL_ID,
-      usage: [
-        { type: 'input', ppm: 2, amount: 100, total: 0.0002 },
-        { type: 'grounding', ppm: 0, amount: 2, total: 0 }
-      ],
-      total: 0.0002,
-      tokensUsed: 100
     } );
   } );
 

--- a/sdk/llm/src/utils/legacy_cost_attribute.spec.js
+++ b/sdk/llm/src/utils/legacy_cost_attribute.spec.js
@@ -4,6 +4,7 @@ import { LLMUsageLegacy, convertCostToLegacy } from './legacy_cost_attribute.js'
 const MODEL_ID = 'test-model';
 const INPUT = 'input';
 const OUTPUT = 'output';
+const REQUEST = 'request';
 const OK = 'ok';
 const FALLBACK = 'fallback';
 const MISSING = 'missing';
@@ -257,6 +258,39 @@ describe( 'convertCostToLegacy', () => {
       ],
       total: 0,
       tokensUsed: 0
+    } );
+  } );
+
+  it( 'carries a priced grounding line without counting it as tokens', () => {
+    expect( convertCostToLegacy( cost( [
+      item( INPUT, null, 100, 2, 0.0002 ),
+      item( OUTPUT, null, 50, 10, 0.0005 ),
+      item( REQUEST, 'grounding_query', 3, 14_000, 0.042 )
+    ] ) ) ).toEqual( {
+      type: 'llm:usage',
+      modelId: MODEL_ID,
+      usage: [
+        { type: 'input', ppm: 2, amount: 100, total: 0.0002 },
+        { type: 'output', ppm: 10, amount: 50, total: 0.0005 },
+        { type: 'grounding_query', ppm: 14_000, amount: 3, total: 0.042 }
+      ],
+      total: 0.0427,
+      tokensUsed: 150
+    } );
+  } );
+
+  it( 'omits an unpriced grounding line', () => {
+    expect( convertCostToLegacy( cost( [
+      item( INPUT, null, 100, 2, 0.0002 ),
+      item( REQUEST, 'grounding', 2, null, null, MISSING )
+    ] ) ) ).toEqual( {
+      type: 'llm:usage',
+      modelId: MODEL_ID,
+      usage: [
+        { type: 'input', ppm: 2, amount: 100, total: 0.0002 }
+      ],
+      total: 0.0002,
+      tokensUsed: 100
     } );
   } );
 

--- a/sdk/llm/src/utils/legacy_cost_attribute.spec.js
+++ b/sdk/llm/src/utils/legacy_cost_attribute.spec.js
@@ -279,7 +279,7 @@ describe( 'convertCostToLegacy', () => {
     } );
   } );
 
-  it( 'omits an unpriced grounding line', () => {
+  it( 'carries an unpriced grounding line as $0 rather than omitting it', () => {
     expect( convertCostToLegacy( cost( [
       item( INPUT, null, 100, 2, 0.0002 ),
       item( REQUEST, 'grounding', 2, null, null, MISSING )
@@ -287,7 +287,8 @@ describe( 'convertCostToLegacy', () => {
       type: 'llm:usage',
       modelId: MODEL_ID,
       usage: [
-        { type: 'input', ppm: 2, amount: 100, total: 0.0002 }
+        { type: 'input', ppm: 2, amount: 100, total: 0.0002 },
+        { type: 'grounding', ppm: 0, amount: 2, total: 0 }
       ],
       total: 0.0002,
       tokensUsed: 100

--- a/sdk/llm/src/utils/usage.full.spec.js
+++ b/sdk/llm/src/utils/usage.full.spec.js
@@ -14,6 +14,7 @@ import { LLMGenerationUsage, LLMGenerationUsageItem, parseLLMUsage } from './usa
 
 const INPUT = LLMGenerationUsageItem.Group.INPUT;
 const OUTPUT = LLMGenerationUsageItem.Group.OUTPUT;
+const REQUEST = LLMGenerationUsageItem.Group.REQUEST;
 
 const cases = [
   {
@@ -125,7 +126,8 @@ const cases = [
       { group: INPUT, label: 'no_cache', amount: 1032 },
       { group: INPUT, label: 'cache_read', amount: 0 },
       { group: OUTPUT, label: 'text', amount: 793 },
-      { group: OUTPUT, label: 'reasoning', amount: 588 }
+      { group: OUTPUT, label: 'reasoning', amount: 588 },
+      { group: REQUEST, label: 'grounding_prompt', amount: 1 }
     ]
   },
   {
@@ -198,7 +200,8 @@ describe( 'parseLLMUsage with AI SDK response fixtures', () => {
           model: modelId
         }
       },
-      usage: fixture.usage
+      usage: fixture.usage,
+      steps: fixture.steps
     } );
 
     expect( JSON.parse( JSON.stringify( result ) ) ).toEqual( {

--- a/sdk/llm/src/utils/usage.js
+++ b/sdk/llm/src/utils/usage.js
@@ -119,7 +119,8 @@ export const parseLLMUsage = ( { prompt, usage, steps } ) => {
   // Per-query families (Gemini 3) return queries.length per step; per-prompt families (Gemini 2.x)
   // return 1 per grounded step. Summing yields total queries and grounded-step count respectively.
   const grounding = ( steps ?? [] )
-    .map( step => parseGroundingUsage( modelId, step?.providerMetadata ) )
+    .filter( step => step?.providerMetadata )
+    .map( step => parseGroundingUsage( modelId, step.providerMetadata ) )
     .filter( Boolean );
   if ( grounding.length > 0 ) {
     const amount = grounding.reduce( ( sum, g ) => sum + g.amount, 0 );

--- a/sdk/llm/src/utils/usage.js
+++ b/sdk/llm/src/utils/usage.js
@@ -1,12 +1,13 @@
 import Decimal from 'decimal.js';
 import { Tracing } from '@outputai/core/sdk/runtime';
+import { parseGroundingUsage } from './grounding.js';
 
 const exists = v => Number.isSafeInteger( v ) && v >= 0;
 
 const safeSum = ( ...values ) => values.filter( exists ).reduce( ( t, v ) => t + v, 0 );
 
 export class LLMGenerationUsageItem {
-  static Group = { INPUT: 'input', OUTPUT: 'output' };
+  static Group = { INPUT: 'input', OUTPUT: 'output', REQUEST: 'request' };
 
   group;
   label;
@@ -65,10 +66,11 @@ export class LLMGenerationUsage extends Tracing.Attribute.BaseAttribute {
  * @param {string} args.prompt.config.provider - Id of the provider
  * @param {string} args.prompt.config.model - Id of the model
  * @param {object} args.usage - AI SDK usage with aggregate token counts and optional input/output token details
+ * @param {object[]} [args.steps] - AI SDK steps, each with its own `providerMetadata`, used for per-request charges
  *
  * @returns {LLMGenerationUsage | null} LLM generation usage with input, output, total and detailed breakdown
  */
-export const parseLLMUsage = ( { prompt, usage } ) => {
+export const parseLLMUsage = ( { prompt, usage, steps } ) => {
   const { provider: providerId, model: modelId } = prompt.config;
   const { inputTokens, inputTokenDetails, outputTokens, outputTokenDetails } = usage;
   const { noCacheTokens, cacheReadTokens, cacheWriteTokens } = inputTokenDetails ?? {};
@@ -111,6 +113,17 @@ export const parseLLMUsage = ( { prompt, usage } ) => {
     } else {
       items.push( new LLMGenerationUsageItem( group, null, outputTokens ) );
     }
+  }
+
+  // Grounding is billed per step, so aggregate across every step rather than only the final one.
+  // Per-query families (Gemini 3) return queries.length per step; per-prompt families (Gemini 2.x)
+  // return 1 per grounded step. Summing yields total queries and grounded-step count respectively.
+  const grounding = ( steps ?? [] )
+    .map( step => parseGroundingUsage( modelId, step?.providerMetadata ) )
+    .filter( Boolean );
+  if ( grounding.length > 0 ) {
+    const amount = grounding.reduce( ( sum, g ) => sum + g.amount, 0 );
+    items.push( new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.REQUEST, grounding[0].label, amount ) );
   }
 
   if ( items.length === 0 ) {

--- a/sdk/llm/src/utils/usage.spec.js
+++ b/sdk/llm/src/utils/usage.spec.js
@@ -10,6 +10,12 @@ const prompt = {
 };
 
 const parse = usage => parseLLMUsage( { prompt, usage } );
+const step = webSearchQueries => ( { providerMetadata: { vertex: { groundingMetadata: { webSearchQueries } } } } );
+const grounded = ( model, ...steps ) => parseLLMUsage( {
+  prompt: { config: { provider: 'google-vertex', model } },
+  usage: { inputTokens: 100, outputTokens: 50 },
+  steps: steps.map( step )
+} );
 const serialize = value => JSON.parse( JSON.stringify( value ) );
 
 describe( 'LLMGenerationUsage', () => {
@@ -227,6 +233,69 @@ describe( 'parseLLMUsage', () => {
     } );
     expect( result.items ).toEqual( [
       new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.OUTPUT, null, 15 )
+    ] );
+  } );
+
+  it( 'records a Gemini 3 grounded call as one request item per web search query', () => {
+    const result = grounded( 'gemini-3.1-flash-lite', [ 'a', 'b', 'c' ] );
+
+    expect( result.items ).toEqual( [
+      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.INPUT, null, 100 ),
+      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.OUTPUT, null, 50 ),
+      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.REQUEST, 'grounding_query', 3 )
+    ] );
+  } );
+
+  it( 'records a Gemini 2 grounded call as a single request item', () => {
+    const result = grounded( 'gemini-2.5-flash', [ 'a', 'b', 'c' ] );
+
+    expect( result.items.at( -1 ) ).toEqual(
+      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.REQUEST, 'grounding_prompt', 1 )
+    );
+  } );
+
+  it( 'keeps grounding out of the token aggregates', () => {
+    const result = grounded( 'gemini-3.1-flash-lite', [ 'a', 'b', 'c' ] );
+
+    expect( result ).toMatchObject( {
+      status: LLMGenerationUsage.Status.COMPLETE,
+      input: 100,
+      output: 50,
+      total: 150
+    } );
+  } );
+
+  it( 'sums Gemini 3 grounding queries across every step', () => {
+    const result = grounded( 'gemini-3.1-flash-lite', [ 'a', 'b' ], [ 'c' ], [] );
+
+    expect( result.items.at( -1 ) ).toEqual(
+      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.REQUEST, 'grounding_query', 3 )
+    );
+  } );
+
+  it( 'charges Gemini 2 once per grounded step across a multi-step run', () => {
+    const result = grounded( 'gemini-2.5-flash', [ 'a', 'b' ], [ 'c' ], [] );
+
+    expect( result.items.at( -1 ) ).toEqual(
+      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.REQUEST, 'grounding_prompt', 2 )
+    );
+  } );
+
+  it( 'reports grounding for a response without token usage', () => {
+    const result = parseLLMUsage( {
+      prompt,
+      usage: {},
+      steps: [ { providerMetadata: { vertex: { groundingMetadata: { webSearchQueries: [ 'a' ] } } } } ]
+    } );
+
+    expect( result ).toMatchObject( {
+      status: LLMGenerationUsage.Status.INCOMPLETE,
+      input: null,
+      output: null,
+      total: null
+    } );
+    expect( result.items ).toEqual( [
+      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.REQUEST, 'grounding', 1 )
     ] );
   } );
 

--- a/sdk/llm/src/utils/wrap.js
+++ b/sdk/llm/src/utils/wrap.js
@@ -16,6 +16,9 @@ const createResponseProxy = ( { response, properties } ) => new Proxy( response,
   }
 } );
 
+/** Provider metadata of the final step, falling back to the response-level metadata */
+const resolveProviderMetadata = response => response.finalStep?.providerMetadata ?? response.providerMetadata;
+
 /** Generate a trace id, starts the tracing and return the id */
 const startTrace = ( { name, prompt } ) => {
   const traceId = `${name}-${Date.now()}-${randomBytes( 4 ).toString( 'hex' )}`;
@@ -74,7 +77,7 @@ export const wrapGeneration = async ( { name, prompt, fn } ) => {
   try {
     const response = await fn();
     const { usage } = response;
-    const providerMetadata = response.finalStep?.providerMetadata ?? response.providerMetadata;
+    const providerMetadata = resolveProviderMetadata( response );
     const cost = await handleMetering( { traceId, usage, prompt, steps: response.steps } );
 
     if ( Array.isArray( response.images ) ) {
@@ -149,8 +152,8 @@ export const wrapStream = ( { name, prompt, abortSignal, fn } ) => {
     const state = { proxyResponse: null };
     removeAbortListener();
     try {
-      const { text: result, finalStep, usage, steps } = response;
-      const { providerMetadata } = finalStep;
+      const { text: result, usage, steps } = response;
+      const providerMetadata = resolveProviderMetadata( response );
       const cost = await handleMetering( { traceId, usage, prompt, steps } );
       const sources = extractSources( response );
       Tracing.addEventEnd( { id: traceId, details: { result, usage, providerMetadata, sources } } );

--- a/sdk/llm/src/utils/wrap.js
+++ b/sdk/llm/src/utils/wrap.js
@@ -16,20 +16,6 @@ const createResponseProxy = ( { response, properties } ) => new Proxy( response,
   }
 } );
 
-/**
- * Provider metadata of the final step, falling back to the response-level metadata.
- *
- * AI SDK v7 attaches provider metadata to `finalStep`; a text/stream response missing `finalStep`
- * signals a shape regression, so surface it before silently substituting the response-level value.
- * Image responses have no `finalStep` by design, so callers pass `expectFinalStep: false` there.
- */
-const resolveProviderMetadata = ( response, { expectFinalStep = true } = {} ) => {
-  if ( expectFinalStep && !response.finalStep ) {
-    Logger.warn( 'Response missing finalStep; using response-level provider metadata', { namespace: 'LLM' } );
-  }
-  return response.finalStep?.providerMetadata ?? response.providerMetadata;
-};
-
 /** Generate a trace id, starts the tracing and return the id */
 const startTrace = ( { name, prompt } ) => {
   const traceId = `${name}-${Date.now()}-${randomBytes( 4 ).toString( 'hex' )}`;
@@ -88,18 +74,17 @@ export const wrapGeneration = async ( { name, prompt, fn } ) => {
   try {
     const response = await fn();
     const { usage } = response;
-    const isImage = Array.isArray( response.images );
-    const providerMetadata = resolveProviderMetadata( response, { expectFinalStep: !isImage } );
     const cost = await handleMetering( { traceId, usage, prompt, steps: response.steps } );
 
-    if ( isImage ) {
-      const { image, images } = response;
+    if ( Array.isArray( response.images ) ) {
+      const { image, images, providerMetadata } = response;
       const mappedImages = images.map( ( { mediaType, base64 } ) => ( { size: calculateBase64FileSize( base64 ), mediaType } ) );
 
       Tracing.addEventEnd( { id: traceId, details: { result: mappedImages, usage, providerMetadata } } );
       return createResponseProxy( { response, properties: { cost, result: image } } );
     } else {
-      const { text: result } = response;
+      const { text: result, finalStep } = response;
+      const { providerMetadata } = finalStep;
       const sources = extractSources( response );
 
       Tracing.addEventEnd( { id: traceId, details: { result, usage, providerMetadata, sources } } );
@@ -164,8 +149,8 @@ export const wrapStream = ( { name, prompt, abortSignal, fn } ) => {
     const state = { proxyResponse: null };
     removeAbortListener();
     try {
-      const { text: result, usage, steps } = response;
-      const providerMetadata = resolveProviderMetadata( response );
+      const { text: result, finalStep, usage, steps } = response;
+      const { providerMetadata } = finalStep;
       const cost = await handleMetering( { traceId, usage, prompt, steps } );
       const sources = extractSources( response );
       Tracing.addEventEnd( { id: traceId, details: { result, usage, providerMetadata, sources } } );

--- a/sdk/llm/src/utils/wrap.js
+++ b/sdk/llm/src/utils/wrap.js
@@ -31,8 +31,8 @@ const handleError = ( { traceId, error: originalError } ) => {
 };
 
 /** Normalize raw AI SDK usage, calculate cost, attach trace attributes, and emit metering events */
-const handleMetering = async ( { traceId, usage: sdkUsage, prompt } ) => {
-  const usageAttribute = parseLLMUsage( { usage: sdkUsage, prompt } );
+const handleMetering = async ( { traceId, usage: sdkUsage, prompt, steps } ) => {
+  const usageAttribute = parseLLMUsage( { usage: sdkUsage, prompt, steps } );
   if ( !usageAttribute ) {
     return null;
   }
@@ -74,17 +74,17 @@ export const wrapGeneration = async ( { name, prompt, fn } ) => {
   try {
     const response = await fn();
     const { usage } = response;
-    const cost = await handleMetering( { traceId, usage, prompt } );
+    const providerMetadata = response.finalStep?.providerMetadata ?? response.providerMetadata;
+    const cost = await handleMetering( { traceId, usage, prompt, steps: response.steps } );
 
     if ( Array.isArray( response.images ) ) {
-      const { image, images, providerMetadata } = response;
+      const { image, images } = response;
       const mappedImages = images.map( ( { mediaType, base64 } ) => ( { size: calculateBase64FileSize( base64 ), mediaType } ) );
 
       Tracing.addEventEnd( { id: traceId, details: { result: mappedImages, usage, providerMetadata } } );
       return createResponseProxy( { response, properties: { cost, result: image } } );
     } else {
-      const { text: result, finalStep } = response;
-      const { providerMetadata } = finalStep;
+      const { text: result } = response;
       const sources = extractSources( response );
 
       Tracing.addEventEnd( { id: traceId, details: { result, usage, providerMetadata, sources } } );
@@ -149,9 +149,9 @@ export const wrapStream = ( { name, prompt, abortSignal, fn } ) => {
     const state = { proxyResponse: null };
     removeAbortListener();
     try {
-      const { text: result, finalStep, usage } = response;
+      const { text: result, finalStep, usage, steps } = response;
       const { providerMetadata } = finalStep;
-      const cost = await handleMetering( { traceId, usage, prompt } );
+      const cost = await handleMetering( { traceId, usage, prompt, steps } );
       const sources = extractSources( response );
       Tracing.addEventEnd( { id: traceId, details: { result, usage, providerMetadata, sources } } );
       state.proxyResponse = createResponseProxy( { response, properties: { cost, sources, result } } );

--- a/sdk/llm/src/utils/wrap.js
+++ b/sdk/llm/src/utils/wrap.js
@@ -16,8 +16,19 @@ const createResponseProxy = ( { response, properties } ) => new Proxy( response,
   }
 } );
 
-/** Provider metadata of the final step, falling back to the response-level metadata */
-const resolveProviderMetadata = response => response.finalStep?.providerMetadata ?? response.providerMetadata;
+/**
+ * Provider metadata of the final step, falling back to the response-level metadata.
+ *
+ * AI SDK v7 attaches provider metadata to `finalStep`; a text/stream response missing `finalStep`
+ * signals a shape regression, so surface it before silently substituting the response-level value.
+ * Image responses have no `finalStep` by design, so callers pass `expectFinalStep: false` there.
+ */
+const resolveProviderMetadata = ( response, { expectFinalStep = true } = {} ) => {
+  if ( expectFinalStep && !response.finalStep ) {
+    Logger.warn( 'Response missing finalStep; using response-level provider metadata', { namespace: 'LLM' } );
+  }
+  return response.finalStep?.providerMetadata ?? response.providerMetadata;
+};
 
 /** Generate a trace id, starts the tracing and return the id */
 const startTrace = ( { name, prompt } ) => {
@@ -77,10 +88,11 @@ export const wrapGeneration = async ( { name, prompt, fn } ) => {
   try {
     const response = await fn();
     const { usage } = response;
-    const providerMetadata = resolveProviderMetadata( response );
+    const isImage = Array.isArray( response.images );
+    const providerMetadata = resolveProviderMetadata( response, { expectFinalStep: !isImage } );
     const cost = await handleMetering( { traceId, usage, prompt, steps: response.steps } );
 
-    if ( Array.isArray( response.images ) ) {
+    if ( isImage ) {
       const { image, images } = response;
       const mappedImages = images.map( ( { mediaType, base64 } ) => ( { size: calculateBase64FileSize( base64 ), mediaType } ) );
 

--- a/sdk/llm/src/utils/wrap.spec.js
+++ b/sdk/llm/src/utils/wrap.spec.js
@@ -483,7 +483,6 @@ describe( 'wrapGeneration / wrapStream', () => {
       expect( steps[0].providerMetadata.vertex.groundingMetadata.webSearchQueries ).toHaveLength( 2 );
     } );
 
-
     it( 'ends the trace and swallows throws from the onEnd callback', async () => {
       const response = textResponse();
       const { onEndHook } = hooksFrom( 'Agent.stream' );

--- a/sdk/llm/src/utils/wrap.spec.js
+++ b/sdk/llm/src/utils/wrap.spec.js
@@ -11,7 +11,12 @@ const mocks = vi.hoisted( () => ( {
   convertCostToLegacy: vi.fn(),
   calculateBase64FileSize: vi.fn(),
   mapAiError: vi.fn(),
-  randomBytes: vi.fn()
+  randomBytes: vi.fn(),
+  logger: { warn: vi.fn(), error: vi.fn() }
+} ) );
+
+vi.mock( '@outputai/core', () => ( {
+  Logger: mocks.logger
 } ) );
 
 vi.mock( './sources.js', () => ( {
@@ -187,6 +192,34 @@ describe( 'wrapGeneration / wrapStream', () => {
         steps: response.steps
       } );
       expect( mocks.calculateCosts ).toHaveBeenCalledWith( mockUsage );
+    } );
+
+    it( 'warns and falls back to response-level metadata when finalStep is missing', async () => {
+      const response = {
+        text: 'hi',
+        usage: { inputTokens: 2 },
+        providerMetadata: { fallback: true },
+        steps: [],
+        sources: []
+      };
+
+      await wrapGeneration( { name: 'generateText', prompt, fn: async () => response } );
+
+      expect( mocks.logger.warn ).toHaveBeenCalledWith(
+        'Response missing finalStep; using response-level provider metadata',
+        { namespace: 'LLM' }
+      );
+      expect( tracing.addEventEnd ).toHaveBeenCalledWith( expect.objectContaining( {
+        details: expect.objectContaining( { providerMetadata: { fallback: true } } )
+      } ) );
+    } );
+
+    it( 'does not warn for an image response, which has no finalStep by design', async () => {
+      const response = imageResponse();
+
+      await wrapGeneration( { name: 'generateImage', prompt, fn: async () => response } );
+
+      expect( mocks.logger.warn ).not.toHaveBeenCalled();
     } );
 
     it( 'wraps an image response using usage and mapped image metadata', async () => {

--- a/sdk/llm/src/utils/wrap.spec.js
+++ b/sdk/llm/src/utils/wrap.spec.js
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import imageResponseFixture from '../fixtures/image_response_v7_openai.js';
 import streamResponseFixture from '../fixtures/stream_response_v7_openai.js';
 import textResponseFixture from '../fixtures/text_response_v7_openai.js';
+import vertexTextResponseFixture from '../fixtures/text_response_v7_google_vertex.js';
 
 const mocks = vi.hoisted( () => ( {
   extractSources: vi.fn(),
@@ -63,6 +64,7 @@ const clone = value => structuredClone( value );
 const textResponse = () => clone( textResponseFixture );
 const streamResponse = () => clone( streamResponseFixture );
 const imageResponse = () => clone( imageResponseFixture );
+const vertexTextResponse = () => clone( vertexTextResponseFixture );
 
 const prompt = {
   name: 'writer@v1',
@@ -122,7 +124,8 @@ describe( 'wrapGeneration / wrapStream', () => {
       expect( mocks.randomBytes ).toHaveBeenCalledWith( 4 );
       expect( mocks.parseLLMUsage ).toHaveBeenCalledWith( {
         usage: response.usage,
-        prompt
+        prompt,
+        steps: response.steps
       } );
       expect( mocks.calculateCosts ).toHaveBeenCalledWith( mockUsage );
       expect( tracing.addEventAttribute ).toHaveBeenNthCalledWith( 1, {
@@ -172,6 +175,7 @@ describe( 'wrapGeneration / wrapStream', () => {
         usage: { inputTokens: 2 },
         totalUsage: { inputTokens: 99 },
         finalStep: { providerMetadata: undefined },
+        steps: [ { providerMetadata: undefined } ],
         sources: []
       };
 
@@ -179,7 +183,8 @@ describe( 'wrapGeneration / wrapStream', () => {
 
       expect( mocks.parseLLMUsage ).toHaveBeenCalledWith( {
         usage: { inputTokens: 2 },
-        prompt
+        prompt,
+        steps: response.steps
       } );
       expect( mocks.calculateCosts ).toHaveBeenCalledWith( mockUsage );
     } );
@@ -195,7 +200,8 @@ describe( 'wrapGeneration / wrapStream', () => {
 
       expect( mocks.parseLLMUsage ).toHaveBeenCalledWith( {
         usage: response.usage,
-        prompt
+        prompt,
+        steps: response.steps
       } );
       expect( mocks.calculateCosts ).toHaveBeenCalledWith( mockUsage );
       expect( mocks.calculateBase64FileSize ).toHaveBeenCalledWith( response.images[0].base64Data );
@@ -294,6 +300,16 @@ describe( 'wrapGeneration / wrapStream', () => {
       expect( wrapped.cost ).toBeNull();
     } );
 
+    it( 'forwards all step grounding metadata to usage parsing', async () => {
+      const response = vertexTextResponse();
+
+      await wrapGeneration( { name: 'generateText', prompt, fn: async () => response } );
+
+      const { steps } = mocks.parseLLMUsage.mock.calls[0][0];
+      expect( steps ).toBe( response.steps );
+      expect( steps[0].providerMetadata.vertex.groundingMetadata.webSearchQueries ).toHaveLength( 2 );
+    } );
+
     it( 'maps fn errors onto the llm trace and rethrows', async () => {
       const original = new Error( 'boom' );
 
@@ -390,7 +406,8 @@ describe( 'wrapGeneration / wrapStream', () => {
 
       expect( mocks.parseLLMUsage ).toHaveBeenCalledWith( {
         usage: response.usage,
-        prompt
+        prompt,
+        steps: response.steps
       } );
       expect( mocks.calculateCosts ).toHaveBeenCalledWith( mockUsage );
       expect( mocks.extractSources ).toHaveBeenCalledWith( response );
@@ -421,6 +438,18 @@ describe( 'wrapGeneration / wrapStream', () => {
       expect( tracing.addEventEnd ).toHaveBeenCalledOnce();
       expect( tracing.addEventError ).not.toHaveBeenCalled();
     } );
+
+    it( 'forwards all step grounding metadata to usage parsing', async () => {
+      const response = vertexTextResponse();
+      const { onEndHook } = hooksFrom( 'Agent.stream' );
+
+      await onEndHook( response, vi.fn() );
+
+      const { steps } = mocks.parseLLMUsage.mock.calls[0][0];
+      expect( steps ).toBe( response.steps );
+      expect( steps[0].providerMetadata.vertex.groundingMetadata.webSearchQueries ).toHaveLength( 2 );
+    } );
+
 
     it( 'ends the trace and swallows throws from the onEnd callback', async () => {
       const response = textResponse();

--- a/sdk/llm/src/utils/wrap.spec.js
+++ b/sdk/llm/src/utils/wrap.spec.js
@@ -194,34 +194,6 @@ describe( 'wrapGeneration / wrapStream', () => {
       expect( mocks.calculateCosts ).toHaveBeenCalledWith( mockUsage );
     } );
 
-    it( 'warns and falls back to response-level metadata when finalStep is missing', async () => {
-      const response = {
-        text: 'hi',
-        usage: { inputTokens: 2 },
-        providerMetadata: { fallback: true },
-        steps: [],
-        sources: []
-      };
-
-      await wrapGeneration( { name: 'generateText', prompt, fn: async () => response } );
-
-      expect( mocks.logger.warn ).toHaveBeenCalledWith(
-        'Response missing finalStep; using response-level provider metadata',
-        { namespace: 'LLM' }
-      );
-      expect( tracing.addEventEnd ).toHaveBeenCalledWith( expect.objectContaining( {
-        details: expect.objectContaining( { providerMetadata: { fallback: true } } )
-      } ) );
-    } );
-
-    it( 'does not warn for an image response, which has no finalStep by design', async () => {
-      const response = imageResponse();
-
-      await wrapGeneration( { name: 'generateImage', prompt, fn: async () => response } );
-
-      expect( mocks.logger.warn ).not.toHaveBeenCalled();
-    } );
-
     it( 'wraps an image response using usage and mapped image metadata', async () => {
       const response = imageResponse();
 


### PR DESCRIPTION
## Summary

Track and report Google Vertex grounding costs for Gemini 2.x and 3.

Using grounded search in prompts (by adding `tools.googleSearch: {}` to the frontmatter) instructs the model to use searching which bills per request separately from tokens. It bills per grounding prompt on Gemini 2.x, and per grounding query on Gemini 3. Our `models.dev/api.json` doesn't have any rate information for those costs (at this time). That cost wasn't tracked in the tracefile or included in the new `llm:generation:cost` or legacy `cost:llm:request`reporting. 

This PR adds parsing `groundingMetadata.webSearchQueries` across all response steps and prices it from a local rate table; unknown model families record the quantity as an unpriced line.