### PR TITLE
feat(llm): New Google Vertex Auth env var (OUT-551)

### DIFF
--- a/.changeset/sparkly-rabbits-yawn.md
+++ b/.changeset/sparkly-rabbits-yawn.md
@@ -1,0 +1,5 @@
+---
+"@outputai/llm": patch
+---
+
+Added `GCP_CREDENTIALS_JSON` support to the built-in `google-vertex` provider. Set it to the contents of a service account key file, either raw JSON or base64 encoded, to authenticate Vertex AI without deploying a credentials file. When the variable is unset the provider keeps using Application Default Credentials, so existing `GOOGLE_APPLICATION_CREDENTIALS`, `gcloud` and metadata server setups are unchanged.

--- a/docs/guides/packages/llm.mdx
+++ b/docs/guides/packages/llm.mdx
@@ -674,7 +674,23 @@ model: gemini-1.5-pro
 ---
 ```
 
-Requires Google Cloud authentication and configuration. The legacy alias `vertex` is still accepted.
+Requires `GOOGLE_VERTEX_PROJECT` and `GOOGLE_VERTEX_LOCATION`, plus service account credentials. The legacy alias `vertex` is still accepted.
+
+Set `GCP_CREDENTIALS_JSON` to the contents of your service account key file to authenticate without deploying the file itself:
+
+```bash .env
+GOOGLE_VERTEX_PROJECT=lead-enrichment-prod
+GOOGLE_VERTEX_LOCATION=us-central1
+GCP_CREDENTIALS_JSON=eyJ0eXBlIjoic2VydmljZV9hY2NvdW50Iiw...
+```
+
+The value accepts the raw JSON document or its base64 encoding. Prefer base64 for `.env` files and container environments: a downloaded key file spans multiple lines, and most environment variable parsers stop at the first newline.
+
+```bash
+base64 -i gcp-credentials.json | tr -d '\n'
+```
+
+When `GCP_CREDENTIALS_JSON` is unset, the provider uses Application Default Credentials instead - a `GOOGLE_APPLICATION_CREDENTIALS` file path, a `gcloud auth application-default login` session, or the metadata server. On Cloud Run or GKE with workload identity, that means you configure the project and location and nothing else.
 
 ### Amazon Bedrock
 

--- a/sdk/llm/src/ai_provider.js
+++ b/sdk/llm/src/ai_provider.js
@@ -8,6 +8,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createPerplexity } from '@ai-sdk/perplexity';
 import { createVertex } from '@ai-sdk/google-vertex';
 import { deprecatedProviderAliases } from './deprecated_provider_aliases.js';
+import { resolveGoogleVertexAuthOptions } from './utils/google_vertex_auth.js';
 
 /** This custom dispatcher has longer timeouts. */
 const customDispatcher = new EnvHttpProxyAgent( {
@@ -24,7 +25,7 @@ const providerInitializers = {
   'amazon-bedrock': createAmazonBedrock,
   anthropic: createAnthropic,
   azure: createAzure,
-  'google-vertex': createVertex,
+  'google-vertex': options => createVertex( { ...options, ...resolveGoogleVertexAuthOptions() } ),
   openai: createOpenAI,
   perplexity: createPerplexity
 };

--- a/sdk/llm/src/ai_provider.spec.js
+++ b/sdk/llm/src/ai_provider.spec.js
@@ -24,7 +24,8 @@ const undiciSpies = vi.hoisted( () => ( {
 } ) );
 
 const importWithMockedProviders = async ( {
-  modules = makeProviderModules()
+  modules = makeProviderModules(),
+  resolveGoogleVertexAuthOptions = () => ( {} )
 } = {} ) => {
   await vi.resetModules();
 
@@ -33,6 +34,8 @@ const importWithMockedProviders = async ( {
       [exportName]: modules[pkg][exportName]
     } ) );
   }
+
+  vi.doMock( './utils/google_vertex_auth.js', () => ( { resolveGoogleVertexAuthOptions } ) );
 
   vi.doMock( 'undici', async importOriginal => {
     const actual = await importOriginal();
@@ -59,6 +62,7 @@ afterEach( () => {
     vi.doUnmock( pkg );
   }
   vi.doUnmock( 'undici' );
+  vi.doUnmock( './utils/google_vertex_auth.js' );
   undiciSpies.EnvHttpProxyAgent.mockReset();
   undiciSpies.fetch.mockReset();
   vi.resetModules();
@@ -89,6 +93,32 @@ describe( 'getProvider', () => {
       bodyTimeout: 15 * 60 * 1000,
       allowH2: false
     } );
+  } );
+
+  it( 'initializes google-vertex with the resolved Google auth options', async () => {
+    const googleAuthOptions = { credentials: { client_email: 'robot@output-test.iam.gserviceaccount.com' } };
+    const { modules, getProvider } = await importWithMockedProviders( {
+      resolveGoogleVertexAuthOptions: () => ( { googleAuthOptions } )
+    } );
+
+    getProvider( 'google-vertex' );
+
+    expect( modules['@ai-sdk/google-vertex'].createVertex ).toHaveBeenCalledWith( {
+      fetch: expect.any( Function ),
+      googleAuthOptions
+    } );
+  } );
+
+  it( 'throws a friendly error when google-vertex credentials cannot be resolved', async () => {
+    const { getProvider } = await importWithMockedProviders( {
+      resolveGoogleVertexAuthOptions: () => {
+        throw new Error( 'Invalid GCP_CREDENTIALS_JSON: value is neither JSON nor base64 encoded JSON' );
+      }
+    } );
+
+    expect( () => getProvider( 'google-vertex' ) ).toThrow(
+      'Failed to initialize provider "google-vertex": Invalid GCP_CREDENTIALS_JSON: value is neither JSON nor base64 encoded JSON'
+    );
   } );
 
   it( 'passes the custom dispatcher through injected fetch', async () => {

--- a/sdk/llm/src/utils/google_vertex_auth.js
+++ b/sdk/llm/src/utils/google_vertex_auth.js
@@ -1,0 +1,31 @@
+import { ValidationError } from '@outputai/core';
+
+const envVar = 'GCP_CREDENTIALS_JSON';
+
+const unescapeLinebreaks = v => v.replaceAll( '\\n', '\n' );
+
+const decodeBase64 = v => Buffer.from( v, 'base64' ).toString( 'utf8' );
+
+const parseJson = v => {
+  try {
+    return JSON.parse( v );
+  } catch ( cause ) {
+    throw new ValidationError( `Invalid ${envVar}: value is neither JSON nor base64 encoded JSON`, { cause } );
+  }
+};
+
+export const resolveGoogleVertexAuthOptions = () => {
+  const value = process.env[envVar]?.trim();
+
+  if ( !value ) {
+    return {};
+  }
+
+  const credentials = parseJson( value.startsWith( '{' ) ? value : decodeBase64( value ) );
+
+  if ( credentials.private_key ) {
+    credentials.private_key = unescapeLinebreaks( credentials.private_key );
+  }
+
+  return { googleAuthOptions: { credentials } };
+};

--- a/sdk/llm/src/utils/google_vertex_auth.spec.js
+++ b/sdk/llm/src/utils/google_vertex_auth.spec.js
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ValidationError } from '@outputai/core';
+import { resolveGoogleVertexAuthOptions } from './google_vertex_auth.js';
+
+const envVar = 'GCP_CREDENTIALS_JSON';
+
+const serviceAccount = {
+  type: 'service_account',
+  project_id: 'output-test',
+  private_key_id: 'a1b2c3',
+  private_key: '-----BEGIN PRIVATE KEY-----\nMIIEvQ\n-----END PRIVATE KEY-----\n',
+  client_email: 'robot@output-test.iam.gserviceaccount.com'
+};
+
+const stubEnv = value => vi.stubEnv( envVar, value );
+const toBase64 = value => Buffer.from( value, 'utf8' ).toString( 'base64' );
+const invalidMessage = `Invalid ${envVar}: value is neither JSON nor base64 encoded JSON`;
+
+afterEach( () => {
+  vi.unstubAllEnvs();
+} );
+
+describe( 'resolveGoogleVertexAuthOptions', () => {
+  it( 'returns no options when the env var is unset, leaving the provider on default credentials', () => {
+    expect( resolveGoogleVertexAuthOptions() ).toEqual( {} );
+  } );
+
+  it( 'returns no options when the env var holds only whitespace', () => {
+    stubEnv( '  \n  ' );
+
+    expect( resolveGoogleVertexAuthOptions() ).toEqual( {} );
+  } );
+
+  it( 'reads raw JSON credentials', () => {
+    stubEnv( JSON.stringify( serviceAccount ) );
+
+    expect( resolveGoogleVertexAuthOptions() ).toEqual( { googleAuthOptions: { credentials: serviceAccount } } );
+  } );
+
+  it( 'reads base64 encoded JSON credentials', () => {
+    stubEnv( toBase64( JSON.stringify( serviceAccount ) ) );
+
+    expect( resolveGoogleVertexAuthOptions() ).toEqual( { googleAuthOptions: { credentials: serviceAccount } } );
+  } );
+
+  it( 'ignores whitespace around the value', () => {
+    stubEnv( `\n  ${JSON.stringify( serviceAccount )}  \n` );
+
+    expect( resolveGoogleVertexAuthOptions() ).toEqual( { googleAuthOptions: { credentials: serviceAccount } } );
+  } );
+
+  it( 'restores linebreaks in a double escaped private key', () => {
+    const doubleEscaped = '-----BEGIN PRIVATE KEY-----\\nMIIEvQ\\n-----END PRIVATE KEY-----\\n';
+    stubEnv( JSON.stringify( { ...serviceAccount, private_key: doubleEscaped } ) );
+
+    const { googleAuthOptions } = resolveGoogleVertexAuthOptions();
+
+    expect( googleAuthOptions.credentials.private_key ).toBe( serviceAccount.private_key );
+  } );
+
+  it( 'passes through credential types that carry no private key', () => {
+    const externalAccount = {
+      type: 'external_account',
+      audience: '//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/pool/providers/provider',
+      subject_token_type: 'urn:ietf:params:oauth:token-type:jwt'
+    };
+    stubEnv( JSON.stringify( externalAccount ) );
+
+    expect( resolveGoogleVertexAuthOptions() ).toEqual( { googleAuthOptions: { credentials: externalAccount } } );
+  } );
+
+  it.each( [
+    [ 'malformed JSON', '{ "type": "service_account"' ],
+    [ 'a value that is not base64', 'not base64 at all!!!' ],
+    [ 'a credentials file path', '/app/test_workflows/gcp-credentials.json' ]
+  ] )( 'throws a ValidationError for %s', ( _label, value ) => {
+    stubEnv( value );
+
+    expect( () => resolveGoogleVertexAuthOptions() ).toThrow( ValidationError );
+    expect( () => resolveGoogleVertexAuthOptions() ).toThrow( invalidMessage );
+  } );
+} );


### PR DESCRIPTION
## Summary

- Added a new env var `GCP_CREDENTIALS_JSON`, that allows to authenticate Google Vertext like the  `gcp_credentials.json` file. It supports plain json or base64 encoded json.
