### PR TITLE
refactor(llm): Renamed cost and usage attribute requests to tools (OUT-571)

### DIFF
--- a/.changeset/legal-teeth-rule.md
+++ b/.changeset/legal-teeth-rule.md
@@ -3,6 +3,6 @@
 "@outputai/llm": minor
 ---
 
-Added support for pricing Gemini grounded search, which providers bill per request rather than per token. `LLMGenerationUsage` and `LLMGenerationCost` items gain a `request` group alongside `input` and `output`. The legacy `cost:llm:request` payload is unchanged and does not carry grounding charges — its shape is frozen, so grounding costs are only visible on the new normalized attribute.
+Added support for pricing Gemini grounded search, which providers bill per request rather than per token. `LLMGenerationUsage` and `LLMGenerationCost` items gain a `tools` group alongside `input` and `output`, and `LLMGenerationCost` gains a matching `tools` aggregate that is included in `total`. The legacy `cost:llm:request` payload is unchanged and does not carry grounding charges - its shape is frozen, so grounding costs are only visible on the new normalized attribute.
 
-`output workflow cost` prices these request-based charges and marks any call with an unpriced charge (grounding or otherwise) with a `*` and a "cost incomplete" footnote, since the reported total understates the actual bill.
+`output workflow cost` prices these tool charges and marks any call with an unpriced charge (grounding or otherwise) with a `*` and a "cost incomplete" footnote, since the reported total understates the actual bill.

--- a/docs/guides/costs/cost-events.mdx
+++ b/docs/guides/costs/cost-events.mdx
@@ -118,7 +118,7 @@ The handler receives the standard event envelope. `payload.usage` is always pres
       "pricingFreshness": "cached",
       "input": 0.001085,
       "output": 0.000135,
-      "request": null,
+      "tools": null,
       "total": 0.00122,
       "items": [
         { "group": "input", "label": "no_cache", "amount": 217, "ppm": 5, "total": 0.001085, "status": "ok" },
@@ -156,13 +156,13 @@ The handler receives the standard event envelope. `payload.usage` is always pres
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `group` | `"input" \| "output" \| "request"` | Aggregate category. `request` covers per-request charges such as grounding with Google Search, billed per request rather than per token. |
-| `label` | `string \| null` | Input detail (`no_cache`, `cache_read`, `cache_write`), output detail (`text`, `reasoning`), request detail (`grounding_query`, `grounding_prompt`, or `grounding` when the rate is unknown), or `null` for aggregate usage. |
-| `amount` | `number` | Count for this dimension: a token count for `input`/`output` items, and a query or grounded-request count for `request` items. |
+| `group` | `"input" \| "output" \| "tools"` | Aggregate category. `tools` covers tool charges such as grounding with Google Search, billed per request rather than per token. |
+| `label` | `string \| null` | Input detail (`no_cache`, `cache_read`, `cache_write`), output detail (`text`, `reasoning`), tool detail (`grounding_query`, `grounding_prompt`, or `grounding` when the rate is unknown), or `null` for aggregate usage. |
+| `amount` | `number` | Count for this dimension: a token count for `input`/`output` items, and a query or grounded-request count for `tools` items. |
 
 When the detailed counts do not reconcile with the aggregate count, Output keeps the aggregate input or output item instead of recording a misleading breakdown.
 
-Per-request items are recorded independently from tokens and are excluded from the `input`, `output`, and `total` token aggregates above.
+Tool items are recorded independently from tokens and are excluded from the `input`, `output`, and `total` token aggregates above.
 
 ### Normalized cost
 
@@ -170,8 +170,8 @@ Per-request items are recorded independently from tokens and are excluded from t
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `input`, `output`, `request`, `total` | `number \| null` | Aggregate dollar costs for available priced items. `request` holds per-request charges (such as grounding), and `total` is the sum of `input`, `output`, and `request`. |
-| `status` | `"precise" \| "imprecise" \| "incomplete"` | Whether all rates were exact, a fallback rate was used or the rates came from the bundled snapshot, or usage/pricing was incomplete. A per-request charge with no known rate lands `incomplete`. |
+| `input`, `output`, `tools`, `total` | `number \| null` | Aggregate dollar costs for available priced items. `tools` holds tool charges (such as grounding), and `total` is the sum of `input`, `output`, and `tools`. |
+| `status` | `"precise" \| "imprecise" \| "incomplete"` | Whether all rates were exact, a fallback rate was used or the rates came from the bundled snapshot, or usage/pricing was incomplete. A tool charge with no known rate lands `incomplete`. |
 | `pricingFreshness` | `"live" \| "cached" \| "stale" \| "snapshot"` | How current the rate table was: fetched during this call, served from the 24-hour cache, kept past its TTL because a refresh failed, or read from the point-in-time snapshot bundled with the package. Only `snapshot` downgrades `status` to `imprecise`. |
 | `items[].ppm` | `number \| null` | Applied price per million tokens. |
 | `items[].total` | `number \| null` | Calculated item cost. |

--- a/sdk/cli/src/services/cost_calculator.spec.ts
+++ b/sdk/cli/src/services/cost_calculator.spec.ts
@@ -68,7 +68,7 @@ function llmCostNode(
     items.filter( item => item.group === group ).reduce( ( sum, item ) => sum + ( item.total ?? 0 ), 0 );
   const input = totalOf( 'input' );
   const output = totalOf( 'output' );
-  const request = totalOf( 'request' );
+  const tools = totalOf( 'tools' );
 
   return {
     id,
@@ -81,8 +81,8 @@ function llmCostNode(
         modelId: model,
         input,
         output,
-        request,
-        total: input + output + request,
+        tools,
+        total: input + output + tools,
         status,
         items
       }
@@ -334,11 +334,11 @@ describe( 'findLLMCalls', () => {
     expect( calls[0].originalCost ).toBeCloseTo( 0.001965, 8 );
   } );
 
-  it( 'reads a priced grounding request item without counting it as tokens', () => {
+  it( 'reads a priced grounding tools item without counting it as tokens', () => {
     const items: LLMGenerationCost['items'] = [
       { group: 'input', label: 'no_cache', amount: 1032, ppm: 0.3, total: 0.0003096, status: 'ok' },
       { group: 'output', label: 'text', amount: 793, ppm: 2.5, total: 0.0019825, status: 'ok' },
-      { group: 'request', label: 'grounding_prompt', amount: 1, ppm: 35_000, total: 0.035, status: 'ok' }
+      { group: 'tools', label: 'grounding_prompt', amount: 1, ppm: 35_000, total: 0.035, status: 'ok' }
     ];
     const calls = findLLMCalls( {
       kind: 'workflow',
@@ -354,8 +354,8 @@ describe( 'findLLMCalls', () => {
       outputTokens: 793,
       reasoningTokens: 0
     } );
-    expect( calls[0].lines.find( l => l.type === 'request_grounding_prompt' ) ).toEqual( {
-      type: 'request_grounding_prompt',
+    expect( calls[0].lines.find( l => l.type === 'tools_grounding_prompt' ) ).toEqual( {
+      type: 'tools_grounding_prompt',
       ppm: 35_000,
       amount: 1,
       total: 0.035
@@ -366,7 +366,7 @@ describe( 'findLLMCalls', () => {
     const items: LLMGenerationCost['items'] = [
       { group: 'input', label: 'no_cache', amount: 1032, ppm: 0.3, total: 0.0003096, status: 'ok' },
       { group: 'output', label: 'text', amount: 793, ppm: 2.5, total: 0.0019825, status: 'ok' },
-      { group: 'request', label: 'grounding_prompt', amount: 1, ppm: 35_000, total: 0.035, status: 'ok' }
+      { group: 'tools', label: 'grounding_prompt', amount: 1, ppm: 35_000, total: 0.035, status: 'ok' }
     ];
     const config = {
       models: { 'gemini-2.5-flash': { provider: 'google-vertex', input: 0.3, output: 2.5 } },
@@ -385,7 +385,7 @@ describe( 'findLLMCalls', () => {
     const items: LLMGenerationCost['items'] = [
       { group: 'input', label: 'no_cache', amount: 1000, ppm: 1, total: 0.001, status: 'ok' },
       { group: 'output', label: null, amount: 500, ppm: 5, total: 0.0025, status: 'ok' },
-      { group: 'request', label: 'grounding', amount: 3, ppm: null, total: null, status: 'missing' }
+      { group: 'tools', label: 'grounding', amount: 3, ppm: null, total: null, status: 'missing' }
     ];
     const calls = findLLMCalls( {
       kind: 'workflow',
@@ -394,8 +394,8 @@ describe( 'findLLMCalls', () => {
 
     expect( calls[0].incomplete ).toBe( true );
     // The unrated line still shows up (as $0), but the call carries the signal.
-    expect( calls[0].lines.find( l => l.type === 'request_grounding' ) ).toEqual( {
-      type: 'request_grounding',
+    expect( calls[0].lines.find( l => l.type === 'tools_grounding' ) ).toEqual( {
+      type: 'tools_grounding',
       ppm: 0,
       amount: 3,
       total: 0

--- a/sdk/llm/src/index.d.ts
+++ b/sdk/llm/src/index.d.ts
@@ -341,9 +341,9 @@ export type ExtractedSource =
 
 export type LLMGenerationUsageStatus = 'complete' | 'incomplete';
 
-/** Token usage reported for one normalized LLM usage component. `request` counts billable requests, not tokens. */
+/** Token usage reported for one normalized LLM usage component. `tools` counts billable tool calls, not tokens. */
 export interface LLMGenerationUsageItem {
-  group: 'input' | 'output' | 'request';
+  group: 'input' | 'output' | 'tools';
   label: string | null;
   amount: number;
 }
@@ -387,7 +387,7 @@ export type LLMGenerationCostPricingFreshness = 'live' | 'cached' | 'stale' | 's
 
 /** Cost calculated for one normalized LLM usage item. */
 export interface LLMGenerationCostItem {
-  group: 'input' | 'output' | 'request';
+  group: 'input' | 'output' | 'tools';
   label: string | null;
   amount: number;
   ppm: number | null;
@@ -402,7 +402,7 @@ export interface LLMGenerationCost extends BaseAttribute {
   modelId: string;
   input: number | null;
   output: number | null;
-  request: number | null;
+  tools: number | null;
   total: number | null;
   status: LLMGenerationCostStatus;
   /** How current the rate table was. Absent on costs recorded before this field existed. */

--- a/sdk/llm/src/utils/cost.full.spec.js
+++ b/sdk/llm/src/utils/cost.full.spec.js
@@ -25,7 +25,7 @@ import { LLMGenerationUsageItem, parseLLMUsage } from './usage.js';
 
 const INPUT = LLMGenerationUsageItem.Group.INPUT;
 const OUTPUT = LLMGenerationUsageItem.Group.OUTPUT;
-const REQUEST = LLMGenerationUsageItem.Group.REQUEST;
+const TOOLS = LLMGenerationUsageItem.Group.TOOLS;
 const OK = LLMGenerationCostItem.Status.OK;
 const FALLBACK = LLMGenerationCostItem.Status.FALLBACK;
 const MISSING = LLMGenerationCostItem.Status.MISSING;
@@ -156,7 +156,7 @@ const cases = [
     modelId: 'gemini-2.5-flash',
     input: 0.0003096,
     output: 0.0034525,
-    request: 0.035,
+    tools: 0.035,
     total: 0.0387621,
     status: LLMGenerationCost.Status.IMPRECISE,
     items: [
@@ -164,7 +164,7 @@ const cases = [
       [ INPUT, 'cache_read', 0, 0.03, 0, OK ],
       [ OUTPUT, 'text', 793, 2.5, 0.0019825, OK ],
       [ OUTPUT, 'reasoning', 588, 2.5, 0.00147, FALLBACK ],
-      [ REQUEST, 'grounding_prompt', 1, 35_000, 0.035, OK ]
+      [ TOOLS, 'grounding_prompt', 1, 35_000, 0.035, OK ]
     ]
   },
   {
@@ -241,7 +241,7 @@ describe( 'calculateCosts with AI SDK response fixtures', () => {
     modelId,
     input,
     output,
-    request = null,
+    tools = null,
     total,
     status,
     items
@@ -264,7 +264,7 @@ describe( 'calculateCosts with AI SDK response fixtures', () => {
       modelId,
       input,
       output,
-      request,
+      tools,
       total,
       status,
       pricingFreshness: Freshness.LIVE,

--- a/sdk/llm/src/utils/cost.js
+++ b/sdk/llm/src/utils/cost.js
@@ -42,7 +42,7 @@ export class LLMGenerationCost extends Tracing.Attribute.BaseAttribute {
   modelId;
   input = null;
   output = null;
-  request = null;
+  tools = null;
   total = null;
   status = LLMGenerationCost.Status.INCOMPLETE;
   pricingFreshness = null;
@@ -70,9 +70,9 @@ export class LLMGenerationCost extends Tracing.Attribute.BaseAttribute {
     };
     this.input = sumGroup( LLMGenerationUsageItem.Group.INPUT );
     this.output = sumGroup( LLMGenerationUsageItem.Group.OUTPUT );
-    this.request = sumGroup( LLMGenerationUsageItem.Group.REQUEST );
-    if ( exists( this.input ) || exists( this.output ) || exists( this.request ) ) {
-      this.total = Decimal( this.input ?? 0 ).add( this.output ?? 0 ).add( this.request ?? 0 ).toNumber();
+    this.tools = sumGroup( LLMGenerationUsageItem.Group.TOOLS );
+    if ( exists( this.input ) || exists( this.output ) || exists( this.tools ) ) {
+      this.total = Decimal( this.input ?? 0 ).add( this.output ?? 0 ).add( this.tools ?? 0 ).toNumber();
     }
   }
 }
@@ -89,8 +89,8 @@ const resolveValue = values => {
 };
 
 const resolvePrice = ( { group, label, pricing } ) => {
-  // Per-request charges are never token-priced: models.dev has no rate for them.
-  if ( group === LLMGenerationUsageItem.Group.REQUEST ) {
+  // Tool charges are never token-priced: models.dev has no rate for them.
+  if ( group === LLMGenerationUsageItem.Group.TOOLS ) {
     return resolveValue( [ GroundingPpmMap.get( label ) ] );
   }
   if ( !pricing ) {
@@ -140,10 +140,10 @@ export const calculateCosts = async usage => {
     return new LLMGenerationCostItem( group, label, amount, ppm, total, status );
   } );
 
-  const unrated = items.some( v =>
-    v.group === LLMGenerationUsageItem.Group.REQUEST && v.status === LLMGenerationCostItem.Status.MISSING );
+  const unrated = items.find( v =>
+    v.group === LLMGenerationUsageItem.Group.TOOLS && v.status === LLMGenerationCostItem.Status.MISSING );
   if ( unrated ) {
-    Logger.warn( 'Grounded call with no grounding rate for model', { namespace: 'LLM', modelId, providerId } );
+    Logger.warn( 'Tool call with no rate for model', { namespace: 'LLM', modelId, providerId, type: unrated.label } );
   }
 
   return new LLMGenerationCost( modelId, providerId, items, usage.status, pricingFreshness );

--- a/sdk/llm/src/utils/cost.spec.js
+++ b/sdk/llm/src/utils/cost.spec.js
@@ -14,7 +14,7 @@ import { LLMGenerationUsage, LLMGenerationUsageItem } from './usage.js';
 
 const INPUT = LLMGenerationUsageItem.Group.INPUT;
 const OUTPUT = LLMGenerationUsageItem.Group.OUTPUT;
-const REQUEST = LLMGenerationUsageItem.Group.REQUEST;
+const TOOLS = LLMGenerationUsageItem.Group.TOOLS;
 const MODEL_ID = 'test-model';
 const PROVIDER_ID = 'test-provider';
 
@@ -64,7 +64,7 @@ describe( 'calculateCosts', () => {
       modelId: MODEL_ID,
       input: 2,
       output: 5,
-      request: null,
+      tools: null,
       total: 7,
       status: LLMGenerationCost.Status.PRECISE,
       pricingFreshness: Freshness.LIVE,
@@ -234,18 +234,18 @@ describe( 'calculateCosts', () => {
     const result = await calculateCosts( usage( [
       item( INPUT, null, 1_000_000 ),
       item( OUTPUT, null, 500_000 ),
-      item( REQUEST, 'grounding_query', 3 )
+      item( TOOLS, 'grounding_query', 3 )
     ] ) );
 
     expect( result ).toMatchObject( {
       input: 2,
       output: 5,
-      request: 0.042,
+      tools: 0.042,
       total: 7.042,
       status: LLMGenerationCost.Status.PRECISE
     } );
     expect( result.items.at( -1 ) ).toEqual(
-      new LLMGenerationCostItem( REQUEST, 'grounding_query', 3, 14_000, 0.042, LLMGenerationCostItem.Status.OK )
+      new LLMGenerationCostItem( TOOLS, 'grounding_query', 3, 14_000, 0.042, LLMGenerationCostItem.Status.OK )
     );
     expect( Logger.warn ).not.toHaveBeenCalled();
   } );
@@ -256,25 +256,25 @@ describe( 'calculateCosts', () => {
     const result = await calculateCosts( usage( [
       item( INPUT, null, 1_000_000 ),
       item( OUTPUT, null, 500_000 ),
-      item( REQUEST, 'grounding_prompt', 1 )
+      item( TOOLS, 'grounding_prompt', 1 )
     ] ) );
 
     expect( result ).toMatchObject( {
-      request: 0.035,
+      tools: 0.035,
       total: 7.035,
       status: LLMGenerationCost.Status.PRECISE
     } );
   } );
 
-  it( 'never prices a request item at the input token rate', async () => {
+  it( 'never prices a tools item at the input token rate', async () => {
     mockFetchModelsPricing.mockResolvedValue( table( new Map() ) );
 
     const result = await calculateCosts( usage( [
-      item( REQUEST, 'grounding_query', 2 )
+      item( TOOLS, 'grounding_query', 2 )
     ] ) );
 
     expect( result.items ).toEqual( [
-      new LLMGenerationCostItem( REQUEST, 'grounding_query', 2, 14_000, 0.028, LLMGenerationCostItem.Status.OK )
+      new LLMGenerationCostItem( TOOLS, 'grounding_query', 2, 14_000, 0.028, LLMGenerationCostItem.Status.OK )
     ] );
   } );
 
@@ -284,26 +284,26 @@ describe( 'calculateCosts', () => {
     const result = await calculateCosts( usage( [
       item( INPUT, null, 1_000_000 ),
       item( OUTPUT, null, 500_000 ),
-      item( REQUEST, 'grounding', 2 )
+      item( TOOLS, 'grounding', 2 )
     ] ) );
 
     expect( result ).toMatchObject( {
       input: 2,
       output: 5,
-      request: null,
+      tools: null,
       total: 7,
       status: LLMGenerationCost.Status.INCOMPLETE
     } );
     expect( result.items.at( -1 ) ).toEqual(
-      new LLMGenerationCostItem( REQUEST, 'grounding', 2, null, null, LLMGenerationCostItem.Status.MISSING )
+      new LLMGenerationCostItem( TOOLS, 'grounding', 2, null, null, LLMGenerationCostItem.Status.MISSING )
     );
     expect( Logger.warn ).toHaveBeenCalledWith(
-      'Grounded call with no grounding rate for model',
-      { namespace: 'LLM', modelId: MODEL_ID, providerId: PROVIDER_ID }
+      'Tool call with no rate for model',
+      { namespace: 'LLM', modelId: MODEL_ID, providerId: PROVIDER_ID, type: 'grounding' }
     );
   } );
 
-  it( 'leaves an ungrounded cost without a request total', async () => {
+  it( 'leaves an ungrounded cost without a tools total', async () => {
     mockFetchModelsPricing.mockResolvedValue( pricing( { input: 2, output: 10 } ) );
 
     const result = await calculateCosts( usage( [
@@ -311,7 +311,7 @@ describe( 'calculateCosts', () => {
       item( OUTPUT, null, 500_000 )
     ] ) );
 
-    expect( result.request ).toBeNull();
+    expect( result.tools ).toBeNull();
     expect( result.total ).toBe( 7 );
   } );
 

--- a/sdk/llm/src/utils/legacy_cost_attribute.spec.js
+++ b/sdk/llm/src/utils/legacy_cost_attribute.spec.js
@@ -4,7 +4,7 @@ import { LLMUsageLegacy, convertCostToLegacy } from './legacy_cost_attribute.js'
 const MODEL_ID = 'test-model';
 const INPUT = 'input';
 const OUTPUT = 'output';
-const REQUEST = 'request';
+const TOOLS = 'tools';
 const OK = 'ok';
 const FALLBACK = 'fallback';
 const MISSING = 'missing';
@@ -261,11 +261,11 @@ describe( 'convertCostToLegacy', () => {
     } );
   } );
 
-  it( 'omits request-group (grounding) lines; they belong to the new cost attribute only', () => {
+  it( 'omits tools-group (grounding) lines; they belong to the new cost attribute only', () => {
     expect( convertCostToLegacy( cost( [
       item( INPUT, null, 100, 2, 0.0002 ),
       item( OUTPUT, null, 50, 10, 0.0005 ),
-      item( REQUEST, 'grounding_query', 3, 14_000, 0.042 )
+      item( TOOLS, 'grounding_query', 3, 14_000, 0.042 )
     ] ) ) ).toEqual( {
       type: 'llm:usage',
       modelId: MODEL_ID,

--- a/sdk/llm/src/utils/usage.full.spec.js
+++ b/sdk/llm/src/utils/usage.full.spec.js
@@ -14,7 +14,7 @@ import { LLMGenerationUsage, LLMGenerationUsageItem, parseLLMUsage } from './usa
 
 const INPUT = LLMGenerationUsageItem.Group.INPUT;
 const OUTPUT = LLMGenerationUsageItem.Group.OUTPUT;
-const REQUEST = LLMGenerationUsageItem.Group.REQUEST;
+const TOOLS = LLMGenerationUsageItem.Group.TOOLS;
 
 const cases = [
   {
@@ -127,7 +127,7 @@ const cases = [
       { group: INPUT, label: 'cache_read', amount: 0 },
       { group: OUTPUT, label: 'text', amount: 793 },
       { group: OUTPUT, label: 'reasoning', amount: 588 },
-      { group: REQUEST, label: 'grounding_prompt', amount: 1 }
+      { group: TOOLS, label: 'grounding_prompt', amount: 1 }
     ]
   },
   {

--- a/sdk/llm/src/utils/usage.js
+++ b/sdk/llm/src/utils/usage.js
@@ -7,7 +7,7 @@ const exists = v => Number.isSafeInteger( v ) && v >= 0;
 const safeSum = ( ...values ) => values.filter( exists ).reduce( ( t, v ) => t + v, 0 );
 
 export class LLMGenerationUsageItem {
-  static Group = { INPUT: 'input', OUTPUT: 'output', REQUEST: 'request' };
+  static Group = { INPUT: 'input', OUTPUT: 'output', TOOLS: 'tools' };
 
   group;
   label;
@@ -124,7 +124,7 @@ export const parseLLMUsage = ( { prompt, usage, steps } ) => {
     .filter( Boolean );
   if ( grounding.length > 0 ) {
     const amount = grounding.reduce( ( sum, g ) => sum + g.amount, 0 );
-    items.push( new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.REQUEST, grounding[0].label, amount ) );
+    items.push( new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.TOOLS, grounding[0].label, amount ) );
   }
 
   if ( items.length === 0 ) {

--- a/sdk/llm/src/utils/usage.spec.js
+++ b/sdk/llm/src/utils/usage.spec.js
@@ -236,21 +236,21 @@ describe( 'parseLLMUsage', () => {
     ] );
   } );
 
-  it( 'records a Gemini 3 grounded call as one request item per web search query', () => {
+  it( 'records a Gemini 3 grounded call as one tools item per web search query', () => {
     const result = grounded( 'gemini-3.1-flash-lite', [ 'a', 'b', 'c' ] );
 
     expect( result.items ).toEqual( [
       new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.INPUT, null, 100 ),
       new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.OUTPUT, null, 50 ),
-      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.REQUEST, 'grounding_query', 3 )
+      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.TOOLS, 'grounding_query', 3 )
     ] );
   } );
 
-  it( 'records a Gemini 2 grounded call as a single request item', () => {
+  it( 'records a Gemini 2 grounded call as a single tools item', () => {
     const result = grounded( 'gemini-2.5-flash', [ 'a', 'b', 'c' ] );
 
     expect( result.items.at( -1 ) ).toEqual(
-      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.REQUEST, 'grounding_prompt', 1 )
+      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.TOOLS, 'grounding_prompt', 1 )
     );
   } );
 
@@ -269,7 +269,7 @@ describe( 'parseLLMUsage', () => {
     const result = grounded( 'gemini-3.1-flash-lite', [ 'a', 'b' ], [ 'c' ], [] );
 
     expect( result.items.at( -1 ) ).toEqual(
-      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.REQUEST, 'grounding_query', 3 )
+      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.TOOLS, 'grounding_query', 3 )
     );
   } );
 
@@ -277,7 +277,7 @@ describe( 'parseLLMUsage', () => {
     const result = grounded( 'gemini-2.5-flash', [ 'a', 'b' ], [ 'c' ], [] );
 
     expect( result.items.at( -1 ) ).toEqual(
-      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.REQUEST, 'grounding_prompt', 2 )
+      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.TOOLS, 'grounding_prompt', 2 )
     );
   } );
 
@@ -295,7 +295,7 @@ describe( 'parseLLMUsage', () => {
       total: null
     } );
     expect( result.items ).toEqual( [
-      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.REQUEST, 'grounding', 1 )
+      new LLMGenerationUsageItem( LLMGenerationUsageItem.Group.TOOLS, 'grounding', 1 )
     ] );
   } );
 


### PR DESCRIPTION
## Summary

- Renamed "request" to "tools" in the `llm:generation:usage` and `llm:generation:cost`. This was done to allow this to hold other non-token usage, besides request/grounding, but clearly distinguish it from normal token based requests.
